### PR TITLE
attempt to stabilize code coverage report in ChangeDetectionState

### DIFF
--- a/.changeset/proud-vans-swim.md
+++ b/.changeset/proud-vans-swim.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-studio': patch
+'@finos/legend-studio-dev-utils': patch
+---

--- a/packages/legend-studio-dev-utils/CodeCheckerUtils.js
+++ b/packages/legend-studio-dev-utils/CodeCheckerUtils.js
@@ -129,6 +129,7 @@ const findFiles = ({
   );
 
   const result = markerStats.dirs // sort directories to the top
+    .slice()
     .sort((a, b) => a.localeCompare(b))
     .map((dir) => ({
       path: dir,

--- a/packages/legend-studio/src/stores/ChangeDetectionState.ts
+++ b/packages/legend-studio/src/stores/ChangeDetectionState.ts
@@ -322,6 +322,16 @@ export class ChangeDetectionState {
   start(): void {
     this.changeDetectionReaction?.();
     /**
+     * It seems like the reaction action is not always called in tests, causing fluctuation in
+     * code coverage report for this file. As such, for test, we would want to disable throttling
+     * to avoid timing issue.
+     *
+     * See https://docs.codecov.io/docs/unexpected-coverage-changes
+     * See https://community.codecov.io/t/codecov-reporting-impacted-files-for-unchanged-and-completely-unrelated-file/2635
+     */
+    // eslint-disable-next-line no-process-env
+    const throttleDuration = process.env.NODE_ENV === 'test' ? 0 : 1000;
+    /**
      * For the reaction, the data we observe is the snapshot of the current hashes, note that we can also use the hashCode
      * of the root package although this might get interesting in the future when we introduce project dependency or
      * auto-gen elements...
@@ -352,7 +362,7 @@ export class ChangeDetectionState {
       () => {
         this.computeLocalChanges(true).catch(noop());
       },
-      { delay: 1000 }, // throttle the call
+      { delay: throttleDuration }, // throttle the call
       /**
        * NOTE: this reaction will not be fired immediately so we have to manually call the first local changes computation
        * See https://mobx.js.org/refguide/reaction.html#options


### PR DESCRIPTION
CodeCov is reporting changes in coverage of `ChangeDetectionState` in PR comment even when we don't actually change anything in this file. Especially, the lines below are pointed out as the culprit:

https://github.com/finos/legend-studio/blob/35119b3421f949da32be5884ace73ab94b010a54/packages/legend-studio/src/stores/ChangeDetectionState.ts#L352-L353

As one can see in these links below:
https://app.codecov.io/gh/finos/legend-studio/compare/99/changes
https://app.codecov.io/gh/finos/legend-studio/compare/104/changes
https://app.codecov.io/gh/finos/legend-studio/compare/106/changes

So one thing to try is to remove the delay in `reaction` to see if this is an issue caused by timing. A more rigorous way is to always mock out the `start()` method which is more error-prone and laborious, we would try that later.