### PR TITLE
fix(service test state): minify url creation for JSON model connection

### DIFF
--- a/.changeset/bright-gorillas-bathe.md
+++ b/.changeset/bright-gorillas-bathe.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-studio": patch
+---
+
+Minify test data when creating JSON model connection data URL for test to reduce traffic load

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -27,6 +27,7 @@ import {
   UnsupportedOperationError,
   uniq,
   isNonNullable,
+  tryToMinifyLosslessJSONString,
   tryToFormatJSONString,
   toGrammarString,
   fromGrammarString,
@@ -179,7 +180,7 @@ export class TestContainerState {
                 ),
                 connection.class,
                 createUrlStringFromData(
-                  testData,
+                  tryToMinifyLosslessJSONString(testData),
                   JsonModelConnection.CONTENT_TYPE,
                   engineConfig.useBase64ForAdhocConnectionDataUrls,
                 ),


### PR DESCRIPTION
URL creation for services with JSON model connections should minify the JSON data so as not to break string size limits in Legend Java generation
