### PR TITLE
introduce basic execution plan processor and more stabilization

### DIFF
--- a/.changeset/hip-lemons-shop.md
+++ b/.changeset/hip-lemons-shop.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-plugin-query-builder': patch
+---

--- a/.changeset/six-llamas-mix.md
+++ b/.changeset/six-llamas-mix.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Fix a bug that prevents graph freezer to work properly with relational property mapping (related to the changes in #207).

--- a/.changeset/tidy-icons-film.md
+++ b/.changeset/tidy-icons-film.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Introduce plan execution processor (#249).

--- a/.changeset/weak-spiders-march.md
+++ b/.changeset/weak-spiders-march.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio-plugin-query-builder': patch
+---
+
+Default to use `graphFetch` function instead of `graphFetchChecked` as the latter does not work out-of-the-box for relational mapping.

--- a/.github/workflows/check-plugin-compatibility.yml
+++ b/.github/workflows/check-plugin-compatibility.yml
@@ -11,9 +11,7 @@ on:
 jobs:
   check-plugin-compatibility:
     name: Run Plugin Compatibility Checks
-    # NOTE: there is currently an issue that makes the following job condition not working as expected
-    # See https://github.com/actions/runner/issues/1145
-    if: ${{ github.context.payload.pull_request.title != 'New Release' }} # avoid running this in `New Release` PR
+    if: ${{ github.event.pull_request.title != 'New Release' }} # avoid running this in `New Release` PR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/packages/legend-studio-components/style/base/_panel.scss
+++ b/packages/legend-studio-components/style/base/_panel.scss
@@ -269,6 +269,13 @@
     }
   }
 
+  &__section__text-editor {
+    width: 100%;
+    height: 15rem;
+    position: relative;
+    border: 0.1rem solid var(--color-dark-grey-100);
+  }
+
   &__section__number-input {
     width: 20rem;
   }

--- a/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderGraphFetchTreePanel.tsx
+++ b/packages/legend-studio-plugin-query-builder/src/components/QueryBuilderGraphFetchTreePanel.tsx
@@ -25,6 +25,8 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   TimesIcon,
+  CheckSquareIcon,
+  SquareIcon,
 } from '@finos/legend-studio-components';
 import type { TreeNodeContainerProps } from '@finos/legend-studio-components';
 import type { QueryBuilderState } from '../stores/QueryBuilderState';
@@ -41,6 +43,7 @@ import {
 } from '../stores/QueryBuilderGraphFetchTreeUtil';
 import type { QueryBuilderExplorerTreeDragSource } from '../stores/QueryBuilderExplorerState';
 import { QUERY_BUILDER_EXPLORER_TREE_DND_TYPE } from '../stores/QueryBuilderExplorerState';
+import type { QueryBuilderGraphFetchTreeState } from '../stores/QueryBuilderGraphFetchTreeState';
 
 const QueryBuilderGraphFetchTreeNodeContainer: React.FC<
   TreeNodeContainerProps<
@@ -131,11 +134,12 @@ const QueryBuilderGraphFetchTreeNodeContainer: React.FC<
 
 export const QueryBuilderGraphFetchTreeExplorer = observer(
   (props: {
+    graphFetchState: QueryBuilderGraphFetchTreeState;
     treeData: QueryBuilderGraphFetchTreeData;
     updateTreeData: (data: QueryBuilderGraphFetchTreeData) => void;
     isReadOnly: boolean;
   }) => {
-    const { treeData, updateTreeData, isReadOnly } = props;
+    const { graphFetchState, treeData, updateTreeData, isReadOnly } = props;
 
     const onNodeSelect = (node: QueryBuilderGraphFetchTreeNodeData): void => {
       if (node.childrenIds.length) {
@@ -156,20 +160,43 @@ export const QueryBuilderGraphFetchTreeExplorer = observer(
       updateTreeData({ ...treeData });
     };
 
+    const toggleChecked = (): void =>
+      graphFetchState.setChecked(!graphFetchState.isChecked);
+
     return (
-      <div className="query-builder-graph-fetch-tree__container">
-        <TreeView
-          components={{
-            TreeNodeContainer: QueryBuilderGraphFetchTreeNodeContainer,
-          }}
-          treeData={treeData}
-          onNodeSelect={onNodeSelect}
-          getChildNodes={getChildNodes}
-          innerProps={{
-            isReadOnly,
-            removeNode,
-          }}
-        />
+      <div className="query-builder-graph-fetch-tree">
+        <div className="query-builder-graph-fetch-tree__settings">
+          <div
+            className={clsx('panel__content__form__section__toggler')}
+            onClick={toggleChecked}
+          >
+            <button
+              className={clsx('panel__content__form__section__toggler__btn', {
+                'panel__content__form__section__toggler__btn--toggled':
+                  graphFetchState.isChecked,
+              })}
+            >
+              {graphFetchState.isChecked ? <CheckSquareIcon /> : <SquareIcon />}
+            </button>
+            <div className="panel__content__form__section__toggler__prompt">
+              Check graph fetch
+            </div>
+          </div>
+        </div>
+        <div className="query-builder-graph-fetch-tree__container">
+          <TreeView
+            components={{
+              TreeNodeContainer: QueryBuilderGraphFetchTreeNodeContainer,
+            }}
+            treeData={treeData}
+            onNodeSelect={onNodeSelect}
+            getChildNodes={getChildNodes}
+            innerProps={{
+              isReadOnly,
+              removeNode,
+            }}
+          />
+        </div>
       </div>
     );
   },
@@ -230,6 +257,7 @@ export const QueryBuilderGraphFetchTreePanel = observer(
         )}
         {treeData && !isGraphFetchTreeDataEmpty(treeData) && (
           <QueryBuilderGraphFetchTreeExplorer
+            graphFetchState={graphFetchState}
             treeData={treeData}
             isReadOnly={false}
             updateTreeData={updateTreeData}

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderGraphFetchTreeState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderGraphFetchTreeState.ts
@@ -32,12 +32,19 @@ export class QueryBuilderGraphFetchTreeState {
   editorStore: EditorStore;
   queryBuilderState: QueryBuilderState;
   treeData?: QueryBuilderGraphFetchTreeData;
+  /**
+   * If set to `true` we will use `graphFetchChecked` function instead of `graphFetch`.
+   * `graphFetchChecked` will do extra checks on constraints and only work on M2M use case for now.
+   * Hence we default this to `false` for graph fetch to work universally.
+   */
+  isChecked = false;
 
   constructor(editorStore: EditorStore, queryBuilderState: QueryBuilderState) {
     makeAutoObservable(this, {
       editorStore: false,
       queryBuilderState: false,
       setGraphFetchTree: action,
+      setChecked: action,
     });
 
     this.editorStore = editorStore;
@@ -46,6 +53,10 @@ export class QueryBuilderGraphFetchTreeState {
 
   setGraphFetchTree(val: QueryBuilderGraphFetchTreeData | undefined): void {
     this.treeData = val;
+  }
+
+  setChecked(val: boolean): void {
+    this.isChecked = val;
   }
 
   init(tree?: RootGraphFetchTree): void {

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderLambdaProcessor.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderLambdaProcessor.ts
@@ -423,9 +423,13 @@ export class QueryBuilderLambdaProcessor
         }
       }
     } else if (
-      functionName === SUPPORTED_FUNCTIONS.GRAPH_FETCH_CHECKED &&
+      (functionName === SUPPORTED_FUNCTIONS.GRAPH_FETCH_CHECKED ||
+        functionName === SUPPORTED_FUNCTIONS.GRAPH_FETCH) &&
       this.getParentSimpleFunctionName() === SUPPORTED_FUNCTIONS.SERIALIZE
     ) {
+      this.queryBuilderState.fetchStructureState.graphFetchTreeState.setChecked(
+        functionName === SUPPORTED_FUNCTIONS.GRAPH_FETCH_CHECKED,
+      );
       if (valueSpecification.parametersValues.length === 2) {
         valueSpecification.parametersValues[0].accept_ValueSpecificationVisitor(
           new QueryBuilderLambdaProcessor(

--- a/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-studio-plugin-query-builder/src/stores/QueryBuilderState.ts
@@ -338,16 +338,15 @@ export class QueryBuilderState extends EditorExtensionState {
         SUPPORTED_FUNCTIONS.SERIALIZE,
         multiplicityOne,
       );
-      const graphFetchCheckedFunc = new SimpleFunctionExpression(
-        SUPPORTED_FUNCTIONS.GRAPH_FETCH_CHECKED,
+      const graphFetchFunc = new SimpleFunctionExpression(
+        this.fetchStructureState.graphFetchTreeState.isChecked
+          ? SUPPORTED_FUNCTIONS.GRAPH_FETCH_CHECKED
+          : SUPPORTED_FUNCTIONS.GRAPH_FETCH,
         multiplicityOne,
       );
       const expression = lambdaFunction.expressionSequence[0];
-      graphFetchCheckedFunc.parametersValues = [expression, graphFetchInstance];
-      serializeFunction.parametersValues = [
-        graphFetchCheckedFunc,
-        graphFetchInstance,
-      ];
+      graphFetchFunc.parametersValues = [expression, graphFetchInstance];
+      serializeFunction.parametersValues = [graphFetchFunc, graphFetchInstance];
       lambdaFunction.expressionSequence[0] = serializeFunction;
     }
     // apply result set modifier options

--- a/packages/legend-studio-plugin-query-builder/style/_graph-fetch-tree.scss
+++ b/packages/legend-studio-plugin-query-builder/style/_graph-fetch-tree.scss
@@ -17,8 +17,22 @@
 @use './mixins' as *;
 
 .query-builder-graph-fetch-tree {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+
+  &__settings {
+    @include flexVCenter;
+
+    justify-content: flex-end;
+    height: 3.4rem;
+    background: var(--color-dark-grey-85);
+    padding: 0 1rem;
+  }
+
   &__container {
-    height: 100%;
+    height: calc(100% - 3.4rem);
     width: 100%;
     padding: 0.5rem 0;
   }

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
@@ -159,6 +159,7 @@ export const PackageableConnectionEditor = observer(() => {
     PackageableConnectionEditorState,
   );
   const isReadOnly = editorState.isReadOnly;
+
   return (
     <ConnectionEditor
       connectionEditorState={editorState.connectionState}

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor.tsx
@@ -156,6 +156,40 @@ export const ConnectionEditor_StringEditor = observer(
 );
 
 // TODO: consider to move this to shared
+export const ConnectionEditor_TextEditor = observer(
+  (props: {
+    propertyName: string;
+    description?: string;
+    value: string | undefined;
+    isReadOnly: boolean;
+    language: EDITOR_LANGUAGE;
+    update: (value: string | undefined) => void;
+  }) => {
+    const { value, propertyName, description, isReadOnly, language, update } =
+      props;
+
+    return (
+      <div className="panel__content__form__section">
+        <div className="panel__content__form__section__header__label">
+          {capitalize(propertyName)}
+        </div>
+        <div className="panel__content__form__section__header__prompt">
+          {description}
+        </div>
+        <div className="panel__content__form__section__text-editor">
+          <TextInputEditor
+            inputValue={value ?? ''}
+            updateInput={update}
+            isReadOnly={isReadOnly}
+            language={language}
+          />
+        </div>
+      </div>
+    );
+  },
+);
+
+// TODO: consider to move this to shared
 export const ConnectionEditor_ArrayEditor = observer(
   (props: {
     propertyName: string;
@@ -343,14 +377,17 @@ const LocalH2DatasourceSpecificationEditor = observer(
     isReadOnly: boolean;
   }) => {
     const { sourceSpec, isReadOnly } = props;
+    const SQLValue = sourceSpec.testDataSetupSqls.join('\n');
+    // TODO: support CSV and toggler to go to CSV mode
     return (
       <>
-        <ConnectionEditor_StringEditor
+        <ConnectionEditor_TextEditor
           isReadOnly={isReadOnly}
-          value={sourceSpec.testDataSetupCsv}
-          propertyName={'test data setup csv'}
+          value={SQLValue}
+          propertyName={'test data setup SQL'}
+          language={EDITOR_LANGUAGE.SQL}
           update={(value: string | undefined): void =>
-            sourceSpec.setTestDataSetupCsv(value)
+            sourceSpec.setTestDataSetupSqls(value ? [value] : [])
           }
         />
       </>
@@ -483,6 +520,23 @@ const SnowflakeDatasourceSpecificationEditor = observer(
             sourceSpec.setDatabaseName(value ?? '')
           }
         />
+        <ConnectionEditor_StringEditor
+          isReadOnly={isReadOnly}
+          value={sourceSpec.cloudType}
+          propertyName={'cloud type'}
+          update={(value: string | undefined): void =>
+            sourceSpec.setCloudType(value)
+          }
+        />
+        {/* TODO: we should reconsider adding this field, it's an optional boolean, should we default it to `undefined` when it's `false`?*/}
+        {/* <ConnectionEditor_BooleanEditor
+          isReadOnly={isReadOnly}
+          value={sourceSpec.quotedIdentifiersIgnoreCase}
+          propertyName={'cloud type'}
+          update={(value: string | undefined): void =>
+            sourceSpec.setCloudType(value)
+          }
+        /> */}
       </>
     );
   },
@@ -542,7 +596,7 @@ const SnowflakePublicAuthenticationStrategyEditor = observer(
         <ConnectionEditor_StringEditor
           isReadOnly={isReadOnly}
           value={authSpec.publicUserName}
-          propertyName={'pass phrase vault reference'}
+          propertyName={'public user name'}
           update={(value: string | undefined): void =>
             authSpec.setPublicUserName(value ?? '')
           }

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/ExecutionPlan.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/ExecutionPlan.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ExecutionNode } from './nodes/ExecutionNode';
+
+export class ExecutionPlan {
+  // TODO: Populate fields when required
+  //   func : FunctionDefinition<Any>[1];
+  //   mapping : Mapping[1];
+  //   runtime : Runtime[1];
+
+  rootExecutionNode!: ExecutionNode;
+  processingTemplateFunctions: string[] = [];
+  authDependent!: boolean;
+  kerberos?: string;
+  // globalImplementationSupport: PlatformImplementation[0..1];
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/ExecutionNode.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/ExecutionNode.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Multiplicity } from '../../packageableElements/domain/Multiplicity';
+import type { ResultType } from '../result/ResultType';
+
+export class ExecutionNode {
+  // fromCluster : ClusteredValueSpecification[0..1];
+  resultType!: ResultType;
+  resultSizeRange?: Multiplicity;
+  executionNodes: ExecutionNode[] = [];
+  authDependent?: boolean;
+  kerberos?: string;
+  supportFunctions: string[] = [];
+  // implementation : PlatformImplementation[0..1];
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/RelationalInstantiationExecutionNode.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/RelationalInstantiationExecutionNode.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExecutionNode } from './ExecutionNode';
+
+export class RelationalInstantiationExecutionNode extends ExecutionNode {}
+
+export class RelationalTdsInstantiationExecutionNode extends RelationalInstantiationExecutionNode {}
+
+export class RelationalClassInstantiationExecutionNode extends RelationalInstantiationExecutionNode {}
+
+export class RelationalRelationDataInstantiationExecutionNode extends RelationalInstantiationExecutionNode {}
+
+export class RelationalDataTypeInstantiationExecutionNode extends RelationalInstantiationExecutionNode {}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/SQLExecutionNode.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/SQLExecutionNode.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DatabaseConnection } from '../../packageableElements/store/relational/connection/RelationalDatabaseConnection';
+import { ExecutionNode } from './ExecutionNode';
+import type { SQLResultColumn } from './SQLResultColumn';
+
+export class SQLExecutionNode extends ExecutionNode {
+  sqlQuery!: string;
+  onConnectionCloseCommitQuery?: string;
+  onConnectionCloseRollbackQuery?: string;
+  resultColumns: SQLResultColumn[] = [];
+  connection!: DatabaseConnection[];
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/SQLResultColumn.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/nodes/SQLResultColumn.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DataType } from '../../packageableElements/store/relational/model/RelationalDataType';
+
+export class SQLResultColumn {
+  label!: string;
+  dataType?: DataType;
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/DataTypeResultType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/DataTypeResultType.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResultType } from './ResultType';
+
+export class DataTypeResultType extends ResultType {}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/ResultType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/ResultType.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GenericType } from '../../packageableElements/domain/GenericType';
+import type { Type } from '../../packageableElements/domain/Type';
+
+export class ResultType {
+  type!: Type;
+  genericType?: GenericType;
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/TDSColumn.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/TDSColumn.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DataType } from '../../packageableElements/domain/DataType';
+
+export class TDSColumn {
+  offset?: number;
+  name!: string;
+  type?: DataType;
+  enumMappingId?: string;
+  documentation?: string;
+  // sourceDataType: Any;
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/TDSResultType.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/executionPlan/result/TDSResultType.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResultType } from './ResultType';
+import type { TDSColumn } from './TDSColumn';
+
+export class TDSResultType extends ResultType {
+  tdsColumns: TDSColumn[] = [];
+}

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
@@ -166,6 +166,7 @@ export class SnowflakeDatasourceSpecification
   region: string;
   warehouseName: string;
   databaseName: string;
+  cloudType?: string;
   quotedIdentifiersIgnoreCase?: boolean;
 
   constructor(
@@ -181,13 +182,17 @@ export class SnowflakeDatasourceSpecification
       region: observable,
       warehouseName: observable,
       databaseName: observable,
+      cloudType: observable,
       quotedIdentifiersIgnoreCase: observable,
       hashCode: computed,
       setAccountName: action,
       setRegion: action,
       setWarehouseName: action,
       setDatabaseName: action,
+      setCloudType: action,
+      setQuotedIdentifiersIgnoreCase: action,
     });
+
     this.region = region;
     this.warehouseName = warehouseName;
     this.databaseName = databaseName;
@@ -197,14 +202,25 @@ export class SnowflakeDatasourceSpecification
   setAccountName(val: string): void {
     this.accountName = val;
   }
+
   setRegion(val: string): void {
     this.region = val;
   }
+
   setWarehouseName(val: string): void {
     this.warehouseName = val;
   }
+
   setDatabaseName(val: string): void {
     this.databaseName = val;
+  }
+
+  setCloudType(val: string | undefined): void {
+    this.cloudType = val;
+  }
+
+  setQuotedIdentifiersIgnoreCase(val: boolean | undefined): void {
+    this.quotedIdentifiersIgnoreCase = val;
   }
 
   get hashCode(): string {
@@ -214,6 +230,7 @@ export class SnowflakeDatasourceSpecification
       this.region,
       this.warehouseName,
       this.databaseName,
+      this.cloudType ?? '',
       this.quotedIdentifiersIgnoreCase?.toString() ?? '',
     ]);
   }

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalPropertyMapping.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/mapping/RelationalPropertyMapping.ts
@@ -45,7 +45,7 @@ export class RelationalPropertyMapping
 
     makeObservable(this, {
       transformer: observable,
-      relationalOperation: observable,
+      relationalOperation: observable.ref,
       setTransformer: action,
       hashCode: computed,
     });

--- a/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/valueSpecification/SimpleFunctionExpression.ts
@@ -37,6 +37,7 @@ export enum SUPPORTED_FUNCTIONS {
   DISTINCT = 'distinct',
   SORT_FUNC = 'sort',
   SERIALIZE = 'serialize',
+  GRAPH_FETCH = 'graphFetch',
   GRAPH_FETCH_CHECKED = 'graphFetchChecked',
   EXISTS = 'exists',
   NOT = 'not',

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/V1_ExecutionPlan.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/V1_ExecutionPlan.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export abstract class V1_ExecutionPlan {}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/V1_SingleExecutionPlan.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/V1_SingleExecutionPlan.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { V1_Protocol } from '../V1_Protocol';
+import type { V1_ExecutionNode } from './nodes/V1_ExecutionNode';
+import { V1_ExecutionPlan } from './V1_ExecutionPlan';
+
+export class V1_SingleExecutionPlan extends V1_ExecutionPlan {
+  authDependent!: boolean;
+  kerberos!: string;
+  serializer!: V1_Protocol;
+  templateFunctions: string[] = [];
+  rootExecutionNode!: V1_ExecutionNode;
+  // globalImplementationSupport!: V1_PlatformImplementation; // TODO: this is WIP for M2M case in engine
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_ExecutionNode.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_ExecutionNode.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { V1_Multiplicity } from '../../packageableElements/domain/V1_Multiplicity';
+import type { V1_ResultType } from '../results/V1_ResultType';
+
+export class V1_ExecutionNode {
+  resultType!: V1_ResultType;
+  executionNodes: V1_ExecutionNode[] = [];
+  resultSizeRange!: V1_Multiplicity;
+  // globalImplementationSupport!: V1_PlatformImplementation; // TODO: this is WIP for M2M case in engine
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_RelationalInstantiationExecutionNode.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_RelationalInstantiationExecutionNode.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1_ExecutionNode } from './V1_ExecutionNode';
+
+export class V1_RelationalInstantiationExecutionNode extends V1_ExecutionNode {}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_RelationalTDSInstantiationExecutionNode.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_RelationalTDSInstantiationExecutionNode.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1_RelationalInstantiationExecutionNode } from './V1_RelationalInstantiationExecutionNode';
+
+export class V1_RelationalTDSInstantiationExecutionNode extends V1_RelationalInstantiationExecutionNode {}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_SQLExecutionNode.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_SQLExecutionNode.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { V1_DatabaseConnection } from '../../packageableElements/store/relational/connection/V1_RelationalDatabaseConnection';
+import { V1_ExecutionNode } from './V1_ExecutionNode';
+import type { V1_SQLResultColumn } from './V1_SQLResultColumn';
+
+export class V1_SQLExecutionNode extends V1_ExecutionNode {
+  sqlQuery!: string;
+  onConnectionCloseCommitQuery!: string;
+  onConnectionCloseRollbackQuery!: string;
+  connection!: V1_DatabaseConnection;
+  resultColumns: V1_SQLResultColumn[] = [];
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_SQLResultColumn.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/nodes/V1_SQLResultColumn.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class V1_SQLResultColumn {
+  label!: string;
+  dataType!: string;
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_DataTypeResultType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_DataTypeResultType.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1_ResultType } from './V1_ResultType';
+
+export class V1_DataTypeResultType extends V1_ResultType {
+  dataType!: string;
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_ResultType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_ResultType.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export abstract class V1_ResultType {}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_TDSColumn.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_TDSColumn.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class V1_TDSColumn {
+  name!: string;
+  type!: string;
+  doc!: string;
+  relationaltype!: string;
+  enumMapping: Map<string, string[]> = new Map<string, string[]>();
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_TDSResultType.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/executionPlan/results/V1_TDSResultType.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1_ResultType } from './V1_ResultType';
+import type { V1_TDSColumn } from './V1_TDSColumn';
+
+export class V1_TDSResultType extends V1_ResultType {
+  tdsColumns: V1_TDSColumn[] = [];
+}

--- a/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/model/packageableElements/store/relational/connection/V1_DatasourceSpecification.ts
@@ -75,6 +75,7 @@ export class V1_SnowflakeDatasourceSpecification
   region!: string;
   warehouseName!: string;
   databaseName!: string;
+  cloudType?: string;
   quotedIdentifiersIgnoreCase?: boolean;
 
   get hashCode(): string {
@@ -84,6 +85,7 @@ export class V1_SnowflakeDatasourceSpecification
       this.region,
       this.warehouseName,
       this.databaseName,
+      this.cloudType ?? '',
       this.quotedIdentifiersIgnoreCase?.toString() ?? '',
     ]);
   }

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ConnectionTransformer.ts
@@ -105,6 +105,7 @@ const transformSnowflakeDatasourceSpecification = (
   source.warehouseName = metamodel.warehouseName;
   source.databaseName = metamodel.databaseName;
   source.accountName = metamodel.accountName;
+  source.cloudType = metamodel.cloudType;
   source.quotedIdentifiersIgnoreCase = metamodel.quotedIdentifiersIgnoreCase;
   return source;
 };

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalConnectionBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalConnectionBuilderHelper.ts
@@ -119,6 +119,7 @@ export const V1_processDatasourceSpecification = (
       protocol.warehouseName,
       protocol.databaseName,
     );
+    snowflakeSpec.cloudType = protocol.cloudType;
     snowflakeSpec.quotedIdentifiersIgnoreCase =
       protocol.quotedIdentifiersIgnoreCase;
     return snowflakeSpec;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
@@ -37,6 +37,7 @@ import type { V1_Connection } from '../../../model/packageableElements/connectio
 import { V1_JsonModelConnection } from '../../../model/packageableElements/store/modelToModel/connection/V1_JsonModelConnection';
 import { V1_XmlModelConnection } from '../../../model/packageableElements/store/modelToModel/connection/V1_XmlModelConnection';
 import { V1_FlatDataConnection } from '../../../model/packageableElements/store/flatData/connection/V1_FlatDataConnection';
+import type { V1_DatabaseConnection } from '../../../model/packageableElements/store/relational/connection/V1_RelationalDatabaseConnection';
 import { V1_RelationalDatabaseConnection } from '../../../model/packageableElements/store/relational/connection/V1_RelationalDatabaseConnection';
 import type { V1_DatasourceSpecification } from '../../../model/packageableElements/store/relational/connection/V1_DatasourceSpecification';
 import {
@@ -431,6 +432,30 @@ export const V1_deserializeConnectionValue = (
     default:
       throw new UnsupportedOperationError(
         `Can't deserialize connection of type '${json._type}'`,
+      );
+  }
+};
+
+export const V1_serializeDatabaseConnectionValue = (
+  protocol: V1_DatabaseConnection,
+): PlainObject<V1_DatabaseConnection> => {
+  if (protocol instanceof V1_RelationalDatabaseConnection) {
+    return serialize(V1_RelationalDatabaseConnection, protocol);
+  }
+  throw new UnsupportedOperationError(
+    `Can't serialize database connection of type '${getClass(protocol).name}'`,
+  );
+};
+
+export const V1_deserializeDatabaseConnectionValue = (
+  json: PlainObject<V1_DatabaseConnection>,
+): V1_DatabaseConnection => {
+  switch (json._type) {
+    case V1_ConnectionType.RELATIONAL_DATABASE_CONNECTION:
+      return deserialize(V1_RelationalDatabaseConnection, json);
+    default:
+      throw new UnsupportedOperationError(
+        `Can't deserialize database connection of type '${json._type}'`,
       );
   }
 };

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ConnectionSerializationHelper.ts
@@ -158,6 +158,7 @@ const snowflakeDatasourceSpecificationModelSchema = createModelSchema(
   {
     _type: usingConstantValueSchema(V1_DatasourceSpecificationType.SNOWFLAKE),
     accountName: primitive(),
+    cloudType: primitive(),
     databaseName: primitive(),
     quotedIdentifiersIgnoreCase: primitive(),
     region: primitive(),

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/executionPlan/V1_ExecutionPlanSerializationHelpers.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/executionPlan/V1_ExecutionPlanSerializationHelpers.ts
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createModelSchema,
+  deserialize,
+  custom,
+  serialize,
+  primitive,
+  list,
+} from 'serializr';
+import type { PlainObject } from '@finos/legend-studio-shared';
+import {
+  deseralizeMap,
+  serializeMap,
+  usingModelSchema,
+  usingConstantValueSchema,
+  getClass,
+  UnsupportedOperationError,
+} from '@finos/legend-studio-shared';
+import type { V1_ExecutionPlan } from '../../../../model/executionPlan/V1_ExecutionPlan';
+import { V1_SingleExecutionPlan } from '../../../../model/executionPlan/V1_SingleExecutionPlan';
+import { V1_Protocol } from '../../../../model/V1_Protocol';
+import { V1_DataTypeResultType } from '../../../../model/executionPlan/results/V1_DataTypeResultType';
+import { V1_TDSResultType } from '../../../../model/executionPlan/results/V1_TDSResultType';
+import { V1_TDSColumn } from '../../../../model/executionPlan/results/V1_TDSColumn';
+import type { V1_ResultType } from '../../../../model/executionPlan/results/V1_ResultType';
+import { V1_RelationalInstantiationExecutionNode } from '../../../../model/executionPlan/nodes/V1_RelationalInstantiationExecutionNode';
+import { V1_multiplicitySchema } from '../V1_CoreSerializationHelper';
+import { V1_RelationalTDSInstantiationExecutionNode } from '../../../../model/executionPlan/nodes/V1_RelationalTDSInstantiationExecutionNode';
+import { V1_SQLExecutionNode } from '../../../../model/executionPlan/nodes/V1_SQLExecutionNode';
+import { V1_SQLResultColumn } from '../../../../model/executionPlan/nodes/V1_SQLResultColumn';
+import {
+  V1_deserializeDatabaseConnectionValue,
+  V1_serializeDatabaseConnectionValue,
+} from '../V1_ConnectionSerializationHelper';
+
+// ---------------------------------------- Result Type ----------------------------------------
+
+export enum V1_ExecutionResultTypeType {
+  DATA_TYPE = 'dataType',
+  TDS = 'tds',
+}
+
+const dataTypeResultTypeModelSchema = createModelSchema(V1_DataTypeResultType, {
+  _type: usingConstantValueSchema(V1_ExecutionResultTypeType.DATA_TYPE),
+  dataType: primitive(),
+});
+
+const TDSColumnModelSchema = createModelSchema(V1_TDSColumn, {
+  doc: primitive(),
+  enumMapping: custom(
+    (val) => serializeMap(val),
+    (val) => deseralizeMap(val),
+  ),
+  name: primitive(),
+  relationaltype: primitive(),
+  type: primitive(),
+});
+
+const TDSResultTypeModelSchema = createModelSchema(V1_TDSResultType, {
+  _type: usingConstantValueSchema(V1_ExecutionResultTypeType.TDS),
+  tdsColumns: list(usingModelSchema(TDSColumnModelSchema)),
+});
+
+export const V1_serializeExecutionResultType = (
+  protocol: V1_ResultType,
+): PlainObject<V1_ResultType> => {
+  if (protocol instanceof V1_DataTypeResultType) {
+    return serialize(dataTypeResultTypeModelSchema, protocol);
+  } else if (protocol instanceof V1_TDSResultType) {
+    return serialize(TDSResultTypeModelSchema, protocol);
+  }
+  throw new UnsupportedOperationError(
+    `Can't serialize execution result type of type '${
+      getClass(protocol).name
+    }'`,
+  );
+};
+
+export const V1_deserializeExecutionResultType = (
+  json: PlainObject<V1_ResultType>,
+): V1_ResultType => {
+  switch (json._type) {
+    case V1_ExecutionResultTypeType.DATA_TYPE:
+      return deserialize(dataTypeResultTypeModelSchema, json);
+    case V1_ExecutionResultTypeType.TDS:
+      return deserialize(TDSResultTypeModelSchema, json);
+    default:
+      throw new UnsupportedOperationError(
+        `Can't deserialize execution result type of type '${json._type}'`,
+      );
+  }
+};
+
+// ---------------------------------------- Node ----------------------------------------
+
+export enum V1_ExecutionNodeType {
+  RELATIONAL_INSTANTIATION = 'relationalInstantiation',
+  RELATIONAL_TDS_INSTANTIATION = 'relationalTdsInstantiation',
+  SQL = 'sql',
+}
+
+const relationalInstantationExecutionNodeModelSchema = createModelSchema(
+  V1_RelationalInstantiationExecutionNode,
+  {
+    _type: usingConstantValueSchema(
+      V1_ExecutionNodeType.RELATIONAL_INSTANTIATION,
+    ),
+    executionNodes: list(
+      custom(
+        (val) => V1_serializeExecutionNode(val),
+        (val) => V1_deserializeExecutionNode(val),
+      ),
+    ),
+    resultSizeRange: usingModelSchema(V1_multiplicitySchema),
+    resultType: custom(
+      (val) => V1_serializeExecutionResultType(val),
+      (val) => V1_deserializeExecutionResultType(val),
+    ),
+  },
+);
+
+const relationalTDSInstantationExecutionNodeModelSchema = createModelSchema(
+  V1_RelationalInstantiationExecutionNode,
+  {
+    _type: usingConstantValueSchema(
+      V1_ExecutionNodeType.RELATIONAL_TDS_INSTANTIATION,
+    ),
+    executionNodes: list(
+      custom(
+        (val) => V1_serializeExecutionNode(val),
+        (val) => V1_deserializeExecutionNode(val),
+      ),
+    ),
+    resultSizeRange: usingModelSchema(V1_multiplicitySchema),
+    resultType: custom(
+      (val) => V1_serializeExecutionResultType(val),
+      (val) => V1_deserializeExecutionResultType(val),
+    ),
+  },
+);
+
+const SQLResultColumnModelSchema = createModelSchema(V1_SQLResultColumn, {
+  dataType: primitive(),
+  label: primitive(),
+});
+
+const SQLExecutionNodeModelSchema = createModelSchema(V1_SQLExecutionNode, {
+  _type: usingConstantValueSchema(V1_ExecutionNodeType.SQL),
+  connection: custom(
+    (val) => V1_serializeDatabaseConnectionValue(val),
+    (val) => V1_deserializeDatabaseConnectionValue(val),
+  ),
+  executionNodes: list(
+    custom(
+      (val) => V1_serializeExecutionNode(val),
+      (val) => V1_deserializeExecutionNode(val),
+    ),
+  ),
+  onConnectionCloseCommitQuery: primitive(),
+  onConnectionCloseRollbackQuery: primitive(),
+  resultColumns: list(usingModelSchema(SQLResultColumnModelSchema)),
+  resultSizeRange: usingModelSchema(V1_multiplicitySchema),
+  resultType: custom(
+    (val) => V1_serializeExecutionResultType(val),
+    (val) => V1_deserializeExecutionResultType(val),
+  ),
+  sqlQuery: primitive(),
+});
+
+export function V1_serializeExecutionNode(
+  protocol: V1_ResultType,
+): PlainObject<V1_ResultType> {
+  if (protocol instanceof V1_RelationalTDSInstantiationExecutionNode) {
+    // this has to go before V1_RelationalInstantionExecutionNode because it's a subtype
+    return serialize(
+      relationalTDSInstantationExecutionNodeModelSchema,
+      protocol,
+    );
+  } else if (protocol instanceof V1_RelationalInstantiationExecutionNode) {
+    return serialize(relationalInstantationExecutionNodeModelSchema, protocol);
+  } else if (protocol instanceof V1_SQLExecutionNode) {
+    return serialize(SQLExecutionNodeModelSchema, protocol);
+  }
+  throw new UnsupportedOperationError(
+    `Can't serialize execution node of type '${getClass(protocol).name}'`,
+  );
+}
+
+export function V1_deserializeExecutionNode(
+  json: PlainObject<V1_ResultType>,
+): V1_ResultType {
+  switch (json._type) {
+    case V1_ExecutionNodeType.RELATIONAL_TDS_INSTANTIATION:
+      return deserialize(
+        relationalTDSInstantationExecutionNodeModelSchema,
+        json,
+      );
+    case V1_ExecutionNodeType.RELATIONAL_INSTANTIATION:
+      return deserialize(relationalInstantationExecutionNodeModelSchema, json);
+    case V1_ExecutionNodeType.SQL:
+      return deserialize(SQLExecutionNodeModelSchema, json);
+    default:
+      throw new UnsupportedOperationError(
+        `Can't deserialize execution node of type '${json._type}'`,
+      );
+  }
+}
+
+// ---------------------------------------- Plan ----------------------------------------
+
+export enum V1_ExecutionPlanType {
+  SINGLE = 'single',
+  COMPOSITE = 'composite',
+}
+
+const singleExecutionPlanModelSchema = createModelSchema(
+  V1_SingleExecutionPlan,
+  {
+    _type: usingConstantValueSchema(V1_ExecutionPlanType.SINGLE),
+    authDependent: primitive(),
+    kerberos: primitive(),
+    rootExecutionNode: custom(
+      (val) => V1_serializeExecutionNode(val),
+      (val) => V1_deserializeExecutionNode(val),
+    ),
+    serializer: usingModelSchema(V1_Protocol.serialization.schema),
+    templateFunctions: list(primitive()),
+  },
+);
+
+export const V1_serializeExecutionPlan = (
+  protocol: V1_ExecutionPlan,
+): PlainObject<V1_ExecutionPlan> => {
+  if (protocol instanceof V1_SingleExecutionPlan) {
+    return serialize(singleExecutionPlanModelSchema, protocol);
+  }
+  throw new UnsupportedOperationError(
+    `Can't serialize execution plan of type '${getClass(protocol).name}'`,
+  );
+};
+
+export const V1_deserializeExecutionPlan = (
+  json: PlainObject<V1_ExecutionPlan>,
+): V1_ExecutionPlan => {
+  switch (json._type) {
+    case V1_ExecutionPlanType.SINGLE:
+      return deserialize(singleExecutionPlanModelSchema, json);
+    default:
+      throw new UnsupportedOperationError(
+        `Can't deserialize execution plan of type '${json._type}'`,
+      );
+  }
+};


### PR DESCRIPTION
Introduce some basic execution plan processing to lay the foundation for https://github.com/finos/legend-studio/issues/249

Also added support for `graphFetch` without check (i.e. `graphFetchCheck`) so we can have better graph fetch support for relational mapping in `query builder`.

Also, we added minor adjustments to the connection form editor.