### PR TITLE
Fix dev-utils to make consumer projects work with published packages from NPM

### DIFF
--- a/.changeset/yellow-plums-float.md
+++ b/.changeset/yellow-plums-float.md
@@ -1,0 +1,7 @@
+---
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-dev-utils': patch
+---
+
+Fix dev-utils for Webpack and Jest to make consumer projects work with published packages from NPM

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@finos/eslint-plugin-legend-studio": "workspace:*",
     "@finos/legend-studio-dev-utils": "workspace:*",
     "@finos/stylelint-config-legend-studio": "workspace:*",
+    "@juggle/resize-observer": "3.3.0",
     "@types/jest": "26.0.20",
     "@types/node": "14.14.33",
     "chalk": "4.1.0",

--- a/packages/legend-studio-app/webpack.config.js
+++ b/packages/legend-studio-app/webpack.config.js
@@ -28,8 +28,8 @@ module.exports = (env, arg) => {
   const baseConfig = getWebAppBaseWebpackConfig(env, arg, __dirname, {
     mainEntryPath: path.resolve(__dirname, './src/index.tsx'),
     indexHtmlPath: path.resolve(__dirname, './src/index.html'),
-    babelConfigPath: path.resolve(__dirname, '../../babel.config.js'),
     appConfig,
+    babelConfigPath: path.resolve(__dirname, '../../babel.config.js'),
   });
   const config = {
     ...baseConfig,

--- a/packages/legend-studio-dev-utils/JestConfigUtils.js
+++ b/packages/legend-studio-dev-utils/JestConfigUtils.js
@@ -25,6 +25,8 @@ const getBaseConfig = ({ babelConfigPath }) => ({
     // See https://jestjs.io/docs/en/getting-started#using-typescript
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: babelConfigPath }],
   },
+  // Since we don't transpile our code, we need to allow `Jest` to be able to transform/transpile them
+  transformIgnorePatterns: ['node_modules/(?!(@finos/legend-studio))'],
   // Setup to run immediately after the test framework has been installed in the environment
   // before each test file in the suite is executed
   // See https://jestjs.io/docs/en/configuration#setupfilesafterenv-array

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -65,7 +65,6 @@
   },
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
-    "@juggle/resize-observer": "3.3.0",
     "@testing-library/dom": "7.30.0",
     "@types/css-font-loading-module": "0.0.4",
     "@types/react": "17.0.3",


### PR DESCRIPTION
Fix `CodeCheckerUtils`
Fix `JestConfigUtils` and `WebpackConfigUtils` to cover scope of untranspiled modules `@finos/legend-studio-*` so that consumers can properly load/transform files coming from `@finos/legend-studio-*`. 