### PR TITLE
fix additional execution input elements function

### DIFF
--- a/.changeset/healthy-pianos-teach.md
+++ b/.changeset/healthy-pianos-teach.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Fix extension that selects additional elements for execution input from `V1_getExtraExecutionInputElements` to the function `V1_getExtraExecutionInputGetters`. This allows the extensions to be used by the plugins by implementing the function.

--- a/packages/legend-studio/src/models/protocols/pure/PureProtocolProcessorPlugin.ts
+++ b/packages/legend-studio/src/models/protocols/pure/PureProtocolProcessorPlugin.ts
@@ -20,6 +20,9 @@ import type { PackageableElement } from '../../metamodels/pure/model/packageable
 import type { V1_PackageableElement } from './v1/model/packageableElements/V1_PackageableElement';
 import type { V1_ElementBuilder } from './v1/transformation/pureGraph/to/V1_ElementBuilder';
 import type { V1_PureModelContextData } from './v1/model/context/V1_PureModelContextData';
+import type { PureModel } from '../../metamodels/pure/graph/PureModel';
+import type { Mapping } from '../../metamodels/pure/model/packageableElements/mapping/Mapping';
+import type { Runtime } from '../../metamodels/pure/model/packageableElements/runtime/Runtime';
 
 export type V1_ElementProtocolClassifierPathGetter = (
   protocol: V1_PackageableElement,
@@ -36,6 +39,13 @@ export type V1_ElementProtocolDeserializer = (
 export type V1_ElementTransformer = (
   metamodel: PackageableElement,
 ) => V1_PackageableElement | undefined;
+
+export type V1_ExecutionInputGetter = (
+  graph: PureModel,
+  mapping: Mapping,
+  runtime: Runtime,
+  protocolGraph: V1_PureModelContextData,
+) => V1_PackageableElement[];
 
 export abstract class PureProtocolProcessorPlugin extends AbstractPlugin {
   private readonly _$nominalTypeBrand!: 'PureProtocolProcessorPlugin';
@@ -60,5 +70,5 @@ export abstract class PureProtocolProcessorPlugin extends AbstractPlugin {
    * sending the server additional elements not needed for execution. This would provide a mechanism
    * to add more elements in this reduced graph.
    */
-  V1_getExtraExecutionInputElements?(): V1_PackageableElement[];
+  V1_getExtraExecutionInputGetters?(): V1_ExecutionInputGetter[];
 }

--- a/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -1794,9 +1794,9 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     const graphData = this.getFullGraphModelData(graph);
     /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
     const prunedGraphData = new V1_PureModelContextData();
-    const extraExecutionElements = this.pureProtocolProcessorPlugins.flatMap(
-      (e) => e.V1_getExtraExecutionInputElements?.() ?? [],
-    );
+    const extraExecutionElements = this.pureProtocolProcessorPlugins
+      .flatMap((e) => e.V1_getExtraExecutionInputGetters?.() ?? [])
+      .flatMap((getter) => getter(graph, mapping, runtime, graphData));
     prunedGraphData.elements = graphData.elements
       .filter(
         (element) =>


### PR DESCRIPTION
Fix extension that selects additional elements for execution input from `V1_getExtraExecutionInputElements` to the function `V1_getExtraExecutionInputSelectors`. This allows the extensions to actual be used by the plugins by implementing the function. (#219 )