### PR TITLE
include mapping/runtime in executeInput

### DIFF
--- a/.changeset/kind-gifts-obey.md
+++ b/.changeset/kind-gifts-obey.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Include all runtime and mappings in executeInput to support connections referencing other mappings such as ModelChainConnections.

--- a/.changeset/kind-gifts-obey.md
+++ b/.changeset/kind-gifts-obey.md
@@ -2,4 +2,4 @@
 '@finos/legend-studio': patch
 ---
 
-Include all runtime and mappings in executeInput to support connections referencing other mappings such as ModelChainConnections.
+Include all runtimes and mappings in execution input to support connections referencing other mappings such as ModelChainConnections.


### PR DESCRIPTION
Include mapping and runtime in execute input. This is to support executing queries with connection that references other mappings such as ModelChainConnections. 

As part of the commit, I removed the light approach of walking the graph and choosing the relevant elements of the graph as this would get more complicated adding these type of connections with not much gain as we expect to implement this relevant walker in the future taking into account these type of connections as well as the elements in the query lambda. 

| Q                       | A                                |
| ----------------------- | -------------------------------- |
| Fixed issues?           | <!-- e.g. Fixes #1, Fixes #2 --> |
| Tests added + passed?   | No                              |
| Changeset added?        | Yes                              |
| Documentation PR link   |                                  |
| Any dependency changes? | No                               |

<!--
Summary fill-out guides:

- Test: https://github.com/finos/legend-studio/blob/master/docs/test-strategy.md
- Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
- Documentation: Link to a PR from https://github.com/finos/legend repo
- Dependency: https://github.com/finos/legend-studio/blob/master/docs/dependencies.md

NOTE: For component/style changes: Please check out our style guide https://github.com/finos/legend-studio/tree/master/docs/ux. Also, PR involving UX/UI might take more time to discuss and review.

Last but not least, describe your changes below in as much detail as possible in the space below 🎉
-->
