### PR TITLE
fix: ensure ObjectInputData stores unformatted test data

### DIFF
--- a/.changeset/fresh-shirts-tie.md
+++ b/.changeset/fresh-shirts-tie.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Ensure that test data is stored with no formatting

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
@@ -15,9 +15,19 @@
  */
 
 import { hashLambda } from '../../../MetaModelUtility';
-import { unitTest } from '@finos/legend-studio-shared';
+import {
+  losslessParse,
+  losslessStringify,
+  unitTest,
+} from '@finos/legend-studio-shared';
 import { ROOT_PACKAGE_NAME } from '../../../MetaModelConst';
 import { Package } from '../model/packageableElements/domain/Package';
+import {
+  ObjectInputData,
+  OBJECT_INPUT_TYPE,
+} from '../model/packageableElements/store/modelToModel/mapping/ObjectInputData';
+import { Class } from '../model/packageableElements/domain/Class';
+import { PackageableElementExplicitReference } from '../model/packageableElements/PackageableElementReference';
 
 test(unitTest('Create valid and invalid packages on a root package'), () => {
   const _root = new Package(ROOT_PACKAGE_NAME.MAIN);
@@ -75,3 +85,27 @@ test(
     );
   },
 );
+
+test(unitTest('JSON Object input data should be minified'), () => {
+  const test1 = new ObjectInputData(
+    PackageableElementExplicitReference.create(Class.createStub()),
+    OBJECT_INPUT_TYPE.JSON,
+    '{"a":1}',
+  );
+
+  const test2 = new ObjectInputData(
+    PackageableElementExplicitReference.create(Class.createStub()),
+    OBJECT_INPUT_TYPE.JSON,
+    '{\n  "a":1\n}',
+  );
+
+  const test3 = new ObjectInputData(
+    PackageableElementExplicitReference.create(Class.createStub()),
+    OBJECT_INPUT_TYPE.JSON,
+    '{\n  "a":1, \n "b" : {\n  "b1":"hello"\n} \n}',
+  );
+
+  expect(test1.data === losslessStringify(losslessParse(test1.data)));
+  expect(test2.data === losslessStringify(losslessParse(test2.data)));
+  expect(test3.data === losslessStringify(losslessParse(test3.data)));
+});

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/ObjectInputData.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/modelToModel/mapping/ObjectInputData.ts
@@ -19,6 +19,7 @@ import {
   hashArray,
   UnsupportedOperationError,
   isValidJSONString,
+  tryToMinifyLosslessJSONString,
 } from '@finos/legend-studio-shared';
 import type { Hashable } from '@finos/legend-studio-shared';
 import { CORE_HASH_STRUCTURE } from '../../../../../../../MetaModelConst';
@@ -67,7 +68,11 @@ export class ObjectInputData extends InputData implements Hashable {
 
     this.sourceClass = sourceClass;
     this.inputType = inputType;
-    this.data = data;
+    /* @MARKER: Workaround for https://github.com/finos/legend-studio/issues/66 */
+    this.data =
+      inputType === OBJECT_INPUT_TYPE.JSON
+        ? tryToMinifyLosslessJSONString(data)
+        : data;
   }
 
   get validationResult(): ValidationIssue | undefined {

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
@@ -175,8 +175,7 @@ export class MappingTestObjectInputDataState extends MappingTestInputDataState {
         this.sourceClass ?? Class.createStub(),
       ),
       OBJECT_INPUT_TYPE.JSON,
-      /* @MARKER: Workaround for https://github.com/finos/legend-studio/issues/68 */
-      tryToMinifyLosslessJSONString(this.data),
+      this.data,
     );
   }
 


### PR DESCRIPTION
Fixes issue where test input data is not necessarily stored in unformatted state: flow is when a user creates a test for M2M, and the test data is filled by createMockDataForClass from MockDataUtils. This function returns formatted JSON which is then stored in the ObjectInputData class. 

If the user does not modify the test data, then the callback to unformat the test data is not called and hence the data is kept with formatting and breaks when switching to grammar mode. 

This change ensures that data stored in ObjectInputData is stored without formatting. 