### PR TITLE
Resolve some issues around grammar roundtrip for embedded relational mapping

### DIFF
--- a/.changeset/eight-tables-refuse.md
+++ b/.changeset/eight-tables-refuse.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-studio': patch
+'@finos/legend-studio-manual-tests': patch
+---
+
+Modify Pure protocol, (de)serialization, and hash computation of relational mapping to match with what grammar parser in engine yields.

--- a/packages/legend-studio-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
+++ b/packages/legend-studio-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
@@ -52,7 +52,8 @@ const ENGINE_SERVER_URL = 'http://localhost:6060/api';
 const TEST_CASE_DIR = path.resolve(__dirname, 'cases');
 const EXCLUDED_CASE_FILES: string[] = [
   'basic-M2M.pure', // until we fix the grammar parser to not include the variable for the property mapping lambda
-  'embedded-relational-mapping-with-imports.pure', // TODO?
+  // 'embedded-relational-mapping.pure',
+  'nested-embedded-relational-mapping.pure',
 ];
 
 const checkGrammarRoundtrip = async (

--- a/packages/legend-studio-manual-tests/src/__tests__/roundtrip-grammar/cases/nested-embedded-relational-mapping.pure
+++ b/packages/legend-studio-manual-tests/src/__tests__/roundtrip-grammar/cases/nested-embedded-relational-mapping.pure
@@ -1,4 +1,5 @@
 import other::*;
+import meta::pure::mapping::*;
 
 Class other::Person
 {
@@ -16,6 +17,7 @@ Class other::Address
 {
     line1:String[1];
 }
+
 ###Relational
 Database mapping::db(
    Table employeeFirmDenormTable
@@ -26,25 +28,36 @@ Database mapping::db(
     legalName VARCHAR(200),
     address VARCHAR(200)
    )
+   Table employeeFirmDenormTable2
+   (
+    id INT PRIMARY KEY,
+    name VARCHAR(200),
+    firmId INT,
+    legalName VARCHAR(200),
+    address VARCHAR(200)
+   )
 )
+
 ###Mapping
+import other::*;
+import mapping::*;
 Mapping mappingPackage::myMapping
 (
-    other::Person: Relational
+    Person: Relational
     {
-        name : [mapping::db]employeeFirmDenormTable.name,
+        name : [db]employeeFirmDenormTable.name,
         firm
         (
-            ~primaryKey ([mapping::db]employeeFirmDenormTable.legalName)
-            legalName : [mapping::db]employeeFirmDenormTable.legalName,
+            ~primaryKey ([db]employeeFirmDenormTable.legalName)
+            legalName : [db]employeeFirmDenormTable.legalName,
             address
             (
-                line1: [mapping::db]employeeFirmDenormTable.address
+                line1: [db]employeeFirmDenormTable.address
             )
         ),
         address
         (
-            line1: [mapping::db]employeeFirmDenormTable.address
+            line1: [db]employeeFirmDenormTable.address
         )
     }
 )

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
@@ -70,13 +70,13 @@ export class PackageableElementImplicitReference<
   readonly initialResolvedPath: string;
   readonly input: string;
   readonly parentSection?: Section;
-  readonly isResolvedFromAutoImports?: boolean;
+  readonly isInferred?: boolean;
 
   private constructor(
     value: T,
     input: string,
     parentSection: Section | undefined,
-    isResolvedFromAutoImports: boolean | undefined,
+    isInferred: boolean | undefined,
   ) {
     super(value);
 
@@ -87,7 +87,7 @@ export class PackageableElementImplicitReference<
     this.initialResolvedPath = value.path;
     this.input = input;
     this.parentSection = parentSection;
-    this.isResolvedFromAutoImports = isResolvedFromAutoImports;
+    this.isInferred = isInferred;
   }
 
   static create<V extends PackageableElement>(
@@ -106,7 +106,7 @@ export class PackageableElementImplicitReference<
 
   get valueForSerialization(): string {
     const currentElementPath = this.value.path;
-    if (this.isResolvedFromAutoImports) {
+    if (this.isInferred) {
       return this.input;
     }
     // when the parent section does not exist or has been deleted
@@ -181,7 +181,7 @@ export class OptionalPackageableElementImplicitReference<
     value: T | undefined,
     input: string | undefined,
     parentSection: Section | undefined,
-    isResolvedFromAutoImports: boolean | undefined,
+    isInferred: boolean | undefined,
   ) {
     super(value);
 
@@ -192,20 +192,20 @@ export class OptionalPackageableElementImplicitReference<
     this.initialResolvedPath = value?.path;
     this.input = input;
     this.parentSection = parentSection;
-    this.isResolvedFromAutoImports = isResolvedFromAutoImports;
+    this.isResolvedFromAutoImports = isInferred;
   }
 
   static create<V extends PackageableElement>(
     value: V | undefined,
     input: string | undefined,
     parentSection: Section | undefined,
-    isResolvedFromAutoImports: boolean | undefined,
+    isInferred: boolean | undefined,
   ): OptionalPackageableElementImplicitReference<V> {
     return new OptionalPackageableElementImplicitReference(
       value,
       input,
       parentSection,
-      isResolvedFromAutoImports,
+      isInferred,
     );
   }
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_PropertyPointer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/domain/V1_PropertyPointer.ts
@@ -19,14 +19,16 @@ import type { Hashable } from '@finos/legend-studio-shared';
 import { CORE_HASH_STRUCTURE } from '../../../../../../MetaModelConst';
 
 export class V1_PropertyPointer implements Hashable {
-  class!: string;
+  // NOTE: In Pure protocol, this property is required, but for cases like embedded property mapping,
+  // this should not be set, so most likely we will change Pure protocol to match this eventually.
+  class?: string;
   property!: string;
 
   get hashCode(): string {
     return hashArray([
       CORE_HASH_STRUCTURE.PROPERTY_POINTER,
       this.property,
-      this.class,
+      this.class ?? '',
     ]);
   }
 }

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ClassMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/mapping/V1_ClassMapping.ts
@@ -41,7 +41,9 @@ export interface V1_ClassMappingVisitor<T> {
 
 export abstract class V1_ClassMapping implements Hashable {
   id?: string;
-  class!: string;
+  // NOTE: In Pure protocol, this property is required, but for cases like embedded property mapping,
+  // this should not be set, so most likely we will change Pure protocol to match this eventually.
+  class?: string;
   root!: boolean;
   mappingClass?: V1_MappingClass;
 
@@ -49,7 +51,7 @@ export abstract class V1_ClassMapping implements Hashable {
     return hashArray([
       CORE_HASH_STRUCTURE.SET_IMPLEMENTATION,
       this.id ?? '',
-      this.class,
+      this.class ?? '',
       this.root.toString(),
     ]);
   }

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
@@ -35,7 +35,7 @@ export class V1_EmbeddedRelationalPropertyMapping
     return hashArray([
       CORE_HASH_STRUCTURE.EMBEDDED_REALTIONAL_PROPERTY_MAPPPING,
       super.hashCode,
-      this.classMapping.class,
+      this.classMapping.class ?? '',
       hashArray(this.classMapping.primaryKey),
       // skip `root` since we disregard it in embedded property mappings
       hashArray(this.classMapping.propertyMappings),

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping.ts
@@ -37,7 +37,7 @@ export class V1_EmbeddedRelationalPropertyMapping
       super.hashCode,
       this.classMapping.class,
       hashArray(this.classMapping.primaryKey),
-      // // skip `root` since we disregard it in embedded property mappings
+      // skip `root` since we disregard it in embedded property mappings
       hashArray(this.classMapping.propertyMappings),
     ]);
   }

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_TablePtr.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/model/V1_TablePtr.ts
@@ -22,7 +22,7 @@ export class V1_TablePtr implements Hashable {
   table!: string;
   schema!: string;
   database!: string;
-  //  mainTableDb!: string; // NOTE: seems like this field is deprecated, we will take it out for now
+  mainTableDb!: string; // NOTE: this field is likely deprecated, we will not account for it in Studio
 
   get hashCode(): string {
     return hashArray([

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
@@ -229,8 +229,7 @@ const transformModelChainConnection = (
   element: ModelChainConnection,
 ): V1_ModelChainConnection => {
   const connection = new V1_ModelChainConnection();
-  // to make this consistent with grammar parser, ModelStore is a pseudo-store and will be skipped
-  connection.store = undefined;
+  connection.store = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   connection.mappings = element.mappings.map(V1_transformElementReference);
   return connection;
 };
@@ -240,8 +239,7 @@ const transformJsonModelConnection = (
 ): V1_JsonModelConnection => {
   const connection = new V1_JsonModelConnection();
   connection.class = V1_transformElementReference(element.class);
-  // to make this consistent with grammar parser, ModelStore is a pseudo-store and will be skipped
-  connection.store = undefined;
+  connection.store = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   connection.url = element.url;
   return connection;
 };
@@ -251,8 +249,7 @@ const transformXmlModelConnection = (
 ): V1_XmlModelConnection => {
   const connection = new V1_XmlModelConnection();
   connection.class = V1_transformElementReference(element.class);
-  // to make this consistent with grammar parser, ModelStore is a pseudo-store and will be skipped
-  connection.store = undefined;
+  connection.store = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   connection.url = element.url;
   return connection;
 };

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
@@ -166,7 +166,8 @@ export const V1_transformTableAliasToTablePointer = (
 ): V1_TablePtr => {
   const tablePtr = new V1_TablePtr();
   tablePtr.database = tableAlias.relation.ownerReference.valueForSerialization;
-  tablePtr.mainTableDb = tablePtr.database; // NOTE: added to be consistent with grammar parser
+  /* @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph */
+  tablePtr.mainTableDb = tablePtr.database;
   tablePtr.schema = tableAlias.isSelfJoinTarget
     ? SELF_JOIN_SCHEMA_NAME
     : tableAlias.relation.value.schema.name;
@@ -179,7 +180,8 @@ export const V1_transformTableAliasToTablePointer = (
 export const V1_transformTableToTablePointer = (table: Table): V1_TablePtr => {
   const tablePtr = new V1_TablePtr();
   tablePtr.database = table.schema.owner.path;
-  tablePtr.mainTableDb = tablePtr.database; // NOTE: added to be consistent with grammar parser
+  /* @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph */
+  tablePtr.mainTableDb = tablePtr.database;
   tablePtr.schema = table.schema.name;
   tablePtr.table = table.name;
   return tablePtr;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
@@ -166,6 +166,7 @@ export const V1_transformTableAliasToTablePointer = (
 ): V1_TablePtr => {
   const tablePtr = new V1_TablePtr();
   tablePtr.database = tableAlias.relation.ownerReference.valueForSerialization;
+  tablePtr.mainTableDb = tablePtr.database; // NOTE: added to be consistent with grammar parser
   tablePtr.schema = tableAlias.isSelfJoinTarget
     ? SELF_JOIN_SCHEMA_NAME
     : tableAlias.relation.value.schema.name;
@@ -178,6 +179,7 @@ export const V1_transformTableAliasToTablePointer = (
 export const V1_transformTableToTablePointer = (table: Table): V1_TablePtr => {
   const tablePtr = new V1_TablePtr();
   tablePtr.database = table.schema.owner.path;
+  tablePtr.mainTableDb = tablePtr.database; // NOTE: added to be consistent with grammar parser
   tablePtr.schema = table.schema.name;
   tablePtr.table = table.name;
   return tablePtr;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DiagramTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DiagramTransformer.ts
@@ -54,7 +54,7 @@ const transformPropertyView = (element: PropertyView): V1_PropertyView => {
   const line = new V1_Line();
   line.points = element.fullPath;
   view.line = line;
-  view.property = V1_transformPropertyReference(element.property);
+  view.property = V1_transformPropertyReference(element.property, false);
   view.sourceView = relationshipEdgeViewTransformer(element.from);
   view.targetView = relationshipEdgeViewTransformer(element.to);
   return view;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -398,9 +398,7 @@ const transformRelationalPropertyMapping = (
   propertyMapping.relationalOperation = V1_transformRelationalOperationElement(
     element.relationalOperation,
   );
-  propertyMapping.source = transformPropertyMappingSource(
-    element.sourceSetImplementation,
-  );
+  propertyMapping.source = undefined;
   propertyMapping.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -417,9 +415,7 @@ const transformEmbeddedRelationalPropertyMapping = (
 ): V1_EmbeddedRelationalPropertyMapping => {
   const embedded = new V1_EmbeddedRelationalPropertyMapping();
   embedded.property = V1_transformPropertyReference(element.property);
-  embedded.source = transformPropertyMappingSource(
-    element.sourceSetImplementation,
-  );
+  embedded.source = undefined;
   embedded.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -449,9 +445,7 @@ const transformInlineEmbeddedRelationalPropertyMapping = (
 ): V1_InlineEmbeddedPropertyMapping => {
   const embedded = new V1_InlineEmbeddedPropertyMapping();
   embedded.property = V1_transformPropertyReference(element.property);
-  embedded.source = transformPropertyMappingSource(
-    element.sourceSetImplementation,
-  );
+  embedded.source = undefined;
   embedded.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -460,6 +454,39 @@ const transformInlineEmbeddedRelationalPropertyMapping = (
     embedded.id = id;
   }
   embedded.setImplementationId = element.inlineSetImplementation.id.value;
+  if (element.localMappingProperty) {
+    embedded.localMappingProperty = transformLocalPropertyInfo(
+      element.localMappingProperty,
+    );
+  }
+  return embedded;
+};
+
+const transformOtherwiseEmbeddedRelationalPropertyMapping = (
+  element: OtherwiseEmbeddedRelationalInstanceSetImplementation,
+): V1_OtherwiseEmbeddedRelationalPropertyMapping => {
+  const embedded = new V1_OtherwiseEmbeddedRelationalPropertyMapping();
+  embedded.property = V1_transformPropertyReference(element.property);
+  embedded.source = undefined;
+  embedded.target = transformPropertyMappingTarget(
+    element.targetSetImplementation,
+  );
+  const classMapping = new V1_RelationalClassMapping();
+  classMapping.primaryKey = element.primaryKey.map(
+    V1_transformRelationalOperationElement,
+  );
+  classMapping.propertyMappings = classMappingPropertyMappingsSerializer(
+    element.propertyMappings,
+  );
+  const root = transformMappingElementRoot(element.root);
+  if (root !== undefined) {
+    classMapping.root = root;
+  }
+  classMapping.class = V1_transformElementReference(element.class);
+  embedded.classMapping = classMapping;
+  embedded.otherwisePropertyMapping = serializeProperyMapping(
+    element.otherwisePropertyMapping,
+  ) as V1_RelationalPropertyMapping;
   if (element.localMappingProperty) {
     embedded.localMappingProperty = transformLocalPropertyInfo(
       element.localMappingProperty,
@@ -490,41 +517,6 @@ const transformXStorePropertyMapping = (
     );
   }
   return xstore;
-};
-
-const transformOtherwiseEmbeddedRelationalPropertyMapping = (
-  element: OtherwiseEmbeddedRelationalInstanceSetImplementation,
-): V1_OtherwiseEmbeddedRelationalPropertyMapping => {
-  const embedded = new V1_OtherwiseEmbeddedRelationalPropertyMapping();
-  embedded.property = V1_transformPropertyReference(element.property);
-  embedded.source = transformPropertyMappingSource(
-    element.sourceSetImplementation,
-  );
-  embedded.target = transformPropertyMappingTarget(
-    element.targetSetImplementation,
-  );
-  const classMapping = new V1_RelationalClassMapping();
-  classMapping.primaryKey = element.primaryKey.map(
-    V1_transformRelationalOperationElement,
-  );
-  classMapping.propertyMappings = classMappingPropertyMappingsSerializer(
-    element.propertyMappings,
-  );
-  const root = transformMappingElementRoot(element.root);
-  if (root !== undefined) {
-    classMapping.root = root;
-  }
-  classMapping.class = V1_transformElementReference(element.class);
-  embedded.classMapping = classMapping;
-  embedded.otherwisePropertyMapping = serializeProperyMapping(
-    element.otherwisePropertyMapping,
-  ) as V1_RelationalPropertyMapping;
-  if (element.localMappingProperty) {
-    embedded.localMappingProperty = transformLocalPropertyInfo(
-      element.localMappingProperty,
-    );
-  }
-  return embedded;
 };
 
 const transformAggregationAwarePropertyMapping = (

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -369,7 +369,7 @@ const transformPurePropertyMapping = (
   purePropertyMapping.property = V1_transformPropertyReference(
     element.property,
   );
-  purePropertyMapping.source = '';
+  purePropertyMapping.source = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   purePropertyMapping.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -398,7 +398,7 @@ const transformRelationalPropertyMapping = (
   propertyMapping.relationalOperation = V1_transformRelationalOperationElement(
     element.relationalOperation,
   );
-  propertyMapping.source = undefined;
+  propertyMapping.source = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   propertyMapping.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -415,7 +415,7 @@ const transformEmbeddedRelationalPropertyMapping = (
 ): V1_EmbeddedRelationalPropertyMapping => {
   const embedded = new V1_EmbeddedRelationalPropertyMapping();
   embedded.property = V1_transformPropertyReference(element.property);
-  embedded.source = undefined;
+  embedded.source = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -430,7 +430,7 @@ const transformEmbeddedRelationalPropertyMapping = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.class = V1_transformElementReference(element.class);
+  classMapping.class = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.classMapping = classMapping;
   if (element.localMappingProperty) {
     embedded.localMappingProperty = transformLocalPropertyInfo(
@@ -445,7 +445,7 @@ const transformInlineEmbeddedRelationalPropertyMapping = (
 ): V1_InlineEmbeddedPropertyMapping => {
   const embedded = new V1_InlineEmbeddedPropertyMapping();
   embedded.property = V1_transformPropertyReference(element.property);
-  embedded.source = undefined;
+  embedded.source = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -467,7 +467,7 @@ const transformOtherwiseEmbeddedRelationalPropertyMapping = (
 ): V1_OtherwiseEmbeddedRelationalPropertyMapping => {
   const embedded = new V1_OtherwiseEmbeddedRelationalPropertyMapping();
   embedded.property = V1_transformPropertyReference(element.property);
-  embedded.source = undefined;
+  embedded.source = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.target = transformPropertyMappingTarget(
     element.targetSetImplementation,
   );
@@ -482,7 +482,7 @@ const transformOtherwiseEmbeddedRelationalPropertyMapping = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.class = V1_transformElementReference(element.class);
+  classMapping.class = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.classMapping = classMapping;
   embedded.otherwisePropertyMapping = serializeProperyMapping(
     element.otherwisePropertyMapping,
@@ -702,7 +702,7 @@ const transsformRelationalInstanceSetImpl = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.class = V1_transformElementReference(element.class);
+  classMapping.class = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   return classMapping;
 };
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -135,7 +135,7 @@ export const V1_transformPropertyReference = (
 ): V1_PropertyPointer => {
   const property = new V1_PropertyPointer();
   property.class = isTransformingEmbeddedPropertyMapping
-    ? ''
+    ? undefined
     : V1_transformElementReference(element.ownerReference);
   property.property = element.value.name;
   return property;
@@ -453,7 +453,7 @@ const transformEmbeddedRelationalPropertyMapping = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.class = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
+  classMapping.class = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.classMapping = classMapping;
   if (element.localMappingProperty) {
     embedded.localMappingProperty = transformLocalPropertyInfo(
@@ -514,7 +514,7 @@ const transformOtherwiseEmbeddedRelationalPropertyMapping = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.class = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
+  classMapping.class = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   embedded.classMapping = classMapping;
   embedded.otherwisePropertyMapping = serializeProperyMapping(
     element.otherwisePropertyMapping,
@@ -760,7 +760,7 @@ const transformRelationalInstanceSetImpl = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.class = ''; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
+  classMapping.class = undefined; // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   return classMapping;
 };
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
@@ -180,11 +180,11 @@ export class V1_ProtocolToMetaModelClassMappingFirstPassVisitor
   ): SetImplementation {
     assertNonEmptyString(
       classMapping.class,
-      'Aggregation Aware class mapping class is missing',
+      'Aggregation-aware class mapping class is missing',
     );
     assertNonNullable(
       classMapping.root,
-      'Aggregation Aware class mapping root flag is missing',
+      'Aggregation-aware class mapping root flag is missing',
     );
     const targetClass = this.context.resolveClass(classMapping.class);
     const mapping = this.context.graph.getMapping(this.parent.path);

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassVisitor.ts
@@ -103,7 +103,7 @@ export class V1_ProtocolToMetaModelClassMappingFirstPassVisitor
         srcClassReference?.value,
         classMapping.srcClass,
         this.context.section,
-        srcClassReference?.isResolvedFromAutoImports,
+        srcClassReference?.isInferred,
       ),
     );
     pureInstanceSetImplementation.filter = classMapping.filter

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassVisitor.ts
@@ -19,6 +19,7 @@ import {
   assertType,
   isNonNullable,
   guaranteeType,
+  assertNonEmptyString,
 } from '@finos/legend-studio-shared';
 import { CORE_LOG_EVENT } from '../../../../../../../utils/Logger';
 import type { Mapping } from '../../../../../../metamodels/pure/model/packageableElements/mapping/Mapping';
@@ -63,6 +64,10 @@ export class V1_ProtocolToMetaModelClassMappingSecondPassVisitor
   }
 
   visit_OperationClassMapping(classMapping: V1_OperationClassMapping): void {
+    assertNonEmptyString(
+      classMapping.class,
+      'Operation class mapping class is missing',
+    );
     const id = V1_getInferredClassMappingId(
       this.context.resolveClass(classMapping.class).value,
       classMapping,
@@ -96,6 +101,10 @@ export class V1_ProtocolToMetaModelClassMappingSecondPassVisitor
   visit_PureInstanceClassMapping(
     classMapping: V1_PureInstanceClassMapping,
   ): void {
+    assertNonEmptyString(
+      classMapping.class,
+      'Model-to-model class mapping class is missing',
+    );
     const pureInstanceSetImplementation = guaranteeType(
       this.parent.getClassMapping(
         V1_getInferredClassMappingId(
@@ -124,6 +133,10 @@ export class V1_ProtocolToMetaModelClassMappingSecondPassVisitor
   visit_RootFlatDataClassMapping(
     classMapping: V1_RootFlatDataClassMapping,
   ): void {
+    assertNonEmptyString(
+      classMapping.class,
+      'Flat-data class mapping class is missing',
+    );
     const flatDataInstanceSetImplementation = guaranteeType(
       this.parent.getClassMapping(
         V1_getInferredClassMappingId(
@@ -153,6 +166,10 @@ export class V1_ProtocolToMetaModelClassMappingSecondPassVisitor
   visit_RootRelationalClassMapping(
     classMapping: V1_RootRelationalClassMapping,
   ): SetImplementation {
+    assertNonEmptyString(
+      classMapping.class,
+      'Relational class mapping class is missing',
+    );
     const rootRelationalInstanceSetImplementation = guaranteeType(
       this.parent.getClassMapping(
         V1_getInferredClassMappingId(
@@ -232,6 +249,10 @@ export class V1_ProtocolToMetaModelClassMappingSecondPassVisitor
   visit_AggregationAwareClassMapping(
     classMapping: V1_AggregationAwareClassMapping,
   ): SetImplementation {
+    assertNonEmptyString(
+      classMapping.class,
+      'Aggregation-aware class mapping class is missing',
+    );
     const aggragetionAwareInstanceSetImplementation = guaranteeType(
       this.parent.getClassMapping(
         V1_getInferredClassMappingId(

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
@@ -38,9 +38,15 @@ import type { Association } from '../../../../../../metamodels/pure/model/packag
 import type { TableAlias } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/model/RelationalOperationElement';
 import { InferableMappingElementIdExplicitValue } from '../../../../../../metamodels/pure/model/packageableElements/mapping/InferableMappingElementId';
 import type { PackageableElementReference } from '../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
-import { PackageableElementExplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
+import {
+  PackageableElementImplicitReference,
+  PackageableElementExplicitReference,
+} from '../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 import type { PropertyReference } from '../../../../../../metamodels/pure/model/packageableElements/domain/PropertyReference';
-import { PropertyExplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/domain/PropertyReference';
+import {
+  PropertyImplicitReference,
+  PropertyExplicitReference,
+} from '../../../../../../metamodels/pure/model/packageableElements/domain/PropertyReference';
 import { RootRelationalInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation';
 import { OtherwiseEmbeddedRelationalInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation';
 import { EmbeddedRelationalInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation';
@@ -60,7 +66,7 @@ import type { V1_FlatDataPropertyMapping } from '../../../model/packageableEleme
 import type { V1_OtherwiseEmbeddedRelationalPropertyMapping } from '../../../model/packageableElements/store/relational/mapping/V1_OtherwiseEmbeddedRelationalPropertyMapping';
 import type { V1_EmbeddedRelationalPropertyMapping } from '../../../model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping';
 import { V1_processRelationalOperationElement } from '../../../transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper';
-import { V1_processEmbeddedRelationalMappingProperties } from '../../../transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder';
+import { V1_processEmbeddedRelationalMappingProperty } from '../../../transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder';
 import type { V1_XStorePropertyMapping } from '../../../model/packageableElements/mapping/xStore/V1_XStorePropertyMapping';
 import { XStorePropertyMapping } from '../../../../../../metamodels/pure/model/packageableElements/mapping/xStore/XStorePropertyMapping';
 import type { XStoreAssociationImplementation } from '../../../../../../metamodels/pure/model/packageableElements/mapping/xStore/XStoreAssociationImplementation';
@@ -442,7 +448,17 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
     );
     const relationalPropertyMapping = new RelationalPropertyMapping(
       this.topParent ?? this.immediateParent,
-      PropertyExplicitReference.create(property),
+      propertyOwner instanceof Class // TODO: we also probably need to handle this for association mapping
+        ? PropertyImplicitReference.create(
+            PackageableElementImplicitReference.create(
+              propertyOwner,
+              protocol.property.class,
+              this.context.section,
+              true,
+            ),
+            property,
+          )
+        : PropertyExplicitReference.create(property),
       operation,
       sourceSetImplementation,
       targetSetImplementation,
@@ -505,7 +521,15 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
         : topParent;
     const inline = new InlineEmbeddedRelationalInstanceSetImplementation(
       this.immediateParent,
-      PropertyExplicitReference.create(property),
+      PropertyImplicitReference.create(
+        PackageableElementImplicitReference.create(
+          propertyOwnerClass,
+          protocol.property.class,
+          this.context.section,
+          true,
+        ),
+        property,
+      ),
       guaranteeType(this.topParent, RootRelationalInstanceSetImplementation),
       sourceSetImplementation,
       _class,
@@ -528,7 +552,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
       protocol.property.property,
       'Embedded property mapping property name is missing',
     );
-    const properties = V1_processEmbeddedRelationalMappingProperties(
+    const property = V1_processEmbeddedRelationalMappingProperty(
       protocol,
       this.immediateParent,
       guaranteeNonNullable(this.topParent),
@@ -536,14 +560,19 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
     );
     const embedded = new EmbeddedRelationalInstanceSetImplementation(
       this.immediateParent,
-      PropertyExplicitReference.create(properties.property),
-      guaranteeType(this.topParent, RootRelationalInstanceSetImplementation),
-      properties.sourceSetImplementation,
-      properties._class,
-      InferableMappingElementIdExplicitValue.create(
-        `${properties.id.value}`,
-        '',
+      PropertyImplicitReference.create(
+        PackageableElementImplicitReference.create(
+          property.propertyOwnerClass,
+          protocol.property.class,
+          this.context.section,
+          true,
+        ),
+        property.property,
       ),
+      guaranteeType(this.topParent, RootRelationalInstanceSetImplementation),
+      property.sourceSetImplementation,
+      property._class,
+      InferableMappingElementIdExplicitValue.create(`${property.id.value}`, ''),
     );
     embedded.primaryKey = protocol.classMapping.primaryKey.map((key) =>
       V1_processRelationalOperationElement(
@@ -579,7 +608,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
       protocol.property.property,
       'Otherwise Embedded property mapping property name is missing',
     );
-    const properties = V1_processEmbeddedRelationalMappingProperties(
+    const property = V1_processEmbeddedRelationalMappingProperty(
       protocol,
       this.immediateParent,
       guaranteeNonNullable(this.topParent),
@@ -587,14 +616,19 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
     );
     const otherwiseEmbedded = new OtherwiseEmbeddedRelationalInstanceSetImplementation(
       this.immediateParent,
-      PropertyExplicitReference.create(properties.property),
-      guaranteeType(this.topParent, RootRelationalInstanceSetImplementation),
-      properties.sourceSetImplementation,
-      properties._class,
-      InferableMappingElementIdExplicitValue.create(
-        `${properties.id.value}`,
-        '',
+      PropertyImplicitReference.create(
+        PackageableElementImplicitReference.create(
+          property.propertyOwnerClass,
+          protocol.property.class,
+          this.context.section,
+          true,
+        ),
+        property.property,
       ),
+      guaranteeType(this.topParent, RootRelationalInstanceSetImplementation),
+      property.sourceSetImplementation,
+      property._class,
+      InferableMappingElementIdExplicitValue.create(`${property.id.value}`, ''),
     );
     otherwiseEmbedded.primaryKey = protocol.classMapping.primaryKey.map((key) =>
       V1_processRelationalOperationElement(

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingVisitor.ts
@@ -452,7 +452,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
         ? PropertyImplicitReference.create(
             PackageableElementImplicitReference.create(
               propertyOwner,
-              protocol.property.class,
+              protocol.property.class ?? '',
               this.context.section,
               true,
             ),
@@ -484,11 +484,11 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
   ): PropertyMapping {
     assertNonNullable(
       protocol.property,
-      'Embedded Relational property mapping property is missing',
+      'Inline embedded property mapping property is missing',
     );
     assertNonEmptyString(
       protocol.property.property,
-      'Embedded property mapping property name is missing',
+      'Inline embedded property mapping property name is missing',
     );
     let propertyOwnerClass: Class;
     if (protocol.property.class) {
@@ -524,7 +524,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
       PropertyImplicitReference.create(
         PackageableElementImplicitReference.create(
           propertyOwnerClass,
-          protocol.property.class,
+          protocol.property.class ?? '',
           this.context.section,
           true,
         ),
@@ -546,11 +546,11 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
   ): PropertyMapping {
     assertNonNullable(
       protocol.property,
-      'Embedded Relational property mapping property is missing',
+      'Embedded relational property mapping property is missing',
     );
     assertNonEmptyString(
       protocol.property.property,
-      'Embedded property mapping property name is missing',
+      'Embedded relational property mapping property name is missing',
     );
     const property = V1_processEmbeddedRelationalMappingProperty(
       protocol,
@@ -563,7 +563,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
       PropertyImplicitReference.create(
         PackageableElementImplicitReference.create(
           property.propertyOwnerClass,
-          protocol.property.class,
+          protocol.property.class ?? '',
           this.context.section,
           true,
         ),
@@ -602,11 +602,11 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
   ): PropertyMapping {
     assertNonNullable(
       protocol.property,
-      'Otherwise Embedded Relational property mapping property is missing',
+      'Otherwise embedded relational property mapping property is missing',
     );
     assertNonEmptyString(
       protocol.property.property,
-      'Otherwise Embedded property mapping property name is missing',
+      'Otherwise embedded relational property mapping property name is missing',
     );
     const property = V1_processEmbeddedRelationalMappingProperty(
       protocol,
@@ -619,7 +619,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
       PropertyImplicitReference.create(
         PackageableElementImplicitReference.create(
           property.propertyOwnerClass,
-          protocol.property.class,
+          protocol.property.class ?? '',
           this.context.section,
           true,
         ),
@@ -687,7 +687,7 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
 
     const xStoreParent = guaranteeNonNullable(
       this.xStoreParent,
-      'XStoreAssociation expected to be parent of XStore PropertyMapping',
+      'XStore property mapping parent is missing',
     );
     const _association = xStoreParent.association.value;
     const property = _association.getProperty(protocol.property.property);
@@ -716,19 +716,19 @@ export class V1_ProtocolToMetaModelPropertyMappingVisitor
   ): PropertyMapping {
     assertNonNullable(
       protocol.property,
-      'Model-to-model property mapping property is missing',
+      'Aggregation-aware property mapping property is missing',
     );
     assertNonEmptyString(
       protocol.property.class,
-      'Model-to-model property mapping property class is missing',
+      'Aggregation-aware property mapping property class is missing',
     );
     assertNonEmptyString(
       protocol.property.property,
-      'Model-to-model property mapping property name is missing',
+      'Aggregation-aware property mapping property name is missing',
     );
     const aggregationAwareParent = guaranteeNonNullable(
       this.aggregationAwareParent,
-      'AggregationAware expected to be parent of Aggregation Aware PropertyMapping',
+      'Aggregation-aware property mapping parent is missing',
     );
 
     const propertyMapping = aggregationAwareParent.mainSetImplementation.propertyMappings.find(

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelRawValueSpecificationVisitor.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelRawValueSpecificationVisitor.ts
@@ -129,7 +129,7 @@ export class V1_ProtocolToMetaModelRawValueSpecificationVisitor
             _classReference.value,
             valueSpecification.subType,
             this.context.section,
-            _classReference.isResolvedFromAutoImports,
+            _classReference.isInferred,
           ),
         );
         _class = _classReference.value;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguator.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguator.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { UnsupportedOperationError } from '@finos/legend-studio-shared';
+import {
+  guaranteeNonNullable,
+  UnsupportedOperationError,
+} from '@finos/legend-studio-shared';
 import type { V1_ModelChainConnection } from '../../../../model/packageableElements/store/modelToModel/connection/V1_ModelChainConnection';
 import type {
   V1_PackageableElement,
@@ -390,7 +393,7 @@ export class V1_DependencyDisambiguator
 
   visit_OperationClassMapping(classMapping: V1_OperationClassMapping): void {
     classMapping.class = V1_processDependencyPath(
-      classMapping.class,
+      guaranteeNonNullable(classMapping.class),
       this.dependencyProcessingContext,
     );
   }
@@ -399,7 +402,7 @@ export class V1_DependencyDisambiguator
     classMapping: V1_PureInstanceClassMapping,
   ): void {
     classMapping.class = V1_processDependencyPath(
-      classMapping.class,
+      guaranteeNonNullable(classMapping.class),
       this.dependencyProcessingContext,
     );
     classMapping.srcClass = classMapping.srcClass
@@ -418,7 +421,7 @@ export class V1_DependencyDisambiguator
     classMapping: V1_RootFlatDataClassMapping,
   ): void {
     classMapping.class = V1_processDependencyPath(
-      classMapping.class,
+      guaranteeNonNullable(classMapping.class),
       this.dependencyProcessingContext,
     );
     classMapping.flatData = V1_processDependencyPath(
@@ -433,7 +436,7 @@ export class V1_DependencyDisambiguator
 
   visit_RelationalClassMapping(classMapping: V1_RelationalClassMapping): void {
     classMapping.class = V1_processDependencyPath(
-      classMapping.class,
+      guaranteeNonNullable(classMapping.class),
       this.dependencyProcessingContext,
     );
     classMapping.propertyMappings.forEach((propertyMapping) =>
@@ -452,16 +455,21 @@ export class V1_DependencyDisambiguator
   visit_AggregationAwareClassMapping(
     classMapping: V1_AggregationAwareClassMapping,
   ): void {
-    classMapping.mainSetImplementation.class = V1_processDependencyPath(
-      classMapping.mainSetImplementation.class,
-      this.dependencyProcessingContext,
-    );
+    classMapping.mainSetImplementation.class = classMapping
+      .mainSetImplementation.class
+      ? V1_processDependencyPath(
+          classMapping.mainSetImplementation.class,
+          this.dependencyProcessingContext,
+        )
+      : classMapping.mainSetImplementation.class;
     classMapping.mainSetImplementation.accept_ClassMappingVisitor(this);
     classMapping.aggregateSetImplementations.forEach((aggregate) => {
-      aggregate.setImplementation.class = V1_processDependencyPath(
-        aggregate.setImplementation.class,
-        this.dependencyProcessingContext,
-      );
+      aggregate.setImplementation.class = aggregate.setImplementation.class
+        ? V1_processDependencyPath(
+            aggregate.setImplementation.class,
+            this.dependencyProcessingContext,
+          )
+        : aggregate.setImplementation.class;
       aggregate.setImplementation.accept_ClassMappingVisitor(this);
       return aggregate;
     });

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguatorHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/dependencyDisambiguator/V1_DependencyDisambiguatorHelper.ts
@@ -219,7 +219,9 @@ export const V1_processDependablePropertyPointer = (
   propertyPtr: V1_PropertyPointer,
   context: V1_DepdendencyProcessingContext,
 ): void => {
-  propertyPtr.class = V1_processDependencyPath(propertyPtr.class, context);
+  propertyPtr.class = propertyPtr.class
+    ? V1_processDependencyPath(propertyPtr.class, context)
+    : undefined;
 };
 
 const processDependableTestContainer = (

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
@@ -157,7 +157,7 @@ export const V1_processEnumerationMapping = (
       sourceTypeReference?.value,
       sourceTypeInput,
       context.section,
-      sourceTypeReference?.isResolvedFromAutoImports,
+      sourceTypeReference?.isInferred,
     ),
   );
   enumerationMapping.enumValueMappings = srcEnumerationMapping.enumValueMappings.map(

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
@@ -71,7 +71,7 @@ export const V1_processEmbeddedRelationalMappingProperty = (
     );
     _class = PackageableElementImplicitReference.create(
       complexClass,
-      propertyMapping.classMapping.class,
+      propertyMapping.classMapping.class ?? '',
       context.section,
       true,
     );

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
@@ -20,7 +20,7 @@ import type { InstanceSetImplementation } from '../../../../../../../metamodels/
 import { RootRelationalInstanceSetImplementation } from '../../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation';
 import { EmbeddedRelationalInstanceSetImplementation } from '../../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation';
 import type { PackageableElementReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
-import { PackageableElementExplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
+import { PackageableElementImplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 import { InferableMappingElementIdExplicitValue } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/InferableMappingElementId';
 import type { Property } from '../../../../../../../metamodels/pure/model/packageableElements/domain/Property';
 import { Class } from '../../../../../../../metamodels/pure/model/packageableElements/domain/Class';
@@ -68,7 +68,12 @@ export const V1_processEmbeddedRelationalMappingProperties = (
       Class,
       'Only complex classes can be the target of an embedded property mapping',
     );
-    _class = PackageableElementExplicitReference.create(complexClass);
+    _class = PackageableElementImplicitReference.create(
+      complexClass,
+      propertyMapping.classMapping.class,
+      context.section,
+      true,
+    );
   }
   const id =
     propertyMapping.classMapping.id || propertyMapping.classMapping.class

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
@@ -30,12 +30,13 @@ import type { V1_GraphBuilderContext } from '../../../../transformation/pureGrap
 import type { V1_EmbeddedRelationalPropertyMapping } from '../../../../model/packageableElements/store/relational/mapping/V1_EmbeddedRelationalPropertyMapping';
 import { V1_getInferredClassMappingId } from '../../../../transformation/pureGraph/to/helpers/V1_MappingBuilderHelper';
 
-export const V1_processEmbeddedRelationalMappingProperties = (
+export const V1_processEmbeddedRelationalMappingProperty = (
   propertyMapping: V1_EmbeddedRelationalPropertyMapping,
   immediateParent: PropertyMappingsImplementation,
   topParent: InstanceSetImplementation,
   context: V1_GraphBuilderContext,
 ): {
+  propertyOwnerClass: Class;
   property: Property;
   _class: PackageableElementReference<Class>;
   id: InferableMappingElementIdExplicitValue;
@@ -86,5 +87,5 @@ export const V1_processEmbeddedRelationalMappingProperties = (
     immediateParent instanceof RootRelationalInstanceSetImplementation
       ? immediateParent
       : topParent;
-  return { property, _class, id, sourceSetImplementation };
+  return { propertyOwnerClass, property, _class, id, sourceSetImplementation };
 };

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
@@ -81,7 +81,7 @@ export const V1_modelChainConnectionModelSchema = createModelSchema(
   V1_ModelChainConnection,
   {
     _type: usingConstantValueSchema(V1_ConnectionType.MODEL_CHAIN_CONNECTION),
-    store: alias('element', optional(primitive())),
+    store: alias('element', optional(primitive())), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
     mappings: list(primitive()),
   },
 );
@@ -91,7 +91,7 @@ export const V1_jsonModelConnectionModelSchema = createModelSchema(
   {
     _type: usingConstantValueSchema(V1_ConnectionType.JSON_MODEL_CONNECTION),
     class: primitive(),
-    store: alias('element', optional(primitive())),
+    store: alias('element', optional(primitive())), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
     url: primitive(),
   },
 );
@@ -101,7 +101,7 @@ export const V1_xmlModelConnectionModelSchema = createModelSchema(
   {
     _type: usingConstantValueSchema(V1_ConnectionType.XML_MODEL_CONNECTION),
     class: primitive(),
-    store: alias('element', optional(primitive())),
+    store: alias('element', optional(primitive())), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
     url: primitive(),
   },
 );

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
@@ -311,7 +311,7 @@ const columnModelSchema = createModelSchema(V1_Column, {
 export const V1_tablePtrModelSchema = createModelSchema(V1_TablePtr, {
   _type: usingConstantValueSchema(V1_TABLE_POINTER_TYPE),
   database: primitive(),
-  mainTableDb: primitive(),
+  mainTableDb: primitive(), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   schema: primitive(),
   table: primitive(),
 });

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
@@ -467,7 +467,7 @@ const V1_joinModelSchema = createModelSchema(V1_Join, {
     (val) => V1_serializeRelationalOperationElement(val),
     (val) => V1_deserializeRelationalOperationElement(val),
   ),
-  target: primitive(),
+  target: optional(primitive()),
 });
 
 const V1_filterModelSchema = createModelSchema(V1_Filter, {

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
@@ -110,7 +110,7 @@ enum V1_RelationalOperationElementType {
   TABLE_ALIAS_COLUMN = 'column',
 }
 
-const V1_TablePtrType = 'Table';
+const V1_TABLE_POINTER_TYPE = 'Table';
 
 enum V1_RelationalDataTypeType {
   VARCHAR = 'Varchar',
@@ -309,8 +309,9 @@ const columnModelSchema = createModelSchema(V1_Column, {
 });
 
 export const V1_tablePtrModelSchema = createModelSchema(V1_TablePtr, {
-  _type: usingConstantValueSchema(V1_TablePtrType),
+  _type: usingConstantValueSchema(V1_TABLE_POINTER_TYPE),
   database: primitive(),
+  mainTableDb: primitive(),
   schema: primitive(),
   table: primitive(),
 });

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
@@ -66,7 +66,7 @@ export const V1_FUNCTION_ELEMENT_PROTOCOL_TYPE = 'function';
 export const V1_propertyPointerModelSchema = createModelSchema(
   V1_PropertyPointer,
   {
-    class: primitive(),
+    class: optional(primitive()),
     property: primitive(),
   },
 );

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
@@ -280,7 +280,7 @@ export const V1_classSchema = createModelSchema(V1_Class, {
   originalMilestonedProperties: custom(
     (values) => serializeArray([], () => SKIP, true),
     (values) => deserializeArray([], () => SKIP, false),
-  ),
+  ), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
   package: primitive(),
   properties: custom(
     (values) =>

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
@@ -272,7 +272,7 @@ const relationalPropertyMappingModelSchema = createModelSchema(
       (val) => V1_serializeRelationalOperationElement(val),
       (val) => V1_deserializeRelationalOperationElement(val),
     ),
-    source: primitive(),
+    source: optional(primitive()),
     target: optional(primitive()),
   },
 );
@@ -287,7 +287,7 @@ const embeddedRelationalPropertyMappingModelSchema = createModelSchema(
       V1_localMappingPropertyInfoModelSchema,
     ),
     property: usingModelSchema(V1_propertyPointerModelSchema),
-    source: primitive(),
+    source: optional(primitive()),
     target: optional(primitive()),
   },
 );
@@ -305,7 +305,7 @@ const otherwiseEmbeddedRelationalPropertyMappingModelSchgema = createModelSchema
       (val) => V1_deserializeRelationalPropertyMapping(val),
     ),
     property: usingModelSchema(V1_propertyPointerModelSchema),
-    source: primitive(),
+    source: optional(primitive()),
     target: optional(primitive()),
     localMappingProperty: usingModelSchema(
       V1_localMappingPropertyInfoModelSchema,
@@ -324,7 +324,7 @@ const inlineEmbeddedPropertyMappingModelSchema = createModelSchema(
       V1_localMappingPropertyInfoModelSchema,
     ),
     property: usingModelSchema(V1_propertyPointerModelSchema),
-    source: primitive(),
+    source: optional(primitive()),
     setImplementationId: primitive(),
     target: optional(primitive()),
   },

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
@@ -287,7 +287,7 @@ const embeddedRelationalPropertyMappingModelSchema = createModelSchema(
       V1_localMappingPropertyInfoModelSchema,
     ),
     property: usingModelSchema(V1_propertyPointerModelSchema),
-    source: optional(primitive()),
+    source: optional(primitive()), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
     target: optional(primitive()),
   },
 );
@@ -305,7 +305,7 @@ const otherwiseEmbeddedRelationalPropertyMappingModelSchgema = createModelSchema
       (val) => V1_deserializeRelationalPropertyMapping(val),
     ),
     property: usingModelSchema(V1_propertyPointerModelSchema),
-    source: optional(primitive()),
+    source: optional(primitive()), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
     target: optional(primitive()),
     localMappingProperty: usingModelSchema(
       V1_localMappingPropertyInfoModelSchema,
@@ -324,7 +324,7 @@ const inlineEmbeddedPropertyMappingModelSchema = createModelSchema(
       V1_localMappingPropertyInfoModelSchema,
     ),
     property: usingModelSchema(V1_propertyPointerModelSchema),
-    source: optional(primitive()),
+    source: optional(primitive()), // @MARKER: GRAMMAR ROUNDTRIP --- omit this information during protocol transformation as it can be interpreted while building the graph
     setImplementationId: primitive(),
     target: optional(primitive()),
   },

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
@@ -241,7 +241,7 @@ const relationalClassMappingModelSchema = createModelSchema(
   V1_RelationalClassMapping,
   {
     _type: usingConstantValueSchema(V1_ClassMappingType.RELATIONAL),
-    class: primitive(),
+    class: optional(primitive()),
     id: optional(primitive()),
     primaryKey: list(
       custom(

--- a/packages/legend-studio/src/stores/__tests__/LambdaRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/LambdaRoundtripTestData.ts
@@ -462,6 +462,7 @@ export const ComplexRelationalModel = [
           mainTable: {
             _type: 'Table',
             database: 'apps::pure::studio::relational::tests::dbInc',
+            mainTableDb: 'apps::pure::studio::relational::tests::dbInc',
             schema: 'default',
             table: 'personTable',
           },
@@ -472,6 +473,7 @@ export const ComplexRelationalModel = [
               table: {
                 _type: 'Table',
                 database: 'apps::pure::studio::relational::tests::dbInc',
+                mainTableDb: 'apps::pure::studio::relational::tests::dbInc',
                 schema: 'default',
                 table: 'personTable',
               },
@@ -491,12 +493,12 @@ export const ComplexRelationalModel = [
                 table: {
                   _type: 'Table',
                   database: 'apps::pure::studio::relational::tests::dbInc',
+                  mainTableDb: 'apps::pure::studio::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
                 tableAlias: 'personTable',
               },
-              source: 'apps_pure_studio_tests_model_simple_Person',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -510,12 +512,12 @@ export const ComplexRelationalModel = [
                 table: {
                   _type: 'Table',
                   database: 'apps::pure::studio::relational::tests::dbInc',
+                  mainTableDb: 'apps::pure::studio::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
                 tableAlias: 'personTable',
               },
-              source: 'apps_pure_studio_tests_model_simple_Person',
             },
           ],
           root: true,

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
@@ -25,6 +25,7 @@ export const testDatabaseRoundtrip = [
       filters: [
         {
           _type: 'filter',
+          name: 'PositiveInteractionTimeFilter',
           operation: {
             _type: 'dynaFunc',
             funcName: 'greaterThan',
@@ -35,6 +36,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'interactionTable',
                 },
@@ -46,10 +48,10 @@ export const testDatabaseRoundtrip = [
               },
             ],
           },
-          name: 'PositiveInteractionTimeFilter',
         },
         {
           _type: 'filter',
+          name: 'ProductSynonymFilter',
           operation: {
             _type: 'dynaFunc',
             funcName: 'notEqual',
@@ -60,6 +62,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'productSchema',
                   table: 'synonymTable',
                 },
@@ -71,10 +74,10 @@ export const testDatabaseRoundtrip = [
               },
             ],
           },
-          name: 'ProductSynonymFilter',
         },
         {
           _type: 'filter',
+          name: 'NonNegativePnlFilter',
           operation: {
             _type: 'dynaFunc',
             funcName: 'greaterThan',
@@ -85,6 +88,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderPnlTable',
                 },
@@ -96,10 +100,10 @@ export const testDatabaseRoundtrip = [
               },
             ],
           },
-          name: 'NonNegativePnlFilter',
         },
         {
           _type: 'filter',
+          name: 'LessThanEqualZeroPnlFilter',
           operation: {
             _type: 'dynaFunc',
             funcName: 'lessThanEqual',
@@ -110,6 +114,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderPnlTable',
                 },
@@ -121,7 +126,6 @@ export const testDatabaseRoundtrip = [
               },
             ],
           },
-          name: 'LessThanEqualZeroPnlFilter',
         },
       ],
       includedStores: ['model::relational::tests::dbInc'],
@@ -138,6 +142,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'productSchema',
                   table: 'synonymTable',
                 },
@@ -149,6 +154,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'productSchema',
                   table: 'productTable',
                 },
@@ -169,6 +175,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeTable',
                 },
@@ -180,6 +187,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'productSchema',
                   table: 'productTable',
                 },
@@ -200,6 +208,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeTable',
                 },
@@ -211,6 +220,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'accountTable',
                 },
@@ -231,6 +241,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'interactionTable',
                 },
@@ -242,6 +253,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -262,6 +274,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'interactionTable',
                 },
@@ -273,6 +286,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -297,6 +311,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionTable',
                     },
@@ -308,6 +323,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionViewMaxTime',
                     },
@@ -325,6 +341,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionTable',
                     },
@@ -336,6 +353,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionViewMaxTime',
                     },
@@ -358,6 +376,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeTable',
                 },
@@ -369,6 +388,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeEventTable',
                 },
@@ -389,6 +409,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeTable',
                 },
@@ -400,6 +421,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeEventViewMaxTradeEventDate',
                 },
@@ -420,6 +442,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'tradeEventTable',
                 },
@@ -431,6 +454,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -455,6 +479,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionTable',
                     },
@@ -466,6 +491,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: '{target}',
                     },
@@ -483,6 +509,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionTable',
                     },
@@ -494,6 +521,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: '{target}',
                     },
@@ -516,6 +544,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -527,6 +556,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'salesPersonTable',
                 },
@@ -547,6 +577,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -558,6 +589,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'accountTable',
                 },
@@ -578,6 +610,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderPnlView',
                 },
@@ -589,6 +622,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -609,6 +643,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderPnlViewOnView',
                 },
@@ -620,6 +655,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -640,6 +676,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderNegativePnlView',
                 },
@@ -651,6 +688,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -671,6 +709,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderNegativePnlViewOnView',
                 },
@@ -682,6 +721,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -702,6 +742,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderPnlView',
                 },
@@ -713,6 +754,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -733,6 +775,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'salesPersonTable',
                 },
@@ -744,6 +787,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'PersonFirmView',
                 },
@@ -764,6 +808,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderPnlTable',
                 },
@@ -775,6 +820,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'orderTable',
                 },
@@ -795,6 +841,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'accountOrderPnlView',
                 },
@@ -806,6 +853,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'accountTable',
                 },
@@ -826,6 +874,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -837,6 +886,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::db',
+                  mainTableDb: 'model::relational::tests::db',
                   schema: 'default',
                   table: 'otherNamesTable',
                 },
@@ -1249,6 +1299,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionTable',
                     },
@@ -1263,6 +1314,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'interactionTable',
                     },
@@ -1281,6 +1333,7 @@ export const testDatabaseRoundtrip = [
                         table: {
                           _type: 'Table',
                           database: 'model::relational::tests::db',
+                          mainTableDb: 'model::relational::tests::db',
                           schema: 'default',
                           table: 'interactionTable',
                         },
@@ -1298,6 +1351,7 @@ export const testDatabaseRoundtrip = [
                   table: {
                     _type: 'Table',
                     database: 'model::relational::tests::db',
+                    mainTableDb: 'model::relational::tests::db',
                     schema: 'default',
                     table: 'interactionTable',
                   },
@@ -1309,6 +1363,7 @@ export const testDatabaseRoundtrip = [
                   table: {
                     _type: 'Table',
                     database: 'model::relational::tests::db',
+                    mainTableDb: 'model::relational::tests::db',
                     schema: 'default',
                     table: 'interactionTable',
                   },
@@ -1328,6 +1383,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'tradeEventTable',
                     },
@@ -1346,6 +1402,7 @@ export const testDatabaseRoundtrip = [
                         table: {
                           _type: 'Table',
                           database: 'model::relational::tests::db',
+                          mainTableDb: 'model::relational::tests::db',
                           schema: 'default',
                           table: 'tradeEventTable',
                         },
@@ -1363,6 +1420,7 @@ export const testDatabaseRoundtrip = [
                   table: {
                     _type: 'Table',
                     database: 'model::relational::tests::db',
+                    mainTableDb: 'model::relational::tests::db',
                     schema: 'default',
                     table: 'tradeEventTable',
                   },
@@ -1382,6 +1440,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderPnlTable',
                     },
@@ -1396,6 +1455,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderPnlTable',
                     },
@@ -1422,6 +1482,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::db',
+                        mainTableDb: 'model::relational::tests::db',
                         schema: 'default',
                         table: 'accountTable',
                       },
@@ -1449,6 +1510,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::db',
+                        mainTableDb: 'model::relational::tests::db',
                         schema: 'default',
                         table: 'salesPersonTable',
                       },
@@ -1476,6 +1538,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::db',
+                        mainTableDb: 'model::relational::tests::db',
                         schema: 'default',
                         table: 'salesPersonTable',
                       },
@@ -1499,6 +1562,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderPnlView',
                     },
@@ -1513,6 +1577,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderPnlView',
                     },
@@ -1535,6 +1600,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderPnlTable',
                     },
@@ -1549,6 +1615,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderPnlTable',
                     },
@@ -1575,6 +1642,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::db',
+                        mainTableDb: 'model::relational::tests::db',
                         schema: 'default',
                         table: 'accountTable',
                       },
@@ -1602,6 +1670,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::db',
+                        mainTableDb: 'model::relational::tests::db',
                         schema: 'default',
                         table: 'salesPersonTable',
                       },
@@ -1629,6 +1698,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::db',
+                        mainTableDb: 'model::relational::tests::db',
                         schema: 'default',
                         table: 'salesPersonTable',
                       },
@@ -1652,6 +1722,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderNegativePnlView',
                     },
@@ -1666,6 +1737,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderNegativePnlView',
                     },
@@ -1688,6 +1760,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::db',
+                      mainTableDb: 'model::relational::tests::db',
                       schema: 'default',
                       table: 'orderTable',
                     },
@@ -1714,6 +1787,7 @@ export const testDatabaseRoundtrip = [
                           table: {
                             _type: 'Table',
                             database: 'model::relational::tests::db',
+                            mainTableDb: 'model::relational::tests::db',
                             schema: 'default',
                             table: 'orderPnlTable',
                           },
@@ -1732,6 +1806,7 @@ export const testDatabaseRoundtrip = [
                   table: {
                     _type: 'Table',
                     database: 'model::relational::tests::db',
+                    mainTableDb: 'model::relational::tests::db',
                     schema: 'default',
                     table: 'orderTable',
                   },
@@ -1754,6 +1829,7 @@ export const testDatabaseRoundtrip = [
       filters: [
         {
           _type: 'filter',
+          name: 'FirmXFilter',
           operation: {
             _type: 'dynaFunc',
             funcName: 'equal',
@@ -1764,6 +1840,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -1775,7 +1852,6 @@ export const testDatabaseRoundtrip = [
               },
             ],
           },
-          name: 'FirmXFilter',
         },
       ],
       includedStores: [],
@@ -1792,6 +1868,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -1803,6 +1880,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'PersonViewWithDistinct',
                 },
@@ -1827,6 +1905,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -1838,6 +1917,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personViewWithGroupBy',
                     },
@@ -1855,6 +1935,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -1866,6 +1947,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personViewWithGroupBy',
                     },
@@ -1888,6 +1970,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
@@ -1899,6 +1982,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -1919,6 +2003,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
@@ -1930,6 +2015,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -1950,6 +2036,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -1961,6 +2048,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -1981,6 +2069,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -1992,6 +2081,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -2012,6 +2102,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmExtensionTable',
                 },
@@ -2023,6 +2114,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'PersonTableExtension',
                 },
@@ -2043,6 +2135,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -2054,6 +2147,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'locationTable',
                 },
@@ -2074,6 +2168,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -2085,6 +2180,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: '{target}',
                 },
@@ -2105,6 +2201,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'locationTable',
                 },
@@ -2116,6 +2213,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'placeOfInterestTable',
                 },
@@ -2136,6 +2234,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -2147,6 +2246,7 @@ export const testDatabaseRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'model::relational::tests::dbInc',
+                  mainTableDb: 'model::relational::tests::dbInc',
                   schema: 'default',
                   table: 'otherFirmTable',
                 },
@@ -2577,6 +2677,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -2591,6 +2692,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -2613,6 +2715,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::dbInc',
+                        mainTableDb: 'model::relational::tests::dbInc',
                         schema: 'default',
                         table: 'firmTable',
                       },
@@ -2636,6 +2739,7 @@ export const testDatabaseRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'model::relational::tests::dbInc',
+                      mainTableDb: 'model::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -2654,6 +2758,7 @@ export const testDatabaseRoundtrip = [
                         table: {
                           _type: 'Table',
                           database: 'model::relational::tests::dbInc',
+                          mainTableDb: 'model::relational::tests::dbInc',
                           schema: 'default',
                           table: 'personTable',
                         },
@@ -2671,6 +2776,7 @@ export const testDatabaseRoundtrip = [
                   table: {
                     _type: 'Table',
                     database: 'model::relational::tests::dbInc',
+                    mainTableDb: 'model::relational::tests::dbInc',
                     schema: 'default',
                     table: 'personTable',
                   },
@@ -2698,6 +2804,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::dbInc',
+                        mainTableDb: 'model::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -2721,6 +2828,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::dbInc',
+                        mainTableDb: 'model::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -2744,6 +2852,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::dbInc',
+                        mainTableDb: 'model::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -2767,6 +2876,7 @@ export const testDatabaseRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'model::relational::tests::dbInc',
+                        mainTableDb: 'model::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -2807,6 +2917,7 @@ export const testDatabaseWithSelfJoin = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -2818,6 +2929,7 @@ export const testDatabaseWithSelfJoin = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: '{target}',
                 },
@@ -2879,6 +2991,7 @@ export const testDatabaseWithSelfJoin = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc1',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc1',
                   schema: 'demoSchema',
                   table: 'personTable',
                 },
@@ -2890,6 +3003,7 @@ export const testDatabaseWithSelfJoin = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc1',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc1',
                   schema: 'default',
                   table: '{target}',
                 },
@@ -2976,7 +3090,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
             upperBound: 1,
           },
           name: 'employees',
-          type: 'Person',
+          type: 'other::Person',
         },
         {
           multiplicity: {
@@ -2984,7 +3098,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
             upperBound: 1,
           },
           name: 'address',
-          type: 'Address',
+          type: 'other::Address',
         },
       ],
     },
@@ -3011,7 +3125,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
             upperBound: 1,
           },
           name: 'firm',
-          type: 'Firm',
+          type: 'other::Firm',
         },
         {
           multiplicity: {
@@ -3019,7 +3133,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
             upperBound: 1,
           },
           name: 'address',
-          type: 'Address',
+          type: 'other::Address',
         },
       ],
     },
@@ -3030,6 +3144,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
     content: {
       _type: 'relational',
       filters: [],
+      includedStores: [],
       joins: [],
       name: 'db',
       package: 'mapping',
@@ -3085,7 +3200,6 @@ export const simpleEmbeddedRelationalRoundtrip = [
           views: [],
         },
       ],
-      includedStores: [],
     },
     classifierPath: 'meta::relational::metamodel::Database',
   },
@@ -3093,7 +3207,6 @@ export const simpleEmbeddedRelationalRoundtrip = [
     path: 'mappingPackage::myMapping',
     content: {
       _type: 'mapping',
-      includedMappings: [],
       classMappings: [
         {
           _type: 'relational',
@@ -3102,6 +3215,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
           mainTable: {
             _type: 'Table',
             database: 'mapping::db',
+            mainTableDb: 'mapping::db',
             schema: 'default',
             table: 'employeeFirmDenormTable',
           },
@@ -3112,6 +3226,7 @@ export const simpleEmbeddedRelationalRoundtrip = [
               table: {
                 _type: 'Table',
                 database: 'mapping::db',
+                mainTableDb: 'mapping::db',
                 schema: 'default',
                 table: 'employeeFirmDenormTable',
               },
@@ -3131,29 +3246,22 @@ export const simpleEmbeddedRelationalRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'mapping::db',
+                  mainTableDb: 'mapping::db',
                   schema: 'default',
                   table: 'employeeFirmDenormTable',
                 },
                 tableAlias: 'employeeFirmDenormTable',
               },
-              source: 'other_Person',
             },
             {
               _type: 'embeddedPropertyMapping',
-              property: {
-                class: 'other::Person',
-                property: 'firm',
-              },
-              source: 'other_Person',
               classMapping: {
                 _type: 'embedded',
-                class: 'other::Firm',
                 primaryKey: [],
                 propertyMappings: [
                   {
                     _type: 'relationalPropertyMapping',
                     property: {
-                      class: 'other::Firm',
                       property: 'legalName',
                     },
                     relationalOperation: {
@@ -3162,15 +3270,19 @@ export const simpleEmbeddedRelationalRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'mapping::db',
+                        mainTableDb: 'mapping::db',
                         schema: 'default',
                         table: 'employeeFirmDenormTable',
                       },
                       tableAlias: 'employeeFirmDenormTable',
                     },
-                    source: 'other_Person',
                   },
                 ],
                 root: false,
+              },
+              property: {
+                class: 'other::Person',
+                property: 'firm',
               },
             },
           ],
@@ -3178,48 +3290,21 @@ export const simpleEmbeddedRelationalRoundtrip = [
         },
       ],
       enumerationMappings: [],
+      includedMappings: [],
       name: 'myMapping',
       package: 'mappingPackage',
       tests: [],
     },
     classifierPath: 'meta::pure::mapping::Mapping',
   },
-  {
-    path: '__internal__::SectionIndex',
-    content: {
-      _type: 'sectionIndex',
-      name: 'SectionIndex',
-      package: '__internal__',
-      sections: [
-        {
-          _type: 'importAware',
-          imports: ['other'],
-          elements: ['other::Person', 'other::Firm', 'other::Address'],
-          parserName: 'Pure',
-        },
-        {
-          _type: 'default',
-          elements: ['mapping::db'],
-          parserName: 'Relational',
-        },
-        {
-          _type: 'importAware',
-          imports: [],
-          elements: ['mappingPackage::myMapping'],
-          parserName: 'Mapping',
-        },
-      ],
-    },
-    classifierPath: 'meta::pure::metamodel::section::SectionIndex',
-  },
 ];
 
 export const multiLevelEmbeddedRelationalRoundtrip = [
   {
-    path: 'other::Person',
+    path: 'other::Address',
     content: {
       _type: 'class',
-      name: 'Person',
+      name: 'Address',
       package: 'other',
       properties: [
         {
@@ -3227,24 +3312,8 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
             lowerBound: 1,
             upperBound: 1,
           },
-          name: 'name',
+          name: 'line1',
           type: 'String',
-        },
-        {
-          multiplicity: {
-            lowerBound: 1,
-            upperBound: 1,
-          },
-          name: 'firm',
-          type: 'other::Firm',
-        },
-        {
-          multiplicity: {
-            lowerBound: 0,
-            upperBound: 1,
-          },
-          name: 'address',
-          type: 'other::Address',
         },
       ],
     },
@@ -3286,10 +3355,10 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
     classifierPath: 'meta::pure::metamodel::type::Class',
   },
   {
-    path: 'other::Address',
+    path: 'other::Person',
     content: {
       _type: 'class',
-      name: 'Address',
+      name: 'Person',
       package: 'other',
       properties: [
         {
@@ -3297,8 +3366,24 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
             lowerBound: 1,
             upperBound: 1,
           },
-          name: 'line1',
+          name: 'name',
           type: 'String',
+        },
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'firm',
+          type: 'other::Firm',
+        },
+        {
+          multiplicity: {
+            lowerBound: 0,
+            upperBound: 1,
+          },
+          name: 'address',
+          type: 'other::Address',
         },
       ],
     },
@@ -3309,6 +3394,7 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
     content: {
       _type: 'relational',
       filters: [],
+      includedStores: [],
       joins: [],
       name: 'db',
       package: 'mapping',
@@ -3364,7 +3450,6 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
           views: [],
         },
       ],
-      includedStores: [],
     },
     classifierPath: 'meta::relational::metamodel::Database',
   },
@@ -3372,7 +3457,6 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
     path: 'mappingPackage::myMapping',
     content: {
       _type: 'mapping',
-      includedMappings: [],
       classMappings: [
         {
           _type: 'relational',
@@ -3381,6 +3465,7 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
           mainTable: {
             _type: 'Table',
             database: 'mapping::db',
+            mainTableDb: 'mapping::db',
             schema: 'default',
             table: 'employeeFirmDenormTable',
           },
@@ -3391,6 +3476,7 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
               table: {
                 _type: 'Table',
                 database: 'mapping::db',
+                mainTableDb: 'mapping::db',
                 schema: 'default',
                 table: 'employeeFirmDenormTable',
               },
@@ -3410,23 +3496,17 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
                 table: {
                   _type: 'Table',
                   database: 'mapping::db',
+                  mainTableDb: 'mapping::db',
                   schema: 'default',
                   table: 'employeeFirmDenormTable',
                 },
                 tableAlias: 'employeeFirmDenormTable',
               },
-              source: 'other_Person',
             },
             {
               _type: 'embeddedPropertyMapping',
-              property: {
-                class: 'other::Person',
-                property: 'firm',
-              },
-              source: 'other_Person',
               classMapping: {
                 _type: 'embedded',
-                class: 'other::Firm',
                 primaryKey: [
                   {
                     _type: 'column',
@@ -3434,6 +3514,7 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
                     table: {
                       _type: 'Table',
                       database: 'mapping::db',
+                      mainTableDb: 'mapping::db',
                       schema: 'default',
                       table: 'employeeFirmDenormTable',
                     },
@@ -3444,7 +3525,6 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
                   {
                     _type: 'relationalPropertyMapping',
                     property: {
-                      class: 'other::Firm',
                       property: 'legalName',
                     },
                     relationalOperation: {
@@ -3453,29 +3533,22 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'mapping::db',
+                        mainTableDb: 'mapping::db',
                         schema: 'default',
                         table: 'employeeFirmDenormTable',
                       },
                       tableAlias: 'employeeFirmDenormTable',
                     },
-                    source: 'other_Person',
                   },
                   {
                     _type: 'embeddedPropertyMapping',
-                    property: {
-                      class: 'other::Firm',
-                      property: 'address',
-                    },
-                    source: 'other_Person',
                     classMapping: {
                       _type: 'embedded',
-                      class: 'other::Address',
                       primaryKey: [],
                       propertyMappings: [
                         {
                           _type: 'relationalPropertyMapping',
                           property: {
-                            class: 'other::Address',
                             property: 'line1',
                           },
                           relationalOperation: {
@@ -3484,37 +3557,37 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
                             table: {
                               _type: 'Table',
                               database: 'mapping::db',
+                              mainTableDb: 'mapping::db',
                               schema: 'default',
                               table: 'employeeFirmDenormTable',
                             },
                             tableAlias: 'employeeFirmDenormTable',
                           },
-                          source: 'other_Person',
                         },
                       ],
                       root: false,
+                    },
+                    property: {
+                      property: 'address',
                     },
                   },
                 ],
                 root: false,
               },
+              property: {
+                class: 'other::Person',
+                property: 'firm',
+              },
             },
             {
               _type: 'embeddedPropertyMapping',
-              property: {
-                class: 'other::Person',
-                property: 'address',
-              },
-              source: 'other_Person',
               classMapping: {
                 _type: 'embedded',
-                class: 'other::Address',
                 primaryKey: [],
                 propertyMappings: [
                   {
                     _type: 'relationalPropertyMapping',
                     property: {
-                      class: 'other::Address',
                       property: 'line1',
                     },
                     relationalOperation: {
@@ -3523,15 +3596,19 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
                       table: {
                         _type: 'Table',
                         database: 'mapping::db',
+                        mainTableDb: 'mapping::db',
                         schema: 'default',
                         table: 'employeeFirmDenormTable',
                       },
                       tableAlias: 'employeeFirmDenormTable',
                     },
-                    source: 'other_Person',
                   },
                 ],
                 root: false,
+              },
+              property: {
+                class: 'other::Person',
+                property: 'address',
               },
             },
           ],
@@ -3539,6 +3616,7 @@ export const multiLevelEmbeddedRelationalRoundtrip = [
         },
       ],
       enumerationMappings: [],
+      includedMappings: [],
       name: 'myMapping',
       package: 'mappingPackage',
       tests: [],
@@ -7416,6 +7494,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -7443,6 +7522,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -7454,6 +7534,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'PersonViewWithDistinct',
                 },
@@ -7478,6 +7559,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -7489,6 +7571,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personViewWithGroupBy',
                     },
@@ -7506,6 +7589,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -7517,6 +7601,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personViewWithGroupBy',
                     },
@@ -7539,6 +7624,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
@@ -7550,6 +7636,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -7570,6 +7657,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
@@ -7581,6 +7669,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -7601,6 +7690,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -7612,6 +7702,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -7632,6 +7723,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
@@ -7643,6 +7735,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -7663,6 +7756,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmExtensionTable',
                 },
@@ -7674,6 +7768,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'PersonTableExtension',
                 },
@@ -7694,6 +7789,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -7705,6 +7801,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'locationTable',
                 },
@@ -7725,6 +7822,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -7736,6 +7834,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: '{target}',
                 },
@@ -7756,6 +7855,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'locationTable',
                 },
@@ -7767,6 +7867,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'placeOfInterestTable',
                 },
@@ -7787,6 +7888,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
@@ -7798,6 +7900,7 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'otherFirmTable',
                 },
@@ -8228,6 +8331,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -8242,6 +8346,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -8264,6 +8369,7 @@ export const testRelationalAssociationMapping = [
                       table: {
                         _type: 'Table',
                         database: 'apps::meta::relational::tests::dbInc',
+                        mainTableDb: 'apps::meta::relational::tests::dbInc',
                         schema: 'default',
                         table: 'firmTable',
                       },
@@ -8287,6 +8393,7 @@ export const testRelationalAssociationMapping = [
                     table: {
                       _type: 'Table',
                       database: 'apps::meta::relational::tests::dbInc',
+                      mainTableDb: 'apps::meta::relational::tests::dbInc',
                       schema: 'default',
                       table: 'personTable',
                     },
@@ -8305,6 +8412,7 @@ export const testRelationalAssociationMapping = [
                         table: {
                           _type: 'Table',
                           database: 'apps::meta::relational::tests::dbInc',
+                          mainTableDb: 'apps::meta::relational::tests::dbInc',
                           schema: 'default',
                           table: 'personTable',
                         },
@@ -8322,6 +8430,7 @@ export const testRelationalAssociationMapping = [
                   table: {
                     _type: 'Table',
                     database: 'apps::meta::relational::tests::dbInc',
+                    mainTableDb: 'apps::meta::relational::tests::dbInc',
                     schema: 'default',
                     table: 'personTable',
                   },
@@ -8349,6 +8458,7 @@ export const testRelationalAssociationMapping = [
                       table: {
                         _type: 'Table',
                         database: 'apps::meta::relational::tests::dbInc',
+                        mainTableDb: 'apps::meta::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -8372,6 +8482,7 @@ export const testRelationalAssociationMapping = [
                       table: {
                         _type: 'Table',
                         database: 'apps::meta::relational::tests::dbInc',
+                        mainTableDb: 'apps::meta::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -8395,6 +8506,7 @@ export const testRelationalAssociationMapping = [
                       table: {
                         _type: 'Table',
                         database: 'apps::meta::relational::tests::dbInc',
+                        mainTableDb: 'apps::meta::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -8418,6 +8530,7 @@ export const testRelationalAssociationMapping = [
                       table: {
                         _type: 'Table',
                         database: 'apps::meta::relational::tests::dbInc',
+                        mainTableDb: 'apps::meta::relational::tests::dbInc',
                         schema: 'default',
                         table: 'personTable',
                       },
@@ -8463,7 +8576,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_PlaceOfInterest',
               target: 'apps_meta_pure_tests_model_simple_Location',
             },
             {
@@ -8481,7 +8593,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Location',
               target: 'apps_meta_pure_tests_model_simple_PlaceOfInterest',
             },
           ],
@@ -8496,6 +8607,7 @@ export const testRelationalAssociationMapping = [
           mainTable: {
             _type: 'Table',
             database: 'apps::meta::relational::tests::dbInc',
+            mainTableDb: 'apps::meta::relational::tests::dbInc',
             schema: 'default',
             table: 'personTable',
           },
@@ -8506,6 +8618,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'personTable',
               },
@@ -8525,12 +8638,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
                 tableAlias: 'personTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8544,12 +8657,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
                 tableAlias: 'personTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8563,12 +8676,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'personTable',
                 },
                 tableAlias: 'personTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8585,7 +8698,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
               target: 'apps_meta_pure_tests_model_simple_Firm',
             },
             {
@@ -8604,7 +8716,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
               target: 'apps_meta_pure_tests_model_simple_Address',
             },
             {
@@ -8623,7 +8734,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
               target: 'apps_meta_pure_tests_model_simple_Location',
             },
             {
@@ -8641,7 +8751,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Person',
               target: 'apps_meta_pure_tests_model_simple_Person',
             },
           ],
@@ -8654,6 +8763,7 @@ export const testRelationalAssociationMapping = [
           mainTable: {
             _type: 'Table',
             database: 'apps::meta::relational::tests::dbInc',
+            mainTableDb: 'apps::meta::relational::tests::dbInc',
             schema: 'default',
             table: 'firmTable',
           },
@@ -8664,6 +8774,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'firmTable',
               },
@@ -8683,12 +8794,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmTable',
                 },
                 tableAlias: 'firmTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Firm',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8705,7 +8816,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Firm',
               target: 'apps_meta_pure_tests_model_simple_Person',
             },
             {
@@ -8724,7 +8834,6 @@ export const testRelationalAssociationMapping = [
                   },
                 ],
               },
-              source: 'apps_meta_pure_tests_model_simple_Firm',
               target: 'apps_meta_pure_tests_model_simple_Address',
             },
           ],
@@ -8737,6 +8846,7 @@ export const testRelationalAssociationMapping = [
           mainTable: {
             _type: 'Table',
             database: 'apps::meta::relational::tests::dbInc',
+            mainTableDb: 'apps::meta::relational::tests::dbInc',
             schema: 'default',
             table: 'firmExtensionTable',
           },
@@ -8747,6 +8857,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'firmExtensionTable',
               },
@@ -8766,12 +8877,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmExtensionTable',
                 },
                 tableAlias: 'firmExtensionTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_FirmExtension',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8785,26 +8896,22 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'firmExtensionTable',
                 },
                 tableAlias: 'firmExtensionTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_FirmExtension',
             },
             {
               _type: 'embeddedPropertyMapping',
               classMapping: {
                 _type: 'embedded',
-                class:
-                  'apps::meta::pure::tests::model::simple::PersonExtension',
                 primaryKey: [],
                 propertyMappings: [
                   {
                     _type: 'relationalPropertyMapping',
                     property: {
-                      class:
-                        'apps::meta::pure::tests::model::simple::PersonExtension',
                       property: 'birthdate',
                     },
                     relationalOperation: {
@@ -8821,13 +8928,13 @@ export const testRelationalAssociationMapping = [
                         table: {
                           _type: 'Table',
                           database: 'apps::meta::relational::tests::dbInc',
+                          mainTableDb: 'apps::meta::relational::tests::dbInc',
                           schema: 'default',
                           table: 'PersonTableExtension',
                         },
                         tableAlias: 'PersonTableExtension',
                       },
                     },
-                    source: 'apps_meta_pure_tests_model_simple_FirmExtension',
                   },
                 ],
                 root: false,
@@ -8836,7 +8943,6 @@ export const testRelationalAssociationMapping = [
                 class: 'apps::meta::pure::tests::model::simple::FirmExtension',
                 property: 'employeesExt',
               },
-              source: 'apps_meta_pure_tests_model_simple_FirmExtension',
             },
           ],
           root: false,
@@ -8848,6 +8954,7 @@ export const testRelationalAssociationMapping = [
           mainTable: {
             _type: 'Table',
             database: 'apps::meta::relational::tests::dbInc',
+            mainTableDb: 'apps::meta::relational::tests::dbInc',
             schema: 'default',
             table: 'addressTable',
           },
@@ -8858,6 +8965,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'addressTable',
               },
@@ -8877,12 +8985,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
                 tableAlias: 'addressTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Address',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8896,12 +9004,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
                 tableAlias: 'addressTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Address',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8917,12 +9025,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
                 tableAlias: 'addressTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Address',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -8936,12 +9044,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'addressTable',
                 },
                 tableAlias: 'addressTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Address',
             },
           ],
           root: false,
@@ -8953,6 +9061,7 @@ export const testRelationalAssociationMapping = [
           mainTable: {
             _type: 'Table',
             database: 'apps::meta::relational::tests::dbInc',
+            mainTableDb: 'apps::meta::relational::tests::dbInc',
             schema: 'default',
             table: 'locationTable',
           },
@@ -8963,6 +9072,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'locationTable',
               },
@@ -8982,12 +9092,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'locationTable',
                 },
                 tableAlias: 'locationTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Location',
             },
             {
               _type: 'relationalPropertyMapping',
@@ -9001,12 +9111,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'locationTable',
                 },
                 tableAlias: 'locationTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_Location',
             },
           ],
           root: false,
@@ -9018,6 +9128,7 @@ export const testRelationalAssociationMapping = [
           mainTable: {
             _type: 'Table',
             database: 'apps::meta::relational::tests::dbInc',
+            mainTableDb: 'apps::meta::relational::tests::dbInc',
             schema: 'default',
             table: 'placeOfInterestTable',
           },
@@ -9028,6 +9139,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'placeOfInterestTable',
               },
@@ -9039,6 +9151,7 @@ export const testRelationalAssociationMapping = [
               table: {
                 _type: 'Table',
                 database: 'apps::meta::relational::tests::dbInc',
+                mainTableDb: 'apps::meta::relational::tests::dbInc',
                 schema: 'default',
                 table: 'placeOfInterestTable',
               },
@@ -9059,12 +9172,12 @@ export const testRelationalAssociationMapping = [
                 table: {
                   _type: 'Table',
                   database: 'apps::meta::relational::tests::dbInc',
+                  mainTableDb: 'apps::meta::relational::tests::dbInc',
                   schema: 'default',
                   table: 'placeOfInterestTable',
                 },
                 tableAlias: 'placeOfInterestTable',
               },
-              source: 'apps_meta_pure_tests_model_simple_PlaceOfInterest',
             },
           ],
           root: false,


### PR DESCRIPTION
See https://github.com/finos/legend-studio/issues/165

> NOTE: this PR attempts to resolve a subset of problem regarding the grammar roundtrip for embedded relational mapping. There are other issues like `mainTable` and `primaryKey` which we will need to address in another fix. Those require some logic (or more like reverse logic to graph building) in the transformer.