### PR TITLE
Maintenance and update copyright header and license year

### DIFF
--- a/.changeset/gold-oranges-retire.md
+++ b/.changeset/gold-oranges-retire.md
@@ -1,0 +1,14 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-network': patch
+'@finos/legend-studio-plugin-management': patch
+'@finos/legend-studio-plugin-tracer-zipkin': patch
+'@finos/legend-studio-preset-dsl-text': patch
+'@finos/legend-studio-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/.changeset/twelve-dodos-flash.md
+++ b/.changeset/twelve-dodos-flash.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio-app': patch
+---
+
+Upgrade legend-shared-server used in Docker image.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.github/containerscan/allowedlist.yml
+++ b/.github/containerscan/allowedlist.yml
@@ -1,8 +1,0 @@
-# See https://github.com/Azure/container-scan
-general:
-  vulnerabilities:
-    # `finos/legend-shared-server` is using an older of `openjdk` with vulnerabilities
-    # TODO: upgrade and remove this file
-    # See https://github.com/finos/legend-shared/pull/93
-    - CVE-2021-24031
-    - CVE-2021-24032

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   // NOTE: if in `User Settings`, specific extension (e.g. ts, tsx) is configured with another formatter, the following config won't work
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.tabSize": 2,
+  "files.eol": "\n",
   "eslint.validate": [
     "javascript",
     "javascriptreact",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ yarn changeset:cli
 
 Make sure to install [Node.js](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/). For IDE, we highly recommend [Visual Studio Code](https://code.visualstudio.com/). Also, to assist development, don't forget to install [ESLint](https://eslint.org/) and [Stylelint](https://stylelint.io/) plugins to help you catch problems while writing code; and install [Prettier](https://prettier.io/) plugin to help you auto-format code. Last but not least, run the `setup` script.
 
+Studio relies on SDLC and Engine servers as its backend. If you don't have these servers setup to run locally, you can make use of [this Docker compose project](https://github.com/finos/legend/tree/master/installers/docker-compose) to quickly set them up. The more convenient approach we found is to run these server and use a remote Gitlab instance, if you choose to follow that direction, pay attention to the [note on development](https://github.com/finos/legend/tree/master/installers/docker-compose/legend-with-remote-gitlab/README.md#note-on-development).
+
 ```sh
 # Install dependencies, link and set up the workspaces, and build the workspaces to make sure your project is in good shape.
 yarn setup

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Goldman Sachs
+   Copyright Goldman Sachs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright Goldman Sachs
+   Copyright 2020 Goldman Sachs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Goldman Sachs
+   Copyright (c) 2020-present, Goldman Sachs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Legend - FINOS
-Copyright 2020 Goldman Sachs - info@gs.com
+Copyright Goldman Sachs - info@gs.com
 
 This product includes software developed at the Fintech Open Source Foundation (https://www.finos.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Legend - FINOS
-Copyright Goldman Sachs - info@gs.com
+Copyright (c) 2020-present, Goldman Sachs - info@gs.com
 
 This product includes software developed at the Fintech Open Source Foundation (https://www.finos.org/).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Read our [contributing guide](./CONTRIBUTING.md) to learn about our development 
 
 ### License
 
-Copyright 2020 Goldman Sachs
+Copyright Goldman Sachs
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Read our [contributing guide](./CONTRIBUTING.md) to learn about our development 
 
 ### License
 
-Copyright Goldman Sachs
+Copyright (c) 2020-present, Goldman Sachs
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 ## Getting started
 
-Make sure you have `Yarn` installed
+Make sure you have SDLC and Engine servers running. If you don't have these servers setup to run locally, you can make use of [this Docker compose project](https://github.com/finos/legend/tree/master/installers/docker-compose) to quickly set them up. The more convenient approach we found is to run these server and use a remote Gitlab instance, if you choose to follow that direction, pay attention to the [note on development](https://github.com/finos/legend/tree/master/installers/docker-compose/legend-with-remote-gitlab/README.md#note-on-development).
+
+Make sure you have `Yarn` installed. Run the following commands in order.
 
 ```bash
   yarn setup

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,12 @@
+# Troubleshooting
+
+## Getting 'Your connection is not private' in Chromium-based browsers
+
+You'd probably run into this issue when running in browsers like Chrome because it does not acknowledge our self-signed certificate. If so, you can follow this [guide](https://www.technipages.com/google-chrome-bypass-your-connection-is-not-private-message) on how to by pass this issue:
+
+1. In the browser address bar, type `chrome://flags/#allow-insecure-localhost` and switch to `Enable`.
+2. Go to the page again `localhost:8080/studio`, you should still see the warning. However, now, click somewhere on the page and type `thisisunsafe` and you should see the page gets reloaded and display properly.
+
+## Getting `Unauthorized` and 401 call to SDLC after logging into Gitlab and being redirected to Studio
+
+Clear all cookies for the site (including SDLC, engine, and Studio) and try to refresh. As a quick try, you can open Studio in a incognito window.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/configs/computationally-expensive.js
+++ b/packages/eslint-plugin/src/configs/computationally-expensive.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/configs/computationally-expensive.js
+++ b/packages/eslint-plugin/src/configs/computationally-expensive.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/configs/recommended.js
+++ b/packages/eslint-plugin/src/configs/recommended.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/configs/recommended.js
+++ b/packages/eslint-plugin/src/configs/recommended.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/configs/scripts-override.js
+++ b/packages/eslint-plugin/src/configs/scripts-override.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/configs/scripts-override.js
+++ b/packages/eslint-plugin/src/configs/scripts-override.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/enforce-module-import-hierarchy.js
+++ b/packages/eslint-plugin/src/rules/enforce-module-import-hierarchy.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/enforce-module-import-hierarchy.js
+++ b/packages/eslint-plugin/src/rules/enforce-module-import-hierarchy.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/enforce-protocol-export-prefix.js
+++ b/packages/eslint-plugin/src/rules/enforce-protocol-export-prefix.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/enforce-protocol-export-prefix.js
+++ b/packages/eslint-plugin/src/rules/enforce-protocol-export-prefix.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/enforce-protocol-file-prefix.js
+++ b/packages/eslint-plugin/src/rules/enforce-protocol-file-prefix.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/enforce-protocol-file-prefix.js
+++ b/packages/eslint-plugin/src/rules/enforce-protocol-file-prefix.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/no-cross-protocol-version-import.js
+++ b/packages/eslint-plugin/src/rules/no-cross-protocol-version-import.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/no-cross-protocol-version-import.js
+++ b/packages/eslint-plugin/src/rules/no-cross-protocol-version-import.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/no-cross-workspace-source-import.js
+++ b/packages/eslint-plugin/src/rules/no-cross-workspace-source-import.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/no-cross-workspace-source-import.js
+++ b/packages/eslint-plugin/src/rules/no-cross-workspace-source-import.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/no-same-workspace-index-import.js
+++ b/packages/eslint-plugin/src/rules/no-same-workspace-index-import.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/eslint-plugin/src/rules/no-same-workspace-index-import.js
+++ b/packages/eslint-plugin/src/rules/no-same-workspace-index-import.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/Dockerfile
+++ b/packages/legend-studio-app/Dockerfile
@@ -1,3 +1,3 @@
-FROM finos/legend-shared-server:0.7.0
+FROM finos/legend-shared-server:0.8.0
 COPY dist/studio /app/bin/webapp-content/web/studio
 CMD java -cp /app/bin/webapp-content:/app/bin/* org.finos.legend.server.shared.staticserver.Server server /config/httpConfig.json

--- a/packages/legend-studio-app/cypress/integration/element-editors/file-generation-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/file-generation-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/file-generation-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/file-generation-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/flatData-mapping-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/flatData-mapping-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/flatData-mapping-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/flatData-mapping-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/m2m-mapping-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/m2m-mapping-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/m2m-mapping-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/m2m-mapping-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/relational-mapping.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/relational-mapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/relational-mapping.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/relational-mapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/uml-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/uml-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/element-editors/uml-editor.ts
+++ b/packages/legend-studio-app/cypress/integration/element-editors/uml-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/sdlc/conflict_resolution.ts
+++ b/packages/legend-studio-app/cypress/integration/sdlc/conflict_resolution.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/sdlc/conflict_resolution.ts
+++ b/packages/legend-studio-app/cypress/integration/sdlc/conflict_resolution.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/sdlc/simple_sdlc.ts
+++ b/packages/legend-studio-app/cypress/integration/sdlc/simple_sdlc.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/sdlc/simple_sdlc.ts
+++ b/packages/legend-studio-app/cypress/integration/sdlc/simple_sdlc.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/viewer/viewer.ts
+++ b/packages/legend-studio-app/cypress/integration/viewer/viewer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/integration/viewer/viewer.ts
+++ b/packages/legend-studio-app/cypress/integration/viewer/viewer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/plugins/index.js
+++ b/packages/legend-studio-app/cypress/plugins/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/plugins/index.js
+++ b/packages/legend-studio-app/cypress/plugins/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/support/commands.ts
+++ b/packages/legend-studio-app/cypress/support/commands.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/support/commands.ts
+++ b/packages/legend-studio-app/cypress/support/commands.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/support/index.d.ts
+++ b/packages/legend-studio-app/cypress/support/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/support/index.d.ts
+++ b/packages/legend-studio-app/cypress/support/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/support/index.ts
+++ b/packages/legend-studio-app/cypress/support/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/support/index.ts
+++ b/packages/legend-studio-app/cypress/support/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/E2ETestUtil.ts
+++ b/packages/legend-studio-app/cypress/utils/E2ETestUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/E2ETestUtil.ts
+++ b/packages/legend-studio-app/cypress/utils/E2ETestUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/ElementEditorTester.ts
+++ b/packages/legend-studio-app/cypress/utils/ElementEditorTester.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/ElementEditorTester.ts
+++ b/packages/legend-studio-app/cypress/utils/ElementEditorTester.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/ElementHelperExtension.ts
+++ b/packages/legend-studio-app/cypress/utils/ElementHelperExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/ElementHelperExtension.ts
+++ b/packages/legend-studio-app/cypress/utils/ElementHelperExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/EndToEndTester.ts
+++ b/packages/legend-studio-app/cypress/utils/EndToEndTester.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/cypress/utils/EndToEndTester.ts
+++ b/packages/legend-studio-app/cypress/utils/EndToEndTester.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/jest.config.js
+++ b/packages/legend-studio-app/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/jest.config.js
+++ b/packages/legend-studio-app/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/scripts/setup.js
+++ b/packages/legend-studio-app/scripts/setup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/scripts/setup.js
+++ b/packages/legend-studio-app/scripts/setup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/src/index.scss
+++ b/packages/legend-studio-app/src/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/src/index.scss
+++ b/packages/legend-studio-app/src/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/src/index.tsx
+++ b/packages/legend-studio-app/src/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/src/index.tsx
+++ b/packages/legend-studio-app/src/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/studio.config.js
+++ b/packages/legend-studio-app/studio.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/studio.config.js
+++ b/packages/legend-studio-app/studio.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/webpack.config.js
+++ b/packages/legend-studio-app/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-app/webpack.config.js
+++ b/packages/legend-studio-app/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/_package.config.js
+++ b/packages/legend-studio-components/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/_package.config.js
+++ b/packages/legend-studio-components/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/jest.config.js
+++ b/packages/legend-studio-components/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/jest.config.js
+++ b/packages/legend-studio-components/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/BaseMuiComponents.tsx
+++ b/packages/legend-studio-components/src/components/BaseMuiComponents.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/BaseMuiComponents.tsx
+++ b/packages/legend-studio-components/src/components/BaseMuiComponents.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/CustomSelectorInput.tsx
+++ b/packages/legend-studio-components/src/components/CustomSelectorInput.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/CustomSelectorInput.tsx
+++ b/packages/legend-studio-components/src/components/CustomSelectorInput.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/Icon.tsx
+++ b/packages/legend-studio-components/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/Icon.tsx
+++ b/packages/legend-studio-components/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/LegendLogo.tsx
+++ b/packages/legend-studio-components/src/components/LegendLogo.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/LegendLogo.tsx
+++ b/packages/legend-studio-components/src/components/LegendLogo.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/TreeView.tsx
+++ b/packages/legend-studio-components/src/components/TreeView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/TreeView.tsx
+++ b/packages/legend-studio-components/src/components/TreeView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/dialog/NonBlockingDialog.tsx
+++ b/packages/legend-studio-components/src/components/dialog/NonBlockingDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/dialog/NonBlockingDialog.tsx
+++ b/packages/legend-studio-components/src/components/dialog/NonBlockingDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/menu/ContextMenu.tsx
+++ b/packages/legend-studio-components/src/components/menu/ContextMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/menu/ContextMenu.tsx
+++ b/packages/legend-studio-components/src/components/menu/ContextMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/menu/DropdownMenu.tsx
+++ b/packages/legend-studio-components/src/components/menu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/menu/DropdownMenu.tsx
+++ b/packages/legend-studio-components/src/components/menu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/menu/MenuContent.tsx
+++ b/packages/legend-studio-components/src/components/menu/MenuContent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/menu/MenuContent.tsx
+++ b/packages/legend-studio-components/src/components/menu/MenuContent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/panel/BlankPanelContent.tsx
+++ b/packages/legend-studio-components/src/components/panel/BlankPanelContent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/panel/BlankPanelContent.tsx
+++ b/packages/legend-studio-components/src/components/panel/BlankPanelContent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/panel/BlankPanelPlaceholder.tsx
+++ b/packages/legend-studio-components/src/components/panel/BlankPanelPlaceholder.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/panel/BlankPanelPlaceholder.tsx
+++ b/packages/legend-studio-components/src/components/panel/BlankPanelPlaceholder.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/panel/PanelLoadingIndicator.tsx
+++ b/packages/legend-studio-components/src/components/panel/PanelLoadingIndicator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/components/panel/PanelLoadingIndicator.tsx
+++ b/packages/legend-studio-components/src/components/panel/PanelLoadingIndicator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/index.ts
+++ b/packages/legend-studio-components/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/index.ts
+++ b/packages/legend-studio-components/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/utils/ComponentUtils.ts
+++ b/packages/legend-studio-components/src/utils/ComponentUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/utils/ComponentUtils.ts
+++ b/packages/legend-studio-components/src/utils/ComponentUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/utils/StubTransition.tsx
+++ b/packages/legend-studio-components/src/utils/StubTransition.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/src/utils/StubTransition.tsx
+++ b/packages/legend-studio-components/src/utils/StubTransition.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/_mixins.scss
+++ b/packages/legend-studio-components/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/_mixins.scss
+++ b/packages/legend-studio-components/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_button.scss
+++ b/packages/legend-studio-components/style/base/_button.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_button.scss
+++ b/packages/legend-studio-components/style/base/_button.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_common.scss
+++ b/packages/legend-studio-components/style/base/_common.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_common.scss
+++ b/packages/legend-studio-components/style/base/_common.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_icon.scss
+++ b/packages/legend-studio-components/style/base/_icon.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_icon.scss
+++ b/packages/legend-studio-components/style/base/_icon.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_input.scss
+++ b/packages/legend-studio-components/style/base/_input.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_input.scss
+++ b/packages/legend-studio-components/style/base/_input.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_menu.scss
+++ b/packages/legend-studio-components/style/base/_menu.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_menu.scss
+++ b/packages/legend-studio-components/style/base/_menu.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_modal.scss
+++ b/packages/legend-studio-components/style/base/_modal.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_modal.scss
+++ b/packages/legend-studio-components/style/base/_modal.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_normalize.scss
+++ b/packages/legend-studio-components/style/base/_normalize.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_normalize.scss
+++ b/packages/legend-studio-components/style/base/_normalize.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_panel.scss
+++ b/packages/legend-studio-components/style/base/_panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_panel.scss
+++ b/packages/legend-studio-components/style/base/_panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_utils.scss
+++ b/packages/legend-studio-components/style/base/_utils.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_utils.scss
+++ b/packages/legend-studio-components/style/base/_utils.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_variables.scss
+++ b/packages/legend-studio-components/style/base/_variables.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/base/_variables.scss
+++ b/packages/legend-studio-components/style/base/_variables.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_blank-panel-placeholder.scss
+++ b/packages/legend-studio-components/style/components/_blank-panel-placeholder.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_blank-panel-placeholder.scss
+++ b/packages/legend-studio-components/style/components/_blank-panel-placeholder.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_panel-loading-indicator.scss
+++ b/packages/legend-studio-components/style/components/_panel-loading-indicator.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_panel-loading-indicator.scss
+++ b/packages/legend-studio-components/style/components/_panel-loading-indicator.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_selector-input.scss
+++ b/packages/legend-studio-components/style/components/_selector-input.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_selector-input.scss
+++ b/packages/legend-studio-components/style/components/_selector-input.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_tree-view.scss
+++ b/packages/legend-studio-components/style/components/_tree-view.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/components/_tree-view.scss
+++ b/packages/legend-studio-components/style/components/_tree-view.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/index.scss
+++ b/packages/legend-studio-components/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-components/style/index.scss
+++ b/packages/legend-studio-components/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ChangesetChangelogUtils.js
+++ b/packages/legend-studio-dev-utils/ChangesetChangelogUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ChangesetChangelogUtils.js
+++ b/packages/legend-studio-dev-utils/ChangesetChangelogUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ChangesetUtils.js
+++ b/packages/legend-studio-dev-utils/ChangesetUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ChangesetUtils.js
+++ b/packages/legend-studio-dev-utils/ChangesetUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/CodeCheckerUtils.js
+++ b/packages/legend-studio-dev-utils/CodeCheckerUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/CodeCheckerUtils.js
+++ b/packages/legend-studio-dev-utils/CodeCheckerUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ConventionalCommitUtils.js
+++ b/packages/legend-studio-dev-utils/ConventionalCommitUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ConventionalCommitUtils.js
+++ b/packages/legend-studio-dev-utils/ConventionalCommitUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/CopyrightUtils.js
+++ b/packages/legend-studio-dev-utils/CopyrightUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/CopyrightUtils.js
+++ b/packages/legend-studio-dev-utils/CopyrightUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/DevUtils.js
+++ b/packages/legend-studio-dev-utils/DevUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/DevUtils.js
+++ b/packages/legend-studio-dev-utils/DevUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ForkTsCheckerWebpackFormatterPlugin.js
+++ b/packages/legend-studio-dev-utils/ForkTsCheckerWebpackFormatterPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ForkTsCheckerWebpackFormatterPlugin.js
+++ b/packages/legend-studio-dev-utils/ForkTsCheckerWebpackFormatterPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ForkTsCheckerWebpackPlugin.js
+++ b/packages/legend-studio-dev-utils/ForkTsCheckerWebpackPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ForkTsCheckerWebpackPlugin.js
+++ b/packages/legend-studio-dev-utils/ForkTsCheckerWebpackPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/JestConfigUtils.js
+++ b/packages/legend-studio-dev-utils/JestConfigUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/JestConfigUtils.js
+++ b/packages/legend-studio-dev-utils/JestConfigUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ProjectReferenceConfigChecker.js
+++ b/packages/legend-studio-dev-utils/ProjectReferenceConfigChecker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/ProjectReferenceConfigChecker.js
+++ b/packages/legend-studio-dev-utils/ProjectReferenceConfigChecker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/TypescriptConfigUtils.js
+++ b/packages/legend-studio-dev-utils/TypescriptConfigUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/TypescriptConfigUtils.js
+++ b/packages/legend-studio-dev-utils/TypescriptConfigUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -347,7 +347,6 @@ const getWebAppBaseWebpackConfig = (
         publicPath: '/',
       },
       open: true,
-      https: true,
       // start - should remove this in next iteration of webpack-dev-server@4.beta
       static: {
         watch: false,

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/__tests__/JestConfigUtils.test.js
+++ b/packages/legend-studio-dev-utils/__tests__/JestConfigUtils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/__tests__/JestConfigUtils.test.js
+++ b/packages/legend-studio-dev-utils/__tests__/JestConfigUtils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/__tests__/TypescriptConfigUtils.test.js
+++ b/packages/legend-studio-dev-utils/__tests__/TypescriptConfigUtils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/__tests__/TypescriptConfigUtils.test.js
+++ b/packages/legend-studio-dev-utils/__tests__/TypescriptConfigUtils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/__tests__/WebpackConfigUtils.test.js
+++ b/packages/legend-studio-dev-utils/__tests__/WebpackConfigUtils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/__tests__/WebpackConfigUtils.test.js
+++ b/packages/legend-studio-dev-utils/__tests__/WebpackConfigUtils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/jest.config.js
+++ b/packages/legend-studio-dev-utils/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/jest.config.js
+++ b/packages/legend-studio-dev-utils/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/mocks/fileMock.js
+++ b/packages/legend-studio-dev-utils/mocks/fileMock.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-dev-utils/mocks/fileMock.js
+++ b/packages/legend-studio-dev-utils/mocks/fileMock.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/_package.config.js
+++ b/packages/legend-studio-network/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/_package.config.js
+++ b/packages/legend-studio-network/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/jest.config.js
+++ b/packages/legend-studio-network/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/jest.config.js
+++ b/packages/legend-studio-network/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/AbstractServerClient.ts
+++ b/packages/legend-studio-network/src/AbstractServerClient.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/AbstractServerClient.ts
+++ b/packages/legend-studio-network/src/AbstractServerClient.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/TelemetryService.ts
+++ b/packages/legend-studio-network/src/TelemetryService.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/TelemetryService.ts
+++ b/packages/legend-studio-network/src/TelemetryService.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/TracerService.ts
+++ b/packages/legend-studio-network/src/TracerService.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/TracerService.ts
+++ b/packages/legend-studio-network/src/TracerService.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/index.ts
+++ b/packages/legend-studio-network/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-network/src/index.ts
+++ b/packages/legend-studio-network/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/_package.config.js
+++ b/packages/legend-studio-plugin-management/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/_package.config.js
+++ b/packages/legend-studio-plugin-management/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/jest.config.js
+++ b/packages/legend-studio-plugin-management/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/jest.config.js
+++ b/packages/legend-studio-plugin-management/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/components/ManagementEditorPlugin.tsx
+++ b/packages/legend-studio-plugin-management/src/components/ManagementEditorPlugin.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/components/ManagementEditorPlugin.tsx
+++ b/packages/legend-studio-plugin-management/src/components/ManagementEditorPlugin.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/components/URLRedirector.tsx
+++ b/packages/legend-studio-plugin-management/src/components/URLRedirector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/components/URLRedirector.tsx
+++ b/packages/legend-studio-plugin-management/src/components/URLRedirector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/components/projectDashboard/ProjectDashboard.tsx
+++ b/packages/legend-studio-plugin-management/src/components/projectDashboard/ProjectDashboard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/components/projectDashboard/ProjectDashboard.tsx
+++ b/packages/legend-studio-plugin-management/src/components/projectDashboard/ProjectDashboard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/index.ts
+++ b/packages/legend-studio-plugin-management/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/src/index.ts
+++ b/packages/legend-studio-plugin-management/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/style/_mixins.scss
+++ b/packages/legend-studio-plugin-management/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/style/_mixins.scss
+++ b/packages/legend-studio-plugin-management/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/style/components/_project-dashboard.scss
+++ b/packages/legend-studio-plugin-management/style/components/_project-dashboard.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/style/components/_project-dashboard.scss
+++ b/packages/legend-studio-plugin-management/style/components/_project-dashboard.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/style/index.scss
+++ b/packages/legend-studio-plugin-management/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-management/style/index.scss
+++ b/packages/legend-studio-plugin-management/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/_package.config.js
+++ b/packages/legend-studio-plugin-tracer-zipkin/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/_package.config.js
+++ b/packages/legend-studio-plugin-tracer-zipkin/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/jest.config.js
+++ b/packages/legend-studio-plugin-tracer-zipkin/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/jest.config.js
+++ b/packages/legend-studio-plugin-tracer-zipkin/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/src/ZipkinTracerPlugin.ts
+++ b/packages/legend-studio-plugin-tracer-zipkin/src/ZipkinTracerPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/src/ZipkinTracerPlugin.ts
+++ b/packages/legend-studio-plugin-tracer-zipkin/src/ZipkinTracerPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/src/index.ts
+++ b/packages/legend-studio-plugin-tracer-zipkin/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-plugin-tracer-zipkin/src/index.ts
+++ b/packages/legend-studio-plugin-tracer-zipkin/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/_package.config.js
+++ b/packages/legend-studio-preset-dsl-text/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/_package.config.js
+++ b/packages/legend-studio-preset-dsl-text/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/jest.config.js
+++ b/packages/legend-studio-preset-dsl-text/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/jest.config.js
+++ b/packages/legend-studio-preset-dsl-text/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/DSLText_Preset.ts
+++ b/packages/legend-studio-preset-dsl-text/src/DSLText_Preset.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/DSLText_Preset.ts
+++ b/packages/legend-studio-preset-dsl-text/src/DSLText_Preset.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/components/DSLText_EditorPlugin.tsx
+++ b/packages/legend-studio-preset-dsl-text/src/components/DSLText_EditorPlugin.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/components/DSLText_EditorPlugin.tsx
+++ b/packages/legend-studio-preset-dsl-text/src/components/DSLText_EditorPlugin.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/components/TextElementEditor.tsx
+++ b/packages/legend-studio-preset-dsl-text/src/components/TextElementEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/components/TextElementEditor.tsx
+++ b/packages/legend-studio-preset-dsl-text/src/components/TextElementEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/index.ts
+++ b/packages/legend-studio-preset-dsl-text/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/index.ts
+++ b/packages/legend-studio-preset-dsl-text/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/DSLText_ModelUtils.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/DSLText_ModelUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/DSLText_ModelUtils.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/DSLText_ModelUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_GraphManagerHelpers.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_GraphManagerHelpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_GraphManagerHelpers.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_GraphManagerHelpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_PureGraphManagerPlugin.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_PureGraphManagerPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_PureGraphManagerPlugin.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/graph/DSLText_PureGraphManagerPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/model/packageableElements/Text.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/model/packageableElements/Text.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/model/packageableElements/Text.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/metamodels/pure/model/packageableElements/Text.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/DSLText_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/DSLText_PureProtocolProcessorPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/DSLText_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/DSLText_PureProtocolProcessorPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/model/packageableElements/V1_Text.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/model/packageableElements/V1_Text.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/model/packageableElements/V1_Text.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/model/packageableElements/V1_Text.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureGraph/V1_DSLText_GraphBuilderHelpers.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureGraph/V1_DSLText_GraphBuilderHelpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureGraph/V1_DSLText_GraphBuilderHelpers.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureGraph/V1_DSLText_GraphBuilderHelpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureProtocol/V1_DSLText_ProtocolHelpers.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureProtocol/V1_DSLText_ProtocolHelpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureProtocol/V1_DSLText_ProtocolHelpers.ts
+++ b/packages/legend-studio-preset-dsl-text/src/models/protocols/pure/v1/transformation/pureProtocol/V1_DSLText_ProtocolHelpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/stores/TextEditorState.ts
+++ b/packages/legend-studio-preset-dsl-text/src/stores/TextEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/stores/TextEditorState.ts
+++ b/packages/legend-studio-preset-dsl-text/src/stores/TextEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_Roundtrip.test.ts
+++ b/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_Roundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_Roundtrip.test.ts
+++ b/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_Roundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_RoundtripTestData.ts
+++ b/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_RoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_RoundtripTestData.ts
+++ b/packages/legend-studio-preset-dsl-text/src/stores/__tests__/DSLText_RoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/style/_mixins.scss
+++ b/packages/legend-studio-preset-dsl-text/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/style/_mixins.scss
+++ b/packages/legend-studio-preset-dsl-text/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/style/index.scss
+++ b/packages/legend-studio-preset-dsl-text/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-preset-dsl-text/style/index.scss
+++ b/packages/legend-studio-preset-dsl-text/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/_package.config.js
+++ b/packages/legend-studio-shared/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/_package.config.js
+++ b/packages/legend-studio-shared/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/jest.config.js
+++ b/packages/legend-studio-shared/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/jest.config.js
+++ b/packages/legend-studio-shared/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/data-structures/Pair.ts
+++ b/packages/legend-studio-shared/src/data-structures/Pair.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/data-structures/Pair.ts
+++ b/packages/legend-studio-shared/src/data-structures/Pair.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/data-structures/Stack.ts
+++ b/packages/legend-studio-shared/src/data-structures/Stack.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/data-structures/Stack.ts
+++ b/packages/legend-studio-shared/src/data-structures/Stack.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/index.ts
+++ b/packages/legend-studio-shared/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/index.ts
+++ b/packages/legend-studio-shared/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/plugins/AbstractPluginManager.ts
+++ b/packages/legend-studio-shared/src/plugins/AbstractPluginManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/plugins/AbstractPluginManager.ts
+++ b/packages/legend-studio-shared/src/plugins/AbstractPluginManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/states/ActionState.ts
+++ b/packages/legend-studio-shared/src/states/ActionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/states/ActionState.ts
+++ b/packages/legend-studio-shared/src/states/ActionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/AssertionUtils.ts
+++ b/packages/legend-studio-shared/src/utils/AssertionUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/AssertionUtils.ts
+++ b/packages/legend-studio-shared/src/utils/AssertionUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/CommonUtils.ts
+++ b/packages/legend-studio-shared/src/utils/CommonUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/CommonUtils.ts
+++ b/packages/legend-studio-shared/src/utils/CommonUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/ErrorUtils.ts
+++ b/packages/legend-studio-shared/src/utils/ErrorUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/ErrorUtils.ts
+++ b/packages/legend-studio-shared/src/utils/ErrorUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/FormatterUtils.ts
+++ b/packages/legend-studio-shared/src/utils/FormatterUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/FormatterUtils.ts
+++ b/packages/legend-studio-shared/src/utils/FormatterUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/HashUtils.ts
+++ b/packages/legend-studio-shared/src/utils/HashUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/HashUtils.ts
+++ b/packages/legend-studio-shared/src/utils/HashUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/NetworkUtils.ts
+++ b/packages/legend-studio-shared/src/utils/NetworkUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/NetworkUtils.ts
+++ b/packages/legend-studio-shared/src/utils/NetworkUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/RandomUtils.ts
+++ b/packages/legend-studio-shared/src/utils/RandomUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/RandomUtils.ts
+++ b/packages/legend-studio-shared/src/utils/RandomUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/SerializationUtils.ts
+++ b/packages/legend-studio-shared/src/utils/SerializationUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/SerializationUtils.ts
+++ b/packages/legend-studio-shared/src/utils/SerializationUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/TestUtils.ts
+++ b/packages/legend-studio-shared/src/utils/TestUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/TestUtils.ts
+++ b/packages/legend-studio-shared/src/utils/TestUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/ValidatorUtils.ts
+++ b/packages/legend-studio-shared/src/utils/ValidatorUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/ValidatorUtils.ts
+++ b/packages/legend-studio-shared/src/utils/ValidatorUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/__tests__/AssertionUtils.test.ts
+++ b/packages/legend-studio-shared/src/utils/__tests__/AssertionUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/__tests__/AssertionUtils.test.ts
+++ b/packages/legend-studio-shared/src/utils/__tests__/AssertionUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/__tests__/CommonUtils.test.ts
+++ b/packages/legend-studio-shared/src/utils/__tests__/CommonUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/__tests__/CommonUtils.test.ts
+++ b/packages/legend-studio-shared/src/utils/__tests__/CommonUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/__tests__/FormatterUtils.test.ts
+++ b/packages/legend-studio-shared/src/utils/__tests__/FormatterUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio-shared/src/utils/__tests__/FormatterUtils.test.ts
+++ b/packages/legend-studio-shared/src/utils/__tests__/FormatterUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/_package.config.js
+++ b/packages/legend-studio/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/_package.config.js
+++ b/packages/legend-studio/_package.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/jest.config.js
+++ b/packages/legend-studio/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/jest.config.js
+++ b/packages/legend-studio/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/DSLGenerationSpecification_Exports.ts
+++ b/packages/legend-studio/src/DSLGenerationSpecification_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/DSLGenerationSpecification_Exports.ts
+++ b/packages/legend-studio/src/DSLGenerationSpecification_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/DSLMapping_Exports.ts
+++ b/packages/legend-studio/src/DSLMapping_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/DSLMapping_Exports.ts
+++ b/packages/legend-studio/src/DSLMapping_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/DSLService_Exports.ts
+++ b/packages/legend-studio/src/DSLService_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/DSLService_Exports.ts
+++ b/packages/legend-studio/src/DSLService_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/StoreFlatData_Exports.ts
+++ b/packages/legend-studio/src/StoreFlatData_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/StoreFlatData_Exports.ts
+++ b/packages/legend-studio/src/StoreFlatData_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/StoreRelational_Exports.ts
+++ b/packages/legend-studio/src/StoreRelational_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/StoreRelational_Exports.ts
+++ b/packages/legend-studio/src/StoreRelational_Exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/application/PluginManager.ts
+++ b/packages/legend-studio/src/application/PluginManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/application/PluginManager.ts
+++ b/packages/legend-studio/src/application/PluginManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/application/Studio.tsx
+++ b/packages/legend-studio/src/application/Studio.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/application/Studio.tsx
+++ b/packages/legend-studio/src/application/Studio.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/App.tsx
+++ b/packages/legend-studio/src/components/App.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/App.tsx
+++ b/packages/legend-studio/src/components/App.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/ComponentTestUtils.tsx
+++ b/packages/legend-studio/src/components/ComponentTestUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/ComponentTestUtils.tsx
+++ b/packages/legend-studio/src/components/ComponentTestUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/__tests__/App.test.tsx
+++ b/packages/legend-studio/src/components/__tests__/App.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/__tests__/App.test.tsx
+++ b/packages/legend-studio/src/components/__tests__/App.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/application/ActionAlert.tsx
+++ b/packages/legend-studio/src/components/application/ActionAlert.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/application/ActionAlert.tsx
+++ b/packages/legend-studio/src/components/application/ActionAlert.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/application/BlockingAlert.tsx
+++ b/packages/legend-studio/src/components/application/BlockingAlert.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/application/BlockingAlert.tsx
+++ b/packages/legend-studio/src/components/application/BlockingAlert.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/ActivityBar.tsx
+++ b/packages/legend-studio/src/components/editor/ActivityBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/ActivityBar.tsx
+++ b/packages/legend-studio/src/components/editor/ActivityBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/Editor.tsx
+++ b/packages/legend-studio/src/components/editor/Editor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/Editor.tsx
+++ b/packages/legend-studio/src/components/editor/Editor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/StatusBar.tsx
+++ b/packages/legend-studio/src/components/editor/StatusBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/StatusBar.tsx
+++ b/packages/legend-studio/src/components/editor/StatusBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/AuxiliaryPanel.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/AuxiliaryPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/AuxiliaryPanel.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/AuxiliaryPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/Console.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/Console.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/Console.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/Console.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/DevTool.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/DevTool.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/DevTool.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/DevTool.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/MappingExecution.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/MappingExecution.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/MappingExecution.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/MappingExecution.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/MappingTestEditorPanel.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/MappingTestEditorPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/MappingTestEditorPanel.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/MappingTestEditorPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/RawGraphFetchTreeExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/RawGraphFetchTreeExplorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/RawGraphFetchTreeExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/RawGraphFetchTreeExplorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTree.test.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTree.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTree.test.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTree.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTreeTestData.ts
+++ b/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTreeTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTreeTestData.ts
+++ b/packages/legend-studio/src/components/editor/aux-panel/__tests__/RawGraphFetchTreeTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/command-center/ProjectSearchCommand.tsx
+++ b/packages/legend-studio/src/components/editor/command-center/ProjectSearchCommand.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/command-center/ProjectSearchCommand.tsx
+++ b/packages/legend-studio/src/components/editor/command-center/ProjectSearchCommand.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/DiagramEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/DiagramEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/FileGenerationViewer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/FileGenerationViewer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/FileGenerationViewer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/FileGenerationViewer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/FunctionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/FunctionEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/FunctionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/FunctionEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/ModelLoader.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/ModelLoader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/ModelLoader.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/ModelLoader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/UnsupportedElementEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/UnsupportedElementEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/UnsupportedElementEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/UnsupportedElementEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/__tests__/EditPanel.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/__tests__/EditPanel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/__tests__/EditPanel.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/__tests__/EditPanel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityChangeConflictEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityChangeConflictEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityChangeConflictEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityChangeConflictEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityDiffView.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityDiffView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityDiffView.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diff-editor/EntityDiffView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementGenerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementGenerationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementGenerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementGenerationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementNativeView.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementNativeView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementNativeView.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementNativeView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/FileGenerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/FileGenerationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/FileGenerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/FileGenerationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataRecordTypeTree.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataRecordTypeTree.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataRecordTypeTree.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataRecordTypeTree.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/OperationSetImplementationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/OperationSetImplementationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/OperationSetImplementationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/OperationSetImplementationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PurePropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PurePropertyMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PurePropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PurePropertyMappingEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/__tests__/EnumerationMappingEditor.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/__tests__/EnumerationMappingEditor.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/__tests__/EnumerationMappingEditor.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/__tests__/EnumerationMappingEditor.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/NewServiceModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/NewServiceModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/NewServiceModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/NewServiceModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionQueryEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionQueryEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionQueryEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionQueryEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceRegistrationModalEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceRegistrationModalEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceRegistrationModalEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceRegistrationModalEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceTestEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceTestEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceTestEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceTestEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/__tests__/ServiceRegistrationTest.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/__tests__/ServiceRegistrationTest.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/__tests__/ServiceRegistrationTest.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/__tests__/ServiceRegistrationTest.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/UMLEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/UMLEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/UMLEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/UMLEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/__tests__/UMLEditor.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/__tests__/UMLEditor.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/__tests__/UMLEditor.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/__tests__/UMLEditor.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/header/AppHeaderMenu.tsx
+++ b/packages/legend-studio/src/components/editor/header/AppHeaderMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/header/AppHeaderMenu.tsx
+++ b/packages/legend-studio/src/components/editor/header/AppHeaderMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/header/ShareProjectHeaderAction.tsx
+++ b/packages/legend-studio/src/components/editor/header/ShareProjectHeaderAction.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/header/ShareProjectHeaderAction.tsx
+++ b/packages/legend-studio/src/components/editor/header/ShareProjectHeaderAction.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/ConflictResolution.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/ConflictResolution.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/ConflictResolution.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/ConflictResolution.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/LocalChanges.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/LocalChanges.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/LocalChanges.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/LocalChanges.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/ProjectOverview.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/ProjectOverview.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/ProjectOverview.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/ProjectOverview.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/SideBar.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/SideBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/SideBar.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/SideBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceBuilds.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceBuilds.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceBuilds.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceBuilds.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceReview.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceReview.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceReview.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceReview.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceUpdater.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceUpdater.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceUpdater.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceUpdater.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/__tests__/Explorer.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/__tests__/Explorer.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/editor/side-bar/__tests__/Explorer.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/__tests__/Explorer.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/review/Review.tsx
+++ b/packages/legend-studio/src/components/review/Review.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/review/Review.tsx
+++ b/packages/legend-studio/src/components/review/Review.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/review/ReviewPanel.tsx
+++ b/packages/legend-studio/src/components/review/ReviewPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/review/ReviewPanel.tsx
+++ b/packages/legend-studio/src/components/review/ReviewPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/review/ReviewSideBar.tsx
+++ b/packages/legend-studio/src/components/review/ReviewSideBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/review/ReviewSideBar.tsx
+++ b/packages/legend-studio/src/components/review/ReviewSideBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/ProjectSelector.tsx
+++ b/packages/legend-studio/src/components/setup/ProjectSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/ProjectSelector.tsx
+++ b/packages/legend-studio/src/components/setup/ProjectSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/Setup.tsx
+++ b/packages/legend-studio/src/components/setup/Setup.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/Setup.tsx
+++ b/packages/legend-studio/src/components/setup/Setup.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
+++ b/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
+++ b/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/__tests__/Setup.test.tsx
+++ b/packages/legend-studio/src/components/setup/__tests__/Setup.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/setup/__tests__/Setup.test.tsx
+++ b/packages/legend-studio/src/components/setup/__tests__/Setup.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/AppHeader.tsx
+++ b/packages/legend-studio/src/components/shared/AppHeader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/AppHeader.tsx
+++ b/packages/legend-studio/src/components/shared/AppHeader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/DiffView.tsx
+++ b/packages/legend-studio/src/components/shared/DiffView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/DiffView.tsx
+++ b/packages/legend-studio/src/components/shared/DiffView.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/Icon.tsx
+++ b/packages/legend-studio/src/components/shared/Icon.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/Icon.tsx
+++ b/packages/legend-studio/src/components/shared/Icon.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/LambdaEditor.tsx
+++ b/packages/legend-studio/src/components/shared/LambdaEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/LambdaEditor.tsx
+++ b/packages/legend-studio/src/components/shared/LambdaEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/MultiplicityBadge.tsx
+++ b/packages/legend-studio/src/components/shared/MultiplicityBadge.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/MultiplicityBadge.tsx
+++ b/packages/legend-studio/src/components/shared/MultiplicityBadge.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/NotificationSnackbar.tsx
+++ b/packages/legend-studio/src/components/shared/NotificationSnackbar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/NotificationSnackbar.tsx
+++ b/packages/legend-studio/src/components/shared/NotificationSnackbar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/TextInputEditor.tsx
+++ b/packages/legend-studio/src/components/shared/TextInputEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/TextInputEditor.tsx
+++ b/packages/legend-studio/src/components/shared/TextInputEditor.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/TypeTree.tsx
+++ b/packages/legend-studio/src/components/shared/TypeTree.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/TypeTree.tsx
+++ b/packages/legend-studio/src/components/shared/TypeTree.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/diagram-viewer/InheritanceDiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/InheritanceDiagramRenderer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/shared/diagram-viewer/InheritanceDiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/InheritanceDiagramRenderer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/viewer/Viewer.tsx
+++ b/packages/legend-studio/src/components/viewer/Viewer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/components/viewer/Viewer.tsx
+++ b/packages/legend-studio/src/components/viewer/Viewer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/const.ts
+++ b/packages/legend-studio/src/const.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/const.ts
+++ b/packages/legend-studio/src/const.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/index.ts
+++ b/packages/legend-studio/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/index.ts
+++ b/packages/legend-studio/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/MetaModelConst.ts
+++ b/packages/legend-studio/src/models/MetaModelConst.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/MetaModelConst.ts
+++ b/packages/legend-studio/src/models/MetaModelConst.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/MetaModelUtility.ts
+++ b/packages/legend-studio/src/models/MetaModelUtility.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/MetaModelUtility.ts
+++ b/packages/legend-studio/src/models/MetaModelUtility.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/__tests__/MetaModelUtility.test.ts
+++ b/packages/legend-studio/src/models/__tests__/MetaModelUtility.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/__tests__/MetaModelUtility.test.ts
+++ b/packages/legend-studio/src/models/__tests__/MetaModelUtility.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/AbstractEngineConfiguration.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/AbstractEngineConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/AbstractEngineConfiguration.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/AbstractEngineConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/EngineError.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/EngineError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/EngineError.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/EngineError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/SourceInformation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/SourceInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/SourceInformation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/SourceInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/execution/ExecutionResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/execution/ExecutionResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/execution/ExecutionResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/execution/ExecutionResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezer.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezer.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezerHelper.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezerHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezerHelper.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/freezer/GraphFreezerHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerateStoreInput.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerateStoreInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerateStoreInput.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerateStoreInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationOutput.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationOutput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationOutput.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/GenerationOutput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/ImportConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/ImportConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/generation/ImportConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/generation/ImportConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceExecutionMode.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceExecutionMode.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceExecutionMode.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceExecutionMode.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceRegistrationResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceRegistrationResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceRegistrationResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceRegistrationResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceTestResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceTestResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceTestResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/service/ServiceTestResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/validator/ValidationResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/validator/ValidationResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/action/validator/ValidationResult.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/action/validator/ValidationResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/AbstractPureGraphManager.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/AbstractPureGraphManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/AbstractPureGraphManager.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/AbstractPureGraphManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/DSLGenerationSpecification_PureGraphManagerPlugin_Extension.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/DSLGenerationSpecification_PureGraphManagerPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/DSLGenerationSpecification_PureGraphManagerPlugin_Extension.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/DSLGenerationSpecification_PureGraphManagerPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/DependencyManager.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/DependencyManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/DependencyManager.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/DependencyManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphExtension.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphExtension.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphManagerPlugin.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphManagerPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphManagerPlugin.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphManagerPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureModel.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureModel.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/InferableValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/InferableValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/InferableValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/InferableValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/Reference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/Reference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/Reference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/Reference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/Stubable.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/Stubable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/Stubable.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/Stubable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/Connection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/Connection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/Connection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/Connection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/PackageableConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/PackageableConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/PackageableConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/connection/PackageableConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/AssociationView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/AssociationView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/AssociationView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/AssociationView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassViewReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassViewReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassViewReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/ClassViewReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/Diagram.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/Diagram.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/Diagram.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/Diagram.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/GeneralizationView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/GeneralizationView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/GeneralizationView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/GeneralizationView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyHolderView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyHolderView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyHolderView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyHolderView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/PropertyView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipEdgeView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipEdgeView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipEdgeView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipEdgeView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipView.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/RelationshipView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Point.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Point.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/PositionedRectangle.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/PositionedRectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/PositionedRectangle.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/PositionedRectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Rectangle.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Rectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Rectangle.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Rectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Vector.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Vector.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Vector.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/geometry/Vector.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AbstractProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AbstractProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AbstractProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AbstractProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AnnotatedElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AnnotatedElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AnnotatedElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/AnnotatedElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Association.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Association.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Association.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Association.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Class.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Class.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Class.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Class.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/ConcreteFunctionDefinition.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/ConcreteFunctionDefinition.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/ConcreteFunctionDefinition.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/ConcreteFunctionDefinition.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Constraint.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Constraint.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Constraint.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Constraint.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DataType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DataType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DerivedProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DerivedProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DerivedProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/DerivedProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enum.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enum.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enum.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enum.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/EnumValueReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/EnumValueReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/EnumValueReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/EnumValueReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enumeration.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enumeration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enumeration.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Enumeration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Function.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Function.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Function.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Function.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericTypeReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericTypeReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericTypeReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/GenericTypeReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Measure.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Measure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Measure.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Measure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Multiplicity.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Multiplicity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Multiplicity.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Multiplicity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PrimitiveType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PrimitiveType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PrimitiveType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PrimitiveType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Profile.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Profile.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Profile.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Profile.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Property.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Property.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Property.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Property.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PropertyReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PropertyReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PropertyReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/PropertyReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Stereotype.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Stereotype.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Stereotype.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Stereotype.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/StereotypeReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/StereotypeReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/StereotypeReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/StereotypeReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Tag.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Tag.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Tag.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Tag.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TagReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TagReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TagReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TagReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TaggedValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TaggedValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TaggedValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/TaggedValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Type.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Type.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Type.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Type.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/ConfigurationProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/ConfigurationProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/ConfigurationProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/ConfigurationProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/FileGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/FileGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/FileGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/fileGeneration/FileGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/AbstractGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/AbstractGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/AbstractGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/AbstractGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/GenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/GenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/GenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/GenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/ModelGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/ModelGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/ModelGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/generationSpecification/ModelGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/AssociationImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/AssociationImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/AssociationImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/AssociationImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EmbeddedSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EmbeddedSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EmbeddedSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EmbeddedSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumValueMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumValueMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumValueMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumValueMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumerationMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumerationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumerationMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/EnumerationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/ExpectedOutputMappingTestAssert.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/ExpectedOutputMappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/ExpectedOutputMappingTestAssert.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/ExpectedOutputMappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementId.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementId.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementId.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementId.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementRoot.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementRoot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementRoot.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InferableMappingElementRoot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/InstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/LocalMappingPropertyInfo.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/LocalMappingPropertyInfo.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/LocalMappingPropertyInfo.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/LocalMappingPropertyInfo.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/Mapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/Mapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/Mapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/Mapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingClass.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingClass.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingClass.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingClass.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingInclude.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingInclude.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingInclude.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingInclude.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTest.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTest.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTestAssert.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTestAssert.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/MappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/OperationSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/OperationSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/OperationSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/OperationSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMappingsImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMappingsImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMappingsImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyMappingsImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyOwnerImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyOwnerImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyOwnerImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/PropertyOwnerImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/RelationalAssociationImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/RelationalAssociationImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/RelationalAssociationImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/RelationalAssociationImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationContainer.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationContainer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationContainer.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationContainer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SetImplementationReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SubstituteStore.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SubstituteStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SubstituteStore.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/SubstituteStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSetImplementationContainer.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSetImplementationContainer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSetImplementationContainer.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSetImplementationContainer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregateSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwarePropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwarePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwarePropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwarePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwareSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwareSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwareSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwareSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationFunctionSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationFunctionSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationFunctionSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationFunctionSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/GroupByFunctionSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/GroupByFunctionSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/GroupByFunctionSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/aggregationAware/GroupByFunctionSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStoreAssociationImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStoreAssociationImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStoreAssociationImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStoreAssociationImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStorePropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStorePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStorePropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/mapping/xStore/XStorePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/PackageableRuntime.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/PackageableRuntime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/PackageableRuntime.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/PackageableRuntime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/Runtime.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/Runtime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/Runtime.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/runtime/Runtime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/Section.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/Section.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/Section.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/Section.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/SectionIndex.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/SectionIndex.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/SectionIndex.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/section/SectionIndex.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/Service.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/Service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/Service.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/Service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceExecution.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceExecution.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceExecution.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceExecution.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceTest.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceTest.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/service/ServiceTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/Store.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/Store.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/Store.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/Store.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/connection/FlatDataConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/connection/FlatDataConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/connection/FlatDataConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/connection/FlatDataConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/AbstractFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/AbstractFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/AbstractFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/AbstractFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/EmbeddedFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/EmbeddedFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/EmbeddedFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/EmbeddedFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataDataType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataDataType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataProperty.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSectionReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSectionReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSectionReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/FlatDataSectionReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/RootFlatDataRecordTypeReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/RootFlatDataRecordTypeReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/RootFlatDataRecordTypeReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/flatData/model/RootFlatDataRecordTypeReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/JsonModelConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/JsonModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/JsonModelConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/JsonModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/ModelChainConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/ModelChainConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/ModelChainConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/ModelChainConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/PureModelConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/PureModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/PureModelConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/PureModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/XmlModelConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/XmlModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/XmlModelConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/connection/XmlModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/ObjectInputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/ObjectInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/ObjectInputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/ObjectInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PurePropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PurePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PurePropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/PurePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/model/ModelStore.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/model/ModelStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/model/ModelStore.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/model/ModelStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/AuthenticationStrategy.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/AuthenticationStrategy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/AuthenticationStrategy.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/AuthenticationStrategy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/RelationalDatabaseConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/RelationalDatabaseConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/RelationalDatabaseConnection.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/RelationalDatabaseConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/Mapper.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/Mapper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/Mapper.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/Mapper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/MapperPostProcessor.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/MapperPostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/MapperPostProcessor.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/MapperPostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/PostProcessor.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/PostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/PostProcessor.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/postprocessor/PostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/FilterMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/FilterMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/FilterMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/FilterMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/GroupByMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/GroupByMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/GroupByMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/GroupByMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/InlineEmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/InlineEmbeddedRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/InlineEmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/InlineEmbeddedRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Column.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Column.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Column.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Column.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ColumnReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Database.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Database.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Database.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Database.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Filter.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Filter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Filter.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Filter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/FilterReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/FilterReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/FilterReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/FilterReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Join.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Join.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Join.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Join.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/JoinReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/JoinReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/JoinReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/JoinReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalDataType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalDataType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalOperationElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalOperationElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalOperationElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/RelationalOperationElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Schema.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Schema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Schema.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Schema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ServiceStore.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ServiceStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ServiceStore.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ServiceStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Table.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Table.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Table.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/Table.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/TableReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/TableReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/TableReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/TableReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/View.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/View.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/View.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/View.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ViewReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ViewReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ViewReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/ViewReference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessMilestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessMilestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessSnapshotMilestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessSnapshotMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessSnapshotMilestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/BusinessSnapshotMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/Milestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/Milestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/Milestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/Milestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/ProcessingMilestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/ProcessingMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/ProcessingMilestoning.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/model/milestoning/ProcessingMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawLambda.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawLambda.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawLambda.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawLambda.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawValueSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawValueSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawVariableExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawVariableExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawVariableExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/rawValueSpecification/RawVariableExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/AlloySerializationConfig.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/AlloySerializationConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/AlloySerializationConfig.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/AlloySerializationConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ExecutionContext.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ExecutionContext.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/GraphFetchTree.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/GraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/GraphFetchTree.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/GraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/InstanceValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/InstanceValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/InstanceValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/InstanceValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/LambdaFunction.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/LambdaFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/LambdaFunction.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/LambdaFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ValueSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ValueSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/ValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/VariableExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/VariableExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/VariableExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/VariableExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/DSLGenerationSpecification_PureProtocolProcessorPlugin_Extension.ts
+++ b/packages/legend-studio/src/models/protocols/pure/DSLGenerationSpecification_PureProtocolProcessorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/DSLGenerationSpecification_PureProtocolProcessorPlugin_Extension.ts
+++ b/packages/legend-studio/src/models/protocols/pure/DSLGenerationSpecification_PureProtocolProcessorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/Pure.ts
+++ b/packages/legend-studio/src/models/protocols/pure/Pure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/Pure.ts
+++ b/packages/legend-studio/src/models/protocols/pure/Pure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/PureProtocolProcessorPlugin.ts
+++ b/packages/legend-studio/src/models/protocols/pure/PureProtocolProcessorPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/PureProtocolProcessorPlugin.ts
+++ b/packages/legend-studio/src/models/protocols/pure/PureProtocolProcessorPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/StoreRelational_PureProtocolProcessorPlugin_Extension.ts
+++ b/packages/legend-studio/src/models/protocols/pure/StoreRelational_PureProtocolProcessorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/StoreRelational_PureProtocolProcessorPlugin_Extension.ts
+++ b/packages/legend-studio/src/models/protocols/pure/StoreRelational_PureProtocolProcessorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_Engine.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_Engine.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineError.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineError.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineServerClient.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/V1_EngineServerClient.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompilationError.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompilationError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompilationError.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompilationError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompileResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompileResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompileResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_CompileResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_LambdaReturnTypeResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_LambdaReturnTypeResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_LambdaReturnTypeResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/compilation/V1_LambdaReturnTypeResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecuteInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecuteInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecuteInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecuteInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecutionResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecutionResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecutionResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/execution/V1_ExecutionResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_FileGenerationInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_FileGenerationInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_FileGenerationInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_FileGenerationInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerateStoreInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerateStoreInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerateStoreInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerateStoreInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationOutput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationOutput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationOutput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/generation/V1_GenerationOutput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_GrammarToJson.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_GrammarToJson.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_GrammarToJson.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_GrammarToJson.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_JsonToGrammarInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_JsonToGrammarInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_JsonToGrammarInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_JsonToGrammarInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_LambdaInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_LambdaInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_LambdaInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_LambdaInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_ParserError.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_ParserError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_ParserError.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/grammar/V1_ParserError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_ImportConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_ImportConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_ImportConfigurationDescription.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_ImportConfigurationDescription.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_PureModelContextGenerationInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_PureModelContextGenerationInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_PureModelContextGenerationInput.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/import/V1_PureModelContextGenerationInput.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceConfiguration.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceConfiguration.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceRegistrationResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceRegistrationResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceRegistrationResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceRegistrationResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceStorage.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceStorage.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceStorage.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceStorage.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceTestResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceTestResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceTestResult.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/engine/service/V1_ServiceTestResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/V1_Protocol.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/V1_Protocol.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/V1_Protocol.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/V1_Protocol.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/V1_SourceInformation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/V1_SourceInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/V1_SourceInformation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/V1_SourceInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_AlloySdlc.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_AlloySdlc.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_AlloySdlc.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_AlloySdlc.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextComposite.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextComposite.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextComposite.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextComposite.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/context/V1_PureModelContextPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/V1_PackageableElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/V1_PackageableElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/V1_PackageableElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/V1_PackageableElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_Connection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_Connection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_Connection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_Connection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_ConnectionPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_ConnectionPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_ConnectionPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_ConnectionPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_PackageableConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_PackageableConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_PackageableConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/connection/V1_PackageableConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_ClassView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_ClassView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_ClassView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_ClassView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_Diagram.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_Diagram.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_Diagram.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_Diagram.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_GeneralizationView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_GeneralizationView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_GeneralizationView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_GeneralizationView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyHolderView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyHolderView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyHolderView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyHolderView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_PropertyView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_RelationshipView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_RelationshipView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_RelationshipView.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/V1_RelationshipView.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Line.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Line.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Line.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Line.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Point.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Point.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_PositionedRectangle.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_PositionedRectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_PositionedRectangle.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_PositionedRectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Rectangle.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Rectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Rectangle.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/diagram/geometry/V1_Rectangle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Association.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Association.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Association.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Association.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Class.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Class.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Class.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Class.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Constraint.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Constraint.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Constraint.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Constraint.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_DerivedProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_DerivedProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_DerivedProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_DerivedProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_EnumValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_EnumValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_EnumValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_EnumValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Enumeration.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Enumeration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Enumeration.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Enumeration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Measure.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Measure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Measure.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Measure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Multiplicity.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Multiplicity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Multiplicity.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Multiplicity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Profile.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Profile.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Profile.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Profile.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Property.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Property.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Property.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_Property.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_PropertyPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_PropertyPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_PropertyPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_PropertyPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_StereotypePtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_StereotypePtr.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_StereotypePtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_StereotypePtr.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TagPtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TagPtr.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TagPtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TagPtr.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TaggedValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TaggedValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TaggedValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_TaggedValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_ConfigurationProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_ConfigurationProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_ConfigurationProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_ConfigurationProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_FileGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_FileGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_FileGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/fileGeneration/V1_FileGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/function/V1_ConcreteFunctionDefinition.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/function/V1_ConcreteFunctionDefinition.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/function/V1_ConcreteFunctionDefinition.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/function/V1_ConcreteFunctionDefinition.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_AbstractGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_AbstractGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_AbstractGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_AbstractGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_GenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_GenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_GenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_GenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_ModelGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_ModelGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_ModelGenerationSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/generationSpecification/V1_ModelGenerationSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_AssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_AssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_AssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_AssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumValueMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumValueMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumValueMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumValueMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumerationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumerationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumerationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_EnumerationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ExpectedOutputMappingTestAssert.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ExpectedOutputMappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ExpectedOutputMappingTestAssert.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ExpectedOutputMappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_InputData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_InputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_InputData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_InputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_LocalMappingPropertyInfo.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_LocalMappingPropertyInfo.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_LocalMappingPropertyInfo.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_LocalMappingPropertyInfo.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_Mapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_Mapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_Mapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_Mapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingClass.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingClass.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingClass.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingClass.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingInclude.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingInclude.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingInclude.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingInclude.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTest.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTest.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTestAssert.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTestAssert.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_MappingTestAssert.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_OperationClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_OperationClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_OperationClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_OperationClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_PropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_PropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_PropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_PropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_RelationalAssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_RelationalAssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_RelationalAssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_RelationalAssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStoreAssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStoreAssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStoreAssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStoreAssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStorePropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStorePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStorePropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/xStore/V1_XStorePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_PackageableRuntime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_PackageableRuntime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_PackageableRuntime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_PackageableRuntime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_Runtime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_Runtime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_Runtime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/runtime/V1_Runtime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_Section.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_Section.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_Section.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_Section.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_SectionIndex.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_SectionIndex.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_SectionIndex.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/section/V1_SectionIndex.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_Service.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_Service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_Service.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_Service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceExecution.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceExecution.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceExecution.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceExecution.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceTest.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceTest.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/service/V1_ServiceTest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/V1_Store.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/V1_Store.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/V1_Store.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/V1_Store.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/connection/V1_FlatDataConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/connection/V1_FlatDataConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/connection/V1_FlatDataConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/connection/V1_FlatDataConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_AbstractFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_AbstractFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_AbstractFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_AbstractFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_EmbeddedFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_EmbeddedFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_EmbeddedFlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_EmbeddedFlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataInputData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataInputData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_FlatDataPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_RootFlatDataClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_RootFlatDataClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_RootFlatDataClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/mapping/V1_RootFlatDataClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataDataType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataDataType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataSection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataSection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataSection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/flatData/model/V1_FlatDataSection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_JsonModelConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_JsonModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_JsonModelConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_JsonModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_ModelChainConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_ModelChainConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_ModelChainConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_ModelChainConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_XmlModelConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_XmlModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_XmlModelConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/connection/V1_XmlModelConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_ObjectInputData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_ObjectInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_ObjectInputData.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_ObjectInputData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PureInstanceClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PureInstanceClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PureInstanceClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PureInstanceClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PurePropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PurePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PurePropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/modelToModel/mapping/V1_PurePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/V1_ServiceStore.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/V1_ServiceStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/V1_ServiceStore.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/V1_ServiceStore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_AuthenticationStrategy.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_AuthenticationStrategy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_AuthenticationStrategy.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_AuthenticationStrategy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_DatasourceSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_DatasourceSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_RelationalDatabaseConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_RelationalDatabaseConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_RelationalDatabaseConnection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_RelationalDatabaseConnection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_Mapper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_Mapper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_Mapper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_Mapper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_MapperPostProcessor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_MapperPostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_MapperPostProcessor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_MapperPostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_PostProcessor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_PostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_PostProcessor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/postprocessor/V1_PostProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_FilterPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_InlineEmbeddedPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_InlineEmbeddedPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_InlineEmbeddedPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_InlineEmbeddedPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_OtherwiseEmbeddedRelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_OtherwiseEmbeddedRelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_OtherwiseEmbeddedRelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_OtherwiseEmbeddedRelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalAssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalAssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalAssociationMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalAssociationMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RelationalPropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RootRelationalClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RootRelationalClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RootRelationalClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_RootRelationalClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateFunction.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateFunction.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSetImplementationContainer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSetImplementationContainer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSetImplementationContainer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSetImplementationContainer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregateSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwareClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwareClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwareClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwareClassMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwarePropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwarePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwarePropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_AggregationAwarePropertyMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_GroupByFunction.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_GroupByFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_GroupByFunction.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/aggregationAware/V1_GroupByFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Column.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Column.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Column.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Column.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_ColumnMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_ColumnMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_ColumnMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_ColumnMapping.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Database.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Database.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Database.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Database.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Filter.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Filter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Filter.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Filter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Join.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Join.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Join.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Join.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_JoinPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_JoinPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_JoinPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_JoinPointer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalDataType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalDataType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalDataType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalOperationElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalOperationElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalOperationElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_RelationalOperationElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Schema.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Schema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Schema.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Schema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Table.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Table.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Table.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_Table.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_TablePtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_TablePtr.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_TablePtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_TablePtr.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_View.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_View.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_View.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_View.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessMilestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessMilestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessSnapshotMilestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessSnapshotMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessSnapshotMilestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_BusinessSnapshotMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_Milestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_Milestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_Milestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_Milestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_ProcessingMilestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_ProcessingMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_ProcessingMilestoning.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/milestoning/V1_ProcessingMilestoning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawLambda.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawLambda.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawLambda.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawLambda.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawValueSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawValueSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawVariable.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawVariable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawVariable.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/rawValueSpecification/V1_RawVariable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_ValueSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_ValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_ValueSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_ValueSpecification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_Variable.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_Variable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_Variable.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/V1_Variable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedFunction.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedFunction.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedFunction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedProperty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_AggregateValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_AggregateValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_AggregateValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_AggregateValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CBoolean.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CBoolean.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CBoolean.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CBoolean.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDate.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDate.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDateTime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDateTime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDateTime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDateTime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDecimal.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDecimal.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDecimal.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CDecimal.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CFloat.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CFloat.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CFloat.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CFloat.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CInteger.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CInteger.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CInteger.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CInteger.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CLatestDate.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CLatestDate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CLatestDate.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CLatestDate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictDate.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictDate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictDate.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictDate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictTime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictTime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictTime.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CStrictTime.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CString.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CString.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CString.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_CString.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Class.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Class.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Class.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Class.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Collection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Collection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Collection.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Collection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Enum.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Enum.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Enum.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Enum.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_EnumValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_EnumValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_EnumValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_EnumValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_ExecutionContextInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_ExecutionContextInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_ExecutionContextInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_ExecutionContextInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_KeyExpression.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_KeyExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_KeyExpression.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_KeyExpression.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Lambda.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Lambda.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Lambda.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Lambda.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_MappingInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_MappingInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_MappingInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_MappingInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Pair.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Pair.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Pair.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_Pair.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PrimitiveType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PrimitiveType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PrimitiveType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PrimitiveType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PureList.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PureList.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PureList.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_PureList.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_RuntimeInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_RuntimeInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_RuntimeInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_RuntimeInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_SerializationConfig.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_SerializationConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_SerializationConfig.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_SerializationConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSAggregateValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSAggregateValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSAggregateValue.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSAggregateValue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSColumnInformation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSColumnInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSColumnInformation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSColumnInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSSortInformation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSSortInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSSortInformation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TDSSortInformation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapAggregation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapAggregation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapAggregation.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapAggregation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapRank.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapRank.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapRank.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_TdsOlapRank.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitInstance.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitInstance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/V1_UnitType.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_AnalyticsExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_AnalyticsExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_AnalyticsExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_AnalyticsExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_BaseExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_BaseExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_BaseExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_BaseExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_ExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_ExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_ExecutionContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/executionContext/V1_ExecutionContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_GraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_GraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_GraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_GraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_PropertyGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_PropertyGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_PropertyGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_PropertyGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_RootGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_RootGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_RootGraphFetchTree.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/graph/V1_RootGraphFetchTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_Path.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_Path.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_Path.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_Path.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PathElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PathElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PathElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PathElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PropertyPathElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PropertyPathElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PropertyPathElement.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/raw/path/V1_PropertyPathElement.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_CoreTransformerHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_CoreTransformerHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_CoreTransformerHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_CoreTransformerHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DiagramTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DiagramTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DiagramTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DiagramTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DomainTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DomainTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DomainTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DomainTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_FlatDataTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_FlatDataTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_FlatDataTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_FlatDataTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_GenerationSpecificationTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_GenerationSpecificationTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_GenerationSpecificationTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_GenerationSpecificationTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MilestoningTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MilestoningTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MilestoningTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MilestoningTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PackageableElementTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PackageableElementTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PackageableElementTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PackageableElementTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PostProcessorTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PostProcessorTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PostProcessorTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_PostProcessorTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RawValueSpecificationTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RawValueSpecificationTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RawValueSpecificationTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RawValueSpecificationTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RuntimeTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RuntimeTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RuntimeTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RuntimeTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_SectionIndexTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_SectionIndexTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_SectionIndexTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_SectionIndexTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceStoreTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceStoreTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceStoreTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceStoreTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ServiceTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ValueSpecificationTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ValueSpecificationTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ValueSpecificationTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ValueSpecificationTransformer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ElementBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ElementBuilder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ElementBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ElementBuilder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderExtensions.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderExtensions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderExtensions.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderExtensions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelConnectionVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelConnectionVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelConnectionVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelConnectionVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFifthPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFifthPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFifthPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFifthPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFourthPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFourthPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFourthPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFourthPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphSecondPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphSecondPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphSecondPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphSecondPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphThirdPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphThirdPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphThirdPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphThirdPassVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelRawValueSpecificationVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelRawValueSpecificationVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelRawValueSpecificationVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelRawValueSpecificationVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/__tests__/V1_GraphBuilderExtensions.test.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/__tests__/V1_GraphBuilderExtensions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/__tests__/V1_GraphBuilderExtensions.test.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/__tests__/V1_GraphBuilderExtensions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguator.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguator.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguator.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguator.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguatorHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguatorHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguatorHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguatorHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/__tests__/V1_DependencyDisambiguator.test.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/__tests__/V1_DependencyDisambiguator.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/__tests__/V1_DependencyDisambiguator.test.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/__tests__/V1_DependencyDisambiguator.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_AssociationMappingHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_AssociationMappingHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_AssociationMappingHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_AssociationMappingHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_CoreBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_CoreBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_CoreBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_CoreBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DiagramBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DiagramBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DiagramBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DiagramBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DomainBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DomainBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DomainBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DomainBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FileGenerationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FileGenerationBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FileGenerationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FileGenerationBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FlatDataStoreBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FlatDataStoreBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FlatDataStoreBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_FlatDataStoreBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_GenerationSpecificationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_GenerationSpecificationBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_GenerationSpecificationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_GenerationSpecificationBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MilestoningBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MilestoningBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MilestoningBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MilestoningBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_PostProcessorBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_PostProcessorBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_PostProcessorBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_PostProcessorBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ProcessingContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ProcessingContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ProcessingContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ProcessingContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalClassMappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalClassMappingBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalClassMappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalClassMappingBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalConnectionBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalConnectionBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalConnectionBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalConnectionBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RuntimeBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RuntimeBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RuntimeBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RuntimeBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_SectionBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_SectionBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_SectionBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_SectionBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PackageableElementSerialization.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PackageableElementSerialization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PackageableElementSerialization.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PackageableElementSerialization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_CoreSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_CoreSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_CoreSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_CoreSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DiagramSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DiagramSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DiagramSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DiagramSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_FileGenerationSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_FileGenerationSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_FileGenerationSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_FileGenerationSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_GenerationSpecificationSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_GenerationSpecificationSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_GenerationSpecificationSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_GenerationSpecificationSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MilestoningSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MilestoningSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MilestoningSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MilestoningSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_PostProcessorSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_PostProcessorSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_PostProcessorSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_PostProcessorSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RawValueSpecificationSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RawValueSpecificationSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RawValueSpecificationSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RawValueSpecificationSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RuntimeSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RuntimeSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RuntimeSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_RuntimeSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_SectionIndexSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_SectionIndexSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_SectionIndexSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_SectionIndexSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ServiceSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ServiceSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ServiceSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ServiceSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_StoreSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_StoreSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_StoreSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_StoreSerializationHelper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/SDLCServerClient.ts
+++ b/packages/legend-studio/src/models/sdlc/SDLCServerClient.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/SDLCServerClient.ts
+++ b/packages/legend-studio/src/models/sdlc/SDLCServerClient.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/SDLCUtils.ts
+++ b/packages/legend-studio/src/models/sdlc/SDLCUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/SDLCUtils.ts
+++ b/packages/legend-studio/src/models/sdlc/SDLCUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/User.ts
+++ b/packages/legend-studio/src/models/sdlc/models/User.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/User.ts
+++ b/packages/legend-studio/src/models/sdlc/models/User.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/build/Build.ts
+++ b/packages/legend-studio/src/models/sdlc/models/build/Build.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/build/Build.ts
+++ b/packages/legend-studio/src/models/sdlc/models/build/Build.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/comparison/Comparison.ts
+++ b/packages/legend-studio/src/models/sdlc/models/comparison/Comparison.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/comparison/Comparison.ts
+++ b/packages/legend-studio/src/models/sdlc/models/comparison/Comparison.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/comparison/EntityDiff.ts
+++ b/packages/legend-studio/src/models/sdlc/models/comparison/EntityDiff.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/comparison/EntityDiff.ts
+++ b/packages/legend-studio/src/models/sdlc/models/comparison/EntityDiff.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/ProjectConfiguration.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/ProjectConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/ProjectConfiguration.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/ProjectConfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/ProjectDependency.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/ProjectDependency.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/ProjectDependency.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/ProjectDependency.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/ProjectStructureVersion.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/ProjectStructureVersion.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/ProjectStructureVersion.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/ProjectStructureVersion.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/UpdateProjectConfigurationCommand.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/UpdateProjectConfigurationCommand.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/configuration/UpdateProjectConfigurationCommand.ts
+++ b/packages/legend-studio/src/models/sdlc/models/configuration/UpdateProjectConfigurationCommand.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/entity/Entity.ts
+++ b/packages/legend-studio/src/models/sdlc/models/entity/Entity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/entity/Entity.ts
+++ b/packages/legend-studio/src/models/sdlc/models/entity/Entity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/entity/EntityChange.ts
+++ b/packages/legend-studio/src/models/sdlc/models/entity/EntityChange.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/entity/EntityChange.ts
+++ b/packages/legend-studio/src/models/sdlc/models/entity/EntityChange.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/entity/EntityChangeConflict.ts
+++ b/packages/legend-studio/src/models/sdlc/models/entity/EntityChangeConflict.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/entity/EntityChangeConflict.ts
+++ b/packages/legend-studio/src/models/sdlc/models/entity/EntityChangeConflict.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/project/Project.ts
+++ b/packages/legend-studio/src/models/sdlc/models/project/Project.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/project/Project.ts
+++ b/packages/legend-studio/src/models/sdlc/models/project/Project.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/review/Review.ts
+++ b/packages/legend-studio/src/models/sdlc/models/review/Review.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/review/Review.ts
+++ b/packages/legend-studio/src/models/sdlc/models/review/Review.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/revision/Revision.ts
+++ b/packages/legend-studio/src/models/sdlc/models/revision/Revision.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/revision/Revision.ts
+++ b/packages/legend-studio/src/models/sdlc/models/revision/Revision.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/version/CreateVersionCommand.ts
+++ b/packages/legend-studio/src/models/sdlc/models/version/CreateVersionCommand.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/version/CreateVersionCommand.ts
+++ b/packages/legend-studio/src/models/sdlc/models/version/CreateVersionCommand.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/version/Version.ts
+++ b/packages/legend-studio/src/models/sdlc/models/version/Version.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/version/Version.ts
+++ b/packages/legend-studio/src/models/sdlc/models/version/Version.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/version/VersionId.ts
+++ b/packages/legend-studio/src/models/sdlc/models/version/VersionId.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/version/VersionId.ts
+++ b/packages/legend-studio/src/models/sdlc/models/version/VersionId.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/workspace/Workspace.ts
+++ b/packages/legend-studio/src/models/sdlc/models/workspace/Workspace.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/workspace/Workspace.ts
+++ b/packages/legend-studio/src/models/sdlc/models/workspace/Workspace.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/workspace/WorkspaceUpdateReport.ts
+++ b/packages/legend-studio/src/models/sdlc/models/workspace/WorkspaceUpdateReport.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/models/sdlc/models/workspace/WorkspaceUpdateReport.ts
+++ b/packages/legend-studio/src/models/sdlc/models/workspace/WorkspaceUpdateReport.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ApplicationConfig.ts
+++ b/packages/legend-studio/src/stores/ApplicationConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ApplicationConfig.ts
+++ b/packages/legend-studio/src/stores/ApplicationConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ApplicationStore.tsx
+++ b/packages/legend-studio/src/stores/ApplicationStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ApplicationStore.tsx
+++ b/packages/legend-studio/src/stores/ApplicationStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ChangeDetectionState.ts
+++ b/packages/legend-studio/src/stores/ChangeDetectionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ChangeDetectionState.ts
+++ b/packages/legend-studio/src/stores/ChangeDetectionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/DSLGenerationSpecification_EditorPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/DSLGenerationSpecification_EditorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/DSLGenerationSpecification_EditorPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/DSLGenerationSpecification_EditorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorConfig.ts
+++ b/packages/legend-studio/src/stores/EditorConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorConfig.ts
+++ b/packages/legend-studio/src/stores/EditorConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorPlugin.ts
+++ b/packages/legend-studio/src/stores/EditorPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorPlugin.ts
+++ b/packages/legend-studio/src/stores/EditorPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorSdlcState.ts
+++ b/packages/legend-studio/src/stores/EditorSdlcState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorSdlcState.ts
+++ b/packages/legend-studio/src/stores/EditorSdlcState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorStore.tsx
+++ b/packages/legend-studio/src/stores/EditorStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/EditorStore.tsx
+++ b/packages/legend-studio/src/stores/EditorStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ExplorerTreeState.ts
+++ b/packages/legend-studio/src/stores/ExplorerTreeState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ExplorerTreeState.ts
+++ b/packages/legend-studio/src/stores/ExplorerTreeState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/GraphState.ts
+++ b/packages/legend-studio/src/stores/GraphState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/GraphState.ts
+++ b/packages/legend-studio/src/stores/GraphState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/NewElementState.tsx
+++ b/packages/legend-studio/src/stores/NewElementState.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/NewElementState.tsx
+++ b/packages/legend-studio/src/stores/NewElementState.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/PureLanguageSupport.ts
+++ b/packages/legend-studio/src/stores/PureLanguageSupport.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/PureLanguageSupport.ts
+++ b/packages/legend-studio/src/stores/PureLanguageSupport.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ReviewStore.tsx
+++ b/packages/legend-studio/src/stores/ReviewStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ReviewStore.tsx
+++ b/packages/legend-studio/src/stores/ReviewStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/RouterConfig.ts
+++ b/packages/legend-studio/src/stores/RouterConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/RouterConfig.ts
+++ b/packages/legend-studio/src/stores/RouterConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/SetupStore.tsx
+++ b/packages/legend-studio/src/stores/SetupStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/SetupStore.tsx
+++ b/packages/legend-studio/src/stores/SetupStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/StoreRelational_EditorPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/StoreRelational_EditorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/StoreRelational_EditorPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/StoreRelational_EditorPlugin_Extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/StoreTestUtils.ts
+++ b/packages/legend-studio/src/stores/StoreTestUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/StoreTestUtils.ts
+++ b/packages/legend-studio/src/stores/StoreTestUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ViewerStore.tsx
+++ b/packages/legend-studio/src/stores/ViewerStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/ViewerStore.tsx
+++ b/packages/legend-studio/src/stores/ViewerStore.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/Inference.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/Inference.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/Inference.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/Inference.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/InferenceTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/InferenceTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/InferenceTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/InferenceTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/LambdaRoundtrip.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/LambdaRoundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/LambdaRoundtrip.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/LambdaRoundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/LambdaRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/LambdaRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/LambdaRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/LambdaRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/Roundtrip.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/Roundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/Roundtrip.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/Roundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/CoreTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/CoreTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/CoreTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/CoreTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/Dependency.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/Dependency.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/Dependency.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/Dependency.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/Generation.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/Generation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/Generation.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/Generation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailure.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailure.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailure.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailure.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailureTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailureTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailureTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildFailureTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/GraphBuildSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/generation/FileGenerationBuildSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/generation/FileGenerationBuildSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/generation/FileGenerationBuildSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/generation/FileGenerationBuildSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/EmbeddedRelational.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/EmbeddedRelational.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/EmbeddedRelational.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/EmbeddedRelational.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/InlineEmbeddedRelational.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/InlineEmbeddedRelational.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/InlineEmbeddedRelational.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/InlineEmbeddedRelational.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/OtherwiseEmbeddedRelational.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/OtherwiseEmbeddedRelational.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/OtherwiseEmbeddedRelational.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/OtherwiseEmbeddedRelational.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/PropertyThroughAssociationGraphSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/PropertyThroughAssociationGraphSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/PropertyThroughAssociationGraphSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/PropertyThroughAssociationGraphSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/RelationalEntitiesTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/RelationalEntitiesTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/RelationalEntitiesTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/RelationalEntitiesTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/SimpleRelationalGraphBuildSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/SimpleRelationalGraphBuildSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/relational/SimpleRelationalGraphBuildSuccess.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/relational/SimpleRelationalGraphBuildSuccess.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/ConnectionRoundtripTestdata.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/ConnectionRoundtripTestdata.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/ConnectionRoundtripTestdata.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/ConnectionRoundtripTestdata.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/DiagramRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/DiagramRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/DiagramRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/DiagramRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/DomainRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/DomainRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/DomainRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/DomainRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/FileGenerationRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/FileGenerationRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/FileGenerationRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/FileGenerationRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/FlatDataRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/FlatDataRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/FlatDataRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/FlatDataRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/GenerationSpecificationTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/GenerationSpecificationTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/GenerationSpecificationTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/GenerationSpecificationTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/MappingRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/MappingRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/MappingRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/MappingRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RuntimeRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RuntimeRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RuntimeRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RuntimeRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/ServiceRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/ServiceRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/ServiceRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/ServiceRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/ValueSpecificationRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/ValueSpecificationRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/ValueSpecificationRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/ValueSpecificationRoundtripTestData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/aux-panel-state/DevToolState.ts
+++ b/packages/legend-studio/src/stores/aux-panel-state/DevToolState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/aux-panel-state/DevToolState.ts
+++ b/packages/legend-studio/src/stores/aux-panel-state/DevToolState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/EditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/EditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/EditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/EditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/FileGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/FileGenerationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/FileGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/FileGenerationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
+++ b/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
+++ b/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/GenerationSpecificationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GenerationSpecificationEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/GenerationSpecificationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GenerationSpecificationEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/GrammarTextEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GrammarTextEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/GrammarTextEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GrammarTextEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/GraphGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GraphGenerationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/GraphGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GraphGenerationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/ModelLoaderState.ts
+++ b/packages/legend-studio/src/stores/editor-state/ModelLoaderState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/ModelLoaderState.ts
+++ b/packages/legend-studio/src/stores/editor-state/ModelLoaderState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/ProjectConfigurationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/ProjectConfigurationEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/ProjectConfigurationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/ProjectConfigurationEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/UnsupportedElementEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/UnsupportedElementEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/UnsupportedElementEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/UnsupportedElementEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ConnectionEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ConnectionEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ConnectionEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ConnectionEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/FileGenerationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/FileGenerationEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/FileGenerationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/FileGenerationEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/FunctionEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/FunctionEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/FunctionEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/FunctionEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/LambdaEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/LambdaEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/LambdaEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/LambdaEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/UMLEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/UMLEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/UMLEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/UMLEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/FlatDataInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/FlatDataInstanceSetImplementationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/FlatDataInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/FlatDataInstanceSetImplementationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MapingElementDecorateVisitor.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MapingElementDecorateVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MapingElementDecorateVisitor.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MapingElementDecorateVisitor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/PureInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/PureInstanceSetImplementationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/PureInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/PureInstanceSetImplementationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/UnsupportedInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/UnsupportedInstanceSetImplementationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/UnsupportedInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/UnsupportedInstanceSetImplementationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceRegistrationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceRegistrationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceRegistrationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceRegistrationState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityChangeConflictEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityChangeConflictEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityChangeConflictEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityChangeConflictEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffEditorState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffViewState.ts
+++ b/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffViewState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffViewState.ts
+++ b/packages/legend-studio/src/stores/editor-state/entity-diff-editor-state/EntityDiffViewState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/network/Telemetry.ts
+++ b/packages/legend-studio/src/stores/network/Telemetry.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/network/Telemetry.ts
+++ b/packages/legend-studio/src/stores/network/Telemetry.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/network/Tracer.ts
+++ b/packages/legend-studio/src/stores/network/Tracer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/network/Tracer.ts
+++ b/packages/legend-studio/src/stores/network/Tracer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/DnDUtil.ts
+++ b/packages/legend-studio/src/stores/shared/DnDUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/DnDUtil.ts
+++ b/packages/legend-studio/src/stores/shared/DnDUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/FileGenerationTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/FileGenerationTreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/FileGenerationTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/FileGenerationTreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/MockDataUtil.ts
+++ b/packages/legend-studio/src/stores/shared/MockDataUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/MockDataUtil.ts
+++ b/packages/legend-studio/src/stores/shared/MockDataUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/RawGraphFetchTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/RawGraphFetchTreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/RawGraphFetchTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/RawGraphFetchTreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/TreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/TreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/TreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/TreeUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/__tests__/MockDataUtil.test.ts
+++ b/packages/legend-studio/src/stores/shared/__tests__/MockDataUtil.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/shared/__tests__/MockDataUtil.test.ts
+++ b/packages/legend-studio/src/stores/shared/__tests__/MockDataUtil.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/ConflictResolutionState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/ConflictResolutionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/ConflictResolutionState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/ConflictResolutionState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/LocalChangesState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/LocalChangesState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/LocalChangesState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/LocalChangesState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/ProjectOverviewState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/ProjectOverviewState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/ProjectOverviewState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/ProjectOverviewState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/WorkspaceBuildsState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkspaceBuildsState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/WorkspaceBuildsState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkspaceBuildsState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/WorkspaceReviewState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkspaceReviewState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/WorkspaceReviewState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkspaceReviewState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/WorkspaceUpdaterState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkspaceUpdaterState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/stores/sidebar-state/WorkspaceUpdaterState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkspaceUpdaterState.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/testMocks/MockedMonacoEditor.ts
+++ b/packages/legend-studio/src/testMocks/MockedMonacoEditor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/testMocks/MockedMonacoEditor.ts
+++ b/packages/legend-studio/src/testMocks/MockedMonacoEditor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/testMocks/MockedReactReflex.tsx
+++ b/packages/legend-studio/src/testMocks/MockedReactReflex.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/testMocks/MockedReactReflex.tsx
+++ b/packages/legend-studio/src/testMocks/MockedReactReflex.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/testMocks/MonacoEditorMockUtils.tsx
+++ b/packages/legend-studio/src/testMocks/MonacoEditorMockUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/testMocks/MonacoEditorMockUtils.tsx
+++ b/packages/legend-studio/src/testMocks/MonacoEditorMockUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/utils/Logger.ts
+++ b/packages/legend-studio/src/utils/Logger.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/utils/Logger.ts
+++ b/packages/legend-studio/src/utils/Logger.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/utils/MappingResolutionUtil.ts
+++ b/packages/legend-studio/src/utils/MappingResolutionUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/utils/MappingResolutionUtil.ts
+++ b/packages/legend-studio/src/utils/MappingResolutionUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/utils/TextEditorUtil.ts
+++ b/packages/legend-studio/src/utils/TextEditorUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/src/utils/TextEditorUtil.ts
+++ b/packages/legend-studio/src/utils/TextEditorUtil.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/_deps.scss
+++ b/packages/legend-studio/style/_deps.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/_deps.scss
+++ b/packages/legend-studio/style/_deps.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/_extensions.scss
+++ b/packages/legend-studio/style/_extensions.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/_extensions.scss
+++ b/packages/legend-studio/style/_extensions.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/_mixins.scss
+++ b/packages/legend-studio/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/_mixins.scss
+++ b/packages/legend-studio/style/_mixins.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_app.scss
+++ b/packages/legend-studio/style/components/_app.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_app.scss
+++ b/packages/legend-studio/style/components/_app.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_create-project.scss
+++ b/packages/legend-studio/style/components/_create-project.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_create-project.scss
+++ b/packages/legend-studio/style/components/_create-project.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_editor.scss
+++ b/packages/legend-studio/style/components/_editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_editor.scss
+++ b/packages/legend-studio/style/components/_editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_review.scss
+++ b/packages/legend-studio/style/components/_review.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_review.scss
+++ b/packages/legend-studio/style/components/_review.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_setup.scss
+++ b/packages/legend-studio/style/components/_setup.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_setup.scss
+++ b/packages/legend-studio/style/components/_setup.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_shared.scss
+++ b/packages/legend-studio/style/components/_shared.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_shared.scss
+++ b/packages/legend-studio/style/components/_shared.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_viewer.scss
+++ b/packages/legend-studio/style/components/_viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/_viewer.scss
+++ b/packages/legend-studio/style/components/_viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_activity-bar.scss
+++ b/packages/legend-studio/style/components/editor/_activity-bar.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_activity-bar.scss
+++ b/packages/legend-studio/style/components/editor/_activity-bar.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_auxiliary-panel.scss
+++ b/packages/legend-studio/style/components/editor/_auxiliary-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_auxiliary-panel.scss
+++ b/packages/legend-studio/style/components/editor/_auxiliary-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_command.scss
+++ b/packages/legend-studio/style/components/editor/_command.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_command.scss
+++ b/packages/legend-studio/style/components/editor/_command.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_connection-editor.scss
+++ b/packages/legend-studio/style/components/editor/_connection-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_connection-editor.scss
+++ b/packages/legend-studio/style/components/editor/_connection-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_edit-panel.scss
+++ b/packages/legend-studio/style/components/editor/_edit-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_edit-panel.scss
+++ b/packages/legend-studio/style/components/editor/_edit-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_entity-change-conflict-editor.scss
+++ b/packages/legend-studio/style/components/editor/_entity-change-conflict-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_entity-change-conflict-editor.scss
+++ b/packages/legend-studio/style/components/editor/_entity-change-conflict-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_entity-diff-view.scss
+++ b/packages/legend-studio/style/components/editor/_entity-diff-view.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_entity-diff-view.scss
+++ b/packages/legend-studio/style/components/editor/_entity-diff-view.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_file-generation-editor.scss
+++ b/packages/legend-studio/style/components/editor/_file-generation-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_file-generation-editor.scss
+++ b/packages/legend-studio/style/components/editor/_file-generation-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_file-generation-viewer.scss
+++ b/packages/legend-studio/style/components/editor/_file-generation-viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_file-generation-viewer.scss
+++ b/packages/legend-studio/style/components/editor/_file-generation-viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_function-editor.scss
+++ b/packages/legend-studio/style/components/editor/_function-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_function-editor.scss
+++ b/packages/legend-studio/style/components/editor/_function-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_generation-spec-editor.scss
+++ b/packages/legend-studio/style/components/editor/_generation-spec-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_generation-spec-editor.scss
+++ b/packages/legend-studio/style/components/editor/_generation-spec-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_header.scss
+++ b/packages/legend-studio/style/components/editor/_header.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_header.scss
+++ b/packages/legend-studio/style/components/editor/_header.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/_mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/_mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_model-loader.scss
+++ b/packages/legend-studio/style/components/editor/_model-loader.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_model-loader.scss
+++ b/packages/legend-studio/style/components/editor/_model-loader.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_project-configuration-editor.scss
+++ b/packages/legend-studio/style/components/editor/_project-configuration-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_project-configuration-editor.scss
+++ b/packages/legend-studio/style/components/editor/_project-configuration-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_runtime-editor.scss
+++ b/packages/legend-studio/style/components/editor/_runtime-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_runtime-editor.scss
+++ b/packages/legend-studio/style/components/editor/_runtime-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_service-editor.scss
+++ b/packages/legend-studio/style/components/editor/_service-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_service-editor.scss
+++ b/packages/legend-studio/style/components/editor/_service-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_side-bar.scss
+++ b/packages/legend-studio/style/components/editor/_side-bar.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_side-bar.scss
+++ b/packages/legend-studio/style/components/editor/_side-bar.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_status-bar.scss
+++ b/packages/legend-studio/style/components/editor/_status-bar.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_status-bar.scss
+++ b/packages/legend-studio/style/components/editor/_status-bar.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_text-editor.scss
+++ b/packages/legend-studio/style/components/editor/_text-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_text-editor.scss
+++ b/packages/legend-studio/style/components/editor/_text-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_uml-editor.scss
+++ b/packages/legend-studio/style/components/editor/_uml-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_uml-editor.scss
+++ b/packages/legend-studio/style/components/editor/_uml-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_unsupported-element-editor.scss
+++ b/packages/legend-studio/style/components/editor/_unsupported-element-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/_unsupported-element-editor.scss
+++ b/packages/legend-studio/style/components/editor/_unsupported-element-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_console-panel.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_console-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_console-panel.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_console-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_dev-tool.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_dev-tool.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_dev-tool.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_dev-tool.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_execution-plan-viewer.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_execution-plan-viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_execution-plan-viewer.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_execution-plan-viewer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_mapping-execution.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_mapping-execution.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_mapping-execution.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_mapping-execution.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_mapping-test-editor-panel.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_mapping-test-editor-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/aux-panel/_mapping-test-editor-panel.scss
+++ b/packages/legend-studio/style/components/editor/aux-panel/_mapping-test-editor-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/command/project-search.scss
+++ b/packages/legend-studio/style/components/editor/command/project-search.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/command/project-search.scss
+++ b/packages/legend-studio/style/components/editor/command/project-search.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/header/share-project.scss
+++ b/packages/legend-studio/style/components/editor/header/share-project.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/header/share-project.scss
+++ b/packages/legend-studio/style/components/editor/header/share-project.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_class-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_class-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_class-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_class-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_enumeration-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_enumeration-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_enumeration-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_enumeration-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_flat-data-column-tree.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_flat-data-column-tree.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_flat-data-column-tree.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_flat-data-column-tree.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_graph-fetch-tree.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_graph-fetch-tree.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_graph-fetch-tree.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_graph-fetch-tree.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-element-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-element-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-element-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-element-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-explorer.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-explorer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-explorer.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-explorer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-explorer.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-explorer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-explorer.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-explorer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_new-mapping-element-modal.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_new-mapping-element-modal.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_new-mapping-element-modal.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_new-mapping-element-modal.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_operation-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_operation-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_operation-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_operation-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_property-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_property-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_property-mapping-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_property-mapping-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_source-panel.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_source-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_source-panel.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_source-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_type-tree.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_type-tree.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/mapping-editor/_type-tree.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_type-tree.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_conflict-resolution.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_conflict-resolution.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_conflict-resolution.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_conflict-resolution.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_diff-panel.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_diff-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_diff-panel.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_diff-panel.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_explorer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_explorer.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_local-changes.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_local-changes.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_local-changes.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_local-changes.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_project-overview.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_project-overview.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_project-overview.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_project-overview.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_workspace-builds.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_workspace-builds.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_workspace-builds.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_workspace-builds.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_workspace-review.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_workspace-review.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_workspace-review.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_workspace-review.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_workspace-updater.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_workspace-updater.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/side-bar/_workspace-updater.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_workspace-updater.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_class-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_class-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_class-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_class-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_enum-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_enum-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_enum-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_enum-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_profile-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_profile-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_profile-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_profile-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_stereotype-selector.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_stereotype-selector.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_stereotype-selector.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_stereotype-selector.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_tagged-value-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_tagged-value-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_tagged-value-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_tagged-value-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_uml-element-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_uml-element-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/editor/uml-editor/_uml-element-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_uml-element-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_backdrop.scss
+++ b/packages/legend-studio/style/components/shared/_backdrop.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_backdrop.scss
+++ b/packages/legend-studio/style/components/shared/_backdrop.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_lambda-editor.scss
+++ b/packages/legend-studio/style/components/shared/_lambda-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_lambda-editor.scss
+++ b/packages/legend-studio/style/components/shared/_lambda-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_multiplicity-badge.scss
+++ b/packages/legend-studio/style/components/shared/_multiplicity-badge.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_multiplicity-badge.scss
+++ b/packages/legend-studio/style/components/shared/_multiplicity-badge.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_notification.scss
+++ b/packages/legend-studio/style/components/shared/_notification.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/components/shared/_notification.scss
+++ b/packages/legend-studio/style/components/shared/_notification.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/index.scss
+++ b/packages/legend-studio/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/index.scss
+++ b/packages/legend-studio/style/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/reset/_monaco-editor.scss
+++ b/packages/legend-studio/style/reset/_monaco-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/reset/_monaco-editor.scss
+++ b/packages/legend-studio/style/reset/_monaco-editor.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/reset/_react-reflex.scss
+++ b/packages/legend-studio/style/reset/_react-reflex.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/reset/_react-reflex.scss
+++ b/packages/legend-studio/style/reset/_react-reflex.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/reset/_react-split-pane.scss
+++ b/packages/legend-studio/style/reset/_react-split-pane.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-studio/style/reset/_react-split-pane.scss
+++ b/packages/legend-studio/style/reset/_react-split-pane.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/COPYRIGHT_HEADER.txt
+++ b/scripts/copyright/COPYRIGHT_HEADER.txt
@@ -1,4 +1,4 @@
-Copyright 2020 Goldman Sachs
+Copyright Goldman Sachs
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/copyright/COPYRIGHT_HEADER.txt
+++ b/scripts/copyright/COPYRIGHT_HEADER.txt
@@ -1,4 +1,4 @@
-Copyright Goldman Sachs
+Copyright (c) 2020-present, Goldman Sachs
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/copyright/PackageCopyrightHelpers.js
+++ b/scripts/copyright/PackageCopyrightHelpers.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/PackageCopyrightHelpers.js
+++ b/scripts/copyright/PackageCopyrightHelpers.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/addBundledCodeCopyrightHeader.js
+++ b/scripts/copyright/addBundledCodeCopyrightHeader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/addBundledCodeCopyrightHeader.js
+++ b/scripts/copyright/addBundledCodeCopyrightHeader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/checkCopyrightHeaders.js
+++ b/scripts/copyright/checkCopyrightHeaders.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/checkCopyrightHeaders.js
+++ b/scripts/copyright/checkCopyrightHeaders.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/copyright.config.js
+++ b/scripts/copyright/copyright.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/copyright/copyright.config.js
+++ b/scripts/copyright/copyright.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/jest.config.base.js
+++ b/scripts/jest/jest.config.base.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/jest.config.base.js
+++ b/scripts/jest/jest.config.base.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/setupTestsEnv.js
+++ b/scripts/jest/setupTestsEnv.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/jest/setupTestsEnv.js
+++ b/scripts/jest/setupTestsEnv.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/loadPackageConfig.js
+++ b/scripts/loadPackageConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/loadPackageConfig.js
+++ b/scripts/loadPackageConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/release/preparePublishContent.js
+++ b/scripts/release/preparePublishContent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/release/preparePublishContent.js
+++ b/scripts/release/preparePublishContent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/typescript/checkProjectReferenceConfigs.js
+++ b/scripts/typescript/checkProjectReferenceConfigs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/typescript/checkProjectReferenceConfigs.js
+++ b/scripts/typescript/checkProjectReferenceConfigs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/workflow/buildCommitPrompt.js
+++ b/scripts/workflow/buildCommitPrompt.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/workflow/buildCommitPrompt.js
+++ b/scripts/workflow/buildCommitPrompt.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/workflow/checkChangesets.js
+++ b/scripts/workflow/checkChangesets.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/workflow/checkChangesets.js
+++ b/scripts/workflow/checkChangesets.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/workflow/generateChangeset.js
+++ b/scripts/workflow/generateChangeset.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Goldman Sachs
+ * Copyright Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/workflow/generateChangeset.js
+++ b/scripts/workflow/generateChangeset.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR does several things:
- Update Docker image to use the latest version of `legend-shared-server`
- Update developer guide
- Update copyright header to use year range (i.e. `2020-present`) instead of `2020`. We should check more on this change as many other projects [start to drop the year](https://github.com/facebook/react/pull/13593) in their copyright header and license (due to Berne Convention)