### PR TITLE
Query builder MVP stabilization

### DIFF
--- a/.changeset/mean-emus-clean.md
+++ b/.changeset/mean-emus-clean.md
@@ -1,9 +1,8 @@
 ---
 '@finos/legend-studio': minor
-'@finos/legend-studio-components': minor
-'@finos/legend-studio-app': minor
 ---
 
+pr: #171
 **BREAKING CHANGE** Studio router is reorganized to be more consistent and to accomondate more use cases.
 
 - All routes now are to be prefixed with the SDLC server key, if there is only one SDLC server specified in the config file (with legacy SDLC field config form: `sdlc: { url: string }`), then the server key is `-`, i.e. `/studio/-/...`, else the server key is the key to the SDLC instance, i.e. `/studio/sdlc1/...`.

--- a/.changeset/neat-beers-report.md
+++ b/.changeset/neat-beers-report.md
@@ -1,0 +1,9 @@
+---
+'@finos/legend-studio-plugin-query-builder': patch
+---
+
+Stabilize query builder MVP (see #174 for more details): This includes some minor UX improvements as well as support for:
+
+- Handling property with multiplicity many `[*]` in filter with `exists()`.
+- Properly handling group operations with more than 2 clauses.
+- Add support for set operators, such as `in/not-in`.

--- a/.changeset/silver-bears-help.md
+++ b/.changeset/silver-bears-help.md
@@ -1,0 +1,7 @@
+---
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-plugin-query-builder': patch
+'@finos/legend-studio-shared': patch
+---

--- a/packages/legend-studio-components/style/base/_variables.scss
+++ b/packages/legend-studio-components/style/base/_variables.scss
@@ -47,6 +47,7 @@
   --color-magenta-50: #d06c99;
   --color-magenta-70: #f152b1;
   --color-magenta-100: #bb619b;
+  --color-magenta-300: #8c4268;
   --color-pink-0: #ffc0cb;
   --color-pink-200: #f05577;
   --color-pink-300: #d14664;

--- a/packages/legend-studio-plugin-query-builder/package.json
+++ b/packages/legend-studio-plugin-query-builder/package.json
@@ -40,6 +40,7 @@
     "@finos/legend-studio": "workspace:*",
     "@finos/legend-studio-components": "workspace:*",
     "@finos/legend-studio-shared": "workspace:*",
+    "@types/papaparse": "5.2.5",
     "@types/react": "17.0.3",
     "@types/react-dom": "17.0.3",
     "@types/react-router-dom": "5.1.7",
@@ -47,6 +48,7 @@
     "mobx": "6.2.0",
     "mobx-react-lite": "3.2.0",
     "monaco-editor": "0.23.0",
+    "papaparse": "5.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "5.2.0"

--- a/packages/legend-studio-plugin-query-builder/src/QueryBuilderPlugin.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/QueryBuilderPlugin.tsx
@@ -37,13 +37,27 @@ import { flowResult } from 'mobx';
 import type { IKeyboardEvent } from 'monaco-editor';
 import { KeyCode } from 'monaco-editor';
 
+interface QueryBuilderPluginConfigData {
+  TEMPORARY__enableGraphFetch: boolean;
+}
+
 export class QueryBuilderPlugin extends EditorPlugin {
+  TEMPORARY__enableGraphFetch = false;
+
   constructor() {
     super(packageJson.name, packageJson.version);
   }
 
   install(pluginManager: PluginManager): void {
     pluginManager.registerEditorPlugin(this);
+  }
+
+  configure(_configData: object): QueryBuilderPlugin {
+    const configData = _configData as QueryBuilderPluginConfigData;
+    this.TEMPORARY__enableGraphFetch = Boolean(
+      configData.TEMPORARY__enableGraphFetch,
+    );
+    return this;
   }
 
   getExtraEditorExtensionComponentRendererConfigurations(): EditorExtensionComponentRendererConfiguration[] {
@@ -62,7 +76,9 @@ export class QueryBuilderPlugin extends EditorPlugin {
   getExtraEditorExtensionStateCreators(): EditorExtensionStateCreator[] {
     return [
       (editorStore: EditorStore): EditorExtensionState | undefined =>
-        new QueryBuilderState(editorStore),
+        new QueryBuilderState(editorStore, {
+          TEMPORARY__enableGraphFetch: this.TEMPORARY__enableGraphFetch,
+        }),
     ];
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/QueryBuilder_Constants.ts
+++ b/packages/legend-studio-plugin-query-builder/src/QueryBuilder_Constants.ts
@@ -23,5 +23,3 @@ export enum QUERY_BUILDER_TEST_ID {
 }
 
 export const DEFAULT_LAMBDA_VARIABLE_NAME = 'x';
-export const NOT_FUNCTION_NAME = 'not';
-export const EXISTS_FUNCTION_NAME = 'exists';

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderFetchStructurePanel.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderFetchStructurePanel.tsx
@@ -78,25 +78,27 @@ export const QueryBuilderFetchStructurePanel = observer(
             <div className="panel__header__title__label">fetch structure</div>
           </div>
           <div className="panel__header__actions">
-            <div className="query-builder__fetch__structure__modes">
-              {Object.values(FETCH_STRUCTURE_MODE).map((fetchMode) => (
-                // TODO: might want to add alert modal to alert user changing fetch structure rests state
-                <button
-                  onClick={(): void =>
-                    fetchStructureState.handleFetchStructureModeChange(
-                      fetchMode,
-                    )
-                  }
-                  className={clsx('query-builder__fetch__structure__mode', {
-                    'query-builder__fetch__structure__mode--selected':
-                      fetchMode === fetchStructureState.fetchStructureMode,
-                  })}
-                  key={fetchMode}
-                >
-                  {prettyCONSTName(fetchMode)}
-                </button>
-              ))}
-            </div>
+            {queryBuilderState.TEMPORARY__enableGraphFetch && (
+              <div className="query-builder__fetch__structure__modes">
+                {Object.values(FETCH_STRUCTURE_MODE).map((fetchMode) => (
+                  // TODO: might want to add alert modal to alert user changing fetch structure rests state
+                  <button
+                    onClick={(): void =>
+                      fetchStructureState.handleFetchStructureModeChange(
+                        fetchMode,
+                      )
+                    }
+                    className={clsx('query-builder__fetch__structure__mode', {
+                      'query-builder__fetch__structure__mode--selected':
+                        fetchMode === fetchStructureState.fetchStructureMode,
+                    })}
+                    key={fetchMode}
+                  >
+                    {prettyCONSTName(fetchMode)}
+                  </button>
+                ))}
+              </div>
+            )}
             <button
               className="panel__header__action"
               onClick={openModal}

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderFilterPanel.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderFilterPanel.tsx
@@ -226,7 +226,7 @@ const QueryBuilderFilterConditionEditor = observer(
             <button
               className="query-builder-filter-tree__condition-node__operator__dropdown__trigger"
               tabIndex={-1}
-              title="Choose Operation..."
+              title="Choose Operator..."
             >
               <FaCaretDown />
             </button>
@@ -235,6 +235,11 @@ const QueryBuilderFilterConditionEditor = observer(
             <div className="query-builder-filter-tree__condition-node__value">
               <QueryBuilderValueSpecificationEditor
                 valueSpecification={node.condition.value}
+                graph={node.condition.editorStore.graphState.graph}
+                expectedType={
+                  node.condition.propertyEditorState.propertyExpression.func
+                    .genericType.value.rawType
+                }
               />
             </div>
           )}

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderFilterPanel.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderFilterPanel.tsx
@@ -26,6 +26,7 @@ import {
   FaPlus,
   FaPlusCircle,
   FaTimes,
+  FaCircle,
   FaCaretDown,
 } from 'react-icons/fa';
 import { BsFillTriangleFill } from 'react-icons/bs';
@@ -646,6 +647,10 @@ export const QueryBuilderFilterPanel = observer(
       filterState.suppressClickawayEventListener();
       filterState.pruneTree();
     };
+    const simplifyTree = (): void => {
+      filterState.suppressClickawayEventListener();
+      filterState.simplifyTree();
+    };
     const createCondition = (): void => {
       filterState.suppressClickawayEventListener();
       filterState.addNodeFromNode(
@@ -778,6 +783,14 @@ export const QueryBuilderFilterPanel = observer(
               title="Cleanup Tree"
             >
               <FaBrush />
+            </button>
+            <button
+              className="panel__header__action"
+              onClick={simplifyTree}
+              tabIndex={-1}
+              title="Simplify Tree"
+            >
+              <FaCircle />
             </button>
             <button
               className="panel__header__action"

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderLambdaEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderLambdaEditor.tsx
@@ -65,9 +65,11 @@ export const QueryBuilderLambdaEditor = observer(
         >
           <div className="modal__header">
             <div className="modal__title">Query</div>
-            <div className="modal__title__error-badge">
-              Failed to parse query
-            </div>
+            {queryTextEditorState.parserError && (
+              <div className="modal__title__error-badge">
+                Failed to parse query
+              </div>
+            )}
           </div>
           <div className="modal__body">
             <div
@@ -98,12 +100,14 @@ export const QueryBuilderLambdaEditor = observer(
             </div>
           </div>
           <div className="modal__footer">
-            <button
-              className="btn btn--dark btn--caution"
-              onClick={discardChanges}
-            >
-              Discard changes
-            </button>
+            {mode === QueryTextEditorMode.TEXT && (
+              <button
+                className="btn btn--dark btn--caution"
+                onClick={discardChanges}
+              >
+                Discard changes
+              </button>
+            )}
             <button
               className="btn btn--dark"
               onClick={close}

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderLambdaEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderLambdaEditor.tsx
@@ -34,6 +34,8 @@ export const QueryBuilderLambdaEditor = observer(
     const queryTextEditorState = queryBuilderState.queryTextEditorState;
     const close = (): Promise<void> =>
       queryBuilderState.queryTextEditorState.closeModal();
+    const discardChanges = (): void =>
+      queryBuilderState.queryTextEditorState.setMode(undefined);
     const mode = queryTextEditorState.mode;
     useEffect(() => {
       queryTextEditorState
@@ -69,13 +71,14 @@ export const QueryBuilderLambdaEditor = observer(
                   forceBackdrop={false}
                   forceExpansion={true}
                   useBaseTextEditorSettings={true}
+                  hideErrorBar={true}
                 />
               )}
               {mode === QueryTextEditorMode.JSON && (
                 <div className="panel__content mapping-execution-panel__json-editor">
                   <TextInputEditor
                     language={EDITOR_LANGUAGE.JSON}
-                    inputValue={queryTextEditorState.lambdaJson}
+                    inputValue={queryTextEditorState.readOnlylambdaJson}
                     isReadOnly={true}
                   />
                 </div>
@@ -84,8 +87,15 @@ export const QueryBuilderLambdaEditor = observer(
           </div>
           <div className="modal__footer">
             <button
-              className="btn query-builder-text-mode__modal__close-btn"
+              className="btn btn--dark btn--caution"
+              onClick={discardChanges}
+            >
+              Discard changes
+            </button>
+            <button
+              className="btn btn--dark"
               onClick={close}
+              disabled={Boolean(queryTextEditorState.parserError)}
             >
               Close
             </button>

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderLambdaEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderLambdaEditor.tsx
@@ -53,9 +53,21 @@ export const QueryBuilderLambdaEditor = observer(
           paper: 'editor-modal__content',
         }}
       >
-        <div className="modal modal--dark editor-modal query-builder-text-mode__modal">
+        <div
+          className={clsx(
+            'modal modal--dark editor-modal query-builder-text-mode__modal',
+            {
+              'query-builder-text-mode__modal--has-error': Boolean(
+                queryTextEditorState.parserError,
+              ),
+            },
+          )}
+        >
           <div className="modal__header">
-            <div className="modal__title">Query </div>
+            <div className="modal__title">Query</div>
+            <div className="modal__title__error-badge">
+              Failed to parse query
+            </div>
           </div>
           <div className="modal__body">
             <div

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -62,6 +62,13 @@ const DerivedPropertyExpressionEditor = observer(
             }`}</div>
             <QueryBuilderValueSpecificationEditor
               valueSpecification={parameterValues[idx]}
+              graph={
+                derivedPropertyExpressionState.editorStore.graphState.graph
+              }
+              expectedType={
+                derivedPropertyExpressionState.propertyExpression.func
+                  .genericType.value.rawType
+              }
             />
             <div className="panel__content__form__section__list"></div>
           </div>

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderValueSpecificationEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderValueSpecificationEditor.tsx
@@ -14,17 +14,41 @@
  * limitations under the License.
  */
 
-import type { Enum, ValueSpecification } from '@finos/legend-studio';
+import { useEffect, useRef, useState } from 'react';
+import type {
+  Enum,
+  PureModel,
+  Type,
+  ValueSpecification,
+} from '@finos/legend-studio';
 import {
+  Enumeration,
+  GenericType,
+  GenericTypeExplicitReference,
+  PrimitiveType,
+  TYPICAL_MULTIPLICITY_TYPE,
+} from '@finos/legend-studio';
+import {
+  CollectionInstanceValue,
   EnumValueExplicitReference,
   EnumValueInstanceValue,
   PrimitiveInstanceValue,
   PRIMITIVE_TYPE,
 } from '@finos/legend-studio';
-import { FaCheckSquare, FaSquare } from 'react-icons/fa';
+import { FaCheckSquare, FaSquare, FaSave } from 'react-icons/fa';
 import { observer } from 'mobx-react-lite';
-import { clsx, CustomSelectorInput } from '@finos/legend-studio-components';
-import { guaranteeNonNullable } from '@finos/legend-studio-shared';
+import {
+  clsx,
+  CustomSelectorInput,
+  PencilIcon,
+} from '@finos/legend-studio-components';
+import {
+  guaranteeNonNullable,
+  isNonNullable,
+  returnUndefOnError,
+  uniq,
+} from '@finos/legend-studio-shared';
+import CSVParser from 'papaparse';
 
 const StringPrimitiveInstanceValueEditor = observer(
   (props: { valueSpecification: PrimitiveInstanceValue }) => {
@@ -148,10 +172,200 @@ const EnumValueInstanceValueEditor = observer(
   },
 );
 
+const stringifyValue = (values: ValueSpecification[]): string => {
+  if (values.length === 0) {
+    return '';
+  }
+  return CSVParser.unparse([
+    values
+      .map((val) => {
+        if (val instanceof PrimitiveInstanceValue) {
+          return val.values[0];
+        } else if (val instanceof EnumValueInstanceValue) {
+          return guaranteeNonNullable(val.values[0]).value.name;
+        }
+        return undefined;
+      })
+      .filter(isNonNullable),
+  ]).trim();
+};
+
+const setCollectionValue = (
+  valueSpecification: CollectionInstanceValue,
+  graph: PureModel,
+  expectedType: Type,
+  value: string,
+): void => {
+  if (value.trim().length === 0) {
+    valueSpecification.changeValues([]);
+    return;
+  }
+  const multiplicityOne = graph.getTypicalMultiplicity(
+    TYPICAL_MULTIPLICITY_TYPE.ONE,
+  );
+  let result: unknown[] = [];
+  const parseResult = CSVParser.parse<string[]>(value.trim());
+  const parseData = parseResult.data[0]; // only take the first line
+  if (parseResult.errors.length) {
+    // just escape
+    return;
+  } else if (expectedType instanceof PrimitiveType) {
+    switch (expectedType.path) {
+      case PRIMITIVE_TYPE.STRING: {
+        result = uniq(parseData)
+          .map((item): PrimitiveInstanceValue | undefined => {
+            const primitiveInstanceValue = new PrimitiveInstanceValue(
+              GenericTypeExplicitReference.create(
+                new GenericType(expectedType),
+              ),
+              multiplicityOne,
+            );
+            primitiveInstanceValue.values = [item.toString()];
+            return primitiveInstanceValue;
+          })
+          .filter(isNonNullable);
+        break;
+      }
+      case PRIMITIVE_TYPE.NUMBER:
+      case PRIMITIVE_TYPE.FLOAT:
+      case PRIMITIVE_TYPE.DECIMAL:
+      case PRIMITIVE_TYPE.INTEGER: {
+        result = uniq(
+          parseData
+            .filter((val) => !isNaN(Number(val)))
+            .map((val) => Number(val)),
+        )
+          .map((item): PrimitiveInstanceValue | undefined => {
+            const primitiveInstanceValue = new PrimitiveInstanceValue(
+              GenericTypeExplicitReference.create(
+                new GenericType(expectedType),
+              ),
+              multiplicityOne,
+            );
+            primitiveInstanceValue.values = [item];
+            return primitiveInstanceValue;
+          })
+          .filter(isNonNullable);
+        break;
+      }
+      default:
+        return;
+    }
+  } else if (expectedType instanceof Enumeration) {
+    result = uniq(parseData.map((item) => item.trim()))
+      .map((item): EnumValueInstanceValue | undefined => {
+        const _enum = returnUndefOnError(() => expectedType.getValue(item));
+        if (!_enum) {
+          return undefined;
+        }
+        const enumValueInstanceValue = new EnumValueInstanceValue(
+          GenericTypeExplicitReference.create(new GenericType(expectedType)),
+          multiplicityOne,
+        );
+        enumValueInstanceValue.values = [
+          EnumValueExplicitReference.create(_enum),
+        ];
+        return enumValueInstanceValue;
+      })
+      .filter(isNonNullable);
+  }
+  valueSpecification.changeValues(result);
+};
+
+const COLLECTION_PREVIEW_CHAR_LIMIT = 50;
+
+const CollectionValueInstanceValueEditor = observer(
+  (props: {
+    valueSpecification: CollectionInstanceValue;
+    graph: PureModel;
+    expectedType: Type;
+  }) => {
+    const { valueSpecification, graph, expectedType } = props;
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [text, setText] = useState(stringifyValue(valueSpecification.values));
+    const [editable, setEditable] = useState(false);
+    const valueText = stringifyValue(valueSpecification.values);
+    const previewText = `List(${
+      valueSpecification.values.length === 0
+        ? 'empty'
+        : valueSpecification.values.length
+    })${
+      valueSpecification.values.length === 0
+        ? ''
+        : `: ${
+            valueText.length > COLLECTION_PREVIEW_CHAR_LIMIT
+              ? `${valueText.substring(0, COLLECTION_PREVIEW_CHAR_LIMIT)}...`
+              : valueText
+          }`
+    }`;
+    const enableEdit = (): void => setEditable(true);
+    const saveEdit = (): void => {
+      setEditable(false);
+      setCollectionValue(valueSpecification, graph, expectedType, text);
+      setText(stringifyValue(valueSpecification.values));
+    };
+    const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) =>
+      setText(event.target.value);
+
+    // focus the input box when edit is enabled
+    useEffect(() => {
+      if (editable) {
+        inputRef.current?.focus();
+      }
+    }, [editable]);
+
+    if (editable) {
+      return (
+        <div className="query-builder-value-spec-editor">
+          <input
+            ref={inputRef}
+            className="panel__content__form__section__input query-builder-value-spec-editor__input"
+            spellCheck={false}
+            value={text}
+            placeholder={text === '' ? '(empty)' : undefined}
+            onChange={changeValue}
+          />
+          <button
+            className="query-builder-value-spec-editor__list-editor__save-button btn--dark"
+            onClick={saveEdit}
+          >
+            <FaSave />
+          </button>
+        </div>
+      );
+    }
+    return (
+      <div
+        className="query-builder-value-spec-editor"
+        onClick={enableEdit}
+        title="Click to edit"
+      >
+        <input
+          className="query-builder-value-spec-editor__list-editor__preview"
+          spellCheck={false}
+          value={previewText}
+          disabled={true}
+        />
+        <button className="query-builder-value-spec-editor__list-editor__edit-icon">
+          <PencilIcon />
+        </button>
+      </div>
+    );
+  },
+);
+
+export const QueryBuilderUnsupportedValueSpecificationEditor: React.FC<{}> = () => (
+  <div className="query-builder-value-spec-editor--unsupported">
+    unsupported
+  </div>
+);
+
 export const QueryBuilderValueSpecificationEditor: React.FC<{
   valueSpecification: ValueSpecification;
+  graph: PureModel;
+  expectedType: Type;
 }> = (props) => {
-  const { valueSpecification } = props;
+  const { valueSpecification, graph, expectedType } = props;
   if (valueSpecification instanceof PrimitiveInstanceValue) {
     const _type = valueSpecification.genericType.value.rawType;
     switch (_type.path) {
@@ -184,14 +398,22 @@ export const QueryBuilderValueSpecificationEditor: React.FC<{
           />
         );
       default:
-        return <div>(unsupported)</div>;
+        return <QueryBuilderUnsupportedValueSpecificationEditor />;
     }
   } else if (valueSpecification instanceof EnumValueInstanceValue) {
     return (
       <EnumValueInstanceValueEditor valueSpecification={valueSpecification} />
     );
+  } else if (valueSpecification instanceof CollectionInstanceValue) {
+    return (
+      <CollectionValueInstanceValueEditor
+        valueSpecification={valueSpecification}
+        graph={graph}
+        expectedType={expectedType}
+      />
+    );
   }
   // property expression
   // variable expression
-  return <div>(unsupported)</div>;
+  return <QueryBuilderUnsupportedValueSpecificationEditor />;
 };

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderValueSpecificationEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderValueSpecificationEditor.tsx
@@ -26,14 +26,12 @@ import {
   GenericType,
   GenericTypeExplicitReference,
   PrimitiveType,
-  TYPICAL_MULTIPLICITY_TYPE,
-} from '@finos/legend-studio';
-import {
   CollectionInstanceValue,
   EnumValueExplicitReference,
   EnumValueInstanceValue,
   PrimitiveInstanceValue,
   PRIMITIVE_TYPE,
+  TYPICAL_MULTIPLICITY_TYPE,
 } from '@finos/legend-studio';
 import { FaCheckSquare, FaSquare, FaSave } from 'react-icons/fa';
 import { observer } from 'mobx-react-lite';
@@ -213,7 +211,7 @@ const setCollectionValue = (
       parseResult.errors.length === 1 &&
       parseResult.errors[0].code === 'UndetectableDelimiter' &&
       parseResult.errors[0].type === 'Delimiter' &&
-      parseResult?.data.length === 1
+      parseResult.data.length === 1
     ) {
       // NOTE: this happens when the user only put one item in the value input
       // we can go the other way by ensure the input has a comma but this is arguably neater

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderValueSpecificationEditor.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderValueSpecificationEditor.tsx
@@ -188,6 +188,12 @@ const stringifyValue = (values: ValueSpecification[]): string => {
   ]).trim();
 };
 
+/**
+ * NOTE: We attempt to be less disruptive here by not throwing errors left and right, instead
+ * we silently remove values which are not valid or parsable. But perhaps, we can consider
+ * passing in logger or notifier to show give the users some idea of what went wrong instead
+ * of silently swallow parts of their inputs like this.
+ */
 const setCollectionValue = (
   valueSpecification: CollectionInstanceValue,
   graph: PureModel,

--- a/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder.test.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder.test.tsx
@@ -33,6 +33,8 @@ import {
   firmPersonGraphFetch,
   simpleGraphFetch,
 } from './QueryBuilderTestData';
+import COVIDDataSimpleModel from './QueryBuilder_Model_COVID.json';
+import SimpleM2MModel from './QueryBuilder_Model_SimpleM2M.json';
 import {
   integrationTest,
   guaranteeNonNullable,
@@ -55,11 +57,20 @@ import {
   RawLambda,
   setUpEditorWithDefaultSDLCData,
 } from '@finos/legend-studio';
-
 import { QUERY_BUILDER_TEST_ID } from '../../QueryBuilder_Constants';
 import { QueryBuilderState } from '../../stores/QueryBuilderState';
 import { flowResult } from 'mobx';
 import { QueryBuilderPlugin } from '../../QueryBuilderPlugin';
+import {
+  lambda_enumerationOperatorFilter,
+  lambda_existsChainFilter,
+  lambda_existsChainFilterWithCustomVariableName,
+  lambda_groupConditionFilter,
+  lambda_groupConditionFilter_withMultipleClauseGroup,
+  lambda_notOperatorFilter,
+  lambda_setOperatorFilter,
+  lambda_simpleSingleConditionFilter,
+} from './QueryBuilder_Roundtrip_TestFilterQueries';
 
 let renderResult: RenderResult;
 
@@ -391,83 +402,6 @@ test(
   // TODO: add more test when we rework the graph fetch tree
 );
 
-const testRoundtrip = (
-  jsonRawLambda: { parameters?: object; body?: object },
-  mockedEditorStore: EditorStore,
-): void => {
-  const queryBuilderState = mockedEditorStore.getEditorExtensionState(
-    QueryBuilderState,
-  );
-  queryBuilderState.buildWithRawLambda(getRawLambda(jsonRawLambda));
-  const jsonQuery = mockedEditorStore.graphState.graphManager.serializeRawValueSpecification(
-    queryBuilderState.getRawLambdaQuery(),
-  );
-  expect([jsonRawLambda]).toIncludeSameMembers([jsonQuery]);
-};
-
-test(
-  integrationTest(
-    'Tests the processing of projection lambdas through the query builder state',
-  ),
-  async () => {
-    const mockedEditorStore = await init(queryBuilderTestData);
-    MOBX__enableSpyOrMock();
-    mockedEditorStore.graphState.globalCompileInFormMode = jest.fn();
-    MOBX__disableSpyOrMock();
-    const queryBuilderState = mockedEditorStore.getEditorExtensionState(
-      QueryBuilderState,
-    );
-    await flowResult(queryBuilderState.setOpenQueryBuilder(true));
-    queryBuilderState.querySetupState.setClass(
-      mockedEditorStore.graphState.graph.getClass(
-        'model::pure::tests::model::simple::Person',
-      ),
-    );
-    queryBuilderState.resetData();
-    const queryBuilderSetup = await waitFor(() =>
-      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
-    );
-    // ensure form has updated with respect to the new state
-    await waitFor(() => getByText(queryBuilderSetup, 'Person'));
-    await waitFor(() =>
-      getByText(queryBuilderSetup, 'simpleRelationalMapping'),
-    );
-    await waitFor(() => getByText(queryBuilderSetup, 'MyRuntime'));
-    // test various lambdas
-    testRoundtrip(simpleProjection, mockedEditorStore);
-    testRoundtrip(projectionWithChainedProperty, mockedEditorStore);
-    testRoundtrip(projectionWithResultSetModifiers, mockedEditorStore);
-    testRoundtrip(getAllWithOneConditionFilter, mockedEditorStore);
-    testRoundtrip(getAllWithGroupedFilter, mockedEditorStore);
-    testRoundtrip(projectWithDerivedProperty, mockedEditorStore);
-    testRoundtrip(fullComplexProjectionQuery, mockedEditorStore);
-  },
-);
-
-test(integrationTest('Roundtrip for graph fetch tree'), async () => {
-  // Graph Fetch
-  const mockedEditorStore = await init(m2mTestData);
-  MOBX__enableSpyOrMock();
-  mockedEditorStore.graphState.globalCompileInFormMode = jest.fn();
-  MOBX__disableSpyOrMock();
-  const queryBuilderState = mockedEditorStore.getEditorExtensionState(
-    QueryBuilderState,
-  );
-  await flowResult(queryBuilderState.setOpenQueryBuilder(true));
-  queryBuilderState.querySetupState.setClass(
-    mockedEditorStore.graphState.graph.getClass('demo::other::NPerson'),
-  );
-  queryBuilderState.resetData();
-  const queryBuilderSetup = await waitFor(() =>
-    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
-  );
-  // ensure form has updated with respect to the new state
-  await waitFor(() => getByText(queryBuilderSetup, 'NPerson'));
-  await waitFor(() => getByText(queryBuilderSetup, 'MyMapping'));
-  testRoundtrip(simpleGraphFetch, mockedEditorStore);
-  testRoundtrip(firmPersonGraphFetch, mockedEditorStore);
-});
-
 test(integrationTest('Test unsupported functions'), async () => {
   const mockedEditorStore = await init(queryBuilderTestData);
   MOBX__enableSpyOrMock();
@@ -500,9 +434,147 @@ test(integrationTest('Test unsupported functions'), async () => {
   expect(() =>
     queryBuilderState.buildWithRawLambda(getRawLambda(errorInGraphLambda)),
   ).toThrowError(
-    "Can't find type 'model::pure::tests::model::simple::NotFound",
+    "Can't find type 'model::pure::tests::model::simple::NotFound'",
   );
   expect(() =>
     queryBuilderState.buildWithRawLambda(getRawLambda(unSupportedFunctionName)),
   ).toThrowError(`Can't process function 'testUnSupported'`);
+});
+
+// ------------------------------------------- ROUNDTRIP -----------------------------------------
+//
+// TODO: consider moving these to state/store directory as these are testing for the state
+// rather than the UI (we only use the UI to launch query builder)
+
+const testRoundtrip = (
+  jsonRawLambda: { parameters?: object; body?: object },
+  mockedEditorStore: EditorStore,
+): void => {
+  const queryBuilderState = mockedEditorStore.getEditorExtensionState(
+    QueryBuilderState,
+  );
+  queryBuilderState.buildWithRawLambda(getRawLambda(jsonRawLambda));
+  const jsonQuery = mockedEditorStore.graphState.graphManager.serializeRawValueSpecification(
+    queryBuilderState.getRawLambdaQuery(),
+  );
+  expect([jsonRawLambda]).toIncludeSameMembers([jsonQuery]);
+};
+
+test(integrationTest('Roundtrip for projection'), async () => {
+  const mockedEditorStore = await init(queryBuilderTestData);
+  MOBX__enableSpyOrMock();
+  mockedEditorStore.graphState.globalCompileInFormMode = jest.fn();
+  MOBX__disableSpyOrMock();
+  const queryBuilderState = mockedEditorStore.getEditorExtensionState(
+    QueryBuilderState,
+  );
+  await flowResult(queryBuilderState.setOpenQueryBuilder(true));
+  queryBuilderState.querySetupState.setClass(
+    mockedEditorStore.graphState.graph.getClass(
+      'model::pure::tests::model::simple::Person',
+    ),
+  );
+  queryBuilderState.resetData();
+  const queryBuilderSetup = await waitFor(() =>
+    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
+  );
+  // ensure form has updated with respect to the new state
+  await waitFor(() => getByText(queryBuilderSetup, 'Person'));
+  await waitFor(() => getByText(queryBuilderSetup, 'simpleRelationalMapping'));
+  await waitFor(() => getByText(queryBuilderSetup, 'MyRuntime'));
+  // test various lambdas
+  testRoundtrip(simpleProjection, mockedEditorStore);
+  testRoundtrip(projectionWithChainedProperty, mockedEditorStore);
+  testRoundtrip(projectionWithResultSetModifiers, mockedEditorStore);
+  testRoundtrip(getAllWithOneConditionFilter, mockedEditorStore);
+  testRoundtrip(getAllWithGroupedFilter, mockedEditorStore);
+  testRoundtrip(projectWithDerivedProperty, mockedEditorStore);
+  testRoundtrip(fullComplexProjectionQuery, mockedEditorStore);
+});
+
+test(integrationTest('Roundtrip for graph fetch tree'), async () => {
+  // Graph Fetch
+  const mockedEditorStore = await init(m2mTestData);
+  MOBX__enableSpyOrMock();
+  mockedEditorStore.graphState.globalCompileInFormMode = jest.fn();
+  MOBX__disableSpyOrMock();
+  const queryBuilderState = mockedEditorStore.getEditorExtensionState(
+    QueryBuilderState,
+  );
+  await flowResult(queryBuilderState.setOpenQueryBuilder(true));
+  queryBuilderState.querySetupState.setClass(
+    mockedEditorStore.graphState.graph.getClass('demo::other::NPerson'),
+  );
+  queryBuilderState.resetData();
+  const queryBuilderSetup = await waitFor(() =>
+    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
+  );
+  // ensure form has updated with respect to the new state
+  await waitFor(() => getByText(queryBuilderSetup, 'NPerson'));
+  await waitFor(() => getByText(queryBuilderSetup, 'MyMapping'));
+  testRoundtrip(simpleGraphFetch, mockedEditorStore);
+  testRoundtrip(firmPersonGraphFetch, mockedEditorStore);
+});
+
+test(
+  integrationTest('Roundtrip for filter expression (relational)'),
+  async () => {
+    const mockedEditorStore = await init(COVIDDataSimpleModel);
+    MOBX__enableSpyOrMock();
+    mockedEditorStore.graphState.globalCompileInFormMode = jest.fn();
+    MOBX__disableSpyOrMock();
+    const queryBuilderState = mockedEditorStore.getEditorExtensionState(
+      QueryBuilderState,
+    );
+    await flowResult(queryBuilderState.setOpenQueryBuilder(true));
+    queryBuilderState.querySetupState.setClass(
+      mockedEditorStore.graphState.graph.getClass('domain::COVIDData'),
+    );
+    queryBuilderState.resetData();
+    const queryBuilderSetup = await waitFor(() =>
+      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
+    );
+    // ensure form has updated with respect to the new state
+    await waitFor(() => getByText(queryBuilderSetup, 'COVIDData'));
+    await waitFor(() => getByText(queryBuilderSetup, 'CovidDataMapping'));
+    await waitFor(() => getByText(queryBuilderSetup, 'H2Runtime'));
+    // test various lambdas
+    testRoundtrip(lambda_simpleSingleConditionFilter, mockedEditorStore);
+    testRoundtrip(lambda_notOperatorFilter, mockedEditorStore);
+    testRoundtrip(lambda_setOperatorFilter, mockedEditorStore);
+    testRoundtrip(lambda_groupConditionFilter, mockedEditorStore);
+    testRoundtrip(
+      lambda_groupConditionFilter_withMultipleClauseGroup,
+      mockedEditorStore,
+    );
+  },
+);
+
+test(integrationTest('Roundtrip for filter expression (M2M)'), async () => {
+  const mockedEditorStore = await init(SimpleM2MModel);
+  MOBX__enableSpyOrMock();
+  mockedEditorStore.graphState.globalCompileInFormMode = jest.fn();
+  MOBX__disableSpyOrMock();
+  const queryBuilderState = mockedEditorStore.getEditorExtensionState(
+    QueryBuilderState,
+  );
+  await flowResult(queryBuilderState.setOpenQueryBuilder(true));
+  queryBuilderState.querySetupState.setClass(
+    mockedEditorStore.graphState.graph.getClass('model::target::_Person'),
+  );
+  queryBuilderState.resetData();
+  const queryBuilderSetup = await waitFor(() =>
+    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
+  );
+  // ensure form has updated with respect to the new state
+  await waitFor(() => getByText(queryBuilderSetup, '_Person'));
+  await waitFor(() => getByText(queryBuilderSetup, 'mapping'));
+  await waitFor(() => getByText(queryBuilderSetup, 'runtime'));
+  // test various lambdas
+  testRoundtrip(lambda_enumerationOperatorFilter, mockedEditorStore);
+  testRoundtrip(lambda_existsChainFilter, mockedEditorStore);
+  testRoundtrip(
+    lambda_existsChainFilterWithCustomVariableName,
+    mockedEditorStore,
+  );
 });

--- a/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_Model_COVID.json
+++ b/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_Model_COVID.json
@@ -1,0 +1,516 @@
+[
+  {
+    "path": "domain::COVIDData",
+    "content": {
+      "_type": "class",
+      "name": "COVIDData",
+      "package": "domain",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "id",
+          "type": "Integer"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "fips",
+          "type": "String"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "date",
+          "type": "StrictDate"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "caseType",
+          "type": "String"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "cases",
+          "type": "Float"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "lastReportedFlag",
+          "type": "Boolean"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "demographics",
+          "type": "domain::Demographics"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "domain::Demographics",
+    "content": {
+      "_type": "class",
+      "name": "Demographics",
+      "package": "domain",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "fips",
+          "type": "String"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "state",
+          "type": "String"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "store::CovidDataStore",
+    "content": {
+      "_type": "relational",
+      "filters": [],
+      "includedStores": [],
+      "joins": [
+        {
+          "name": "CovidDataDemographicsJoin",
+          "operation": {
+            "_type": "dynaFunc",
+            "funcName": "equal",
+            "parameters": [
+              {
+                "_type": "column",
+                "column": "FIPS",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "DEMOGRAPHICS"
+                },
+                "tableAlias": "DEMOGRAPHICS"
+              },
+              {
+                "_type": "column",
+                "column": "FIPS",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              }
+            ]
+          }
+        }
+      ],
+      "name": "CovidDataStore",
+      "package": "store",
+      "schemas": [
+        {
+          "name": "PUBLIC",
+          "tables": [
+            {
+              "columns": [
+                {
+                  "name": "FIPS",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Varchar",
+                    "size": 200
+                  }
+                },
+                {
+                  "name": "STATE",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Varchar",
+                    "size": 200
+                  }
+                }
+              ],
+              "name": "DEMOGRAPHICS",
+              "primaryKey": []
+            },
+            {
+              "columns": [
+                {
+                  "name": "ID",
+                  "nullable": false,
+                  "type": {
+                    "_type": "Integer"
+                  }
+                },
+                {
+                  "name": "FIPS",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Varchar",
+                    "size": 200
+                  }
+                },
+                {
+                  "name": "DATE",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Date"
+                  }
+                },
+                {
+                  "name": "CASE_TYPE",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Varchar",
+                    "size": 200
+                  }
+                },
+                {
+                  "name": "CASES",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Integer"
+                  }
+                },
+                {
+                  "name": "LAST_REPORTED_FLAG",
+                  "nullable": true,
+                  "type": {
+                    "_type": "Bit"
+                  }
+                }
+              ],
+              "name": "COVID_DATA",
+              "primaryKey": ["ID"]
+            }
+          ],
+          "views": []
+        }
+      ]
+    },
+    "classifierPath": "meta::relational::metamodel::Database"
+  },
+  {
+    "path": "mapping::CovidDataMapping",
+    "content": {
+      "_type": "mapping",
+      "classMappings": [
+        {
+          "_type": "relational",
+          "class": "domain::Demographics",
+          "distinct": false,
+          "mainTable": {
+            "_type": "Table",
+            "database": "store::CovidDataStore",
+            "schema": "PUBLIC",
+            "table": "DEMOGRAPHICS"
+          },
+          "primaryKey": [
+            {
+              "_type": "column",
+              "column": "FIPS",
+              "table": {
+                "_type": "Table",
+                "database": "store::CovidDataStore",
+                "schema": "PUBLIC",
+                "table": "DEMOGRAPHICS"
+              },
+              "tableAlias": "DEMOGRAPHICS"
+            }
+          ],
+          "propertyMappings": [
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::Demographics",
+                "property": "fips"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "FIPS",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "DEMOGRAPHICS"
+                },
+                "tableAlias": "DEMOGRAPHICS"
+              },
+              "source": "domain_Demographics"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::Demographics",
+                "property": "state"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "STATE",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "DEMOGRAPHICS"
+                },
+                "tableAlias": "DEMOGRAPHICS"
+              },
+              "source": "domain_Demographics"
+            }
+          ],
+          "root": false
+        },
+        {
+          "_type": "relational",
+          "class": "domain::COVIDData",
+          "distinct": false,
+          "mainTable": {
+            "_type": "Table",
+            "database": "store::CovidDataStore",
+            "schema": "PUBLIC",
+            "table": "COVID_DATA"
+          },
+          "primaryKey": [
+            {
+              "_type": "column",
+              "column": "ID",
+              "table": {
+                "_type": "Table",
+                "database": "store::CovidDataStore",
+                "schema": "PUBLIC",
+                "table": "COVID_DATA"
+              },
+              "tableAlias": "COVID_DATA"
+            }
+          ],
+          "propertyMappings": [
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "id"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "ID",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              },
+              "source": "domain_COVIDData"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "fips"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "FIPS",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              },
+              "source": "domain_COVIDData"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "date"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "DATE",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              },
+              "source": "domain_COVIDData"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "caseType"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "CASE_TYPE",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              },
+              "source": "domain_COVIDData"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "cases"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "CASES",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              },
+              "source": "domain_COVIDData"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "lastReportedFlag"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "LAST_REPORTED_FLAG",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::CovidDataStore",
+                  "schema": "PUBLIC",
+                  "table": "COVID_DATA"
+                },
+                "tableAlias": "COVID_DATA"
+              },
+              "source": "domain_COVIDData"
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "domain::COVIDData",
+                "property": "demographics"
+              },
+              "relationalOperation": {
+                "_type": "elemtWithJoins",
+                "joins": [
+                  {
+                    "db": "store::CovidDataStore",
+                    "name": "CovidDataDemographicsJoin"
+                  }
+                ]
+              },
+              "source": "domain_COVIDData",
+              "target": "domain_Demographics"
+            }
+          ],
+          "root": false
+        }
+      ],
+      "enumerationMappings": [],
+      "includedMappings": [],
+      "name": "CovidDataMapping",
+      "package": "mapping",
+      "tests": []
+    },
+    "classifierPath": "meta::pure::mapping::Mapping"
+  },
+  {
+    "path": "runtime::H2Runtime",
+    "content": {
+      "_type": "runtime",
+      "name": "H2Runtime",
+      "package": "runtime",
+      "runtimeValue": {
+        "_type": "engineRuntime",
+        "connections": [
+          {
+            "store": {
+              "path": "store::CovidDataStore",
+              "type": "STORE"
+            },
+            "storeConnections": [
+              {
+                "connection": {
+                  "_type": "connectionPointer",
+                  "connection": "runtime::connection::H2Connection"
+                },
+                "id": "connection_1"
+              }
+            ]
+          }
+        ],
+        "mappings": [
+          {
+            "path": "mapping::CovidDataMapping",
+            "type": "MAPPING"
+          }
+        ]
+      }
+    },
+    "classifierPath": "meta::pure::runtime::PackageableRuntime"
+  },
+  {
+    "path": "runtime::connection::H2Connection",
+    "content": {
+      "_type": "connection",
+      "connectionValue": {
+        "_type": "RelationalDatabaseConnection",
+        "authenticationStrategy": {
+          "_type": "h2Default"
+        },
+        "datasourceSpecification": {
+          "_type": "static",
+          "databaseName": "test",
+          "host": "test",
+          "port": 8080
+        },
+        "element": "store::CovidDataStore",
+        "type": "H2"
+      },
+      "name": "H2Connection",
+      "package": "runtime::connection"
+    },
+    "classifierPath": "meta::pure::runtime::PackageableConnection"
+  }
+]

--- a/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_Model_SimpleM2M.json
+++ b/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_Model_SimpleM2M.json
@@ -1,0 +1,285 @@
+[
+  {
+    "path": "model::target::IncType",
+    "content": {
+      "_type": "Enumeration",
+      "name": "IncType",
+      "package": "model::target",
+      "values": [
+        {
+          "value": "LLC"
+        },
+        {
+          "value": "QB"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Enumeration"
+  },
+  {
+    "path": "model::Firm",
+    "content": {
+      "_type": "class",
+      "name": "Firm",
+      "package": "model",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1
+          },
+          "name": "employees",
+          "type": "model::Person"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "type",
+          "type": "String"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "model::Person",
+    "content": {
+      "_type": "class",
+      "name": "Person",
+      "package": "model",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "firstName",
+          "type": "String"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "lastName",
+          "type": "String"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "model::target::_Firm",
+    "content": {
+      "_type": "class",
+      "name": "_Firm",
+      "package": "model::target",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1
+          },
+          "name": "employees",
+          "type": "model::target::_Person"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "type",
+          "type": "model::target::IncType"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "model::target::_Person",
+    "content": {
+      "_type": "class",
+      "name": "_Person",
+      "package": "model::target",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "fullName",
+          "type": "String"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "model::mapping",
+    "content": {
+      "_type": "mapping",
+      "classMappings": [
+        {
+          "_type": "pureInstance",
+          "class": "model::target::_Person",
+          "propertyMappings": [
+            {
+              "_type": "purePropertyMapping",
+              "explodeProperty": false,
+              "property": {
+                "class": "model::target::_Person",
+                "property": "fullName"
+              },
+              "source": "model_target__Person",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "src"
+                      }
+                    ],
+                    "property": "firstName"
+                  }
+                ],
+                "parameters": []
+              }
+            }
+          ],
+          "root": true,
+          "srcClass": "model::Person"
+        },
+        {
+          "_type": "pureInstance",
+          "class": "model::target::_Firm",
+          "propertyMappings": [
+            {
+              "_type": "purePropertyMapping",
+              "explodeProperty": false,
+              "property": {
+                "class": "model::target::_Firm",
+                "property": "employees"
+              },
+              "source": "model_target__Firm",
+              "target": "model_target__Person",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "src"
+                      }
+                    ],
+                    "property": "employees"
+                  }
+                ],
+                "parameters": []
+              }
+            },
+            {
+              "_type": "purePropertyMapping",
+              "enumMappingId": "model_target_IncType",
+              "explodeProperty": false,
+              "property": {
+                "class": "model::target::_Firm",
+                "property": "type"
+              },
+              "source": "model_target__Firm",
+              "transform": {
+                "_type": "lambda",
+                "body": [
+                  {
+                    "_type": "property",
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "src"
+                      }
+                    ],
+                    "property": "type"
+                  }
+                ],
+                "parameters": []
+              }
+            }
+          ],
+          "root": true,
+          "srcClass": "model::Firm"
+        }
+      ],
+      "enumerationMappings": [
+        {
+          "enumValueMappings": [
+            {
+              "enumValue": "LLC",
+              "sourceValues": [
+                {
+                  "_type": "stringSourceValue",
+                  "value": "llc"
+                }
+              ]
+            },
+            {
+              "enumValue": "QB",
+              "sourceValues": [
+                {
+                  "_type": "stringSourceValue",
+                  "value": "qb"
+                }
+              ]
+            }
+          ],
+          "enumeration": "model::target::IncType"
+        }
+      ],
+      "includedMappings": [],
+      "name": "mapping",
+      "package": "model",
+      "tests": []
+    },
+    "classifierPath": "meta::pure::mapping::Mapping"
+  },
+  {
+    "path": "model::runtime",
+    "content": {
+      "_type": "runtime",
+      "name": "runtime",
+      "package": "model",
+      "runtimeValue": {
+        "_type": "engineRuntime",
+        "connections": [
+          {
+            "store": {
+              "path": "ModelStore",
+              "type": "STORE"
+            },
+            "storeConnections": [
+              {
+                "connection": {
+                  "_type": "JsonModelConnection",
+                  "class": "model::Firm",
+                  "element": "ModelStore",
+                  "url": "data:application/json,%7B%22employees%22%3A%5B%7B%22firstName%22%3A%22firstName%2013%22%2C%22lastName%22%3A%22lastName%2035%22%7D%5D%7D"
+                },
+                "id": "connection_1"
+              }
+            ]
+          }
+        ],
+        "mappings": [
+          {
+            "path": "model::mapping",
+            "type": "MAPPING"
+          }
+        ]
+      }
+    },
+    "classifierPath": "meta::pure::runtime::PackageableRuntime"
+  }
+]

--- a/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_Roundtrip_TestFilterQueries.ts
+++ b/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_Roundtrip_TestFilterQueries.ts
@@ -1,0 +1,835 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const lambda_simpleSingleConditionFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'domain::COVIDData',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'equal',
+              parameters: [
+                {
+                  _type: 'property',
+                  property: 'state',
+                  parameters: [
+                    {
+                      _type: 'property',
+                      property: 'demographics',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'string',
+                  values: ['NY'],
+                  multiplicity: {
+                    lowerBound: 1,
+                    upperBound: 1,
+                  },
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_notOperatorFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'domain::COVIDData',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'not',
+              parameters: [
+                {
+                  _type: 'func',
+                  function: 'equal',
+                  parameters: [
+                    {
+                      _type: 'property',
+                      property: 'state',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'demographics',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'string',
+                      values: ['NY'],
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_setOperatorFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'domain::COVIDData',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'not',
+              parameters: [
+                {
+                  _type: 'func',
+                  function: 'in',
+                  parameters: [
+                    {
+                      _type: 'property',
+                      property: 'state',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'demographics',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'collection',
+                      values: [
+                        {
+                          _type: 'string',
+                          values: ['NY'],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                        {
+                          _type: 'string',
+                          values: ['NJ'],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                      multiplicity: {
+                        lowerBound: 2,
+                        upperBound: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_groupConditionFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'domain::COVIDData',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'and',
+              parameters: [
+                {
+                  _type: 'func',
+                  function: 'or',
+                  parameters: [
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'cases',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'float',
+                          values: [99],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'fips',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'string',
+                          values: ['def'],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'func',
+                  function: 'or',
+                  parameters: [
+                    {
+                      _type: 'func',
+                      function: 'and',
+                      parameters: [
+                        {
+                          _type: 'func',
+                          function: 'equal',
+                          parameters: [
+                            {
+                              _type: 'property',
+                              property: 'cases',
+                              parameters: [
+                                {
+                                  _type: 'var',
+                                  name: 'x',
+                                },
+                              ],
+                            },
+                            {
+                              _type: 'float',
+                              values: [0],
+                              multiplicity: {
+                                lowerBound: 1,
+                                upperBound: 1,
+                              },
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'func',
+                          function: 'equal',
+                          parameters: [
+                            {
+                              _type: 'property',
+                              property: 'fips',
+                              parameters: [
+                                {
+                                  _type: 'var',
+                                  name: 'x',
+                                },
+                              ],
+                            },
+                            {
+                              _type: 'string',
+                              values: ['abc'],
+                              multiplicity: {
+                                lowerBound: 1,
+                                upperBound: 1,
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'func',
+                      function: 'not',
+                      parameters: [
+                        {
+                          _type: 'func',
+                          function: 'in',
+                          parameters: [
+                            {
+                              _type: 'property',
+                              property: 'state',
+                              parameters: [
+                                {
+                                  _type: 'property',
+                                  property: 'demographics',
+                                  parameters: [
+                                    {
+                                      _type: 'var',
+                                      name: 'x',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                            {
+                              _type: 'collection',
+                              values: [
+                                {
+                                  _type: 'string',
+                                  values: ['NY'],
+                                  multiplicity: {
+                                    lowerBound: 1,
+                                    upperBound: 1,
+                                  },
+                                },
+                                {
+                                  _type: 'string',
+                                  values: ['NJ'],
+                                  multiplicity: {
+                                    lowerBound: 1,
+                                    upperBound: 1,
+                                  },
+                                },
+                              ],
+                              multiplicity: {
+                                lowerBound: 2,
+                                upperBound: 2,
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_groupConditionFilter_withMultipleClauseGroup = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'domain::COVIDData',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'and',
+              parameters: [
+                {
+                  _type: 'func',
+                  function: 'equal',
+                  parameters: [
+                    {
+                      _type: 'property',
+                      property: 'cases',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'float',
+                      values: [99],
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                    },
+                  ],
+                },
+                {
+                  _type: 'func',
+                  function: 'and',
+                  parameters: [
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'fips',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'string',
+                          values: ['def'],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'func',
+                      function: 'not',
+                      parameters: [
+                        {
+                          _type: 'func',
+                          function: 'in',
+                          parameters: [
+                            {
+                              _type: 'property',
+                              property: 'state',
+                              parameters: [
+                                {
+                                  _type: 'property',
+                                  property: 'demographics',
+                                  parameters: [
+                                    {
+                                      _type: 'var',
+                                      name: 'x',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                            {
+                              _type: 'collection',
+                              values: [
+                                {
+                                  _type: 'string',
+                                  values: ['NY'],
+                                  multiplicity: {
+                                    lowerBound: 1,
+                                    upperBound: 1,
+                                  },
+                                },
+                                {
+                                  _type: 'string',
+                                  values: ['NJ'],
+                                  multiplicity: {
+                                    lowerBound: 1,
+                                    upperBound: 1,
+                                  },
+                                },
+                              ],
+                              multiplicity: {
+                                lowerBound: 2,
+                                upperBound: 2,
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_enumerationOperatorFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'model::target::_Firm',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'not',
+              parameters: [
+                {
+                  _type: 'func',
+                  function: 'in',
+                  parameters: [
+                    {
+                      _type: 'property',
+                      property: 'type',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                    },
+                    {
+                      _type: 'collection',
+                      values: [
+                        {
+                          _type: 'enumValue',
+                          fullPath: 'model::target::IncType',
+                          value: 'LLC',
+                        },
+                        {
+                          _type: 'enumValue',
+                          fullPath: 'model::target::IncType',
+                          value: 'QB',
+                        },
+                      ],
+                      multiplicity: {
+                        lowerBound: 2,
+                        upperBound: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_existsChainFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'model::target::_Firm',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'exists',
+              parameters: [
+                {
+                  _type: 'property',
+                  property: 'employees',
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                },
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'fullName',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x_1',
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'string',
+                          values: ['abc'],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x_1',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_existsChainFilterWithCustomVariableName = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'model::target::_Firm',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'exists',
+              parameters: [
+                {
+                  _type: 'property',
+                  property: 'employees',
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'c',
+                    },
+                  ],
+                },
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'fullName',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'f',
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'string',
+                          values: ['abc'],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'f',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'c',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};

--- a/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_TestFilterQueriesWithExits.ts
+++ b/packages/legend-studio-plugin-query-builder/src/components/__tests__/QueryBuilder_TestFilterQueriesWithExits.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const lambda_input_filterWithExists = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'model::target::_Firm',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'exists',
+              parameters: [
+                {
+                  _type: 'property',
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                  property: 'employees',
+                },
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'func',
+                      function: 'exists',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x_1',
+                            },
+                          ],
+                          property: 'fullName',
+                        },
+                        {
+                          _type: 'lambda',
+                          body: [
+                            {
+                              _type: 'func',
+                              function: 'equal',
+                              parameters: [
+                                {
+                                  _type: 'var',
+                                  name: 'c',
+                                },
+                                {
+                                  _type: 'string',
+                                  multiplicity: {
+                                    lowerBound: 1,
+                                    upperBound: 1,
+                                  },
+                                  values: [''],
+                                },
+                              ],
+                            },
+                          ],
+                          parameters: [{ _type: 'var', name: 'c' }],
+                        },
+                      ],
+                    },
+                  ],
+                  parameters: [{ _type: 'var', name: 'x_1' }],
+                },
+              ],
+            },
+          ],
+          parameters: [{ _type: 'var', name: 'x' }],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
+export const lambda_output_filterWithExists = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'class',
+              fullPath: 'model::target::_Firm',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'exists',
+              parameters: [
+                {
+                  _type: 'property',
+                  property: 'employees',
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                },
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          property: 'fullName',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x_1',
+                            },
+                          ],
+                        },
+                        {
+                          _type: 'string',
+                          values: [''],
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x_1',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderExplorerState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderExplorerState.ts
@@ -102,15 +102,15 @@ export class QueryBuilderExplorerTreePropertyNodeData extends QueryBuilderExplor
 export const getPropertyExpression = (
   treeData: TreeData<QueryBuilderExplorerTreeNodeData>,
   node: QueryBuilderExplorerTreePropertyNodeData,
-  multiplicity_ONE: Multiplicity,
+  multiplicityOne: Multiplicity,
 ): AbstractPropertyExpression => {
   const projectionColumnLambdaVariable = new VariableExpression(
     DEFAULT_LAMBDA_VARIABLE_NAME,
-    multiplicity_ONE,
+    multiplicityOne,
   );
   const propertyExpression = new AbstractPropertyExpression(
     '',
-    multiplicity_ONE,
+    multiplicityOne,
   );
   propertyExpression.func = guaranteeNonNullable(node.property);
   let currentExpression = propertyExpression;
@@ -118,7 +118,7 @@ export const getPropertyExpression = (
   while (parentNode instanceof QueryBuilderExplorerTreePropertyNodeData) {
     const parentPropertyExpression = new AbstractPropertyExpression(
       '',
-      multiplicity_ONE,
+      multiplicityOne,
     );
     parentPropertyExpression.func = guaranteeNonNullable(parentNode.property);
     currentExpression.parametersValues.push(parentPropertyExpression);

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderFilterState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderFilterState.ts
@@ -688,7 +688,8 @@ export class QueryBuilderFilterState
         });
         // remove the current group node
         parentNode.removeChildNode(node);
-        // do somehting
+        // remove the node
+        this.nodes.delete(node.id);
       });
       nodesToProcess = getUnnecessaryNodes();
     }

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderFilterState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderFilterState.ts
@@ -102,6 +102,7 @@ export class FilterConditionState {
   propertyEditorState: QueryBuilderPropertyEditorState;
   operator!: QueryBuilderOperator;
   value?: ValueSpecification;
+  existsLambdaParamNames: string[] = [];
 
   constructor(
     editorStore: EditorStore,
@@ -116,6 +117,7 @@ export class FilterConditionState {
       changeOperator: action,
       setOperator: action,
       setValue: action,
+      addExistsLambdaParamNames: action,
     });
 
     this.editorStore = editorStore;
@@ -177,6 +179,10 @@ export class FilterConditionState {
 
   setValue(val: ValueSpecification | undefined): void {
     this.value = val;
+  }
+
+  addExistsLambdaParamNames(val: string): void {
+    this.existsLambdaParamNames.push(val);
   }
 
   getFunctionExpression(): ValueSpecification {

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderFilterState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderFilterState.ts
@@ -329,6 +329,7 @@ export class QueryBuilderFilterState
       newGroupWithConditionFromNode: action,
       removeNodeAndPruneBranch: action,
       pruneTree: action,
+      simplifyTree: action,
       collapseTree: action,
       expandTree: action,
     });
@@ -601,6 +602,7 @@ export class QueryBuilderFilterState
   }
 
   pruneTree(): void {
+    this.setSelectedNode(undefined);
     // remove all blank nodes
     Array.from(this.nodes.values())
       .filter(
@@ -650,6 +652,48 @@ export class QueryBuilderFilterState
     }
   }
 
+  /**
+   * Cleanup unecessary group nodes (i.e. group node whose group operation is the same as its parent's)
+   */
+  simplifyTree(): void {
+    this.setSelectedNode(undefined);
+    const getUnnecessaryNodes = (): QueryBuilderFilterTreeGroupNodeData[] =>
+      Array.from(this.nodes.values())
+        .filter(
+          (node): node is QueryBuilderFilterTreeGroupNodeData =>
+            node instanceof QueryBuilderFilterTreeGroupNodeData,
+        )
+        .filter((node) => {
+          if (!node.parentId || !this.nodes.has(node.parentId)) {
+            return false;
+          }
+          const parentGroupNode = guaranteeType(
+            this.nodes.get(node.parentId),
+            QueryBuilderFilterTreeGroupNodeData,
+          );
+          return parentGroupNode.groupOperation === node.groupOperation;
+        });
+    // Squash these unnecessary group nodes
+    let nodesToProcess = getUnnecessaryNodes();
+    while (nodesToProcess.length) {
+      nodesToProcess.forEach((node) => {
+        const parentNode = guaranteeType(
+          this.nodes.get(guaranteeNonNullable(node.parentId)),
+          QueryBuilderFilterTreeGroupNodeData,
+        );
+        // send all children of the current group node to their grandparent node
+        [...node.childrenIds].forEach((childId) => {
+          const childNode = this.getNode(childId);
+          parentNode.addChildNode(childNode);
+        });
+        // remove the current group node
+        parentNode.removeChildNode(node);
+        // do somehting
+      });
+      nodesToProcess = getUnnecessaryNodes();
+    }
+  }
+
   isValidMove(
     node: QueryBuilderFilterTreeNodeData,
     toNode: QueryBuilderFilterTreeNodeData,
@@ -682,23 +726,49 @@ export class QueryBuilderFilterState
     Array.from(this.nodes.values()).forEach((node) => node.setIsOpen(true));
   }
 
-  getSimpleFunctionExpression(
+  buildSimpleFunctionExpression(
     node: QueryBuilderFilterTreeNodeData,
   ): ValueSpecification | undefined {
     if (node instanceof QueryBuilderFilterTreeConditionNodeData) {
       return node.condition.getFunctionExpression();
     } else if (node instanceof QueryBuilderFilterTreeGroupNodeData) {
+      const multiplicityOne = this.editorStore.graphState.graph.getTypicalMultiplicity(
+        TYPICAL_MULTIPLICITY_TYPE.ONE,
+      );
       const func = new SimpleFunctionExpression(
         node.groupOperation,
-        this.editorStore.graphState.graph.getTypicalMultiplicity(
-          TYPICAL_MULTIPLICITY_TYPE.ONE,
-        ),
+        multiplicityOne,
       );
-      func.parametersValues = node.childrenIds
+      const clauses = node.childrenIds
         .map((e) => this.nodes.get(e))
         .filter(isNonNullable)
-        .map((e) => this.getSimpleFunctionExpression(e))
+        .map((e) => this.buildSimpleFunctionExpression(e))
         .filter(isNonNullable);
+      /**
+       * NOTE: Due to a limitation (or perhaps design decision) in the engine, group operations
+       * like and/or do not take more than 2 parameters, as such, if we have more than 2, we need
+       * to create a chain of this operation to accomondate.
+       *
+       * This means that in the read direction, we might need to flatten the chains down to group with
+       * multiple clauses. This means user's intended grouping will not be kept.
+       */
+      if (clauses.length > 2) {
+        const firstClause = clauses[0];
+        let currentClause: ValueSpecification = clauses[clauses.length - 1];
+        for (let i = clauses.length - 2; i > 0; --i) {
+          const clause1 = clauses[i];
+          const clause2 = currentClause;
+          const groupClause = new SimpleFunctionExpression(
+            node.groupOperation,
+            multiplicityOne,
+          );
+          groupClause.parametersValues = [clause1, clause2];
+          currentClause = groupClause;
+        }
+        func.parametersValues = [firstClause, currentClause];
+      } else {
+        func.parametersValues = clauses;
+      }
       return func.parametersValues.length ? func : undefined;
     }
     return undefined;
@@ -707,7 +777,7 @@ export class QueryBuilderFilterState
   getParameterValues(): ValueSpecification[] | undefined {
     const parametersValues = this.rootIds
       .map((e) => guaranteeNonNullable(this.nodes.get(e)))
-      .map((e) => this.getSimpleFunctionExpression(e))
+      .map((e) => this.buildSimpleFunctionExpression(e))
       .filter(isNonNullable);
     return !parametersValues.length ? undefined : parametersValues;
   }

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderLambdaProcessor.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderLambdaProcessor.ts
@@ -380,6 +380,13 @@ export class QueryBuilderLambdaProcessor
         const filterExpression = valueSpecification.parametersValues[1];
         if (filterExpression instanceof LambdaFunctionInstanceValue) {
           processFilterFunction(filterExpression, filterState);
+          /**
+           * NOTE: Since group operations ike and/or do not take more than 2 parameters, if there are
+           * more than 2 clauses in each group operations, then these clauses are converted into an
+           * unbalanced tree. However, this would look quite bad for UX, as such, we simplify the tree.
+           * After building the filter state.
+           */
+          filterState.simplifyTree();
           return;
         }
       }

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
@@ -98,19 +98,19 @@ export class QueryBuilderState extends EditorExtensionState {
   openQueryBuilder = false;
   operators: QueryBuilderOperator[] = [
     new QueryBuilderEqualOperator(),
-    new QueryBuilderNotEqualOperator(),
-    new QueryBuilderLessThanOperator(),
-    new QueryBuilderLessThanEqualOperator(),
-    new QueryBuilderGreaterThanOperator(),
-    new QueryBuilderGreaterThanEqualOperator(),
-    new QueryBuilderStartWithOperator(),
-    new QueryBuilderNotStartWithOperator(),
-    new QueryBuilderContainOperator(),
-    new QueryBuilderNotContainOperator(),
-    new QueryBuilderEndWithOperator(),
-    new QueryBuilderNotEndWithOperator(),
-    new QueryBuilderIsEmptyOperator(),
-    new QueryBuilderIsNotEmptyOperator(),
+    // new QueryBuilderNotEqualOperator(),
+    // new QueryBuilderLessThanOperator(),
+    // new QueryBuilderLessThanEqualOperator(),
+    // new QueryBuilderGreaterThanOperator(),
+    // new QueryBuilderGreaterThanEqualOperator(),
+    // new QueryBuilderStartWithOperator(),
+    // new QueryBuilderNotStartWithOperator(),
+    // new QueryBuilderContainOperator(),
+    // new QueryBuilderNotContainOperator(),
+    // new QueryBuilderEndWithOperator(),
+    // new QueryBuilderNotEndWithOperator(),
+    // new QueryBuilderIsEmptyOperator(),
+    // new QueryBuilderIsNotEmptyOperator(),
   ];
 
   constructor(editorStore: EditorStore) {

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
@@ -84,6 +84,10 @@ import {
   QueryBuilderIsEmptyOperator,
   QueryBuilderIsNotEmptyOperator,
 } from './operators/QueryBuilderIsEmptyOperator';
+import {
+  QueryBuilderInOperator,
+  QueryBuilderNotInOperator,
+} from './operators/QueryBuilderInOperator';
 
 export class QueryBuilderState extends EditorExtensionState {
   editorStore: EditorStore;
@@ -109,6 +113,8 @@ export class QueryBuilderState extends EditorExtensionState {
     new QueryBuilderNotContainOperator(),
     new QueryBuilderEndWithOperator(),
     new QueryBuilderNotEndWithOperator(),
+    new QueryBuilderInOperator(),
+    new QueryBuilderNotInOperator(),
     new QueryBuilderIsEmptyOperator(),
     new QueryBuilderIsNotEmptyOperator(),
   ];

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
@@ -100,6 +100,7 @@ export class QueryBuilderState extends EditorExtensionState {
   queryTextEditorState: QueryTextEditorState;
   queryUnsupportedState: QueryBuilderUnsupportedState;
   openQueryBuilder = false;
+  TEMPORARY__enableGraphFetch = false;
   operators: QueryBuilderOperator[] = [
     new QueryBuilderEqualOperator(),
     new QueryBuilderNotEqualOperator(),
@@ -119,7 +120,12 @@ export class QueryBuilderState extends EditorExtensionState {
     new QueryBuilderIsNotEmptyOperator(),
   ];
 
-  constructor(editorStore: EditorStore) {
+  constructor(
+    editorStore: EditorStore,
+    options?: {
+      TEMPORARY__enableGraphFetch?: boolean;
+    },
+  ) {
     super();
 
     makeObservable(this, {
@@ -160,6 +166,10 @@ export class QueryBuilderState extends EditorExtensionState {
     this.queryUnsupportedState = new QueryBuilderUnsupportedState(
       editorStore,
       this,
+    );
+
+    this.TEMPORARY__enableGraphFetch = Boolean(
+      options?.TEMPORARY__enableGraphFetch,
     );
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
@@ -98,19 +98,19 @@ export class QueryBuilderState extends EditorExtensionState {
   openQueryBuilder = false;
   operators: QueryBuilderOperator[] = [
     new QueryBuilderEqualOperator(),
-    // new QueryBuilderNotEqualOperator(),
-    // new QueryBuilderLessThanOperator(),
-    // new QueryBuilderLessThanEqualOperator(),
-    // new QueryBuilderGreaterThanOperator(),
-    // new QueryBuilderGreaterThanEqualOperator(),
-    // new QueryBuilderStartWithOperator(),
-    // new QueryBuilderNotStartWithOperator(),
-    // new QueryBuilderContainOperator(),
-    // new QueryBuilderNotContainOperator(),
-    // new QueryBuilderEndWithOperator(),
-    // new QueryBuilderNotEndWithOperator(),
-    // new QueryBuilderIsEmptyOperator(),
-    // new QueryBuilderIsNotEmptyOperator(),
+    new QueryBuilderNotEqualOperator(),
+    new QueryBuilderLessThanOperator(),
+    new QueryBuilderLessThanEqualOperator(),
+    new QueryBuilderGreaterThanOperator(),
+    new QueryBuilderGreaterThanEqualOperator(),
+    new QueryBuilderStartWithOperator(),
+    new QueryBuilderNotStartWithOperator(),
+    new QueryBuilderContainOperator(),
+    new QueryBuilderNotContainOperator(),
+    new QueryBuilderEndWithOperator(),
+    new QueryBuilderNotEndWithOperator(),
+    new QueryBuilderIsEmptyOperator(),
+    new QueryBuilderIsNotEmptyOperator(),
   ];
 
   constructor(editorStore: EditorStore) {

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderContainOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderContainOperator.ts
@@ -34,7 +34,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
   unwrapNotExpression,
 } from './QueryBuilderOperatorHelpers';
 
@@ -57,13 +57,10 @@ export class QueryBuilderContainOperator extends QueryBuilderOperator {
   isCompatibleWithFilterConditionValue(
     filterConditionState: FilterConditionState,
   ): boolean {
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
-    return (
-      PRIMITIVE_TYPE.STRING === typeInfo?.type.path &&
-      typeInfo.isCollection === false
-    );
+    return PRIMITIVE_TYPE.STRING === type?.path;
   }
 
   getDefaultFilterConditionValue(

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderEndWithOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderEndWithOperator.ts
@@ -34,7 +34,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
   unwrapNotExpression,
 } from './QueryBuilderOperatorHelpers';
 
@@ -57,13 +57,10 @@ export class QueryBuilderEndWithOperator extends QueryBuilderOperator {
   isCompatibleWithFilterConditionValue(
     filterConditionState: FilterConditionState,
   ): boolean {
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
-    return (
-      PRIMITIVE_TYPE.STRING === typeInfo?.type.path &&
-      typeInfo.isCollection === false
-    );
+    return PRIMITIVE_TYPE.STRING === type?.path;
   }
 
   getDefaultFilterConditionValue(

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderEqualOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderEqualOperator.ts
@@ -42,7 +42,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
   unwrapNotExpression,
 } from './QueryBuilderOperatorHelpers';
 
@@ -80,11 +80,11 @@ export class QueryBuilderEqualOperator extends QueryBuilderOperator {
     const propertyType =
       filterConditionState.propertyEditorState.propertyExpression.func
         .genericType.value.rawType;
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
     return (
-      typeInfo !== undefined &&
+      type !== undefined &&
       ((([
         PRIMITIVE_TYPE.STRING,
         PRIMITIVE_TYPE.BOOLEAN,
@@ -93,9 +93,8 @@ export class QueryBuilderEqualOperator extends QueryBuilderOperator {
         PRIMITIVE_TYPE.DECIMAL,
         PRIMITIVE_TYPE.FLOAT,
         PRIMITIVE_TYPE.STRICTDATE,
-      ] as unknown) as string).includes(typeInfo.type.path) ||
-        typeInfo.type === propertyType) &&
-      typeInfo.isCollection === false
+      ] as unknown) as string).includes(type.path) ||
+        type === propertyType)
     );
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderGreaterThanEqualOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderGreaterThanEqualOperator.ts
@@ -33,7 +33,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
 } from './QueryBuilderOperatorHelpers';
 
 const GREATER_THAN_EQUAL_FUNCTION_NAME = 'greaterThanEqual';
@@ -60,18 +60,17 @@ export class QueryBuilderGreaterThanEqualOperator extends QueryBuilderOperator {
   isCompatibleWithFilterConditionValue(
     filterConditionState: FilterConditionState,
   ): boolean {
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
     return (
-      typeInfo !== undefined &&
+      type !== undefined &&
       (([
         PRIMITIVE_TYPE.NUMBER,
         PRIMITIVE_TYPE.INTEGER,
         PRIMITIVE_TYPE.DECIMAL,
         PRIMITIVE_TYPE.FLOAT,
-      ] as unknown) as string).includes(typeInfo.type.path) &&
-      typeInfo.isCollection === false
+      ] as unknown) as string).includes(type.path)
     );
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderGreaterThanOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderGreaterThanOperator.ts
@@ -33,7 +33,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
 } from './QueryBuilderOperatorHelpers';
 
 const GREATER_THAN_FUNCTION_NAME = 'greaterThan';
@@ -60,18 +60,17 @@ export class QueryBuilderGreaterThanOperator extends QueryBuilderOperator {
   isCompatibleWithFilterConditionValue(
     filterConditionState: FilterConditionState,
   ): boolean {
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
     return (
-      typeInfo !== undefined &&
+      type !== undefined &&
       (([
         PRIMITIVE_TYPE.NUMBER,
         PRIMITIVE_TYPE.INTEGER,
         PRIMITIVE_TYPE.DECIMAL,
         PRIMITIVE_TYPE.FLOAT,
-      ] as unknown) as string).includes(typeInfo.type.path) &&
-      typeInfo.isCollection === false
+      ] as unknown) as string).includes(type.path)
     );
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderLessThanEqualOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderLessThanEqualOperator.ts
@@ -33,7 +33,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
 } from './QueryBuilderOperatorHelpers';
 
 const LESS_THAN_EQUAL_FUNCTION_NAME = 'lessThanEqual';
@@ -60,18 +60,17 @@ export class QueryBuilderLessThanEqualOperator extends QueryBuilderOperator {
   isCompatibleWithFilterConditionValue(
     filterConditionState: FilterConditionState,
   ): boolean {
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
     return (
-      typeInfo !== undefined &&
+      type !== undefined &&
       (([
         PRIMITIVE_TYPE.NUMBER,
         PRIMITIVE_TYPE.INTEGER,
         PRIMITIVE_TYPE.DECIMAL,
         PRIMITIVE_TYPE.FLOAT,
-      ] as unknown) as string).includes(typeInfo.type.path) &&
-      typeInfo.isCollection === false
+      ] as unknown) as string).includes(type.path)
     );
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderLessThanOperator.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderLessThanOperator.ts
@@ -33,7 +33,7 @@ import {
   buildPrimitiveInstanceValue,
   buildFilterConditionExpression,
   getDefaultPrimitiveInstanceValueForType,
-  getValueSpecificationTypeInfo,
+  getNonCollectionValueSpecificationType,
 } from './QueryBuilderOperatorHelpers';
 
 const LESS_THAN_FUNCTION_NAME = 'lessThan';
@@ -60,18 +60,17 @@ export class QueryBuilderLessThanOperator extends QueryBuilderOperator {
   isCompatibleWithFilterConditionValue(
     filterConditionState: FilterConditionState,
   ): boolean {
-    const typeInfo = filterConditionState.value
-      ? getValueSpecificationTypeInfo(filterConditionState.value)
+    const type = filterConditionState.value
+      ? getNonCollectionValueSpecificationType(filterConditionState.value)
       : undefined;
     return (
-      typeInfo !== undefined &&
+      type !== undefined &&
       (([
         PRIMITIVE_TYPE.NUMBER,
         PRIMITIVE_TYPE.INTEGER,
         PRIMITIVE_TYPE.DECIMAL,
         PRIMITIVE_TYPE.FLOAT,
-      ] as unknown) as string).includes(typeInfo.type.path) &&
-      typeInfo.isCollection === false
+      ] as unknown) as string).includes(type.path)
     );
   }
 

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderOperatorHelpers.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderOperatorHelpers.ts
@@ -370,7 +370,7 @@ const buildFilterConditionStateWithExists = (
       propertyExpression,
     );
     existsLambdaParameterNames.forEach((paramName) =>
-      filterConditionState?.addExistsLambdaParamNames(paramName),
+      filterConditionState.addExistsLambdaParamNames(paramName),
     );
     return filterConditionState;
   }

--- a/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderOperatorHelpers.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/operators/QueryBuilderOperatorHelpers.ts
@@ -16,6 +16,9 @@
 
 import type { Type, ValueSpecification } from '@finos/legend-studio';
 import {
+  LambdaFunctionInstanceValue,
+  VariableExpression,
+  SUPPORTED_FUNCTIONS,
   AbstractPropertyExpression,
   GenericType,
   GenericTypeExplicitReference,
@@ -29,6 +32,7 @@ import {
   guaranteeType,
   UnsupportedOperationError,
   guaranteeNonNullable,
+  assertTrue,
 } from '@finos/legend-studio-shared';
 import type {
   QueryBuilderFilterState,
@@ -37,7 +41,11 @@ import type {
 import { FilterConditionState } from '../QueryBuilderFilterState';
 import format from 'date-fns/format';
 import { DATE_FORMAT } from '@finos/legend-studio/lib/const';
-import { NOT_FUNCTION_NAME } from '../../QueryBuilder_Constants';
+
+export interface QueryBuilderValueSpecificationInfo {
+  type: Type;
+  isCollection: boolean;
+}
 
 export const getDefaultPrimitiveInstanceValueForType = (
   type: PRIMITIVE_TYPE,
@@ -87,13 +95,35 @@ export const buildFilterConditionExpression = (
   filterConditionState: FilterConditionState,
   functionName: string,
 ): ValueSpecification => {
-  // TODO: handle `exists`
-  const multiplicityOne = filterConditionState.editorStore.graphState.graph.getTypicalMultiplicity(
+  const multiplicity_ONE = filterConditionState.editorStore.graphState.graph.getTypicalMultiplicity(
     TYPICAL_MULTIPLICITY_TYPE.ONE,
   );
+  // if (filterConditionState.propertyEditorState.requiresExistsHandling) {
+  //   const pes: AbstractPropertyExpression[] = [];
+  //   let currentPe: ValueSpecification =
+  //     filterConditionState.propertyEditorState.propertyExpression;
+  //   while (currentPe instanceof AbstractPropertyExpression) {
+  //     const pe = new AbstractPropertyExpression('', multiplicity_ONE);
+  //     pe.func = currentPropertyExpression.func;
+  //     pes.push(pe);
+  //     currentPe = currentPe.parametersValues[0];
+  //   }
+  //   // generateTestName(): string {
+  //   //   const generatedName = generateEnumerableNameFromToken(
+  //   //     this.tests.map((test) => test.name),
+  //   //     'test',
+  //   //   );
+  //   //   assertTrue(
+  //   //     !this.tests.find((test) => test.name === generatedName),
+  //   //     `Can't auto-generate test name for value '${generatedName}'`,
+  //   //   );
+  //   //   return generatedName;
+  //   // }
+  //   return new ValueSpecification();
+  // }
   const expression = new SimpleFunctionExpression(
     functionName,
-    multiplicityOne,
+    multiplicity_ONE,
   );
   expression.parametersValues.push(
     filterConditionState.propertyEditorState.propertyExpression,
@@ -105,10 +135,178 @@ export const buildFilterConditionExpression = (
   return expression;
 };
 
+// buildFilterExpression(
+//   getAllFunc: SimpleFunctionExpression,
+// ): SimpleFunctionExpression | undefined {
+//   const lambdaVariable = new VariableExpression(
+//     this.filterState.lambdaVariableName,
+//     this.editorStore.graphState.graph.getTypicalMultiplicity(
+//       TYPICAL_MULTIPLICITY_TYPE.ONE,
+//     ),
+//   );
+//   const parameters = this.filterState.getParameterValues();
+//   if (!parameters) {
+//     return undefined;
+//   }
+//   const typeAny = this.editorStore.graphState.graph.getClass(
+//     CORE_ELEMENT_PATH.ANY,
+//   );
+//   const multiplicityOne = this.editorStore.graphState.graph.getTypicalMultiplicity(
+//     TYPICAL_MULTIPLICITY_TYPE.ONE,
+//   );
+//   // main filter expression
+//   const filterExpression = new SimpleFunctionExpression(
+//     SUPPORTED_FUNCTIONS.FILTER,
+//     multiplicityOne,
+//   );
+//   // param [0]
+//   filterExpression.parametersValues.push(getAllFunc);
+//   // param [1]
+//   const filterLambda = new LambdaFunctionInstanceValue(multiplicityOne);
+//   const filterLambdaFunctionType = new FunctionType(typeAny, multiplicityOne);
+//   filterLambdaFunctionType.parameters.push(lambdaVariable);
+//   const colLambdaFunction = new LambdaFunction(filterLambdaFunctionType);
+//   colLambdaFunction.expressionSequence = parameters;
+//   filterLambda.values.push(colLambdaFunction);
+//   filterExpression.parametersValues.push(filterLambda);
+//   return filterExpression;
+// }
+
+/**
+ * Handling exists() lambda found in the filter condition expression.
+ * The general approach for handling exists() is we will flat out the chain
+ * of exists() expressions into a normal filter condition state.
+ *
+ * When we build the condition function expression from the filter condition state,
+ * we walk the property expression chain, find property with multiplitiy upper bound
+ * other than 1 and create an exists() lambda there
+ *
+ * NOTE: to ensure we respect user's choice of variable name, as we build the state
+ * we record the lambda parameter names, so we can use those while re-building the function
+ * If for some reason, this list is stale, we can start adding our own parameter names
+ */
+const buildFilterConditionStateWithExists = (
+  filterState: QueryBuilderFilterState,
+  expression: SimpleFunctionExpression,
+  operatorFunctionName: string,
+): FilterConditionState | undefined => {
+  if (expression.functionName === SUPPORTED_FUNCTIONS.EXISTS) {
+    const existsLambdaParameterNames: string[] = [];
+    const propertyExpressions: AbstractPropertyExpression[] = [];
+    let currentExpression: SimpleFunctionExpression = expression;
+    while (currentExpression.functionName === SUPPORTED_FUNCTIONS.EXISTS) {
+      // loop into and extract and build the property expression
+      const existsLambda = guaranteeNonNullable(
+        guaranteeType(
+          expression.parametersValues[1],
+          LambdaFunctionInstanceValue,
+        ).values[0],
+        'exists() lambda function is missing',
+      );
+      if (
+        existsLambda.expressionSequence.length === 1 &&
+        existsLambda.expressionSequence[0] instanceof
+          SimpleFunctionExpression &&
+        existsLambda.functionType.parameters.length === 1 &&
+        existsLambda.functionType.parameters[0] instanceof VariableExpression
+      ) {
+        currentExpression = guaranteeType(
+          existsLambda.expressionSequence[0],
+          SimpleFunctionExpression,
+        );
+        // record the lambda parameter name
+        existsLambdaParameterNames.push(
+          guaranteeType(
+            existsLambda.functionType.parameters[0],
+            VariableExpression,
+          ).name,
+        );
+        // record the lambda property expression
+        if (
+          currentExpression.parametersValues[0] instanceof
+          AbstractPropertyExpression
+        ) {
+          propertyExpressions.push(
+            guaranteeType(
+              currentExpression.parametersValues[0],
+              AbstractPropertyExpression,
+            ),
+          );
+        }
+      } else {
+        throw new Error(`Can't process exists() lambda function`);
+      }
+    }
+    if (currentExpression.functionName !== operatorFunctionName) {
+      return undefined;
+    }
+    const multiplicity_ONE = filterState.editorStore.graphState.graph.getTypicalMultiplicity(
+      TYPICAL_MULTIPLICITY_TYPE.ONE,
+    );
+    // form the property expression chain
+    const initialPropertyExpression = guaranteeType(
+      expression.parametersValues[0],
+      AbstractPropertyExpression,
+    );
+    let propertyExpression = new AbstractPropertyExpression(
+      '',
+      multiplicity_ONE,
+    );
+    propertyExpression.func = initialPropertyExpression.func;
+    propertyExpression.parametersValues =
+      initialPropertyExpression.parametersValues;
+    for (const currentPropertyExpression of propertyExpressions) {
+      // when rebuilding the property expression chain, disregard the initial variable that starts the chain
+      const pes: AbstractPropertyExpression[] = [];
+      let currentPe: ValueSpecification = currentPropertyExpression;
+      while (currentPe instanceof AbstractPropertyExpression) {
+        const pe = new AbstractPropertyExpression('', multiplicity_ONE);
+        pe.func = currentPe.func;
+        pe.parametersValues =
+          currentPe.parametersValues.length > 1
+            ? // NOTE: we must retain the rest of the parameters as those are derived property parameters
+              currentPe.parametersValues.slice(1)
+            : [];
+        pes.push(pe);
+        currentPe = currentPe.parametersValues[0];
+      }
+      assertTrue(
+        pes.length > 0,
+        `exists() usage with non-chain property expression is not supported`,
+      );
+      for (let i = 0; i < pes.length - 1; ++i) {
+        pes[i].parametersValues.unshift(pes[i + 1]);
+      }
+      pes[pes.length - 1].parametersValues.unshift(propertyExpression);
+      propertyExpression = pes[0];
+    }
+    const filterConditionState = new FilterConditionState(
+      filterState.editorStore,
+      filterState,
+      propertyExpression,
+    );
+    existsLambdaParameterNames.forEach((paramName) =>
+      filterConditionState?.addExistsLambdaParamNames(paramName),
+    );
+    return filterConditionState;
+  }
+  return undefined;
+};
+
+const getPropertyExpressionChainVariable = (
+  propertyExpression: AbstractPropertyExpression,
+): VariableExpression => {
+  let currentPe: ValueSpecification = propertyExpression;
+  while (currentPe instanceof AbstractPropertyExpression) {
+    currentPe = currentPe.parametersValues[0];
+  }
+  return guaranteeType(currentPe, VariableExpression);
+};
+
 export const buildFilterConditionState = (
   filterState: QueryBuilderFilterState,
   expression: SimpleFunctionExpression,
-  functionName: string,
+  operatorFunctionName: string,
   operator: QueryBuilderOperator,
   /**
    * Use this flag for operator that does not require any param (e.g. isEmpty)
@@ -117,49 +315,33 @@ export const buildFilterConditionState = (
    */
   hasNoValue = false,
 ): FilterConditionState | undefined => {
-  // const chainList: string[] = [];
-  // const currentPropertyExpression: AbstractPropertyExpression | undefined = undefined;
-  // Handling `exists`
-  // if (expression.functionName === EXISTS_FUNCTION_NAME) {
-  // the first param
-  // expression.parametersValues[0], -> the lambda
-  // the second param
-  // expression.
-  // Handling the actual function
-  // }
-  // } else
-  if (expression.functionName === functionName) {
+  let filterConditionState: FilterConditionState | undefined;
+  if (expression.functionName === operatorFunctionName) {
     const propertyExpression = guaranteeType(
       expression.parametersValues[0],
       AbstractPropertyExpression,
     );
-    // WIP-QB: support `exists()`
-    // NOTE: right now we're blocked by the faulty handling of scoped variables in core Studio
-    /**
-     * model::target::_Firm.all()
-   ->filter
-    (
-      x|$x.employees->exists(c | $c.fullName == '')
-    )
-
-    model::target::_Firm.all()
-   ->filter
-    (
-      x|$x.employees->exists(x |$x.fullName == '')
-    )
-    the variable in the `exists` lambda will not be recognised properly
-     */
-    // const variable = guaranteeType(
-    //   propertyExpression.parametersValues[0],
-    //   VariableExpression,
-    // );
-    // chainList.push(variable.name);
-    // columnState.setLambdaVariableName(variable.name);
-    const filterConditionState = new FilterConditionState(
+    // Make sure the variable name used in the property expression matches the lambda parameter
+    if (
+      filterState.lambdaVariableName !==
+      getPropertyExpressionChainVariable(propertyExpression).name
+    ) {
+      return undefined;
+    }
+    filterConditionState = new FilterConditionState(
       filterState.editorStore,
       filterState,
       propertyExpression,
     );
+  } else if (expression.functionName === SUPPORTED_FUNCTIONS.EXISTS) {
+    filterConditionState = buildFilterConditionStateWithExists(
+      filterState,
+      expression,
+      operatorFunctionName,
+    );
+  }
+  // Do some check to make sure the simple filter condition LHS, RHS, and operator are compatible
+  if (filterConditionState) {
     if (
       !operator.isCompatibleWithFilterConditionProperty(filterConditionState)
     ) {
@@ -190,7 +372,7 @@ export const buildNotExpression = (
     TYPICAL_MULTIPLICITY_TYPE.ONE,
   );
   const expressionNot = new SimpleFunctionExpression(
-    NOT_FUNCTION_NAME,
+    SUPPORTED_FUNCTIONS.NOT,
     multiplicityOne,
   );
   expressionNot.parametersValues.push(expression);
@@ -200,7 +382,7 @@ export const buildNotExpression = (
 export const unwrapNotExpression = (
   expression: SimpleFunctionExpression,
 ): SimpleFunctionExpression | undefined => {
-  if (expression.functionName === NOT_FUNCTION_NAME) {
+  if (expression.functionName === SUPPORTED_FUNCTIONS.NOT) {
     return guaranteeType(
       expression.parametersValues[0],
       SimpleFunctionExpression,
@@ -208,11 +390,6 @@ export const unwrapNotExpression = (
   }
   return undefined;
 };
-
-export interface QueryBuilderValueSpecificationInfo {
-  type: Type;
-  isCollection: boolean;
-}
 
 export const getValueSpecificationTypeInfo = (
   valueSpecification: ValueSpecification,
@@ -228,35 +405,6 @@ export const getValueSpecificationTypeInfo = (
       isCollection: false,
     };
   }
-  // TODO: support collection here
+  // WIP-QB: support collection here
   return undefined;
 };
-
-// TODO: we might want to check and make sure lambda variable name is preserved in `filter()`
-
-// export const buildExistsExpression = (
-//   filterConditionState: FilterConditionState,
-//   expression: ValueSpecification,
-// ): ValueSpecification => {
-//   const multiplicityOne = filterConditionState.editorStore.graphState.graph.getTypicalMultiplicity(
-//     TYPICAL_MULTIPLICITY_TYPE.ONE,
-//   );
-//   const expressionNot = new SimpleFunctionExpression(
-//     NOT_FUNCTION_NAME,
-//     multiplicityOne,
-//   );
-//   expressionNot.parametersValues.push(expression);
-//   return expressionNot;
-// };
-
-// export const unwrapExistsExpression = (
-//   expression: SimpleFunctionExpression,
-// ): SimpleFunctionExpression | undefined => {
-//   if (expression.functionName === NOT_FUNCTION_NAME) {
-//     return guaranteeType(
-//       expression.parametersValues[0],
-//       SimpleFunctionExpression,
-//     );
-//   }
-//   return undefined;
-// };

--- a/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
+++ b/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
@@ -515,15 +515,17 @@
   }
 
   &__mode {
-    padding: 0.5rem;
     display: flex;
     align-items: center;
     background: var(--color-dark-grey-250);
     color: var(--color-light-grey-200);
+    height: 2.2rem;
+    font-size: 1.2rem;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
   }
 
   &__mode--selected {
-    cursor: default;
     background: var(--color-blue-200);
   }
 }

--- a/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
+++ b/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
@@ -1124,7 +1124,8 @@
     }
 
     &__operator__dropdown__option {
-      font-size: 1.2rem;
+      font-size: 1.1rem;
+      height: 2.2rem;
       font-family: 'Roboto Mono', monospace;
     }
 
@@ -1292,6 +1293,26 @@
           background: var(--color-dark-grey-50) !important;
         }
       }
+    }
+  }
+
+  &__modal--has-error {
+    border: 0.1rem solid var(--color-red-280) !important;
+
+    .modal__header {
+      background: var(--color-red-200);
+    }
+
+    .modal__title__error-badge {
+      @include flexCenter;
+
+      margin-right: 1rem;
+      background: var(--color-red-400);
+      height: 2.2rem;
+      border-radius: 0.2rem;
+      padding: 0.5rem;
+      font-size: 1.2rem;
+      user-select: none;
     }
   }
 }

--- a/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
+++ b/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
@@ -356,7 +356,7 @@
     display: inline-flex;
     font-weight: 700;
     font-size: 1.1rem;
-    font-family: 'Roboto Mono', sans-serif;
+    font-family: 'Roboto Mono', monospace;
     color: var(--color-light-grey-400);
     height: 2rem;
     line-height: 2rem;
@@ -367,7 +367,7 @@
     display: inline-flex;
     font-weight: 700;
     font-size: 1.6rem;
-    font-family: 'Roboto Mono', sans-serif;
+    font-family: 'Roboto Mono', monospace;
     height: 2rem;
     line-height: 2rem;
     margin-left: 0.5rem;
@@ -865,7 +865,7 @@
     line-height: 1.8rem;
     font-weight: 700;
     font-size: 1rem;
-    font-family: 'Roboto Mono', sans-serif;
+    font-family: 'Roboto Mono', monospace;
     color: var(--color-light-grey-200);
     background: var(--color-dark-shade-230);
 
@@ -1096,8 +1096,6 @@
     }
 
     &__operator__label {
-      @include flexCenter;
-
       padding: 0 0.5rem;
       font-weight: 500;
       background: var(--color-dark-grey-280);
@@ -1105,6 +1103,8 @@
       color: var(--color-light-grey-100);
       border-radius: 0.2rem 0 0 0.2rem;
       font-size: 1.1rem;
+      line-height: 1.8rem;
+      white-space: nowrap;
     }
 
     &__operator__dropdown__trigger {
@@ -1125,7 +1125,7 @@
 
     &__operator__dropdown__option {
       font-size: 1.2rem;
-      font-family: 'Roboto Mono', sans-serif;
+      font-family: 'Roboto Mono', monospace;
     }
 
     &__value {
@@ -1164,6 +1164,16 @@
 
   height: 100%;
   width: 100%;
+
+  &--unsupported {
+    @include flexCenter;
+
+    width: 100%;
+    height: 1.8rem;
+    background: var(--color-dark-grey-280);
+    border-radius: 0.2rem;
+    font-size: 1.1rem;
+  }
 
   &__input {
     height: 100%;
@@ -1212,6 +1222,52 @@
       cursor: not-allowed;
       color: var(--color-dark-grey-300);
     }
+  }
+
+  &__list-editor__preview {
+    @include ellipsisTextOverflow;
+
+    line-height: 1.8rem;
+    width: calc(100% - 1.8rem);
+    height: 1.8rem;
+    font-size: 1.1rem;
+    font-family: 'Roboto Mono', monospace;
+    background: var(--color-dark-grey-250);
+    padding-left: 0.5rem;
+    color: var(--color-light-grey-300);
+    cursor: pointer;
+  }
+
+  &__list-editor__save-button {
+    @include flexCenter;
+
+    height: 2.2rem;
+    width: 2.2rem;
+    min-width: 2.2rem;
+
+    svg {
+      font-size: 1.2rem;
+    }
+  }
+
+  &__list-editor__edit-icon {
+    @include flexCenter;
+
+    height: 1.8rem;
+    width: 2.7rem;
+    min-width: 2.7rem;
+    background: var(--color-dark-grey-250);
+    border-radius: 0 0.9rem 0.9rem 0;
+
+    svg {
+      font-size: 1.2rem;
+      color: var(--color-light-grey-250);
+    }
+  }
+
+  &:hover &__list-editor__preview,
+  &:hover &__list-editor__edit-icon {
+    background: var(--color-dark-grey-300);
   }
 }
 

--- a/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
+++ b/packages/legend-studio-plugin-query-builder/style/_query-builder.scss
@@ -16,11 +16,6 @@
 
 @use './mixins' as *;
 
-:root {
-  --color-magenta-300: #8c4268;
-}
-
-// TODO: when we componentize query builder, we should move this out
 .query-builder__dialog {
   height: calc(100vh - 4rem);
   width: calc(100vw - 4rem);
@@ -1226,11 +1221,6 @@
       width: 100%;
       height: 100%;
       background: var(--color-dark-grey-50);
-    }
-
-    &__close-btn {
-      border-color: var(--color-blue-200);
-      background: var(--color-blue-300);
     }
   }
 

--- a/packages/legend-studio-shared/src/data-structures/Stack.ts
+++ b/packages/legend-studio-shared/src/data-structures/Stack.ts
@@ -36,7 +36,17 @@ export class Stack<T> implements StackInterface<T> {
     return this.storage[this.size() - 1];
   }
 
+  peekAll(): T[] {
+    return [...this.storage];
+  }
+
   size(): number {
     return this.storage.length;
+  }
+
+  clone(): Stack<T> {
+    const stack = new Stack<T>();
+    this.storage.forEach((item) => stack.push(item));
+    return stack;
   }
 }

--- a/packages/legend-studio/src/components/shared/LambdaEditor.tsx
+++ b/packages/legend-studio/src/components/shared/LambdaEditor.tsx
@@ -88,6 +88,7 @@ const LambdaEditorInner = observer(
     forceBackdrop: boolean;
     forceExpansion?: boolean;
     useBaseTextEditorSettings?: boolean;
+    hideErrorBar?: boolean;
   }) => {
     const {
       className,
@@ -100,6 +101,7 @@ const LambdaEditorInner = observer(
       forceBackdrop,
       forceExpansion,
       useBaseTextEditorSettings,
+      hideErrorBar,
     } = props;
     const editorStore = useEditorStore();
     const applicationStore = useApplicationStore();
@@ -414,10 +416,12 @@ const LambdaEditorInner = observer(
             </button>
           )}
         </div>
-        <LambdaErrorFeedback
-          error={parserError ?? compilationError}
-          discardChanges={discardChanges}
-        />
+        {!hideErrorBar && (
+          <LambdaErrorFeedback
+            error={parserError ?? compilationError}
+            discardChanges={discardChanges}
+          />
+        )}
       </>
     );
   },
@@ -439,6 +443,7 @@ export const LambdaEditor = observer(
     forceBackdrop: boolean;
     forceExpansion?: boolean;
     useBaseTextEditorSettings?: boolean;
+    hideErrorBar?: boolean;
   }) => {
     const {
       className,
@@ -450,6 +455,7 @@ export const LambdaEditor = observer(
       matchedExpectedType,
       forceExpansion,
       useBaseTextEditorSettings,
+      hideErrorBar,
     } = props;
     const debouncedTransformStringToLambda = useMemo(
       () =>
@@ -499,6 +505,7 @@ export const LambdaEditor = observer(
         forceBackdrop={forceBackdrop}
         forceExpansion={forceExpansion}
         useBaseTextEditorSettings={useBaseTextEditorSettings}
+        hideErrorBar={hideErrorBar}
       />
     );
   },

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/InstanceValue.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/InstanceValue.ts
@@ -43,11 +43,17 @@ export class InstanceValue extends ValueSpecification {
   deleteValue(val: unknown): void {
     deleteEntry(this.values, val);
   }
+
   addValue(val: unknown): void {
     addUniqueEntry(this.values, val);
   }
+
   changeValue(val: unknown, idx: number): void {
     this.values[idx] = val;
+  }
+
+  changeValues(val: unknown[]): void {
+    this.values = val;
   }
 
   accept_ValueSpecificationVisitor<T>(
@@ -201,6 +207,20 @@ export class PureListInstanceValue extends InstanceValue {
 
 export class CollectionInstanceValue extends InstanceValue {
   values: ValueSpecification[] = [];
+
+  constructor(
+    multiplicity: Multiplicity,
+    genericTypeReference?: GenericTypeReference,
+  ) {
+    super(multiplicity, genericTypeReference);
+
+    makeObservable<CollectionInstanceValue>(this, {
+      genericType: observable,
+      values: observable,
+      changeValues: action,
+    });
+  }
+
   accept_ValueSpecificationVisitor<T>(
     visitor: ValueSpecificationVisitor<T>,
   ): T {

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
@@ -38,6 +38,8 @@ export enum SUPPORTED_FUNCTIONS {
   SORT_FUNC = 'sort',
   SERIALIZE = 'serialize',
   GRAPH_FETCH_CHECKED = 'graphFetchChecked',
+  EXISTS = 'exists',
+  NOT = 'not',
 }
 
 export class Expression extends ValueSpecification {

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ProcessingContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ProcessingContext.ts
@@ -84,4 +84,17 @@ export class V1_ProcessingContext {
     map.set(name, variable);
     this.inferredVariableList.push(map);
   }
+
+  clone(): V1_ProcessingContext {
+    const ctx = new V1_ProcessingContext('');
+    ctx.tags = this.tags.clone();
+    ctx.inferredVariableList = this.inferredVariableList.map((varMap) => {
+      const newVarMap = new Map<string, ValueSpecification>();
+      varMap.forEach((valueSpec, key) => {
+        newVarMap.set(key, valueSpec);
+      });
+      return newVarMap;
+    });
+    return ctx;
+  }
 }

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
@@ -120,6 +120,8 @@ import type { V1_TDSSortInformation } from '../../../../model/valueSpecification
 import type { V1_UnitInstance } from '../../../../model/valueSpecification/raw/V1_UnitInstance';
 import type { V1_UnitType } from '../../../../model/valueSpecification/raw/V1_UnitType';
 import { V1_getAppliedProperty } from './V1_DomainBuilderHelper';
+import { Enumeration } from '../../../../../../../metamodels/pure/model/packageableElements/domain/Enumeration';
+import { EnumValueExplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/domain/EnumValueReference';
 
 const LET_FUNCTION = 'letFunction';
 
@@ -167,7 +169,7 @@ export class V1_ValueSpecificationBuilder
       const vs = this.processingContext.getInferredVariable(variable.name);
       if (!vs) {
         throw new GraphError(
-          `Can't find variable class for variable '${variable.name}' in the graph`,
+          `Can't find variable '${variable.name}' in the graph`,
         );
       }
       return vs;
@@ -179,7 +181,7 @@ export class V1_ValueSpecificationBuilder
       valueSpecification.body,
       valueSpecification.parameters,
       this.context,
-      this.processingContext,
+      this.processingContext.clone(), // clone the context for lambda
     );
     const instance = new LambdaFunctionInstanceValue(
       this.context.graph.getTypicalMultiplicity(TYPICAL_MULTIPLICITY_TYPE.ONE),
@@ -605,18 +607,6 @@ export function V1_buildLambdaBody(
   return _lambda;
 }
 
-export function V1_buildLambda(
-  lambda: V1_Lambda,
-  context: V1_GraphBuilderContext,
-): LambdaFunction {
-  return V1_buildLambdaBody(
-    lambda.body,
-    lambda.parameters,
-    context,
-    new V1_ProcessingContext('build V1_Lambda'),
-  );
-}
-
 export function V1_buildValueSpecification(
   valueSpecification: V1_ValueSpecification,
   context: V1_GraphBuilderContext,
@@ -862,9 +852,18 @@ export function V1_processProperty(
     );
     processedProperty.parametersValues = processedParameters;
     return processedProperty;
+  } else if (inferredType instanceof Enumeration) {
+    const enumValueInstanceValue = new EnumValueInstanceValue(
+      GenericTypeExplicitReference.create(new GenericType(inferredType)),
+      context.graph.getTypicalMultiplicity(TYPICAL_MULTIPLICITY_TYPE.ONE),
+    );
+    enumValueInstanceValue.values = [
+      EnumValueExplicitReference.create(inferredType.getValue(property)),
+    ];
+    return enumValueInstanceValue;
   }
   throw new Error(
-    `Unable to resolve property for type '${inferredType?.name}'`,
+    `Unable to resolve property '${property}' of type '${inferredType?.name}'`,
   );
 }
 
@@ -932,6 +931,15 @@ export function V1_buildFunctionExpression(
         processingContext,
       );
     }
+    case SUPPORTED_FUNCTIONS.EXISTS: {
+      return V1_buildExistsFunctionExpression(
+        functionName,
+        parameters,
+        openVariables,
+        compileContext,
+        processingContext,
+      );
+    }
     default: {
       const processed = parameters.map((p) =>
         p.accept_ValueSpecificationVisitor(
@@ -953,6 +961,74 @@ export function V1_buildFunctionExpression(
 }
 
 // ------------------------------------------ RESOLVE SUPPORTED FUNCTIONS -----------------------------------------
+
+export function V1_buildExistsFunctionExpression(
+  functionName: string,
+  parameters: V1_ValueSpecification[],
+  openVariables: string[],
+  compileContext: V1_GraphBuilderContext,
+  processingContext: V1_ProcessingContext,
+): [SimpleFunctionExpression, ValueSpecification[]] {
+  if (parameters.length === 2) {
+    const processedValue = parameters[0].accept_ValueSpecificationVisitor(
+      new V1_ValueSpecificationBuilder(
+        compileContext,
+        processingContext,
+        openVariables,
+      ),
+    );
+    processedValue.genericType = guaranteeType(
+      processedValue,
+      AbstractPropertyExpression,
+    ).func.genericType;
+    const lambda = parameters[1];
+    if (lambda instanceof V1_Lambda) {
+      lambda.parameters.forEach((p): void => {
+        if (p.name && !p.class) {
+          const _var = new VariableExpression(
+            p.name,
+            compileContext.graph.getTypicalMultiplicity(
+              TYPICAL_MULTIPLICITY_TYPE.ONE,
+            ),
+          );
+          _var.genericType = processedValue.genericType;
+          processingContext.addInferredVariables(p.name, _var);
+        }
+      });
+    }
+    const _processed = [
+      processedValue,
+      parameters[1].accept_ValueSpecificationVisitor(
+        new V1_ValueSpecificationBuilder(
+          compileContext,
+          processingContext,
+          openVariables,
+        ),
+      ),
+    ];
+    const _simpleFunction = processSimpleFunctionExpression(
+      _processed,
+      functionName,
+      compileContext,
+    );
+    return [_simpleFunction, _processed];
+  }
+  const processed = parameters.map((p) =>
+    p.accept_ValueSpecificationVisitor(
+      new V1_ValueSpecificationBuilder(
+        compileContext,
+        processingContext,
+        openVariables,
+      ),
+    ),
+  );
+  const simpleFunction = processSimpleFunctionExpression(
+    processed,
+    functionName,
+    compileContext,
+  );
+  return [simpleFunction, processed];
+}
 
 export function V1_buildFilterFunctionExpression(
   functionName: string,
@@ -999,7 +1075,7 @@ export function V1_buildFilterFunctionExpression(
       functionName,
       compileContext,
     );
-    // return type of filtered is of type of param 0
+    // return type of filtered is of type of param 0 - filter_T_MANY__Function_1__T_MANY_
     _simpleFunction.genericType = processedValue.genericType;
     _simpleFunction.multiplicity = processedValue.multiplicity;
     return [_simpleFunction, _processed];

--- a/packages/legend-studio/style/components/editor/_service-editor.scss
+++ b/packages/legend-studio/style/components/editor/_service-editor.scss
@@ -733,7 +733,7 @@
 
   &__result__text {
     line-height: 2rem;
-    font-family: 'Roboto Mono', sans-serif;
+    font-family: 'Roboto Mono', monospace;
     font-size: 1.3rem;
 
     &--failed,

--- a/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-editor.scss
+++ b/packages/legend-studio/style/components/editor/mapping-editor/_mapping-test-editor.scss
@@ -54,7 +54,7 @@
     padding: 2rem;
     color: var(--color-light-grey-150);
     background: var(--color-dark-grey-50);
-    font-family: 'Roboto Mono', sans-serif;
+    font-family: 'Roboto Mono', monospace;
   }
 
   &__result--failed,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,6 +1982,7 @@ __metadata:
     "@finos/legend-studio-shared": "workspace:*"
     "@testing-library/dom": 7.30.4
     "@testing-library/react": 11.2.6
+    "@types/papaparse": 5.2.5
     "@types/react": 17.0.3
     "@types/react-dom": 17.0.3
     "@types/react-router-dom": 5.1.7
@@ -1993,6 +1994,7 @@ __metadata:
     mobx-react-lite: 3.2.0
     monaco-editor: 0.23.0
     npm-run-all: 4.1.5
+    papaparse: 5.3.0
     react: 17.0.2
     react-dom: 17.0.2
     react-router-dom: 5.2.0
@@ -3014,6 +3016,15 @@ __metadata:
   version: 1.0.1
   resolution: "@types/pako@npm:1.0.1"
   checksum: dea6f4b8e4cc1a8a129b373bced446f8c3b02d5b98a9669f4598a82a45b72912146f578ccb6a0b75a0d29ea125e272b07c1ffc15225635d30cf8807f07ed0d81
+  languageName: node
+  linkType: hard
+
+"@types/papaparse@npm:5.2.5":
+  version: 5.2.5
+  resolution: "@types/papaparse@npm:5.2.5"
+  dependencies:
+    "@types/node": "*"
+  checksum: c212250add6ab83825b3ebb7afbe4df47888dd800ea2e1bf06758394efaab047beb12c50bfaf45a6066cf5ead95b250042fa92675ef1fff1c235990c8ec14d8b
   languageName: node
   linkType: hard
 
@@ -11527,6 +11538,13 @@ __metadata:
   version: 2.0.3
   resolution: "pako@npm:2.0.3"
   checksum: a89beeaf07a8853f1b1b4868088489582f9f3ba4170e779c2af6a9f2f91735c67a4e63e52b9c7cdef6e0b530838b72437cf53ff624ef5315d6eb2ae0c459b1dd
+  languageName: node
+  linkType: hard
+
+"papaparse@npm:5.3.0":
+  version: 5.3.0
+  resolution: "papaparse@npm:5.3.0"
+  checksum: 65a492e6dcfd03ea39114cdedbc3bf71be3ec16e622e94e09f6ffbba5a964bba6bd11c6aecec6a93d2f700d6f847716357266f9f6206a23ee1ee896c3f2bb2b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                       | A                                |
| ----------------------- | -------------------------------- |
| Fixed issues?           | <!-- e.g. Fixes #1, Fixes #2 --> |
| Tests added + passed?   | Yes                              |
| Changeset added?        | Yes                              |
| Documentation PR link   |                                  |
| Any dependency changes? | Yes                               |

This is more a continuation of query builder MVP in https://github.com/finos/legend-studio/pull/166

This adds support for more complex filter features and stabilizes the query builder UI. In particular, the major points of this PR are:
- [x] Handling property expressions which includes properties with multiplicity `many - [*]` in filter with `exists()`
- [x] Properly handling group operations with more than 2 clauses
- [x] Add the ability to simplify filter boolean expression tree (unnecessary group node can be squashed into its parent group node who has the same group operator). This is done to help with handling reading filter expression with group operations with more than 2 clauses
- [x] Add support for set operators, such as `in/not-in`
- [x] Fix issue where enumeration operators cannot resolve the enum values after exiting text-mode
- [x] Add more round-trip tests for the query filter lambda processing
- [x] Stabilize certain DnD interactions in filter boolean expression tree
- [x] Respect user's input for variable names in lambda
- [x] Add a workaround to hide `graph fetch` option in query builder as it's `WIP`
