### PR TITLE
Handle OOM issue in Webpack application build

### DIFF
--- a/.changeset/fresh-singers-shout.md
+++ b/.changeset/fresh-singers-shout.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-plugin-query-builder': patch
+---

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -106,3 +106,37 @@ jobs:
         uses: codecov/codecov-action@v1.5.0
         with:
           directory: ./build/coverage
+
+  # This job is to make sure Webpack builds the application fine. This is helpful
+  # to know as we don't want to find out this failure as late as when we prepare the
+  # artifacts to publish to Docker.
+  application-test-build:
+    name: Check Application Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Setup Yarn cache
+        uses: actions/cache@v2.1.6
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14.x
+      - name: Install dependencies
+        run: yarn
+      - name: Build application
+        run: yarn build:setup && yarn workspace @finos/legend-studio-app build
+        env:
+          # TODO: After https://github.com/finos/legend-studio/pull/227 it seems like due to either
+          # the upgrade of Webpack/Typescript that we start seeing some OOM when building Webpack
+          # while publishing to Docker. We should once in a while remove this line and try again.
+          NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
         # `@finos/legend-studio` in order to trigger a version bump in `@finos/legend-studio-app`
         if: steps.changesets.outputs.published == 'true'
         run: yarn workspace @finos/legend-studio-app publish:docker
+        env:
+          # TODO: After https://github.com/finos/legend-studio/pull/227 it seems like due to either
+          # the upgrade of Webpack/Typescript that we start seeing some OOM when building Webpack
+          # while publishing to Docker. We should once in a while remove this line and try again.
+          NODE_OPTIONS: '--max_old_space_size=4096'
       - name: Upload publish content
         # If publish never happened, there's no point in uploading this content
         if: steps.changesets.outputs.published == 'true'

--- a/packages/legend-studio-app/package.json
+++ b/packages/legend-studio-app/package.json
@@ -29,7 +29,7 @@
     "dev:tsc": "tsc --watch --preserveWatchOutput",
     "dev:webpack": "cross-env NODE_ENV=development webpack serve --mode development",
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location ./build/.eslintcache --report-unused-disable-directives --parser-options=project:\"./tsconfig.json\",requireConfigFile:false \"./scripts/**/*.{mjs,cjs,js}\" \"./src/**/*.{js,ts,tsx}\"",
-    "publish:docker": "echo 'Building webapp content...' && yarn workspace @finos/legend-studio-app build && ./scripts/publish-docker.sh",
+    "publish:docker": "echo 'Building webapp content...' && yarn build && ./scripts/publish-docker.sh",
     "serve": "npx http-server ./dist -p 3000 -a localhost -g --cors -o /studio",
     "setup": "rimraf \"dev\" && yarn node ./scripts/setup.js ./dev",
     "test": "jest",


### PR DESCRIPTION
After https://github.com/finos/legend-studio/pull/227 it seems like due to either the upgrade of Webpack/Typescript that we start seeing some OOM when building Webpack while publishing to Docker. We should once in a while remove this line and try again.