### PR TITLE
add lambda resolver

### DIFF
--- a/.changeset/good-years-bake.md
+++ b/.changeset/good-years-bake.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': minor
+---
+
+A RawLambda resolver is added to resolve element paths inside lambdas that leverage imports. This allow successful compilation of graph that contain lambdas using imports.

--- a/packages/legend-studio/src/models/metamodels/pure/graph/AbstractPureGraphManager.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/AbstractPureGraphManager.ts
@@ -65,6 +65,7 @@ export interface GraphBuilderOptions {
   quiet?: boolean;
   DEV__enableGraphImmutabilityRuntimeCheck?: boolean;
   TEMPORARY__keepSectionIndex?: boolean;
+  TEMPORARY__disableRawLambdaResolver?: boolean;
 }
 
 export abstract class AbstractPureGraphManager {

--- a/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -567,17 +567,21 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
         data: indexPureModelContextData(dependencyData, this.extensions),
         model: graph.dependencyManager.getModel(dependencyKey),
       }));
-      yield this.initializeAndIndexElements(graph, graphBuilderInput);
+      yield this.initializeAndIndexElements(graph, graphBuilderInput, options);
       // NOTE: we might need to process sectionIndex if we support unresolved element paths in dependencies
-      yield this.buildTypes(graph, graphBuilderInput);
-      yield this.buildStores(graph, graphBuilderInput);
-      yield this.buildMappings(graph, graphBuilderInput);
-      yield this.buildConnectionsAndRuntimes(graph, graphBuilderInput);
-      yield this.buildServices(graph, graphBuilderInput);
-      yield this.buildDiagrams(graph, graphBuilderInput);
-      yield this.buildFileGenerations(graph, graphBuilderInput);
-      yield this.buildGenerationSpecificationss(graph, graphBuilderInput);
-      yield this.buildOtherElements(graph, graphBuilderInput);
+      yield this.buildTypes(graph, graphBuilderInput, options);
+      yield this.buildStores(graph, graphBuilderInput, options);
+      yield this.buildMappings(graph, graphBuilderInput, options);
+      yield this.buildConnectionsAndRuntimes(graph, graphBuilderInput, options);
+      yield this.buildServices(graph, graphBuilderInput, options);
+      yield this.buildDiagrams(graph, graphBuilderInput, options);
+      yield this.buildFileGenerations(graph, graphBuilderInput, options);
+      yield this.buildGenerationSpecificationss(
+        graph,
+        graphBuilderInput,
+        options,
+      );
+      yield this.buildOtherElements(graph, graphBuilderInput, options);
 
       yield this.postProcess(graph, graphBuilderInput, {
         DEV__enableGraphImmutabilityRuntimeCheck:
@@ -654,7 +658,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       }
       stepStartTime = stepFinishedTime;
 
-      yield this.initializeAndIndexElements(graph, graphBuilderInput);
+      yield this.initializeAndIndexElements(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -667,7 +671,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Section index
-      yield this.buildSectionIndex(graph, graphBuilderInput);
+      yield this.buildSectionIndex(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -678,9 +682,8 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
         );
       }
       stepStartTime = stepFinishedTime;
-
       // Types
-      yield this.buildTypes(graph, graphBuilderInput);
+      yield this.buildTypes(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -693,7 +696,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Stores
-      yield this.buildStores(graph, graphBuilderInput);
+      yield this.buildStores(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       // TODO: we might want to detail out the number of stores by type
       if (!options?.quiet) {
@@ -707,7 +710,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Mappings
-      yield this.buildMappings(graph, graphBuilderInput);
+      yield this.buildMappings(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -720,7 +723,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Connections
-      yield this.buildConnectionsAndRuntimes(graph, graphBuilderInput);
+      yield this.buildConnectionsAndRuntimes(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -733,7 +736,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Services
-      yield this.buildServices(graph, graphBuilderInput);
+      yield this.buildServices(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -746,7 +749,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Diagrams
-      yield this.buildDiagrams(graph, graphBuilderInput);
+      yield this.buildDiagrams(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -759,7 +762,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // File Generation
-      yield this.buildFileGenerations(graph, graphBuilderInput);
+      yield this.buildFileGenerations(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -772,7 +775,11 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Generation Specifications (tree)
-      yield this.buildGenerationSpecificationss(graph, graphBuilderInput);
+      yield this.buildGenerationSpecificationss(
+        graph,
+        graphBuilderInput,
+        options,
+      );
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -785,7 +792,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       stepStartTime = stepFinishedTime;
 
       // Other elements
-      yield this.buildOtherElements(graph, graphBuilderInput);
+      yield this.buildOtherElements(graph, graphBuilderInput, options);
       stepFinishedTime = Date.now();
       if (!options?.quiet) {
         this.logger.info(
@@ -917,12 +924,14 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     graph: PureModel,
     currentSubGraph: BasicModel,
     element: V1_PackageableElement,
+    options?: GraphBuilderOptions,
   ): V1_GraphBuilderContext {
     return new V1_GraphBuilderContextBuilder(
       graph,
       currentSubGraph,
       this.extensions,
       this.logger,
+      options,
     )
       .withElement(element)
       .build();
@@ -940,6 +949,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -947,7 +957,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphFirstPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -963,7 +973,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
               this.visitWithErrorHandling(
                 element,
                 new V1_ProtocolToMetaModelGraphFirstPassVisitor(
-                  this.getBuilderContext(graph, input.model, element),
+                  this.getBuilderContext(graph, input.model, element, options),
                 ),
               ),
             ),
@@ -1026,6 +1036,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     // Second pass
     yield Promise.all(
@@ -1034,7 +1045,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1046,7 +1057,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1058,7 +1069,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1070,7 +1081,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1082,7 +1093,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1095,7 +1106,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphThirdPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1107,7 +1118,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphThirdPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1120,7 +1131,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphFifthPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1132,6 +1143,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1139,7 +1151,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1151,7 +1163,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphThirdPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1163,7 +1175,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphFourthPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1175,7 +1187,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphFifthPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1187,6 +1199,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1194,7 +1207,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1206,7 +1219,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphThirdPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1218,7 +1231,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphFourthPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1230,6 +1243,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     // NOTE: connections must be built before runtimes
     yield Promise.all(
@@ -1238,7 +1252,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1250,7 +1264,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1262,6 +1276,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1269,7 +1284,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1281,6 +1296,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1288,7 +1304,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1300,6 +1316,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1307,7 +1324,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1319,6 +1336,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1326,7 +1344,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1338,6 +1356,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       inputs.flatMap((input) =>
@@ -1345,7 +1364,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
           this.visitWithErrorHandling(
             element,
             new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-              this.getBuilderContext(graph, input.model, element),
+              this.getBuilderContext(graph, input.model, element, options),
             ),
           ),
         ),
@@ -1357,6 +1376,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     this: V1_PureGraphManager,
     graph: PureModel,
     inputs: V1_GraphBuilderInput[],
+    options?: GraphBuilderOptions,
   ) {
     yield Promise.all(
       this.extensions.sortedExtraElementBuilders.map(async (builder) => {
@@ -1368,7 +1388,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
               this.visitWithErrorHandling(
                 element,
                 new V1_ProtocolToMetaModelGraphSecondPassVisitor(
-                  this.getBuilderContext(graph, input.model, element),
+                  this.getBuilderContext(graph, input.model, element, options),
                 ),
               ),
             ),
@@ -1382,7 +1402,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
               this.visitWithErrorHandling(
                 element,
                 new V1_ProtocolToMetaModelGraphThirdPassVisitor(
-                  this.getBuilderContext(graph, input.model, element),
+                  this.getBuilderContext(graph, input.model, element, options),
                 ),
               ),
             ),
@@ -1396,7 +1416,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
               this.visitWithErrorHandling(
                 element,
                 new V1_ProtocolToMetaModelGraphFourthPassVisitor(
-                  this.getBuilderContext(graph, input.model, element),
+                  this.getBuilderContext(graph, input.model, element, options),
                 ),
               ),
             ),
@@ -1410,7 +1430,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
               this.visitWithErrorHandling(
                 element,
                 new V1_ProtocolToMetaModelGraphFifthPassVisitor(
-                  this.getBuilderContext(graph, input.model, element),
+                  this.getBuilderContext(graph, input.model, element, options),
                 ),
               ),
             ),

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedProperty.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/valueSpecification/application/V1_AppliedProperty.ts
@@ -18,7 +18,7 @@ import type { V1_ValueSpecificationVisitor } from '../../../model/valueSpecifica
 import { V1_ValueSpecification } from '../../../model/valueSpecification/V1_ValueSpecification';
 
 export class V1_AppliedProperty extends V1_ValueSpecification {
-  class!: string;
+  class?: string;
   property!: string;
   parameters: V1_ValueSpecification[] = [];
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
@@ -71,6 +71,7 @@ import { V1_getRelation } from './helpers/V1_DatabaseBuilderHelper';
 import type { Logger } from '../../../../../../../utils/Logger';
 import type { BasicModel } from '../../../../../../metamodels/pure/graph/BasicModel';
 import type { V1_GraphBuilderExtensions } from './V1_GraphBuilderExtensions';
+import type { GraphBuilderOptions } from '../../../../../../metamodels/pure/graph/AbstractPureGraphManager';
 
 type ResolutionResult<T> = [T, boolean | undefined];
 
@@ -81,6 +82,7 @@ export class V1_GraphBuilderContext {
   readonly graph: PureModel;
   readonly imports: Package[] = [];
   readonly section?: Section;
+  readonly options?: GraphBuilderOptions;
 
   constructor(builder: V1_GraphBuilderContextBuilder) {
     this.logger = builder.logger;
@@ -89,6 +91,7 @@ export class V1_GraphBuilderContext {
     this.extensions = builder.extensions;
     this.imports = builder.imports;
     this.section = builder.section;
+    this.options = builder.options;
   }
 
   resolve<T>(
@@ -410,17 +413,20 @@ export class V1_GraphBuilderContextBuilder {
   graph: PureModel;
   imports: Package[] = [];
   section?: Section;
+  options?: GraphBuilderOptions;
 
   constructor(
     graph: PureModel,
     currentSubGraph: BasicModel,
     extensions: V1_GraphBuilderExtensions,
     logger: Logger,
+    options?: GraphBuilderOptions,
   ) {
     this.graph = graph;
     this.currentSubGraph = currentSubGraph;
     this.extensions = extensions;
     this.logger = logger;
+    this.options = options;
   }
 
   withElement(element: V1_PackageableElement): V1_GraphBuilderContextBuilder {

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
@@ -28,7 +28,6 @@ import {
 import { PureInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation';
 import { FlatDataInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation';
 import { RootRelationalInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation';
-import { RawLambda } from '../../../../../../metamodels/pure/model/rawValueSpecification/RawLambda';
 import { OptionalPackageableElementImplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 import { InferableMappingElementRootExplicitValue } from '../../../../../../metamodels/pure/model/packageableElements/mapping/InferableMappingElementRoot';
 import type { V1_GraphBuilderContext } from '../../../transformation/pureGraph/to/V1_GraphBuilderContext';
@@ -43,6 +42,7 @@ import { V1_getInferredClassMappingId } from '../../../transformation/pureGraph/
 import { AggregationAwareSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwareSetImplementation';
 import type { InstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/mapping/InstanceSetImplementation';
 import { V1_processAggregateContainer } from './helpers/V1_AggregationAwareClassMappingBuilderHelper';
+import { V1_rawLambdaBuilderWithResolver } from './helpers/V1_RawLambdaResolver';
 
 export class V1_ProtocolToMetaModelClassMappingFirstPassVisitor
   implements V1_ClassMappingVisitor<SetImplementation> {
@@ -107,7 +107,11 @@ export class V1_ProtocolToMetaModelClassMappingFirstPassVisitor
       ),
     );
     pureInstanceSetImplementation.filter = classMapping.filter
-      ? new RawLambda([], classMapping.filter.body)
+      ? V1_rawLambdaBuilderWithResolver(
+          this.context,
+          [],
+          classMapping.filter.body,
+        )
       : undefined;
     return pureInstanceSetImplementation;
   }
@@ -135,7 +139,11 @@ export class V1_ProtocolToMetaModelClassMappingFirstPassVisitor
       sourceRootRecordType,
     );
     flatDataInstanceSetImplementation.filter = classMapping.filter
-      ? new RawLambda([], classMapping.filter.body)
+      ? V1_rawLambdaBuilderWithResolver(
+          this.context,
+          [],
+          classMapping.filter.body,
+        )
       : undefined;
     return flatDataInstanceSetImplementation;
   }

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFifthPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFifthPassVisitor.ts
@@ -78,7 +78,7 @@ export class V1_ProtocolToMetaModelGraphFifthPassVisitor
         V1_processDerivedProperty(derivedProperty, this.context, _class),
     );
     _class.constraints = element.constraints.map((constraint) =>
-      V1_processClassConstraint(constraint, _class),
+      V1_processClassConstraint(constraint, _class, this.context),
     );
   }
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphSecondPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphSecondPassVisitor.ts
@@ -138,10 +138,15 @@ export class V1_ProtocolToMetaModelGraphSecondPassVisitor
       this.context.graph.buildPackageString(element.package, element.name),
     );
     measure.setCanonicalUnit(
-      V1_processUnit(element.canonicalUnit, measure, this.context.graph),
+      V1_processUnit(
+        element.canonicalUnit,
+        measure,
+        this.context.graph,
+        this.context,
+      ),
     );
     measure.nonCanonicalUnits = element.nonCanonicalUnits.map((unit) =>
-      V1_processUnit(unit, measure, this.context.currentSubGraph),
+      V1_processUnit(unit, measure, this.context.currentSubGraph, this.context),
     );
   }
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
@@ -33,7 +33,6 @@ import { EmbeddedFlatDataPropertyMapping } from '../../../../../../metamodels/pu
 import { FlatDataPropertyMapping } from '../../../../../../metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataPropertyMapping';
 import type { EnumerationMapping } from '../../../../../../metamodels/pure/model/packageableElements/mapping/EnumerationMapping';
 import type { SetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/mapping/SetImplementation';
-import { RawLambda } from '../../../../../../metamodels/pure/model/rawValueSpecification/RawLambda';
 import { Class } from '../../../../../../metamodels/pure/model/packageableElements/domain/Class';
 import type { Association } from '../../../../../../metamodels/pure/model/packageableElements/domain/Association';
 import type { TableAlias } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/model/RelationalOperationElement';
@@ -70,6 +69,7 @@ import { MappingClass } from '../../../../../../metamodels/pure/model/packageabl
 import { LocalMappingPropertyInfo } from '../../../../../../metamodels/pure/model/packageableElements/mapping/LocalMappingPropertyInfo';
 import type { AggregationAwareSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwareSetImplementation';
 import { AggregationAwarePropertyMapping } from '../../../../../../metamodels/pure/model/packageableElements/mapping/aggregationAware/AggregationAwarePropertyMapping';
+import { V1_rawLambdaBuilderWithResolver } from './helpers/V1_RawLambdaResolver';
 
 const resolveRelationalPropertyMappingSource = (
   immediateParent: PropertyMappingsImplementation,
@@ -197,7 +197,11 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
     const purePropertyMapping = new PurePropertyMapping(
       topParent,
       property,
-      new RawLambda([], protocol.transform.body),
+      V1_rawLambdaBuilderWithResolver(
+        this.context,
+        [],
+        protocol.transform.body,
+      ),
       sourceSetImplementation ?? topParent,
       targetSetImplementation,
       protocol.explodeProperty,
@@ -268,7 +272,11 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
     const flatDataPropertyMapping = new FlatDataPropertyMapping(
       this.immediateParent,
       PropertyExplicitReference.create(property),
-      new RawLambda([], protocol.transform.body),
+      V1_rawLambdaBuilderWithResolver(
+        this.context,
+        [],
+        protocol.transform.body,
+      ),
       sourceSetImplementation,
       targetSetImplementation,
     );
@@ -661,7 +669,8 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
       guaranteeNonNullable(sourceSetImplementation),
       targetSetImplementation,
     );
-    xStorePropertyMapping.crossExpression = new RawLambda(
+    xStorePropertyMapping.crossExpression = V1_rawLambdaBuilderWithResolver(
+      this.context,
       protocol.crossExpression.parameters,
       protocol.crossExpression.body,
     );

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
@@ -33,7 +33,6 @@ import {
   SourceValue,
 } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/EnumValueMapping';
 import { MappingTest } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/MappingTest';
-import { RawLambda } from '../../../../../../../metamodels/pure/model/rawValueSpecification/RawLambda';
 import {
   ObjectInputData,
   getObjectInputType,
@@ -61,6 +60,7 @@ import { V1_ObjectInputData } from '../../../../model/packageableElements/store/
 import { V1_FlatDataInputData } from '../../../../model/packageableElements/store/flatData/mapping/V1_FlatDataInputData';
 import type { V1_ClassMapping } from '../../../../model/packageableElements/mapping/V1_ClassMapping';
 import type { V1_MappingInclude } from '../../../../model/packageableElements/mapping/V1_MappingInclude';
+import { V1_rawLambdaBuilderWithResolver } from './V1_RawLambdaResolver';
 
 export const V1_getInferredClassMappingId = (
   _class: Class,
@@ -237,7 +237,8 @@ export const V1_processMappingTest = (
 ): MappingTest => {
   assertNonEmptyString(mappingTest.name, 'Mapping test name is missing');
   assertNonNullable(mappingTest.query);
-  const query = new RawLambda(
+  const query = V1_rawLambdaBuilderWithResolver(
+    context,
     mappingTest.query.parameters,
     mappingTest.query.body,
   );

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RawLambdaResolver.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RawLambdaResolver.ts
@@ -1,0 +1,384 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  assertErrorThrown,
+  returnUndefOnError,
+} from '@finos/legend-studio-shared';
+import { CORE_LOG_EVENT } from '../../../../../../../../utils/Logger';
+import type { PackageableElement } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElement';
+import type { PackageableElementImplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
+import { RawLambda } from '../../../../../../../metamodels/pure/model/rawValueSpecification/RawLambda';
+import { isValidFullPath } from '../../../../../../../MetaModelUtility';
+import { V1_RawLambda } from '../../../../model/rawValueSpecification/V1_RawLambda';
+import type { V1_AppliedFunction } from '../../../../model/valueSpecification/application/V1_AppliedFunction';
+import type { V1_AppliedProperty } from '../../../../model/valueSpecification/application/V1_AppliedProperty';
+import type { V1_PropertyGraphFetchTree } from '../../../../model/valueSpecification/raw/graph/V1_PropertyGraphFetchTree';
+import type { V1_RootGraphFetchTree } from '../../../../model/valueSpecification/raw/graph/V1_RootGraphFetchTree';
+import type { V1_Path } from '../../../../model/valueSpecification/raw/path/V1_Path';
+import type { V1_AggregateValue } from '../../../../model/valueSpecification/raw/V1_AggregateValue';
+import type { V1_CBoolean } from '../../../../model/valueSpecification/raw/V1_CBoolean';
+import type { V1_CDateTime } from '../../../../model/valueSpecification/raw/V1_CDateTime';
+import type { V1_CDecimal } from '../../../../model/valueSpecification/raw/V1_CDecimal';
+import type { V1_CFloat } from '../../../../model/valueSpecification/raw/V1_CFloat';
+import type { V1_CInteger } from '../../../../model/valueSpecification/raw/V1_CInteger';
+import type { V1_Class } from '../../../../model/valueSpecification/raw/V1_Class';
+import type { V1_CLatestDate } from '../../../../model/valueSpecification/raw/V1_CLatestDate';
+import type { V1_Collection } from '../../../../model/valueSpecification/raw/V1_Collection';
+import type { V1_CStrictDate } from '../../../../model/valueSpecification/raw/V1_CStrictDate';
+import type { V1_CStrictTime } from '../../../../model/valueSpecification/raw/V1_CStrictTime';
+import type { V1_CString } from '../../../../model/valueSpecification/raw/V1_CString';
+import type { V1_Enum } from '../../../../model/valueSpecification/raw/V1_Enum';
+import type { V1_EnumValue } from '../../../../model/valueSpecification/raw/V1_EnumValue';
+import type { V1_ExecutionContextInstance } from '../../../../model/valueSpecification/raw/V1_ExecutionContextInstance';
+import type { V1_KeyExpression } from '../../../../model/valueSpecification/raw/V1_KeyExpression';
+import type { V1_Lambda } from '../../../../model/valueSpecification/raw/V1_Lambda';
+import type { V1_MappingInstance } from '../../../../model/valueSpecification/raw/V1_MappingInstance';
+import type { V1_Pair } from '../../../../model/valueSpecification/raw/V1_Pair';
+import type { V1_PrimitiveType } from '../../../../model/valueSpecification/raw/V1_PrimitiveType';
+import type { V1_PureList } from '../../../../model/valueSpecification/raw/V1_PureList';
+import type { V1_RuntimeInstance } from '../../../../model/valueSpecification/raw/V1_RuntimeInstance';
+import type { V1_SerializationConfig } from '../../../../model/valueSpecification/raw/V1_SerializationConfig';
+import type { V1_TDSAggregateValue } from '../../../../model/valueSpecification/raw/V1_TDSAggregateValue';
+import type { V1_TDSColumnInformation } from '../../../../model/valueSpecification/raw/V1_TDSColumnInformation';
+import type { V1_TdsOlapAggregation } from '../../../../model/valueSpecification/raw/V1_TdsOlapAggregation';
+import type { V1_TdsOlapRank } from '../../../../model/valueSpecification/raw/V1_TdsOlapRank';
+import type { V1_TDSSortInformation } from '../../../../model/valueSpecification/raw/V1_TDSSortInformation';
+import type { V1_UnitInstance } from '../../../../model/valueSpecification/raw/V1_UnitInstance';
+import type { V1_UnitType } from '../../../../model/valueSpecification/raw/V1_UnitType';
+import type {
+  V1_ValueSpecification,
+  V1_ValueSpecificationVisitor,
+} from '../../../../model/valueSpecification/V1_ValueSpecification';
+import type { V1_Variable } from '../../../../model/valueSpecification/V1_Variable';
+import {
+  V1_serializeRawValueSpecification,
+  V1_deserializeRawValueSpecification,
+} from '../../../pureProtocol/serializationHelpers/V1_RawValueSpecificationSerializationHelper';
+import {
+  V1_deserializeValueSpecification,
+  V1_serializeValueSpecification,
+} from '../../../pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer';
+import type { V1_GraphBuilderContext } from '../V1_GraphBuilderContext';
+
+const V1_shouldResolvePath = (fullPath: string): boolean =>
+  !isValidFullPath(fullPath);
+
+export class V1_ValueSpecificationResolver
+  implements V1_ValueSpecificationVisitor<V1_ValueSpecification> {
+  context: V1_GraphBuilderContext;
+  hasModifiedLambda = false;
+  constructor(context: V1_GraphBuilderContext) {
+    this.context = context;
+  }
+  visit_Class(spec: V1_Class): V1_ValueSpecification {
+    const classPath = spec.fullPath;
+    if (V1_shouldResolvePath(classPath)) {
+      spec.fullPath =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(classPath, this.context.resolveClass, this),
+        ) ?? classPath;
+    }
+    return spec;
+  }
+  visit_Enum(spec: V1_Enum): V1_ValueSpecification {
+    const enumPath = spec.fullPath;
+    if (V1_shouldResolvePath(enumPath)) {
+      spec.fullPath =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(
+            enumPath,
+            this.context.resolveEnumeration,
+            this,
+          ),
+        ) ?? enumPath;
+    }
+    return spec;
+  }
+  visit_EnumValue(spec: V1_EnumValue): V1_ValueSpecification {
+    const enumPath = spec.fullPath;
+    if (V1_shouldResolvePath(enumPath)) {
+      spec.fullPath =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(
+            enumPath,
+            this.context.resolveEnumeration,
+            this,
+          ),
+        ) ?? enumPath;
+    }
+    return spec;
+  }
+  visit_Variable(spec: V1_Variable): V1_ValueSpecification {
+    const classPath = spec.class;
+    if (classPath && V1_shouldResolvePath(classPath)) {
+      spec.class =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(classPath, this.context.resolveClass, this),
+        ) ?? classPath;
+    }
+    return spec;
+  }
+  visit_Lambda(spec: V1_Lambda): V1_ValueSpecification {
+    spec.body.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    spec.parameters.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_Path(valueSpecification: V1_Path): V1_ValueSpecification {
+    return valueSpecification;
+  }
+  visit_AppliedFunction(spec: V1_AppliedFunction): V1_ValueSpecification {
+    spec.parameters.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_AppliedProperty(spec: V1_AppliedProperty): V1_ValueSpecification {
+    const classPath = spec.class;
+    if (classPath && V1_shouldResolvePath(classPath)) {
+      spec.class =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(classPath, this.context.resolveClass, this),
+        ) ?? spec.class;
+    }
+    spec.parameters.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_Collection(spec: V1_Collection): V1_ValueSpecification {
+    spec.values.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_CInteger(spec: V1_CInteger): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CDecimal(spec: V1_CDecimal): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CString(spec: V1_CString): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CBoolean(spec: V1_CBoolean): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CFloat(spec: V1_CFloat): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CDateTime(spec: V1_CDateTime): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CStrictDate(spec: V1_CStrictDate): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CStrictTime(spec: V1_CStrictTime): V1_ValueSpecification {
+    return spec;
+  }
+  visit_CLatestDate(spec: V1_CLatestDate): V1_ValueSpecification {
+    return spec;
+  }
+  visit_AggregateValue(spec: V1_AggregateValue): V1_ValueSpecification {
+    spec.aggregateFn.accept_ValueSpecificationVisitor(this);
+    spec.mapFn.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+  visit_Pair(spec: V1_Pair): V1_ValueSpecification {
+    spec.first.accept_ValueSpecificationVisitor(this);
+    spec.second.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+  visit_MappingInstance(spec: V1_MappingInstance): V1_ValueSpecification {
+    const mappingPath = spec.fullPath;
+    if (V1_shouldResolvePath(mappingPath)) {
+      spec.fullPath =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(mappingPath, this.context.resolveMapping, this),
+        ) ?? mappingPath;
+    }
+    return spec;
+  }
+  visit_RuntimeInstance(spec: V1_RuntimeInstance): V1_ValueSpecification {
+    return spec;
+  }
+  visit_ExecutionContextInstance(
+    spec: V1_ExecutionContextInstance,
+  ): V1_ValueSpecification {
+    return spec;
+  }
+  visit_PureList(spec: V1_PureList): V1_ValueSpecification {
+    spec.values.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_RootGraphFetchTree(spec: V1_RootGraphFetchTree): V1_ValueSpecification {
+    const classPath = spec.class;
+    if (V1_shouldResolvePath(classPath)) {
+      spec.class =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(classPath, this.context.resolveClass, this),
+        ) ?? classPath;
+    }
+    spec.subTrees.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_PropertyGraphFetchTree(
+    spec: V1_PropertyGraphFetchTree,
+  ): V1_ValueSpecification {
+    const subType = spec.subType;
+    if (subType && V1_shouldResolvePath(subType)) {
+      spec.subType =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(subType, this.context.resolveType, this),
+        ) ?? subType;
+    }
+    spec.parameters.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    spec.subTrees.forEach((v) => v.accept_ValueSpecificationVisitor(this));
+    return spec;
+  }
+  visit_SerializationConfig(
+    spec: V1_SerializationConfig,
+  ): V1_ValueSpecification {
+    return spec;
+  }
+  visit_UnitType(spec: V1_UnitType): V1_ValueSpecification {
+    const unitPath = spec.unitType;
+    if (V1_shouldResolvePath(unitPath)) {
+      spec.unitType =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(unitPath, this.context.resolveUnit, this),
+        ) ?? unitPath;
+    }
+    return spec;
+  }
+  visit_UnitInstance(spec: V1_UnitInstance): V1_ValueSpecification {
+    const unitPath = spec.unitType;
+    if (V1_shouldResolvePath(unitPath)) {
+      spec.unitType =
+        returnUndefOnError(() =>
+          V1_resolveElementPath(unitPath, this.context.resolveUnit, this),
+        ) ?? unitPath;
+    }
+    return spec;
+  }
+  visit_KeyExpression(spec: V1_KeyExpression): V1_ValueSpecification {
+    spec.key.accept_ValueSpecificationVisitor(this);
+    spec.expression.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+  visit_PrimitiveType(spec: V1_PrimitiveType): V1_ValueSpecification {
+    return spec;
+  }
+  visit_TDSAggregateValue(spec: V1_TDSAggregateValue): V1_ValueSpecification {
+    spec.pmapFn.accept_ValueSpecificationVisitor(this);
+    spec.aggregateFn.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+  visit_TDSColumnInformation(
+    spec: V1_TDSColumnInformation,
+  ): V1_ValueSpecification {
+    spec.columnFn.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+  visit_TDSSortInformation(spec: V1_TDSSortInformation): V1_ValueSpecification {
+    return spec;
+  }
+  visit_TdsOlapRank(spec: V1_TdsOlapRank): V1_ValueSpecification {
+    spec.function.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+  visit_TdsOlapAggregation(spec: V1_TdsOlapAggregation): V1_ValueSpecification {
+    spec.function.accept_ValueSpecificationVisitor(this);
+    return spec;
+  }
+}
+
+function V1_resolveElementPath(
+  path: string,
+  resolverFunc: (
+    path: string,
+  ) => PackageableElementImplicitReference<PackageableElement>,
+  resolver: V1_ValueSpecificationResolver,
+): string {
+  const resolvedPath = resolverFunc(path).value.path;
+  // Note: this handles any system elements + primitve types already resolved. i.e String, ModelStore
+  if (resolvedPath !== path) {
+    resolver.hasModifiedLambda = true;
+  }
+  return resolvedPath;
+}
+
+const V1_transformV1RawLambdaToV1Lambda = (
+  v1RawLambda: V1_RawLambda,
+): V1_ValueSpecification => {
+  const v1RawLambdaJson = V1_serializeRawValueSpecification(v1RawLambda);
+  return V1_deserializeValueSpecification(v1RawLambdaJson);
+};
+
+const V1_transformV1LambdaToV1RawLambda = (
+  v1Lambda: V1_ValueSpecification,
+): V1_RawLambda => {
+  const v1LambdaJson = V1_serializeValueSpecification(v1Lambda);
+  const resolvedV1RawLambda = V1_deserializeRawValueSpecification(
+    v1LambdaJson,
+  ) as V1_RawLambda;
+  return resolvedV1RawLambda;
+};
+
+/**
+ * Method resolves element paths inside V1_RawLambda
+ * To do this we take V1_RawLamba (body: object, parameters: obect) convert it to V1_Lambda and
+ * resolve where possible (where an element path is defined as part of the value specification flow.
+ * When completed we convert it back to V1_RawLambda.
+ * This method ignores any function matching therefore if any time we encounter an error resolving an element path
+ * inside the value specification, we continue on the graph unchanging the value spec.
+ * We use this new resolved lamba if we have changed any element path (noted by the hasModifiedLambda flag)
+ * The whole flow is wrapper around a try/catch and we use the orginal lambda if any errors arise from this flow.
+ */
+const V1_resolveLambdaElementPaths = (
+  _context: V1_GraphBuilderContext,
+  v1RawLambda: V1_RawLambda,
+): V1_RawLambda => {
+  try {
+    // 1. Convert V1_RawLambda to V1_Lambda
+    const v1lambda = V1_transformV1RawLambdaToV1Lambda(v1RawLambda);
+    // 2. resolve V1_Lambda
+    const resolver = new V1_ValueSpecificationResolver(_context);
+    v1lambda.accept_ValueSpecificationVisitor(resolver);
+    // if the resolver has modified lambda then convert V1_Lambda to V1RawLambda and return
+    // else return orginal lambda
+    return resolver.hasModifiedLambda
+      ? V1_transformV1LambdaToV1RawLambda(v1lambda)
+      : v1RawLambda;
+  } catch (error: unknown) {
+    // return orginal lambda if anything goes wrong
+    assertErrorThrown(error);
+    error.message = `Can't resolve element paths for lambda:\n${error.message}`;
+    _context.logger.warn(CORE_LOG_EVENT.GRAPH_PROBLEM, error);
+    return v1RawLambda;
+  }
+};
+export const V1_rawLambdaBuilderWithResolver = (
+  _context: V1_GraphBuilderContext,
+  parameters?: object,
+  body?: object,
+): RawLambda => {
+  const rawLambda = new V1_RawLambda();
+  rawLambda.parameters = parameters ?? [];
+  rawLambda.body = body ?? [];
+  const resolverEnabled =
+    !_context.options?.TEMPORARY__disableRawLambdaResolver &&
+    !_context.options?.TEMPORARY__keepSectionIndex;
+  let resolved = rawLambda;
+  if (resolverEnabled) {
+    resolved = V1_resolveLambdaElementPaths(_context, rawLambda);
+  }
+  return new RawLambda(resolved.parameters, resolved.body);
+};

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
@@ -32,7 +32,6 @@ import {
   TestContainer,
   KeyedSingleExecutionTest,
 } from '../../../../../../../metamodels/pure/model/packageableElements/service/ServiceTest';
-import { RawLambda } from '../../../../../../../metamodels/pure/model/rawValueSpecification/RawLambda';
 import type { ServiceExecution } from '../../../../../../../metamodels/pure/model/packageableElements/service/ServiceExecution';
 import {
   PureSingleExecution,
@@ -63,6 +62,7 @@ import {
   V1_PackageableElementPointer,
   V1_PackageableElementPointerType,
 } from '../../../../model/packageableElements/V1_PackageableElement';
+import { V1_rawLambdaBuilderWithResolver } from './V1_RawLambdaResolver';
 
 export const V1_processServiceTest = (
   serviceTest: V1_ServiceTest,
@@ -78,7 +78,11 @@ export const V1_processServiceTest = (
     const singleTest = new SingleExecutionTest(parentService, serviceTest.data);
     singleTest.asserts = serviceTest.asserts.map((assert) => {
       const testContainer = new TestContainer(
-        new RawLambda(assert.assert.parameters, assert.assert.body),
+        V1_rawLambdaBuilderWithResolver(
+          context,
+          assert.assert.parameters,
+          assert.assert.body,
+        ),
         singleTest,
       );
       testContainer.parameterValues = assert.parameterValues;
@@ -120,7 +124,11 @@ export const V1_processServiceTest = (
       );
       keyedTest.asserts = test.asserts.map((assert) => {
         const testContaier = new TestContainer(
-          new RawLambda(assert.assert.parameters, assert.assert.body),
+          V1_rawLambdaBuilderWithResolver(
+            context,
+            assert.assert.parameters,
+            assert.assert.body,
+          ),
           keyedTest,
         );
         testContaier.parameterValues = assert.parameterValues;
@@ -232,7 +240,8 @@ export const V1_processServiceExecution = (
       'Service Pure execution function is missing',
     );
     return new PureSingleExecution(
-      new RawLambda(
+      V1_rawLambdaBuilderWithResolver(
+        context,
         serviceExecution.func.parameters,
         serviceExecution.func.body,
       ),
@@ -258,7 +267,8 @@ export const V1_processServiceExecution = (
     );
     const execution = new PureMultiExecution(
       serviceExecution.executionKey,
-      new RawLambda(
+      V1_rawLambdaBuilderWithResolver(
+        context,
         serviceExecution.func.parameters,
         serviceExecution.func.body,
       ),

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ValueSpecificationSerializer.ts
@@ -207,13 +207,13 @@ const V1_appliedFunctionModelSchema = createModelSchema(V1_AppliedFunction, {
 const appliedPropertyModelSchema = createModelSchema(V1_AppliedProperty, {
   _type: usingConstantValueSchema(V1_ValueSpecificationType.APPLIED_PROPERTY),
   class: optional(primitive()),
-  property: primitive(),
   parameters: list(
     custom(
       (val) => V1_serializeValueSpecification(val),
       (val) => V1_deserializeValueSpecification(val),
     ),
   ),
+  property: primitive(),
 });
 
 const collectionModelSchema = createModelSchema(V1_Collection, {

--- a/packages/legend-studio/src/stores/ApplicationConfig.ts
+++ b/packages/legend-studio/src/stores/ApplicationConfig.ts
@@ -98,7 +98,15 @@ class ApplicationCoreOptions {
    * to figure out how we want to store this element in SDLC.
    */
   EXPERIMENTAL__enableFullGrammarImportSupport = false;
-
+  /**
+   * Allows disabling of resolving element paths inside a RawLambda
+   *
+   * NOTE: when we move to save imports as part of the user's project, this feature
+   * will no longer be needed and can be removed. This flag will only be relevant if
+   * EXPERIMENTAL__enableFullGrammarImportSupport is set to false since full grammar import support
+   * will not require a lambda resolver.
+   */
+  TEMPORARY__disableRawLambdaResolver = false;
   /**
    * Allows disabling service registration as the Legend service operational infrastructure
    * has not been open-sourced yet.
@@ -125,6 +133,7 @@ class ApplicationCoreOptions {
       TEMPORARY__useSDLCProductionProjectsOnly: optional(primitive()),
       EXPERIMENTAL__enableFullGrammarImportSupport: optional(primitive()),
       TEMPORARY__disableServiceRegistration: optional(primitive()),
+      TEMPORARY__disableRawLambdaResolver: optional(primitive()),
       TEMPORARY__serviceRegistrationConfig: list(
         custom(
           (value) => SKIP,

--- a/packages/legend-studio/src/stores/GraphState.ts
+++ b/packages/legend-studio/src/stores/GraphState.ts
@@ -349,6 +349,8 @@ export class GraphState {
           .DEV__enableGraphImmutabilityRuntimeCheck,
         TEMPORARY__keepSectionIndex: this.editorStore.applicationStore.config
           .options.EXPERIMENTAL__enableFullGrammarImportSupport,
+        TEMPORARY__disableRawLambdaResolver: this.editorStore.applicationStore
+          .config.options.TEMPORARY__disableRawLambdaResolver,
       });
       // build generations
       yield this.graphManager.buildGenerations(
@@ -855,6 +857,8 @@ export class GraphState {
           .DEV__enableGraphImmutabilityRuntimeCheck,
         TEMPORARY__keepSectionIndex: this.editorStore.applicationStore.config
           .options.EXPERIMENTAL__enableFullGrammarImportSupport,
+        TEMPORARY__disableRawLambdaResolver: this.editorStore.applicationStore
+          .config.options.TEMPORARY__disableRawLambdaResolver,
       });
 
       // NOTE: build model generation entities every-time we rebuild the graph - should we do this?

--- a/packages/legend-studio/src/stores/StoreTestUtils.ts
+++ b/packages/legend-studio/src/stores/StoreTestUtils.ts
@@ -171,3 +171,37 @@ export const checkBuildingElementsRoundtrip = async (
     ).length,
   ).toBe(0);
 };
+
+export const checkBuildingResolvedElements = async (
+  entities: Entity[],
+  resolvedEntities: Entity[],
+  editorStore = getTestEditorStore(),
+): Promise<void> => {
+  await editorStore.graphState.initializeSystem();
+  await editorStore.graphState.graphManager.buildGraph(
+    editorStore.graphState.graph,
+    entities,
+  );
+  const transformedEntities = editorStore.graphState.graph.allElements.map(
+    (element) => editorStore.graphState.graphManager.elementToEntity(element),
+  );
+  // ensure that transformed entities have all fields ordered alphabetically
+  transformedEntities.forEach((entity) =>
+    ensureObjectFieldsAreSortedAlphabetically(entity.content),
+  );
+  // check if the contents are the same (i.e. roundtrip test)
+  expect(transformedEntities).toIncludeSameMembers(
+    excludeSectionIndex(resolvedEntities),
+  );
+  // check hash
+  await editorStore.graphState.graph.precomputeHashes(
+    editorStore.applicationStore.logger,
+  );
+  const protocolHashesIndex = await editorStore.graphState.graphManager.buildHashesIndex(
+    entities,
+  );
+  editorStore.changeDetectionState.workspaceLatestRevisionState.setEntityHashesIndex(
+    protocolHashesIndex,
+  );
+  await editorStore.changeDetectionState.computeLocalChanges(true);
+};

--- a/packages/legend-studio/src/stores/__tests__/buildGraph/RawLambaResolver.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/buildGraph/RawLambaResolver.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { unitTest } from '@finos/legend-studio-shared';
+import type { Entity } from '../../../models/sdlc/models/entity/Entity';
+import { checkBuildingResolvedElements } from '../../StoreTestUtils';
+
+const classEntity = (enumPath: string): Entity => ({
+  classifierPath: 'meta::pure::metamodel::type::Class',
+  content: {
+    _type: 'class',
+    name: 'Person',
+    package: 'model',
+    properties: [
+      {
+        multiplicity: {
+          lowerBound: 1,
+          upperBound: 1,
+        },
+        name: 'firstName',
+        type: 'String',
+      },
+    ],
+    qualifiedProperties: [
+      {
+        body: [
+          {
+            _type: 'func',
+            function: 'toString',
+            parameters: [
+              {
+                _type: 'property',
+                parameters: [
+                  {
+                    _type: 'enum',
+                    fullPath: enumPath,
+                  },
+                ],
+                property: 'A',
+              },
+            ],
+          },
+        ],
+        name: 'getEnum',
+        parameters: [],
+        returnMultiplicity: {
+          lowerBound: 1,
+          upperBound: 1,
+        },
+        returnType: 'String',
+      },
+    ],
+  },
+  path: 'model::Person',
+});
+
+const enumEntity: Entity = {
+  classifierPath: 'meta::pure::metamodel::type::Enumeration',
+  content: {
+    _type: 'Enumeration',
+    name: 'MyEnum',
+    package: 'model',
+    values: [
+      {
+        value: 'A',
+      },
+      {
+        value: 'B',
+      },
+    ],
+  },
+  path: 'model::MyEnum',
+};
+
+const sectionEntity: Entity = {
+  path: '__internal__::SectionIndex',
+  content: {
+    _type: 'sectionIndex',
+    name: 'SectionIndex',
+    package: '__internal__',
+    sections: [
+      {
+        _type: 'importAware',
+        elements: ['model::MyEnum', 'model::Person'],
+        imports: ['model'],
+        parserName: 'Pure',
+      },
+    ],
+  },
+  classifierPath: 'meta::pure::metamodel::section::SectionIndex',
+};
+
+test(
+  unitTest(`Raw Lambda inside a class's derived property has been resolved`),
+  async () => {
+    await checkBuildingResolvedElements(
+      [classEntity('MyEnum'), enumEntity, sectionEntity],
+      [classEntity('model::MyEnum'), enumEntity],
+    );
+  },
+);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Before making a PR, please read our contributing guidelines
https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md

🎉 Please fill out the summary table and read through the instructions.
-->

| Q                       | A                                |
| ----------------------- | -------------------------------- |
| Fixed issues?           | <!-- e.g. Fixes #1, Fixes #2 --> |
| Tests added + passed?   | Yes                              |
| Changeset added?        | Yes                              |
| Documentation PR link   |                                  |
| Any dependency changes? | No                               |

<!--
Summary fill-out guides:

- Test: https://github.com/finos/legend-studio/blob/master/docs/test-strategy.md
- Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
- Documentation: Link to a PR from https://github.com/finos/legend repo
- Dependency: https://github.com/finos/legend-studio/blob/master/docs/dependencies.md

NOTE: For component/style changes: Please check out our style guide https://github.com/finos/legend-studio/tree/master/docs/ux. Also, PR involving UX/UI might take more time to discuss and review.

Last but not least, describe your changes below in as much detail as possible in the space below 🎉
-->
This adds a RawLambdaResolver as well as small fixes to the schema and model definition of V1_AppliedProperty. The main points of the PR are 

- [X] A RawLambda resolver is added to resolve element paths inside lambdas that leverage imports. The resolver was added since the SDLC server does not currently support the use of sections (element containing imports). Currently, we resolve element paths everywhere in the app except in the lambdas since lambdas are kept in the format they are saved in the SDLC server. This resolver allows the graph to be compiled without the need to save the section elements.
- [X]  The cardinality of V1_AppliedProperty was fixed to not require a class and match the protocol in pure.
- [X] The ordering of the schema of V1_AppliedProperty was fixed to be alphabetically ordered.

