### PR TITLE
Simplify pure model context data handling

### DIFF
--- a/app/api/NetworkClient.ts
+++ b/app/api/NetworkClient.ts
@@ -110,10 +110,15 @@ export class NetworkClientError extends Error {
 
   constructor(response: Response, payload: Payload | undefined) {
     super();
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
-    // This only works in Chrome for now. Firefox (as of Feb 2020) will throw error
-    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
-    Error.captureStackTrace(this, NetworkClientError);
+    if (typeof Error.captureStackTrace === 'function') {
+      // Maintains proper stack trace for where our error was thrown (only available on V8)
+      // This only works in Chrome for now. Firefox (as of Feb 2020) will throw error
+      // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      // otherwise, use the non-standard but defacto stack trace (available in most browser)
+      this.stack = (new Error()).stack;
+    }
     this.name = 'Network Client Error';
     this.response = response;
     const { status, statusText, url } = response;

--- a/app/models/metamodels/pure/AbstractPureGraphManager.ts
+++ b/app/models/metamodels/pure/AbstractPureGraphManager.ts
@@ -53,23 +53,7 @@ export interface PureModelContextDataObject {
       version: string;
     }
   },
-  domain: {
-    classes: PackageableElementObject[];
-    associations: PackageableElementObject[];
-    enums: PackageableElementObject[];
-    measures: PackageableElementObject[];
-    profiles: PackageableElementObject[];
-    functions: PackageableElementObject[];
-  };
-  stores: PackageableElementObject[];
-  connections: PackageableElementObject[];
-  runtimes: PackageableElementObject[];
-  mappings: PackageableElementObject[];
-  diagrams: PackageableElementObject[];
-  texts: PackageableElementObject[];
-  fileGenerations: PackageableElementObject[];
-  generationSpecifications: PackageableElementObject[];
-  sectionIndices: PackageableElementObject[];
+  elements: PackageableElementObject[];
 }
 
 export const elementProtocolToEntity = (graphManager: AbstractPureGraphManager, elementProtocol: PackageableElementObject): Entity => ({
@@ -78,23 +62,8 @@ export const elementProtocolToEntity = (graphManager: AbstractPureGraphManager, 
   classifierPath: getClassiferPathFromType(graphManager.getTypeFromProtocolType(elementProtocol._type))
 });
 
-/* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
 export const graphModelDataToEntities = (graphManager: AbstractPureGraphManager, graphModelData: Partial<PureModelContextDataObject>): Entity[] => [
-  ...(graphModelData.domain?.classes ?? []),
-  ...(graphModelData.domain?.associations ?? []),
-  ...(graphModelData.domain?.enums ?? []),
-  ...(graphModelData.domain?.measures ?? []),
-  ...(graphModelData.domain?.profiles ?? []),
-  ...(graphModelData.domain?.functions ?? []),
-  ...(graphModelData.stores ?? []),
-  ...(graphModelData.mappings ?? []),
-  ...(graphModelData.diagrams ?? []),
-  ...(graphModelData.texts ?? []),
-  ...(graphModelData.connections ?? []),
-  ...(graphModelData.runtimes ?? []),
-  ...(graphModelData.fileGenerations ?? []),
-  ...(graphModelData.generationSpecifications ?? []),
-  ...(graphModelData.sectionIndices ?? []),
+  ...(graphModelData.elements ?? []),
 ].map(element => elementProtocolToEntity(graphManager, element));
 
 export abstract class AbstractPureGraphManager {

--- a/app/models/metamodels/pure/system/System.json
+++ b/app/models/metamodels/pure/system/System.json
@@ -1,30 +1,23 @@
 {
-  "domain": {
-    "profiles": [
-      {
-        "stereotypes": ["deprecated"],
-        "package": "meta::pure::profiles",
-        "_type": "profile",
-        "name": "doc",
-        "tags": ["doc", "todo"]
-      },
-      {
-        "stereotypes": ["abstract"],
-        "package": "meta::pure::profiles",
-        "_type": "profile",
-        "name": "typemodifiers"
-      },
-      {
-        "package": "meta::pure::metamodel::type",
-        "_type": "class",
-        "name": "Any",
-        "properties": []
-      }
-    ],
-    "enums": [],
-    "measures": [],
-    "classes": [],
-    "associations": [],
-    "functions": []
-  }
+  "elements": [
+    {
+      "stereotypes": ["deprecated"],
+      "package": "meta::pure::profiles",
+      "_type": "profile",
+      "name": "doc",
+      "tags": ["doc", "todo"]
+    },
+    {
+      "stereotypes": ["abstract"],
+      "package": "meta::pure::profiles",
+      "_type": "profile",
+      "name": "typemodifiers"
+    },
+    {
+      "package": "meta::pure::metamodel::type",
+      "_type": "class",
+      "name": "Any",
+      "properties": []
+    }
+  ]
 }

--- a/app/models/protocols/pure/v1/model/context/PureModelContextData.ts
+++ b/app/models/protocols/pure/v1/model/context/PureModelContextData.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { deserialize, object, list, serializable } from 'serializr';
-import { PROTOCOL_CLASSIFIER_PATH } from 'MetaModelConst';
-import { Clazz } from 'Utilities/GeneralUtil';
+import { deserialize, list, serializable, custom, SKIP } from 'serializr';
+import { UnsupportedOperationError } from 'Utilities/GeneralUtil';
 import { Entity } from 'SDLC/entity/Entity';
 import { GraphDataParserError } from 'MetaModelUtility';
 import { SectionIndex } from 'V1/model/packageableElements/section/SectionIndex';
@@ -24,94 +23,55 @@ import { Measure } from 'V1/model/packageableElements/domain/Measure';
 import { GenerationSpecification } from 'V1/model/packageableElements/generationSpecification/GenerationSpecification';
 import { Class } from 'V1/model/packageableElements/domain/Class';
 import { Association } from 'V1/model/packageableElements/domain/Association';
+import { ConcreteFunctionDefinition } from 'V1/model/packageableElements/function/ConcreteFunctionDefinition';
 import { Enumeration } from 'V1/model/packageableElements/domain/Enumeration';
 import { Profile } from 'V1/model/packageableElements/domain/Profile';
 import { Mapping } from 'V1/model/packageableElements/mapping/Mapping';
 import { Diagram } from 'V1/model/packageableElements/diagram/Diagram';
-import { Domain } from 'V1/model/packageableElements/domain/Domain';
 import { PureModelContext, PureModelContextType } from 'V1/model/context/PureModelContext';
-import { PackageableElement } from 'V1/model/packageableElements/PackageableElement';
+import { PackageableElement, PackageableElementType } from 'V1/model/packageableElements/PackageableElement';
 import { Text } from 'V1/model/packageableElements/text/Text';
-import { ConcreteFunctionDefinition } from 'V1/model/packageableElements/function/ConcreteFunctionDefinition';
-import { Store } from 'V1/model/packageableElements/store/Store';
-import { PackageableRuntime } from 'V1/model/packageableElements/runtime/PackageableRuntime';
-import { PackageableConnection } from 'V1/model/packageableElements/connection/PackageableConnection';
 import { FileGeneration } from 'V1/model/packageableElements/fileGeneration/FileGeneration';
+
+export const deserializePackageableElement = (val: Record<PropertyKey, unknown>): PackageableElement => {
+  switch (val._type) {
+    /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
+    case PackageableElementType.PROFILE: return deserialize(Profile, val);
+    case PackageableElementType.CLASS: return deserialize(Class, val);
+    case PackageableElementType.ENUMERATION: return deserialize(Enumeration, val);
+    case PackageableElementType.ASSOCIATION: return deserialize(Association, val);
+    case PackageableElementType.FUNCTION: return deserialize(ConcreteFunctionDefinition, val);
+    case PackageableElementType.MEASURE: return deserialize(Measure, val);
+    case PackageableElementType.MAPPING: return deserialize(Mapping, val);
+    case PackageableElementType.DIAGRAM: return deserialize(Diagram, val);
+    case PackageableElementType.TEXT: return deserialize(Text, val);
+    case PackageableElementType.FILE_GENERATION: return deserialize(FileGeneration, val);
+    case PackageableElementType.GENERATION_SPECIFICATION: return deserialize(GenerationSpecification, val);
+    // TODO: runtime, connection
+    case PackageableElementType.SECTION_INDEX: return deserialize(SectionIndex, val);
+    default: throw new UnsupportedOperationError(`Can't deserialize element of unsupported type '${val._type}'`);
+  }
+};
 
 export class PureModelContextData extends PureModelContext {
   @serializable _type = PureModelContextType.DATA;
-  /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
-  @serializable(object(Domain)) domain = new Domain();
-  stores: Store[] = [];
-  @serializable(list(object(Mapping))) mappings: Mapping[] = [];
-  @serializable(list(object(Diagram))) diagrams: Diagram[] = [];
-  @serializable(list(object(Text))) texts: Text[] = [];
-  @serializable(list(object(PackageableRuntime))) runtimes: PackageableRuntime[] = [];
-  @serializable(list(object(PackageableConnection))) connections: PackageableConnection[] = [];
-  @serializable(list(object(FileGeneration))) fileGenerations: FileGeneration[] = [];
-  @serializable(list(object(GenerationSpecification))) generationSpecifications: GenerationSpecification[] = [];
-  @serializable(list(object(SectionIndex))) sectionIndices: SectionIndex[] = [];
+  @serializable(list(custom(() => SKIP, val => deserializePackageableElement(val)))) elements: PackageableElement[] = [];
 
   /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
   async build(entities: Entity[] | undefined): Promise<void> {
     try {
-      if (entities?.length) {
-        const buildEntitiesForType = async <T>(ents: Entity[], type: Clazz<T>): Promise<T[]> => ents.length
-          ? Promise.all<T>(ents.map(e => new Promise((resolve, reject) => setTimeout(() => {
-            try {
-              resolve(deserialize(type, e.content));
-            } catch (error) {
-              reject(error);
-            }
-          }, 0))))
-          : [];
-        this.domain.profiles = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.PROFILE), Profile);
-        this.domain.enums = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.ENUMERATION), Enumeration);
-        this.domain.measures = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.MEASURE), Measure);
-        this.domain.classes = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.CLASS), Class);
-        this.domain.functions = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.FUNCTION), ConcreteFunctionDefinition);
-        this.domain.associations = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.ASSOCIATION), Association);
-        this.stores = [];
-        this.mappings = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.MAPPING), Mapping);
-        this.diagrams = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.DIAGRAM), Diagram);
-        this.texts = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.TEXT), Text);
-        this.connections = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.CONNECTION), PackageableConnection);
-        this.runtimes = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.RUNTIME), PackageableRuntime);
-        this.fileGenerations = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.FILE_GENERATION), FileGeneration);
-        this.generationSpecifications = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.GENERATION_SPECIFICATION), GenerationSpecification);
-        this.sectionIndices = await buildEntitiesForType(entities.filter(e => e.classifierPath === PROTOCOL_CLASSIFIER_PATH.SECTION_INDEX), SectionIndex);
+      if (entities) {
+        this.elements = await Promise.all<PackageableElement>(entities.map(e => new Promise((resolve, reject) => setTimeout(() => {
+          try {
+            resolve(deserializePackageableElement(e.content as unknown as Record<PropertyKey, unknown>));
+          } catch (error) {
+            reject(error);
+          }
+        }, 0))));
       }
     } catch (error) {
       // wrap all de-serializer error so we can handle them downstream
       throw new GraphDataParserError(error);
     }
-  }
-
-  /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
-  get types(): PackageableElement[] {
-    return [
-      ...this.domain.profiles,
-      ...this.domain.enums,
-      ...this.domain.measures,
-      ...this.domain.classes,
-      ...this.domain.associations,
-      ...this.domain.functions
-    ];
-  }
-
-  /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
-  get elements(): PackageableElement[] {
-    return [
-      ...this.types,
-      ...this.stores,
-      ...this.mappings,
-      ...this.diagrams,
-      ...this.texts,
-      ...this.runtimes,
-      ...this.connections,
-      ...this.fileGenerations,
-      ...this.generationSpecifications,
-      ...this.sectionIndices,
-    ];
   }
 }


### PR DESCRIPTION
This is to address the change in `legend-engine` to use `elements` instead of separate indices for each element types