### PR TITLE
Diagram editor UX improvements

### DIFF
--- a/.changeset/beige-ladybugs-add.md
+++ b/.changeset/beige-ladybugs-add.md
@@ -1,0 +1,17 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-manual-tests': patch
+'@finos/legend-studio-network': patch
+'@finos/legend-studio-plugin-management': patch
+'@finos/legend-studio-plugin-tracer-zipkin': patch
+'@finos/legend-studio-preset-dsl-text': patch
+'@finos/legend-studio-preset-external-format-json-schema': patch
+'@finos/legend-studio-preset-query-builder': patch
+'@finos/legend-studio-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/.changeset/brown-fireants-fly.md
+++ b/.changeset/brown-fireants-fly.md
@@ -1,0 +1,17 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-manual-tests': patch
+'@finos/legend-studio-network': patch
+'@finos/legend-studio-plugin-management': patch
+'@finos/legend-studio-plugin-tracer-zipkin': patch
+'@finos/legend-studio-preset-dsl-text': patch
+'@finos/legend-studio-preset-external-format-json-schema': patch
+'@finos/legend-studio-preset-query-builder': patch
+'@finos/legend-studio-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/.changeset/friendly-bulldogs-doubt.md
+++ b/.changeset/friendly-bulldogs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio-components': patch
+---
+
+Add `PanelDisplayState` that holds and organizes panel size and size-related interactions, such as `open`, `close`, `toggle`, `maxmize`, `snap`, etc.

--- a/.changeset/tidy-zoos-boil.md
+++ b/.changeset/tidy-zoos-boil.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Rework diagram editor layout and state management. Allow user to edit property in-place (see https://github.com/finos/legend-studio/issues/300).

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@finos/stylelint-config-legend-studio": "workspace:*",
     "@juggle/resize-observer": "3.3.1",
     "@types/jest": "26.0.24",
-    "@types/node": "16.3.2",
+    "@types/node": "16.3.3",
     "chalk": "4.1.1",
     "cross-env": "7.0.3",
     "eslint": "7.30.0",

--- a/packages/legend-studio-app/package.json
+++ b/packages/legend-studio-app/package.json
@@ -54,7 +54,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "typescript": "4.3.5",
-    "webpack": "5.44.0",
+    "webpack": "5.45.1",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.7.2",
     "webpack-dev-server": "4.0.0-beta.3"

--- a/packages/legend-studio-components/src/index.ts
+++ b/packages/legend-studio-components/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/Icon';
 export * from './components/LegendLogo';
 export * from './components/TreeView';
 export * from './components/CustomSelectorInput';
+export * from './components/BaseMuiComponents';
 
 export * from './components/dialog/NonBlockingDialog';
 

--- a/packages/legend-studio-components/src/index.ts
+++ b/packages/legend-studio-components/src/index.ts
@@ -16,6 +16,7 @@
 
 export * from './utils/ComponentUtils';
 export * from './utils/StubTransition';
+export * from './utils/PanelDisplayState';
 
 export * from './components/Icon';
 export * from './components/LegendLogo';

--- a/packages/legend-studio-components/src/utils/PanelDisplayState.ts
+++ b/packages/legend-studio-components/src/utils/PanelDisplayState.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { action, makeAutoObservable } from 'mobx';
+
+export class PanelDisplayState {
+  _tempSize: number;
+  size: number;
+  _initialDefaultSize: number;
+  defaultSize: number;
+  snapSize?: number;
+  maxSize?: number;
+
+  constructor(size: {
+    initial: number;
+    default: number;
+    snap: number | undefined;
+  }) {
+    this.size = size.initial;
+    this._tempSize = size.default;
+    this.defaultSize = size.default;
+    this._initialDefaultSize = size.default;
+    this.snapSize = size.snap;
+
+    makeAutoObservable(this, {
+      // open/close
+      setSize: action,
+      open: action,
+      close: action,
+      toggle: action,
+      // maximize/minimize
+      setMaxSize: action,
+      maximize: action,
+      minimize: action,
+      toggleMaximize: action,
+    });
+  }
+
+  get isOpen(): boolean {
+    return this.size !== 0;
+  }
+
+  get isMaximizable(): boolean {
+    return this.maxSize !== undefined;
+  }
+
+  get isMaximized(): boolean {
+    return this.maxSize !== undefined && this.size === this.maxSize;
+  }
+
+  setSize(val: number): void {
+    // correct the value (cannot be less than 0 and greater than max size)
+    val = Math.max(val, 0);
+    if (this.maxSize) {
+      val = Math.min(val, this.maxSize);
+    }
+
+    // do nothing if the size is the same as the value
+    if (this.size === val) {
+      return;
+    }
+
+    if (this.snapSize !== undefined) {
+      if (val > this.size) {
+        // expanding
+        if (this.maxSize) {
+          this.size = val > this.maxSize - this.snapSize ? this.maxSize : val;
+        } else {
+          this.size = val;
+        }
+      } else {
+        // shrinking
+        this.size = val < this.snapSize ? 0 : val;
+      }
+    } else {
+      this.size = val;
+    }
+  }
+
+  open(): void {
+    if (this.size === 0) {
+      this.size = this._tempSize;
+    }
+  }
+
+  close(): void {
+    if (this.size !== 0) {
+      this._tempSize = this.size || this.defaultSize;
+      this.size = 0;
+    }
+  }
+
+  toggle(): void {
+    if (this.size === 0) {
+      this.open();
+    } else {
+      this.close();
+    }
+  }
+
+  maximize(): void {
+    if (this.maxSize !== undefined) {
+      if (this.size !== this.maxSize) {
+        this._tempSize = this.size;
+        this.size = this.maxSize;
+      }
+    }
+  }
+
+  minimize(): void {
+    if (this.maxSize !== undefined) {
+      if (this.size === this.maxSize) {
+        this.size =
+          this._tempSize === this.maxSize ? this.defaultSize : this._tempSize;
+      }
+    }
+  }
+
+  toggleMaximize(): void {
+    if (this.maxSize !== undefined) {
+      if (this.size === this.maxSize) {
+        this.minimize();
+      } else {
+        this.maximize();
+      }
+    }
+  }
+
+  setMaxSize(val: number): void {
+    this._tempSize = Math.min(this._tempSize, val);
+    this.size = Math.min(this.size, val);
+    this.defaultSize = Math.min(this._initialDefaultSize, val);
+    this.maxSize = val;
+  }
+}

--- a/packages/legend-studio-components/style/_mixins.scss
+++ b/packages/legend-studio-components/style/_mixins.scss
@@ -49,3 +49,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+@mixin flexConstantDimension {
+  flex-grow: 0;
+  flex-shrink: 0;
+}

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -338,13 +338,10 @@ export const getWebAppBaseWebpackConfig = (
     },
     resolve: {
       ...baseConfig.resolve,
-      // Ignore usage of Node module `os` in `zipkin`
-      // See https://github.com/openzipkin/zipkin-js/issues/465
       fallback: {
+        // Ignore usage of Node module `os` in `zipkin`
+        // See https://github.com/openzipkin/zipkin-js/issues/465
         os: false,
-        // NOTE: do not support resolving `path`. This happens in `monaco-editor@0.26.0`
-        // See https://github.com/microsoft/monaco-editor/issues/2578
-        path: false,
       },
       alias: {
         ...baseConfig.resolve.alias,

--- a/packages/legend-studio-dev-utils/package.json
+++ b/packages/legend-studio-dev-utils/package.json
@@ -71,8 +71,8 @@
     "jsonc-parser": "3.0.0",
     "micromatch": "4.0.4",
     "mini-css-extract-plugin": "2.1.0",
-    "monaco-editor": "0.26.0",
-    "monaco-editor-webpack-plugin": "4.1.0",
+    "monaco-editor": "0.26.1",
+    "monaco-editor-webpack-plugin": "4.1.1",
     "postcss": "8.3.5",
     "postcss-loader": "6.1.1",
     "react-refresh": "0.10.0",
@@ -82,7 +82,7 @@
     "strip-ansi": "7.0.0",
     "text-table": "0.2.0",
     "typescript": "4.3.5",
-    "webpack": "5.44.0",
+    "webpack": "5.45.1",
     "wrap-ansi": "8.0.0"
   },
   "devDependencies": {

--- a/packages/legend-studio-preset-dsl-text/package.json
+++ b/packages/legend-studio-preset-dsl-text/package.json
@@ -46,7 +46,7 @@
     "@types/react": "17.0.14",
     "mobx": "6.3.2",
     "mobx-react-lite": "3.2.0",
-    "monaco-editor": "0.26.0",
+    "monaco-editor": "0.26.1",
     "react": "17.0.2",
     "serializr": "2.0.5"
   },

--- a/packages/legend-studio-preset-query-builder/package.json
+++ b/packages/legend-studio-preset-query-builder/package.json
@@ -52,7 +52,7 @@
     "date-fns": "2.22.1",
     "mobx": "6.3.2",
     "mobx-react-lite": "3.2.0",
-    "monaco-editor": "0.26.0",
+    "monaco-editor": "0.26.1",
     "papaparse": "5.3.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -50,7 +50,7 @@
     "history": "5.0.0",
     "mobx": "6.3.2",
     "mobx-react-lite": "3.2.0",
-    "monaco-editor": "0.26.0",
+    "monaco-editor": "0.26.1",
     "node-diff3": "3.0.0",
     "react": "17.0.2",
     "react-dnd": "14.0.2",

--- a/packages/legend-studio/src/components/editor/ActivityBar.tsx
+++ b/packages/legend-studio/src/components/editor/ActivityBar.tsx
@@ -29,7 +29,7 @@ import {
   GoCloudDownload,
 } from 'react-icons/go';
 import { useEditorStore } from '../../stores/EditorStore';
-import { ACTIVITY_MODE, AUX_PANEL_MODE } from '../../stores/EditorConfig';
+import { ACTIVITY_MODE } from '../../stores/EditorConfig';
 import { CORE_TEST_ID } from '../../const';
 import { CheckIcon } from '../shared/Icon';
 import {
@@ -46,15 +46,6 @@ const SettingsMenu = observer(
     const editorStore = useEditorStore();
     const toggleDevTool = (): void => {
       editorStore.setDevTool(!editorStore.isDevToolEnabled);
-      if (editorStore.isDevToolEnabled) {
-        editorStore.openAuxPanel(AUX_PANEL_MODE.DEV_TOOL, true);
-      } else if (
-        editorStore.auxPanelSize &&
-        editorStore.activeAuxPanelMode === AUX_PANEL_MODE.DEV_TOOL
-      ) {
-        editorStore.toggleAuxPanel();
-        editorStore.setActiveAuxPanelMode(AUX_PANEL_MODE.CONSOLE);
-      }
     };
 
     return (
@@ -268,7 +259,7 @@ export const ActivityBar = observer(() => {
             key={activity.mode}
             className={clsx('activity-bar__item', {
               'activity-bar__item--active':
-                editorStore.sideBarSize &&
+                editorStore.sideBarDisplayState.isOpen &&
                 editorStore.activeActivity === activity.mode,
             })}
             onClick={changeActivity(activity.mode)}

--- a/packages/legend-studio/src/components/editor/Editor.tsx
+++ b/packages/legend-studio/src/components/editor/Editor.tsx
@@ -31,11 +31,6 @@ import { GrammarTextEditor } from './edit-panel/GrammarTextEditor';
 import { StatusBar } from './StatusBar';
 import { ActivityBar } from './ActivityBar';
 import { useParams, Prompt } from 'react-router-dom';
-import {
-  SIDE_BAR_RESIZE_SNAP_THRESHOLD,
-  DEFAULT_SIDE_BAR_SIZE,
-  AUX_PANEL_RESIZE_SNAP_THRESHOLD,
-} from '../../stores/EditorConfig';
 import type { EditorHotkey } from '../../stores/EditorStore';
 import { EditorStoreProvider, useEditorStore } from '../../stores/EditorStore';
 import Backdrop from '@material-ui/core/Backdrop';
@@ -89,39 +84,22 @@ export const EditorInner = observer(() => {
   // Resize
   const { ref, width, height } = useResizeDetector<HTMLDivElement>();
   // These create snapping effect on panel resizing
-  const snapSideBar = (newSize: number | undefined): void => {
+  const resizeSideBar = (newSize: number | undefined): void => {
     if (newSize !== undefined) {
-      editorStore.setSideBarSize(
-        newSize < SIDE_BAR_RESIZE_SNAP_THRESHOLD
-          ? editorStore.sideBarSize > 0
-            ? 0
-            : DEFAULT_SIDE_BAR_SIZE
-          : newSize,
-      );
+      editorStore.sideBarDisplayState.setSize(newSize);
     }
   };
-  const snapAuxPanel = (newSize: number | undefined): void => {
+  const resizeAuxPanel = (newSize: number | undefined): void => {
     if (ref.current) {
       if (newSize !== undefined) {
-        if (
-          newSize >=
-          ref.current.offsetHeight - AUX_PANEL_RESIZE_SNAP_THRESHOLD
-        ) {
-          editorStore.setAuxPanelSize(ref.current.offsetHeight);
-        } else if (newSize <= AUX_PANEL_RESIZE_SNAP_THRESHOLD) {
-          editorStore.setAuxPanelSize(
-            editorStore.auxPanelSize > 0 ? 0 : AUX_PANEL_RESIZE_SNAP_THRESHOLD,
-          );
-        } else {
-          editorStore.setAuxPanelSize(newSize);
-        }
+        editorStore.auxPanelDisplayState.setSize(newSize);
       }
     }
   };
 
   useEffect(() => {
     if (ref.current) {
-      editorStore.setMaxAuxPanelSize(ref.current.offsetHeight);
+      editorStore.auxPanelDisplayState.setMaxSize(ref.current.offsetHeight);
     }
   }, [editorStore, ref, height, width]);
 
@@ -279,8 +257,8 @@ export const EditorInner = observer(() => {
                 >
                   <SplitPane
                     split="vertical"
-                    size={editorStore.sideBarSize}
-                    onDragFinished={snapSideBar}
+                    size={editorStore.sideBarDisplayState.size}
+                    onDragFinished={resizeSideBar}
                     minSize={0}
                     maxSize={-600}
                   >
@@ -288,8 +266,8 @@ export const EditorInner = observer(() => {
                     <SplitPane
                       primary="second"
                       split="horizontal"
-                      size={editorStore.auxPanelSize}
-                      onDragFinished={snapAuxPanel}
+                      size={editorStore.auxPanelDisplayState.size}
+                      onDragFinished={resizeAuxPanel}
                       minSize={0}
                       maxSize={0}
                     >

--- a/packages/legend-studio/src/components/editor/StatusBar.tsx
+++ b/packages/legend-studio/src/components/editor/StatusBar.tsx
@@ -101,7 +101,7 @@ export const StatusBar = observer((props: { actionsDisabled: boolean }) => {
       : 'all conflicts resolved';
 
   // Other actions
-  const toggleAuxPanel = (): void => editorStore.toggleAuxPanel();
+  const toggleAuxPanel = (): void => editorStore.auxPanelDisplayState.toggle();
   const toggleExpandMode = (): void =>
     editorStore.setExpandedMode(!editorStore.isInExpandedMode);
   const handleTextModeClick = applicationStore.guaranteeSafeAction(() =>
@@ -306,9 +306,8 @@ export const StatusBar = observer((props: { actionsDisabled: boolean }) => {
           className={clsx(
             'editor__status-bar__action editor__status-bar__action__toggler',
             {
-              'editor__status-bar__action__toggler--active': Boolean(
-                editorStore.auxPanelSize,
-              ),
+              'editor__status-bar__action__toggler--active':
+                editorStore.auxPanelDisplayState.isOpen,
             },
           )}
           onClick={toggleAuxPanel}

--- a/packages/legend-studio/src/components/editor/aux-panel/AuxiliaryPanel.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/AuxiliaryPanel.tsx
@@ -30,8 +30,9 @@ export const AuxiliaryPanel = observer(() => {
     (mode: AUX_PANEL_MODE): (() => void) =>
     (): void =>
       editorStore.setActiveAuxPanelMode(mode);
-  const closePanel = (): void => editorStore.toggleAuxPanel();
-  const toggleExpandAuxPanel = (): void => editorStore.toggleExpandAuxPanel();
+  const closePanel = (): void => editorStore.auxPanelDisplayState.toggle();
+  const toggleExpandAuxPanel = (): void =>
+    editorStore.auxPanelDisplayState.toggleMaximize();
 
   const auxTabMap: {
     [key in AUX_PANEL_MODE]: {
@@ -102,7 +103,7 @@ export const AuxiliaryPanel = observer(() => {
             tabIndex={-1}
             title={'Toggle expand/collapse'}
           >
-            {editorStore.isAuxPanelMaximized ? (
+            {editorStore.auxPanelDisplayState.isMaximized ? (
               <GoChevronDown />
             ) : (
               <GoChevronUp />

--- a/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
@@ -40,7 +40,7 @@ import {
 } from '../../../stores/editor-state/entity-diff-editor-state/EntityDiffViewState';
 import { EntityDiffView } from '../../editor/edit-panel/diff-editor/EntityDiffView';
 import { DiagramEditorState } from '../../../stores/editor-state/element-editor-state/DiagramEditorState';
-import { DiagramEditor } from './DiagramEditor';
+import { DiagramEditor } from './diagram-editor/DiagramEditor';
 import { ModelLoader } from '../../editor/edit-panel/ModelLoader';
 import { ModelLoaderState } from '../../../stores/editor-state/ModelLoaderState';
 import { FunctionEditorState } from '../../../stores/editor-state/element-editor-state/FunctionEditorState';

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -330,7 +330,15 @@ export const DiagramRendererHotkeyInfosModal = observer(
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
-                  Separate the property being hovered on
+                  Edit the selected element
+                </div>
+                <div className="diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">e</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Eject the property
                 </div>
                 <div className="diagram-editor__hotkey__keys">
                   <div className="hotkey__key">a</div>
@@ -640,8 +648,12 @@ export const DiagramEditor = observer(() => {
     editorStore.getCurrentEditorState(DiagramEditorState);
   const diagramCanvasRef = useRef<HTMLDivElement>(null);
 
-  const toggleSidePanel = (): void =>
+  const toggleSidePanel = (): void => {
     diagramEditorState.sidePanelDisplayState.toggle();
+    if (!diagramEditorState.sidePanelDisplayState.isOpen) {
+      diagramEditorState.setSidePanelState(undefined);
+    }
+  };
 
   return (
     <div className="diagram-editor">

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -298,7 +298,7 @@ export const DiagramRendererHotkeyInfosModal = observer(
             <div className="diagram-editor__hotkey__groups">
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
-                  Remove selected element
+                  Remove selected element(s)
                 </div>
                 <div className="diagram-editor__hotkey__keys">
                   <div className="hotkey__key">Delete</div>
@@ -306,7 +306,7 @@ export const DiagramRendererHotkeyInfosModal = observer(
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
-                  Toggle display for properties
+                  Toggle display for properties of selected element(s)
                 </div>
                 <div className="diagram-editor__hotkey__keys">
                   <div className="hotkey__key">h</div>
@@ -314,7 +314,7 @@ export const DiagramRendererHotkeyInfosModal = observer(
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
-                  Toggle display for stereotypes
+                  Toggle display for stereotypes of selected element(s)
                 </div>
                 <div className="diagram-editor__hotkey__keys">
                   <div className="hotkey__key">s</div>
@@ -322,7 +322,7 @@ export const DiagramRendererHotkeyInfosModal = observer(
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
-                  Toggle display for tagged values
+                  Toggle display for tagged values of selected element(s)
                 </div>
                 <div className="diagram-editor__hotkey__keys">
                   <div className="hotkey__key">t</div>

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -398,7 +398,7 @@ const DiagramEditorToolPanel = observer(
       diagramEditorState.setShowHotkeyInfosModal(false);
 
     const switchToLayoutMode = (): void => {
-      if (diagramRenderer && !isReadOnly) {
+      if (!isReadOnly) {
         diagramRenderer.changeMode(
           DIAGRAM_EDIT_MODE.LAYOUT,
           DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
@@ -407,7 +407,7 @@ const DiagramEditorToolPanel = observer(
     };
 
     const switchToRelationshipPropertyMode = (): void => {
-      if (diagramRenderer && !isReadOnly) {
+      if (!isReadOnly) {
         diagramRenderer.changeMode(
           DIAGRAM_EDIT_MODE.RELATIONSHIP,
           DIAGRAM_RELATIONSHIP_EDIT_MODE.PROPERTY,
@@ -416,7 +416,7 @@ const DiagramEditorToolPanel = observer(
     };
 
     const switchToRelationshipAssociationMode = (): void => {
-      if (diagramRenderer && !isReadOnly) {
+      if (!isReadOnly) {
         applicationStore.notifyUnsupportedFeature(`Create association`);
         // diagramRenderer.changeMode(
         //   DIAGRAM_EDIT_MODE.RELATIONSHIP,
@@ -426,7 +426,7 @@ const DiagramEditorToolPanel = observer(
     };
 
     const switchToRelationshipInheritanceMode = (): void => {
-      if (diagramRenderer && !isReadOnly) {
+      if (!isReadOnly) {
         diagramRenderer.changeMode(
           DIAGRAM_EDIT_MODE.RELATIONSHIP,
           DIAGRAM_RELATIONSHIP_EDIT_MODE.INHERITANCE,
@@ -435,7 +435,7 @@ const DiagramEditorToolPanel = observer(
     };
 
     const addNewClassView = (): void => {
-      if (diagramRenderer && !isReadOnly) {
+      if (!isReadOnly) {
         diagramRenderer.changeMode(
           DIAGRAM_EDIT_MODE.ADD_CLASS,
           DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
@@ -448,7 +448,7 @@ const DiagramEditorToolPanel = observer(
         <button
           className={clsx('diagram-editor__tool', {
             'diagram-editor__tool--active':
-              diagramRenderer?.editMode === DIAGRAM_EDIT_MODE.LAYOUT,
+              diagramRenderer.editMode === DIAGRAM_EDIT_MODE.LAYOUT,
           })}
           tabIndex={-1}
           onClick={switchToLayoutMode}
@@ -459,7 +459,6 @@ const DiagramEditorToolPanel = observer(
         <button
           className={clsx('diagram-editor__tool', {
             'diagram-editor__tool--active':
-              diagramRenderer &&
               diagramRenderer.editMode === DIAGRAM_EDIT_MODE.RELATIONSHIP &&
               diagramRenderer.relationshipMode ===
                 DIAGRAM_RELATIONSHIP_EDIT_MODE.PROPERTY,
@@ -473,7 +472,6 @@ const DiagramEditorToolPanel = observer(
         <button
           className={clsx('diagram-editor__tool', {
             'diagram-editor__tool--active':
-              diagramRenderer &&
               diagramRenderer.editMode === DIAGRAM_EDIT_MODE.RELATIONSHIP &&
               diagramRenderer.relationshipMode ===
                 DIAGRAM_RELATIONSHIP_EDIT_MODE.INHERITANCE,
@@ -487,8 +485,8 @@ const DiagramEditorToolPanel = observer(
         <button
           className={clsx('diagram-editor__tool', {
             // 'diagram-editor__tool--active':
-            //   diagramRenderer?.editMode === DIAGRAM_EDIT_MODE.RELATIONSHIP &&
-            //   diagramRenderer?.relationshipMode ===
+            //   diagramRenderer.editMode === DIAGRAM_EDIT_MODE.RELATIONSHIP &&
+            //   diagramRenderer.relationshipMode ===
             //     DIAGRAM_RELATIONSHIP_EDIT_MODE.ASSOCIATION,
           })}
           tabIndex={-1}
@@ -500,7 +498,7 @@ const DiagramEditorToolPanel = observer(
         <button
           className={clsx('diagram-editor__tool', {
             'diagram-editor__tool--active':
-              diagramRenderer?.editMode === DIAGRAM_EDIT_MODE.ADD_CLASS,
+              diagramRenderer.editMode === DIAGRAM_EDIT_MODE.ADD_CLASS,
           })}
           tabIndex={-1}
           title="New Class..."
@@ -673,9 +671,7 @@ const DiagramEditorInlinePropertyEditorInner = observer(
     };
 
     useEffect(() => {
-      if (inlinePropertyEditorState) {
-        propertyNameInputRef.current?.focus();
-      }
+      propertyNameInputRef.current?.focus();
     }, [inlinePropertyEditorState]);
 
     return (
@@ -763,7 +759,8 @@ const DiagramEditorDiagramCanvas = observer(
     ref: React.Ref<HTMLDivElement>,
   ) => {
     const { diagramEditorState } = props;
-    const diagramCanvasRef = ref as React.MutableRefObject<HTMLDivElement>;
+    const diagramCanvasRef =
+      ref as React.MutableRefObject<HTMLDivElement | null>;
     const isReadOnly = diagramEditorState.isReadOnly;
 
     const { width, height } = useResizeDetector<HTMLDivElement>({

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -823,15 +823,10 @@ const DiagramEditorDiagramCanvas = observer(
     return (
       <div
         ref={diagramCanvasRef}
-        // TODO: do something better with cursor, this is very rudimentary
-        className={clsx('diagram-canvas diagram-editor__canvas', {
-          'diagram-editor__canvas--with-cursor--crosshair':
-            diagramEditorState.isDiagramRendererInitialized &&
-            (diagramEditorState.diagramRenderer.editMode ===
-              DIAGRAM_EDIT_MODE.RELATIONSHIP ||
-              diagramEditorState.diagramRenderer.editMode ===
-                DIAGRAM_EDIT_MODE.ADD_CLASS),
-        })}
+        className={clsx(
+          'diagram-canvas diagram-editor__canvas',
+          diagramEditorState.diagramCursorClass,
+        )}
         tabIndex={0}
         onContextMenu={(event): void => event.preventDefault()}
       />

--- a/packages/legend-studio/src/components/review/Review.tsx
+++ b/packages/legend-studio/src/components/review/Review.tsx
@@ -28,11 +28,7 @@ import {
   FaRegWindowMaximize,
 } from 'react-icons/fa';
 import { NotificationSnackbar } from '../shared/NotificationSnackbar';
-import {
-  ACTIVITY_MODE,
-  SIDE_BAR_RESIZE_SNAP_THRESHOLD,
-  DEFAULT_SIDE_BAR_SIZE,
-} from '../../stores/EditorConfig';
+import { ACTIVITY_MODE } from '../../stores/EditorConfig';
 import { MdPlaylistAddCheck } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import { EditorStoreProvider, useEditorStore } from '../../stores/EditorStore';
@@ -139,15 +135,9 @@ const ReviewExplorer = observer(() => {
   const reviewStore = useReviewStore();
   const editorStore = useEditorStore();
   const applicationStore = useApplicationStore();
-  const snapSideBar = (newSize: number | undefined): void => {
+  const resizeSideBar = (newSize: number | undefined): void => {
     if (newSize !== undefined) {
-      editorStore.setSideBarSize(
-        newSize < SIDE_BAR_RESIZE_SNAP_THRESHOLD
-          ? editorStore.sideBarSize > 0
-            ? 0
-            : DEFAULT_SIDE_BAR_SIZE
-          : newSize,
-      );
+      editorStore.sideBarDisplayState.setSize(newSize);
     }
   };
 
@@ -161,8 +151,8 @@ const ReviewExplorer = observer(() => {
     <SplitPane
       className="review-explorer__content"
       split="vertical"
-      onDragFinished={snapSideBar}
-      size={editorStore.sideBarSize}
+      onDragFinished={resizeSideBar}
+      size={editorStore.sideBarDisplayState.size}
       minSize={0}
       maxSize={-600}
     >

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -2150,12 +2150,8 @@ export class DiagramRenderer {
     // Click on a class view
     if (selectedClass) {
       this.editClass(selectedClass);
-      return;
-    }
-    // Click outside of a classview
-    if (!selectedClass) {
+    } else {
       this.onBackgroundDoubleClick(e);
-      return;
     }
   }
 

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -198,12 +198,14 @@ export class DiagramRenderer {
   positionBeforeLastMove: Point;
 
   // functions to interact with diagram editor
-  onAddClassViewClick: (event: MouseEvent) => void = noop();
-  onBackgroundDoubleClick: (event: MouseEvent) => void = noop();
+  onAddClassViewClick: (mouseEvent: MouseEvent) => void = noop();
+  onBackgroundDoubleClick: (mouseEvent: MouseEvent) => void = noop();
   editClass: (classView: ClassView) => void = noop();
   editProperty: (property: AbstractProperty, point: Point) => void = noop();
   editPropertyView: (propertyView: PropertyHolderView) => void = noop();
-  addClassPropertyForSelectedClass: (classView: ClassView) => void = noop();
+  addSimpleProperty: (classView: ClassView) => void = noop();
+  addSelectedClassAsPropertyOfOpenedClass: (classView: ClassView) => void =
+    noop();
 
   constructor(div: HTMLDivElement, diagram: Diagram) {
     makeObservable(this, {
@@ -1920,25 +1922,36 @@ export class DiagramRenderer {
         this.selectedClassProperty = undefined;
       }
     }
+    // Add a new simple property to selected class
+    else if (e.key === 'b') {
+      if (this.selectedClasses.length === 1) {
+        this.addSimpleProperty(this.selectedClasses[0]);
+      }
+    }
     // Add currently selected class as property to the currently opened class
     else if (e.key === 'p') {
       if (this.selectedClasses.length !== 0) {
         this.selectedClasses.forEach((classView) =>
-          this.addClassPropertyForSelectedClass(classView),
+          this.addSelectedClassAsPropertyOfOpenedClass(classView),
         );
       }
     }
     // Edit selected view
+    // NOTE: since the current behavior when editing property is to immediately
+    // focus on the property name input when the inline editor pops up
+    // we need to call `preventDefault` to avoid typing `e` in the property name input
     else if (e.key === 'e') {
       if (this.selectedClassProperty) {
         this.editProperty(
           this.selectedClassProperty.property,
           this.selectedClassProperty.selectionPoint,
         );
-      } else if (this.selectedClasses.length === 1) {
-        this.editClass(this.selectedClasses[0]);
+        e.preventDefault();
       } else if (this.selectedPropertyOrAssociation) {
         this.editPropertyView(this.selectedPropertyOrAssociation);
+        e.preventDefault();
+      } else if (this.selectedClasses.length === 1) {
+        this.editClass(this.selectedClasses[0]);
       }
     }
   }

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -63,6 +63,7 @@ export enum DIAGRAM_RELATIONSHIP_EDIT_MODE {
 
 export class DiagramRenderer {
   diagram: Diagram;
+
   isReadOnly: boolean;
 
   div: HTMLDivElement;
@@ -199,9 +200,11 @@ export class DiagramRenderer {
 
   constructor(div: HTMLDivElement, diagram: Diagram) {
     makeObservable(this, {
+      isReadOnly: observable,
       editMode: observable,
       relationshipMode: observable,
       changeMode: action,
+      setIsReadOnly: action,
     });
 
     this.diagram = diagram;
@@ -334,6 +337,10 @@ export class DiagramRenderer {
   refresh(): void {
     this.refreshCanvas();
     this.redraw();
+  }
+
+  setIsReadOnly(val: boolean): void {
+    this.isReadOnly = val;
   }
 
   changeMode(

--- a/packages/legend-studio/src/components/viewer/Viewer.tsx
+++ b/packages/legend-studio/src/components/viewer/Viewer.tsx
@@ -31,13 +31,7 @@ import { EditPanel } from '../editor/edit-panel/EditPanel';
 import { GrammarTextEditor } from '../editor/edit-panel/GrammarTextEditor';
 import { useParams, Link } from 'react-router-dom';
 import { CORE_TEST_ID } from '../../const';
-import {
-  ACTIVITY_MODE,
-  HOTKEY,
-  HOTKEY_MAP,
-  SIDE_BAR_RESIZE_SNAP_THRESHOLD,
-  DEFAULT_SIDE_BAR_SIZE,
-} from '../../stores/EditorConfig';
+import { ACTIVITY_MODE, HOTKEY, HOTKEY_MAP } from '../../stores/EditorConfig';
 import { EditorStoreProvider, useEditorStore } from '../../stores/EditorStore';
 import { clsx } from '@finos/legend-studio-components';
 import { NotificationSnackbar } from '../shared/NotificationSnackbar';
@@ -180,15 +174,9 @@ export const ViewerInner = observer(() => {
     editorStore.sdlcState.currentProject &&
     !editorStore.graphState.graph.failedToBuild &&
     editorStore.graphState.graph.isBuilt;
-  const snapSideBar = (newSize: number | undefined): void => {
+  const resizeSideBar = (newSize: number | undefined): void => {
     if (newSize !== undefined) {
-      editorStore.setSideBarSize(
-        newSize < SIDE_BAR_RESIZE_SNAP_THRESHOLD
-          ? editorStore.sideBarSize > 0
-            ? 0
-            : DEFAULT_SIDE_BAR_SIZE
-          : newSize,
-      );
+      editorStore.sideBarDisplayState.setSize(newSize);
     }
   };
   // Resize
@@ -211,7 +199,7 @@ export const ViewerInner = observer(() => {
 
   useEffect(() => {
     if (ref.current) {
-      editorStore.setMaxAuxPanelSize(ref.current.offsetHeight);
+      editorStore.auxPanelDisplayState.setMaxSize(ref.current.offsetHeight);
     }
   }, [ref, editorStore, width, height]);
 
@@ -245,8 +233,8 @@ export const ViewerInner = observer(() => {
                 >
                   <SplitPane
                     split="vertical"
-                    onDragFinished={snapSideBar}
-                    size={editorStore.sideBarSize}
+                    onDragFinished={resizeSideBar}
+                    size={editorStore.sideBarDisplayState.size}
                     minSize={0}
                     maxSize={-600}
                   >

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElementReference.ts
@@ -239,6 +239,10 @@ export class OptionalPackageableElementImplicitReference<
     );
   }
 
+  /**
+   * Use this creator method when the reference is created by
+   * resolving imports using section majorly when building the graph.
+   */
   static resolveFromSection<V extends PackageableElement>(
     value: V | undefined,
     input: string,
@@ -283,13 +287,13 @@ export const toOptionalPackageableElementReference = <
   assertType(reference, PackageableElementImplicitReference);
   if (reference.skipSectionCheck) {
     return OptionalPackageableElementImplicitReference.create(
-      reference?.value,
-      reference?.input,
+      reference.value,
+      reference.input,
     );
   }
   return OptionalPackageableElementImplicitReference.resolveFromSection(
-    reference?.value,
-    reference?.input,
-    reference?.parentSection,
+    reference.value,
+    reference.input,
+    reference.parentSection,
   );
 };

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
@@ -152,6 +152,20 @@ export class V1_GraphBuilderContext {
     }
   }
 
+  // TODO: create small enum flag for the outcome instead of putting boolean (....), make this function private as well?
+  createImplicitPackageableElementReference = <T extends PackageableElement>(
+    path: string,
+    resolverFn: (path: string) => T,
+  ): PackageableElementImplicitReference<T> => {
+    const resolutionResult = this.resolve(path, resolverFn);
+    return PackageableElementImplicitReference.create(
+      resolutionResult[0],
+      path,
+      this.section,
+      resolutionResult[1],
+    );
+  };
+
   resolveStereotype = (
     stereotypePtr: V1_StereotypePtr,
   ): StereotypeImplicitReference => {
@@ -290,19 +304,6 @@ export class V1_GraphBuilderContext {
     return EnumValueImplicitReference.create(
       parent,
       parent.value.getValue(value),
-    );
-  };
-
-  createImplicitPackageableElementReference = <T extends PackageableElement>(
-    path: string,
-    resolverFn: (path: string) => T,
-  ): PackageableElementImplicitReference<T> => {
-    const resolutionResult = this.resolve(path, resolverFn);
-    return PackageableElementImplicitReference.create(
-      resolutionResult[0],
-      path,
-      this.section,
-      resolutionResult[1],
     );
   };
 

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
@@ -61,7 +61,6 @@ import { RootFlatDataRecordTypeImplicitReference } from '../../../../../../metam
 import type { ViewImplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/model/ViewReference';
 import type { TableImplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/model/TableReference';
 import { createImplicitRelationReference } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/model/RelationReference';
-import type { EnumValueReference } from '../../../../../../metamodels/pure/model/packageableElements/domain/EnumValueReference';
 import { EnumValueImplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/domain/EnumValueReference';
 import type { V1_StereotypePtr } from '../../../model/packageableElements/domain/V1_StereotypePtr';
 import type { V1_PackageableElement } from '../../../model/packageableElements/V1_PackageableElement';
@@ -78,7 +77,7 @@ import type { V1_GraphBuilderExtensions } from './V1_GraphBuilderExtensions';
 import type { GraphBuilderOptions } from '../../../../../../metamodels/pure/graph/AbstractPureGraphManager';
 import { DataType } from '../../../../../../metamodels/pure/model/packageableElements/domain/DataType';
 
-type ResolutionResult<T> = [T, boolean | undefined];
+type ResolutionResult<T> = [T, boolean];
 
 export class V1_GraphBuilderContext {
   readonly logger: Logger;
@@ -106,11 +105,11 @@ export class V1_GraphBuilderContext {
     // Try the find from special types (not user-defined top level types)
     const SPECIAL_TYPES: string[] = Object.values(PRIMITIVE_TYPE).concat([]);
     if (SPECIAL_TYPES.includes(path)) {
-      return [resolverFn(path), undefined];
+      return [resolverFn(path), true];
     }
     // if the path is a path with package, no resolution from import is needed
     if (path.includes(ELEMENT_PATH_DELIMITER)) {
-      return [resolverFn(path), undefined];
+      return [resolverFn(path), true];
     }
     // NOTE: here we make the assumption that we have populated the indices properly so the same element
     // is not referred using 2 different paths in the same element index
@@ -139,7 +138,7 @@ export class V1_GraphBuilderContext {
        * here we count on the `resolver` to do the validation of the type of element instead
        */
       case 0:
-        return [resolverFn(path), undefined];
+        return [resolverFn(path), true];
       case 1:
         return Array.from(results.values())[0];
       default:
@@ -152,17 +151,31 @@ export class V1_GraphBuilderContext {
     }
   }
 
-  // TODO: create small enum flag for the outcome instead of putting boolean (....), make this function private as well?
+  /**
+   * This method and this class in general demonstrates the difference
+   * between explicit and implicit reference.
+   * See {@link PackageableElementImplicitReference} for more details.
+   *
+   * Notice that every method in the resolver ends up creating an implicit reference.
+   * It does not matter whether the full path is specified or not (i.e. so almost
+   * no inference was done), the resulting reference must be implicit, as we took the
+   * input into account when creating this reference.
+   */
   createImplicitPackageableElementReference = <T extends PackageableElement>(
     path: string,
     resolverFn: (path: string) => T,
   ): PackageableElementImplicitReference<T> => {
-    const resolutionResult = this.resolve(path, resolverFn);
-    return PackageableElementImplicitReference.create(
-      resolutionResult[0],
+    const [element, skippedSectionImportResolution] = this.resolve(
+      path,
+      resolverFn,
+    );
+    if (skippedSectionImportResolution) {
+      return PackageableElementImplicitReference.create(element, path);
+    }
+    return PackageableElementImplicitReference.resolveFromSection(
+      element,
       path,
       this.section,
-      resolutionResult[1],
     );
   };
 
@@ -178,28 +191,22 @@ export class V1_GraphBuilderContext {
       'Steoreotype pointer value is missing',
     );
     const ownerReference = this.resolveProfile(stereotypePtr.profile);
-    return StereotypeImplicitReference.create(
-      ownerReference,
-      ownerReference.value.getStereotype(stereotypePtr.value),
-    );
+    const value = ownerReference.value.getStereotype(stereotypePtr.value);
+    return StereotypeImplicitReference.create(ownerReference, value);
   };
 
   resolveTag = (tagPtr: V1_TagPtr): TagImplicitReference => {
     assertNonEmptyString(tagPtr.profile, 'Tag pointer profile is missing');
     assertNonEmptyString(tagPtr.value, 'Tag pointer value is missing');
     const ownerReference = this.resolveProfile(tagPtr.profile);
-    return TagImplicitReference.create(
-      ownerReference,
-      ownerReference.value.getTag(tagPtr.value),
-    );
+    const value = ownerReference.value.getTag(tagPtr.value);
+    return TagImplicitReference.create(ownerReference, value);
   };
 
   resolveGenericType = (path: string): GenericTypeImplicitReference => {
     const ownerReference = this.resolveType(path);
-    return GenericTypeImplicitReference.create(
-      ownerReference,
-      new GenericType(ownerReference.value),
-    );
+    const value = new GenericType(ownerReference.value);
+    return GenericTypeImplicitReference.create(ownerReference, value);
   };
 
   resolveOwnedProperty = (
@@ -214,10 +221,8 @@ export class V1_GraphBuilderContext {
       'Property pointer name is missing',
     );
     const ownerReference = this.resolveClass(propertyPtr.class);
-    return PropertyImplicitReference.create(
-      ownerReference,
-      ownerReference.value.getOwnedProperty(propertyPtr.property),
-    );
+    const value = ownerReference.value.getOwnedProperty(propertyPtr.property);
+    return PropertyImplicitReference.create(ownerReference, value);
   };
 
   resolveProperty = (
@@ -232,10 +237,8 @@ export class V1_GraphBuilderContext {
       'Property pointer name is missing',
     );
     const ownerReference = this.resolveClass(propertyPtr.class);
-    return PropertyImplicitReference.create(
-      ownerReference,
-      ownerReference.value.getProperty(propertyPtr.property),
-    );
+    const value = ownerReference.value.getProperty(propertyPtr.property);
+    return PropertyImplicitReference.create(ownerReference, value);
   };
 
   resolveRootFlatDataRecordType = (
@@ -250,31 +253,12 @@ export class V1_GraphBuilderContext {
       'Flat-data class mapping source flat-data section is missing',
     );
     const ownerReference = this.resolveFlatDataStore(classMapping.flatData);
+    const value = ownerReference.value
+      .findSection(classMapping.sectionName)
+      .getRecordType();
     return RootFlatDataRecordTypeImplicitReference.create(
       ownerReference,
-      ownerReference.value
-        .findSection(classMapping.sectionName)
-        .getRecordType(),
-    );
-  };
-
-  resolveJoin = (joinPtr: V1_JoinPointer): JoinImplicitReference => {
-    assertNonEmptyString(joinPtr.db, 'Join pointer database is missing');
-    assertNonEmptyString(joinPtr.name, 'Join pointer name is missing');
-    const ownerReference = this.resolveDatabase(joinPtr.db);
-    return JoinImplicitReference.create(
-      ownerReference,
-      ownerReference.value.getJoin(joinPtr.name),
-    );
-  };
-
-  resolveFilter = (filterPtr: V1_FilterPointer): FilterImplicitReference => {
-    assertNonEmptyString(filterPtr.db, 'Filter pointer database is missing');
-    assertNonEmptyString(filterPtr.name, 'Filter pointer name is missing');
-    const ownerReference = this.resolveDatabase(filterPtr.db);
-    return FilterImplicitReference.create(
-      ownerReference,
-      ownerReference.value.getJoin(filterPtr.name),
+      value,
     );
   };
 
@@ -288,23 +272,37 @@ export class V1_GraphBuilderContext {
     assertNonEmptyString(tablePtr.schema, 'Table pointer schema is missing');
     assertNonEmptyString(tablePtr.table, 'Table pointer table is missing');
     const ownerReference = this.resolveDatabase(tablePtr.database);
-    const relation = V1_getRelation(
+    const value = V1_getRelation(
       ownerReference.value,
       tablePtr.schema,
       tablePtr.table,
     );
-    return createImplicitRelationReference(ownerReference, relation);
+    return createImplicitRelationReference(ownerReference, value);
+  };
+
+  resolveJoin = (joinPtr: V1_JoinPointer): JoinImplicitReference => {
+    assertNonEmptyString(joinPtr.db, 'Join pointer database is missing');
+    assertNonEmptyString(joinPtr.name, 'Join pointer name is missing');
+    const ownerReference = this.resolveDatabase(joinPtr.db);
+    const value = ownerReference.value.getJoin(joinPtr.name);
+    return JoinImplicitReference.create(ownerReference, value);
+  };
+
+  resolveFilter = (filterPtr: V1_FilterPointer): FilterImplicitReference => {
+    assertNonEmptyString(filterPtr.db, 'Filter pointer database is missing');
+    assertNonEmptyString(filterPtr.name, 'Filter pointer name is missing');
+    const ownerReference = this.resolveDatabase(filterPtr.db);
+    const value = ownerReference.value.getFilter(filterPtr.name);
+    return FilterImplicitReference.create(ownerReference, value);
   };
 
   resolveEnumValue = (
     enumeration: string,
-    value: string,
-  ): EnumValueReference => {
-    const parent = this.resolveEnumeration(enumeration);
-    return EnumValueImplicitReference.create(
-      parent,
-      parent.value.getValue(value),
-    );
+    enumValue: string,
+  ): EnumValueImplicitReference => {
+    const ownerReference = this.resolveEnumeration(enumeration);
+    const value = ownerReference.value.getValue(enumValue);
+    return EnumValueImplicitReference.create(ownerReference, value);
   };
 
   /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassBuilder.ts
@@ -28,7 +28,6 @@ import {
 import { PureInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation';
 import { FlatDataInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation';
 import { RootRelationalInstanceSetImplementation } from '../../../../../../metamodels/pure/model/packageableElements/store/relational/mapping/RootRelationalInstanceSetImplementation';
-import { OptionalPackageableElementImplicitReference } from '../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 import { InferableMappingElementRootExplicitValue } from '../../../../../../metamodels/pure/model/packageableElements/mapping/InferableMappingElementRoot';
 import type { V1_GraphBuilderContext } from '../../../transformation/pureGraph/to/V1_GraphBuilderContext';
 import type { V1_ClassMappingVisitor } from '../../../model/packageableElements/mapping/V1_ClassMapping';
@@ -44,6 +43,7 @@ import type { InstanceSetImplementation } from '../../../../../../metamodels/pur
 import { V1_buildAggregateContainer } from './helpers/V1_AggregationAwareClassMappingBuilderHelper';
 import { V1_resolvePathsInRawLambda } from './helpers/V1_RawPathLambdaResolver';
 import { V1_buildRelationalMappingFilter } from './helpers/V1_RelationalClassMappingBuilderHelper';
+import { toOptionalPackageableElementReference } from '../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 
 export class V1_ProtocolToMetaModelClassMappingFirstPassBuilder
   implements V1_ClassMappingVisitor<SetImplementation>
@@ -101,12 +101,7 @@ export class V1_ProtocolToMetaModelClassMappingFirstPassBuilder
       this.parent,
       targetClass,
       InferableMappingElementRootExplicitValue.create(classMapping.root),
-      OptionalPackageableElementImplicitReference.create(
-        srcClassReference?.value,
-        classMapping.srcClass,
-        this.context.section,
-        srcClassReference?.isInferred,
-      ),
+      toOptionalPackageableElementReference(srcClassReference),
     );
     pureInstanceSetImplementation.filter = classMapping.filter
       ? V1_resolvePathsInRawLambda(this.context, [], classMapping.filter.body)

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingBuilder.ts
@@ -446,8 +446,6 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
             PackageableElementImplicitReference.create(
               propertyOwner,
               protocol.property.class ?? '',
-              this.context.section,
-              true,
             ),
             property,
           )
@@ -545,8 +543,6 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
         PackageableElementImplicitReference.create(
           propertyOwnerClass,
           protocol.property.class ?? '',
-          this.context.section,
-          true,
         ),
         property,
       ),
@@ -584,8 +580,6 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
         PackageableElementImplicitReference.create(
           property.propertyOwnerClass,
           protocol.property.class ?? '',
-          this.context.section,
-          true,
         ),
         property.property,
       ),
@@ -641,8 +635,6 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
           PackageableElementImplicitReference.create(
             property.propertyOwnerClass,
             protocol.property.class ?? '',
-            this.context.section,
-            true,
           ),
           property.property,
         ),

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
@@ -42,8 +42,8 @@ import { FlatDataInputData } from '../../../../../../../metamodels/pure/model/pa
 import { ExpectedOutputMappingTestAssert } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/ExpectedOutputMappingTestAssert';
 import type { Class } from '../../../../../../../metamodels/pure/model/packageableElements/domain/Class';
 import { InferableMappingElementIdImplicitValue } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/InferableMappingElementId';
-import type { PackageableElementImplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
-import { OptionalPackageableElementImplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
+import type { PackageableElementReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
+import { toOptionalPackageableElementReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 import { EnumValueExplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/domain/EnumValueReference';
 import { MappingInclude } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/MappingInclude';
 import { SubstituteStore } from '../../../../../../../metamodels/pure/model/packageableElements/mapping/SubstituteStore';
@@ -79,7 +79,7 @@ export const V1_getInferredClassMappingId = (
 
 const buildEnumValueMapping = (
   srcEnumValueMapping: V1_EnumValueMapping,
-  enumeration: PackageableElementImplicitReference<Enumeration>,
+  enumeration: PackageableElementReference<Enumeration>,
   sourceType?: Type,
 ): EnumValueMapping => {
   assertNonNullable(
@@ -160,12 +160,7 @@ export const V1_buildEnumerationMapping = (
     ),
     targetEnumeration,
     parentMapping,
-    OptionalPackageableElementImplicitReference.create(
-      sourceTypeReference?.value,
-      sourceTypeInput,
-      context.section,
-      sourceTypeReference?.isInferred,
-    ),
+    toOptionalPackageableElementReference(sourceTypeReference),
   );
   enumerationMapping.enumValueMappings =
     srcEnumerationMapping.enumValueMappings.map((enumValueMapping) =>

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RawPathLambdaResolver.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RawPathLambdaResolver.ts
@@ -20,7 +20,7 @@ import {
 } from '@finos/legend-studio-shared';
 import { CORE_LOG_EVENT } from '../../../../../../../../utils/Logger';
 import type { PackageableElement } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElement';
-import type { PackageableElementImplicitReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
+import type { PackageableElementReference } from '../../../../../../../metamodels/pure/model/packageableElements/PackageableElementReference';
 import { RawLambda } from '../../../../../../../metamodels/pure/model/rawValueSpecification/RawLambda';
 import { isValidFullPath } from '../../../../../../../MetaModelUtils';
 import { V1_RawLambda } from '../../../../model/rawValueSpecification/V1_RawLambda';
@@ -316,7 +316,7 @@ function V1_resolveElementPath(
   path: string,
   resolverFunc: (
     path: string,
-  ) => PackageableElementImplicitReference<PackageableElement>,
+  ) => PackageableElementReference<PackageableElement>,
   resolver: V1_ValueSpecificationPathResolver,
 ): string {
   const resolvedPath = resolverFunc(path).value.path;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_RelationalPropertyMappingBuilder.ts
@@ -73,8 +73,6 @@ export const V1_buildEmbeddedRelationalMappingProperty = (
     _class = PackageableElementImplicitReference.create(
       complexClass,
       propertyMapping.classMapping.class ?? '',
-      context.section,
-      true,
     );
   }
   const id =

--- a/packages/legend-studio/src/stores/EditorConfig.ts
+++ b/packages/legend-studio/src/stores/EditorConfig.ts
@@ -23,12 +23,6 @@ export enum EDITOR_MODE {
 
 export const TAB_SIZE = 2;
 
-export const SIDE_BAR_RESIZE_SNAP_THRESHOLD = 150;
-export const DEFAULT_SIDE_BAR_SIZE = 300;
-
-export const AUX_PANEL_RESIZE_SNAP_THRESHOLD = 50;
-export const DEFAULT_AUX_PANEL_SIZE = 300;
-
 export const MONOSPACED_FONT_FAMILY = 'Roboto Mono';
 
 export enum HOTKEY {

--- a/packages/legend-studio/src/stores/EditorStore.tsx
+++ b/packages/legend-studio/src/stores/EditorStore.tsx
@@ -164,9 +164,10 @@ export class EditorStore {
   activeAuxPanelMode: AUX_PANEL_MODE = AUX_PANEL_MODE.CONSOLE;
   maxAuxPanelSize = DEFAULT_AUX_PANEL_SIZE;
   auxPanelSize = 0;
-  previousAuxPanelSize = DEFAULT_AUX_PANEL_SIZE;
-  // Side Bar
+  auxPanelSizeBeforeHidden = DEFAULT_AUX_PANEL_SIZE;
+  // Activity Bar
   activeActivity?: ACTIVITY_MODE = ACTIVITY_MODE.EXPLORER;
+  // Side Bar
   sideBarSize = DEFAULT_SIDE_BAR_SIZE;
   sideBarSizeBeforeHidden = DEFAULT_SIDE_BAR_SIZE;
   // Hot keys
@@ -819,9 +820,10 @@ export class EditorStore {
 
   toggleAuxPanel(): void {
     if (this.auxPanelSize === 0) {
-      this.auxPanelSize = this.previousAuxPanelSize;
+      this.auxPanelSize = this.auxPanelSizeBeforeHidden;
     } else {
-      this.previousAuxPanelSize = this.auxPanelSize || DEFAULT_AUX_PANEL_SIZE;
+      this.auxPanelSizeBeforeHidden =
+        this.auxPanelSize || DEFAULT_AUX_PANEL_SIZE;
       this.auxPanelSize = 0;
     }
   }
@@ -829,19 +831,19 @@ export class EditorStore {
   toggleExpandAuxPanel(): void {
     if (this.auxPanelSize === this.maxAuxPanelSize) {
       this.auxPanelSize =
-        this.previousAuxPanelSize === this.maxAuxPanelSize
+        this.auxPanelSizeBeforeHidden === this.maxAuxPanelSize
           ? DEFAULT_AUX_PANEL_SIZE
-          : this.previousAuxPanelSize;
+          : this.auxPanelSizeBeforeHidden;
     } else {
-      this.previousAuxPanelSize = this.auxPanelSize;
+      this.auxPanelSizeBeforeHidden = this.auxPanelSize;
       this.auxPanelSize = this.maxAuxPanelSize;
     }
   }
 
   setMaxAuxPanelSize(val: number): void {
     if (this.isMaxAuxPanelSizeSet) {
-      if (this.previousAuxPanelSize === this.maxAuxPanelSize) {
-        this.previousAuxPanelSize = val;
+      if (this.auxPanelSizeBeforeHidden === this.maxAuxPanelSize) {
+        this.auxPanelSizeBeforeHidden = val;
       }
       if (this.auxPanelSize === this.maxAuxPanelSize) {
         this.auxPanelSize = val;

--- a/packages/legend-studio/src/stores/EditorStore.tsx
+++ b/packages/legend-studio/src/stores/EditorStore.tsx
@@ -32,10 +32,8 @@ import { editor as monacoEditorAPI } from 'monaco-editor';
 import { ExplorerTreeState } from './ExplorerTreeState';
 import {
   ACTIVITY_MODE,
-  DEFAULT_SIDE_BAR_SIZE,
   AUX_PANEL_MODE,
   GRAPH_EDITOR_MODE,
-  DEFAULT_AUX_PANEL_SIZE,
   EDITOR_MODE,
   MONOSPACED_FONT_FAMILY,
   TAB_SIZE,
@@ -90,7 +88,10 @@ import type { GenerationFile } from './shared/FileGenerationTreeUtil';
 import type { ElementFileGenerationState } from './editor-state/element-editor-state/ElementFileGenerationState';
 import { DevToolState } from './aux-panel-state/DevToolState';
 import { generateSetupRoute, generateViewProjectRoute } from './Router';
-import { NonBlockingDialogState } from '@finos/legend-studio-components';
+import {
+  NonBlockingDialogState,
+  PanelDisplayState,
+} from '@finos/legend-studio-components';
 import type {
   PackageableElement,
   PackageableElementSelectOption,
@@ -160,16 +161,19 @@ export class EditorStore {
   mode = EDITOR_MODE.STANDARD;
   graphEditMode = GRAPH_EDITOR_MODE.FORM;
   // Aux Panel
-  isMaxAuxPanelSizeSet = false;
   activeAuxPanelMode: AUX_PANEL_MODE = AUX_PANEL_MODE.CONSOLE;
-  maxAuxPanelSize = DEFAULT_AUX_PANEL_SIZE;
-  auxPanelSize = 0;
-  auxPanelSizeBeforeHidden = DEFAULT_AUX_PANEL_SIZE;
-  // Activity Bar
-  activeActivity?: ACTIVITY_MODE = ACTIVITY_MODE.EXPLORER;
+  auxPanelDisplayState = new PanelDisplayState({
+    initial: 0,
+    default: 300,
+    snap: 100,
+  });
   // Side Bar
-  sideBarSize = DEFAULT_SIDE_BAR_SIZE;
-  sideBarSizeBeforeHidden = DEFAULT_SIDE_BAR_SIZE;
+  activeActivity?: ACTIVITY_MODE = ACTIVITY_MODE.EXPLORER;
+  sideBarDisplayState = new PanelDisplayState({
+    initial: 300,
+    default: 300,
+    snap: 150,
+  });
   // Hot keys
   blockGlobalHotkeys = false;
   defaultHotkeys: EditorHotkey[] = [];
@@ -200,19 +204,13 @@ export class EditorStore {
       setCurrentEditorState: action,
       setBackdrop: action,
       setExpandedMode: action,
-      setAuxPanelSize: action,
       setActiveAuxPanelMode: action,
-      setSideBarSize: action,
       setIgnoreNavigationBlocking: action,
       refreshCurrentEntityDiffEditorState: action,
       setBlockingAlert: action,
       setActionAltertInfo: action,
       cleanUp: action,
       reset: action,
-      openAuxPanel: action,
-      toggleAuxPanel: action,
-      toggleExpandAuxPanel: action,
-      setMaxAuxPanelSize: action,
       setGraphEditMode: action,
       setActiveActivity: action,
       closeState: action,
@@ -326,7 +324,7 @@ export class EditorStore {
       new EditorHotkey(
         HOTKEY.TOGGLE_AUX_PANEL,
         [HOTKEY_MAP.TOGGLE_AUX_PANEL],
-        this.createGlobalHotKeyAction(() => this.toggleAuxPanel()),
+        this.createGlobalHotKeyAction(() => this.auxPanelDisplayState.toggle()),
       ),
       new EditorHotkey(
         HOTKEY.TOGGLE_SIDEBAR_EXPLORER,
@@ -381,9 +379,6 @@ export class EditorStore {
   get isInFormMode(): boolean {
     return this.graphEditMode === GRAPH_EDITOR_MODE.FORM;
   }
-  get isAuxPanelMaximized(): boolean {
-    return this.auxPanelSize === this.maxAuxPanelSize;
-  }
   get hasUnsyncedChanges(): boolean {
     return Boolean(
       this.changeDetectionState.workspaceLatestRevisionState.changes.length,
@@ -414,14 +409,8 @@ export class EditorStore {
   setExpandedMode(val: boolean): void {
     this.isInExpandedMode = val;
   }
-  setAuxPanelSize(val: number): void {
-    this.auxPanelSize = val;
-  }
   setActiveAuxPanelMode(val: AUX_PANEL_MODE): void {
     this.activeAuxPanelMode = val;
-  }
-  setSideBarSize(val: number): void {
-    this.sideBarSize = val;
   }
   setIgnoreNavigationBlocking(val: boolean): void {
     this.ignoreNavigationBlocking = val;
@@ -803,56 +792,6 @@ export class EditorStore {
     );
   }
 
-  openAuxPanel(
-    auxPanelMode: AUX_PANEL_MODE,
-    resetHeightIfTooSmall: boolean,
-  ): void {
-    this.activeAuxPanelMode = auxPanelMode;
-    if (this.auxPanelSize === 0) {
-      this.toggleAuxPanel();
-    } else if (
-      this.auxPanelSize < DEFAULT_AUX_PANEL_SIZE &&
-      resetHeightIfTooSmall
-    ) {
-      this.auxPanelSize = DEFAULT_AUX_PANEL_SIZE;
-    }
-  }
-
-  toggleAuxPanel(): void {
-    if (this.auxPanelSize === 0) {
-      this.auxPanelSize = this.auxPanelSizeBeforeHidden;
-    } else {
-      this.auxPanelSizeBeforeHidden =
-        this.auxPanelSize || DEFAULT_AUX_PANEL_SIZE;
-      this.auxPanelSize = 0;
-    }
-  }
-
-  toggleExpandAuxPanel(): void {
-    if (this.auxPanelSize === this.maxAuxPanelSize) {
-      this.auxPanelSize =
-        this.auxPanelSizeBeforeHidden === this.maxAuxPanelSize
-          ? DEFAULT_AUX_PANEL_SIZE
-          : this.auxPanelSizeBeforeHidden;
-    } else {
-      this.auxPanelSizeBeforeHidden = this.auxPanelSize;
-      this.auxPanelSize = this.maxAuxPanelSize;
-    }
-  }
-
-  setMaxAuxPanelSize(val: number): void {
-    if (this.isMaxAuxPanelSizeSet) {
-      if (this.auxPanelSizeBeforeHidden === this.maxAuxPanelSize) {
-        this.auxPanelSizeBeforeHidden = val;
-      }
-      if (this.auxPanelSize === this.maxAuxPanelSize) {
-        this.auxPanelSize = val;
-      }
-    }
-    this.maxAuxPanelSize = val;
-    this.isMaxAuxPanelSizeSet = true;
-  }
-
   setGraphEditMode(graphEditor: GRAPH_EDITOR_MODE): void {
     this.graphEditMode = graphEditor;
     this.graphState.clearCompilationError();
@@ -862,14 +801,13 @@ export class EditorStore {
     activity: ACTIVITY_MODE,
     options?: { keepShowingIfMatchedCurrent?: boolean },
   ): void {
-    if (this.sideBarSize === 0) {
-      this.sideBarSize = this.sideBarSizeBeforeHidden;
+    if (!this.sideBarDisplayState.isOpen) {
+      this.sideBarDisplayState.open();
     } else if (
       activity === this.activeActivity &&
       !options?.keepShowingIfMatchedCurrent
     ) {
-      this.sideBarSizeBeforeHidden = this.sideBarSize || DEFAULT_SIDE_BAR_SIZE;
-      this.sideBarSize = 0;
+      this.sideBarDisplayState.close();
     }
     this.activeActivity = activity;
   }

--- a/packages/legend-studio/src/stores/__tests__/ImportResolutionRoundtrip.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/ImportResolutionRoundtrip.test.ts
@@ -142,7 +142,7 @@ describe(unitTest('Flat-data import resolution roundtrip'), () => {
 describe(unitTest('Relational import resolution roundtrip'), () => {
   test.each([
     // TODO: import resolution for included stores?
-    ['Simple database', testDatabaseRoundtrip],
+    ['Complex database with includes', testDatabaseRoundtrip],
     ['Database with self join', testDatabaseWithSelfJoin],
     // testRelationalInputData
     // targetSetImplementationThroughAssociation

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  computed,
-  action,
-  makeObservable,
-  observable,
-  makeAutoObservable,
-} from 'mobx';
+import { computed, action, makeObservable, observable } from 'mobx';
 import type { EditorStore } from '../../EditorStore';
 import {
   guaranteeNonNullable,
@@ -40,6 +34,7 @@ import {
 import { Package } from '../../../models/metamodels/pure/model/packageableElements/domain/Package';
 import type { PackageTreeNodeData } from '../../shared/TreeUtil';
 import type { TreeData } from '@finos/legend-studio-components';
+import { PanelDisplayState } from '@finos/legend-studio-components';
 import type { ClassView } from '../../../models/metamodels/pure/model/packageableElements/diagram/ClassView';
 import { GenericTypeExplicitReference } from '../../../models/metamodels/pure/model/packageableElements/domain/GenericTypeReference';
 import { TYPICAL_MULTIPLICITY_TYPE } from '../../../models/MetaModelConst';
@@ -115,66 +110,6 @@ export class DiagramEditorNewClassSidePanelState extends DiagramEditorSidePanelS
 
   setPackageTreeData(val: TreeData<PackageTreeNodeData>): void {
     this.packageTreeData = val;
-  }
-}
-
-class PanelDisplayState {
-  size: number;
-  sizeBeforeHidden: number;
-  defaultSize: number;
-  snapSize?: number;
-
-  constructor(size: {
-    initial: number;
-    default: number;
-    snap: number | undefined;
-  }) {
-    this.size = size.initial;
-    this.sizeBeforeHidden = size.default;
-    this.defaultSize = size.default;
-    this.snapSize = size.snap;
-
-    makeAutoObservable(this, {
-      isOpen: computed,
-      setSize: action,
-      toggle: action,
-      open: action,
-      close: action,
-    });
-  }
-
-  get isOpen(): boolean {
-    return this.size !== 0;
-  }
-
-  setSize(val: number): void {
-    if (this.snapSize !== undefined) {
-      this.size =
-        val < this.snapSize ? (this.size > 0 ? 0 : this.defaultSize) : val;
-    } else {
-      this.size = val;
-    }
-  }
-
-  open(): void {
-    if (this.size === 0) {
-      this.size = this.sizeBeforeHidden;
-    }
-  }
-
-  close(): void {
-    if (this.size !== 0) {
-      this.sizeBeforeHidden = this.size || this.defaultSize;
-      this.size = 0;
-    }
-  }
-
-  toggle(): void {
-    if (this.size === 0) {
-      this.open();
-    } else {
-      this.close();
-    }
   }
 }
 

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -174,9 +174,7 @@ export class DiagramEditorState extends ElementEditorState {
 
   setupDiagramRenderer(): void {
     this.diagramRenderer.setIsReadOnly(this.isReadOnly);
-    this.diagramRenderer.onClassViewDoubleClick = (
-      classView: ClassView,
-    ): void => {
+    this.diagramRenderer.editClass = (classView: ClassView): void => {
       this.setSidePanelState(
         new DiagramEditorClassEditorSidePanelState(
           this.editorStore,
@@ -207,7 +205,7 @@ export class DiagramEditorState extends ElementEditorState {
     };
     this.diagramRenderer.onBackgroundDoubleClick = createNewClassView;
     this.diagramRenderer.onAddClassViewClick = createNewClassView;
-    this.diagramRenderer.onAddClassPropertyForSelectedClass = (
+    this.diagramRenderer.addClassPropertyForSelectedClass = (
       classView: ClassView,
     ): void => {
       if (

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -19,15 +19,103 @@ import type { EditorStore } from '../../EditorStore';
 import {
   guaranteeNonNullable,
   guaranteeType,
+  uuid,
 } from '@finos/legend-studio-shared';
 import { ElementEditorState } from './ElementEditorState';
 import type { PackageableElement } from '../../../models/metamodels/pure/model/packageableElements/PackageableElement';
 import { Diagram } from '../../../models/metamodels/pure/model/packageableElements/diagram/Diagram';
 import type { DiagramRenderer } from '../../../components/shared/diagram-viewer/DiagramRenderer';
+import { ClassEditorState } from './ClassEditorState';
+import {
+  getPackableElementTreeData,
+  getSelectedPackageTreeNodePackage,
+  openNode,
+} from '../../shared/PackageTreeUtil';
+import { Package } from '../../../models/metamodels/pure/model/packageableElements/domain/Package';
+import type { PackageTreeNodeData } from '../../shared/TreeUtil';
+import type { TreeData } from '@finos/legend-studio-components';
+import type { ClassView } from '../../../models/metamodels/pure/model/packageableElements/diagram/ClassView';
+import { GenericTypeExplicitReference } from '../../../models/metamodels/pure/model/packageableElements/domain/GenericTypeReference';
+import { TYPICAL_MULTIPLICITY_TYPE } from '../../../models/MetaModelConst';
+import { Property } from '../../../models/metamodels/pure/model/packageableElements/domain/Property';
+import { GenericType } from '../../../models/metamodels/pure/model/packageableElements/domain/GenericType';
+
+export abstract class DiagramEditorSidePanelState {
+  uuid = uuid();
+  editorStore: EditorStore;
+  diagramEditorState: DiagramEditorState;
+
+  constructor(
+    editorStore: EditorStore,
+    diagramEditorState: DiagramEditorState,
+  ) {
+    this.editorStore = editorStore;
+    this.diagramEditorState = diagramEditorState;
+  }
+}
+
+export class DiagramEditorClassEditorSidePanelState extends DiagramEditorSidePanelState {
+  classEditorState: ClassEditorState;
+
+  constructor(
+    editorStore: EditorStore,
+    diagramEditorState: DiagramEditorState,
+    classEditorState: ClassEditorState,
+  ) {
+    super(editorStore, diagramEditorState);
+    this.classEditorState = classEditorState;
+  }
+}
+
+export class DiagramEditorNewClassSidePanelState extends DiagramEditorSidePanelState {
+  creationMouseEvent: MouseEvent;
+  packageTreeData: TreeData<PackageTreeNodeData>;
+
+  constructor(
+    editorStore: EditorStore,
+    diagramEditorState: DiagramEditorState,
+    creationMouseEvent: MouseEvent,
+  ) {
+    super(editorStore, diagramEditorState);
+
+    makeObservable(this, {
+      packageTreeData: observable,
+      setPackageTreeData: action,
+    });
+
+    this.creationMouseEvent = creationMouseEvent;
+    const treeData = getPackableElementTreeData(
+      editorStore,
+      editorStore.graphState.graph.root,
+      '',
+      (childElement: PackageableElement) => childElement instanceof Package,
+    );
+    const selectedPackageTreeNodePackage = getSelectedPackageTreeNodePackage(
+      editorStore.explorerTreeState.selectedNode,
+    );
+    if (selectedPackageTreeNodePackage) {
+      const openingNode = openNode(
+        editorStore,
+        selectedPackageTreeNodePackage,
+        treeData,
+        (childElement: PackageableElement) => childElement instanceof Package,
+      );
+      if (openingNode) {
+        openingNode.isSelected = true;
+      }
+    }
+    this.packageTreeData = treeData;
+  }
+
+  setPackageTreeData(val: TreeData<PackageTreeNodeData>): void {
+    this.packageTreeData = val;
+  }
+}
 
 export class DiagramEditorState extends ElementEditorState {
   _diagramRenderer?: DiagramRenderer;
   showHotkeyInfosModal = false;
+  sidePanelState?: DiagramEditorSidePanelState;
 
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
@@ -35,11 +123,13 @@ export class DiagramEditorState extends ElementEditorState {
     makeObservable(this, {
       _diagramRenderer: observable,
       showHotkeyInfosModal: observable,
+      sidePanelState: observable,
       diagramRenderer: computed,
       diagram: computed,
       isDiagramRendererInitialized: computed,
       setShowHotkeyInfosModal: action,
       setDiagramRenderer: action,
+      setSidePanelState: action,
       reprocess: action,
     });
   }
@@ -69,6 +159,68 @@ export class DiagramEditorState extends ElementEditorState {
 
   setShowHotkeyInfosModal(val: boolean): void {
     this.showHotkeyInfosModal = val;
+  }
+
+  setSidePanelState(val: DiagramEditorSidePanelState | undefined): void {
+    this.sidePanelState = val;
+  }
+
+  setupDiagramRenderer(): void {
+    this.diagramRenderer.setIsReadOnly(this.isReadOnly);
+    this.diagramRenderer.onClassViewDoubleClick = (
+      classView: ClassView,
+    ): void => {
+      this.setSidePanelState(
+        new DiagramEditorClassEditorSidePanelState(
+          this.editorStore,
+          this,
+          guaranteeType(
+            this.editorStore.openedEditorStates.find(
+              (elementState): elementState is ClassEditorState =>
+                elementState instanceof ClassEditorState &&
+                elementState.element === classView.class.value,
+            ) ?? this.editorStore.createElementState(classView.class.value),
+            ClassEditorState,
+          ),
+        ),
+      );
+      // showSidePanel();
+    };
+    const createNewClassView = (event: MouseEvent): void => {
+      if (!this.isReadOnly) {
+        this.setSidePanelState(
+          new DiagramEditorNewClassSidePanelState(
+            this.editorStore,
+            this,
+            event,
+          ),
+        );
+        // showSidePanel();
+      }
+    };
+    this.diagramRenderer.onBackgroundDoubleClick = createNewClassView;
+    this.diagramRenderer.onAddClassViewClick = createNewClassView;
+    this.diagramRenderer.onAddClassPropertyForSelectedClass = (
+      classView: ClassView,
+    ): void => {
+      if (
+        this.sidePanelState instanceof DiagramEditorClassEditorSidePanelState
+      ) {
+        const _class = this.sidePanelState.classEditorState.class;
+        _class.addProperty(
+          new Property(
+            `newProperty_${_class.properties.length}`,
+            this.editorStore.graphState.graph.getTypicalMultiplicity(
+              TYPICAL_MULTIPLICITY_TYPE.ONE,
+            ),
+            GenericTypeExplicitReference.create(
+              new GenericType(classView.class.value),
+            ),
+            _class,
+          ),
+        );
+      }
+    };
   }
 
   reprocess(

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -14,19 +14,32 @@
  * limitations under the License.
  */
 
-import { computed, action, makeObservable } from 'mobx';
+import { computed, action, makeObservable, observable } from 'mobx';
 import type { EditorStore } from '../../EditorStore';
-import { guaranteeType } from '@finos/legend-studio-shared';
+import {
+  guaranteeNonNullable,
+  guaranteeType,
+} from '@finos/legend-studio-shared';
 import { ElementEditorState } from './ElementEditorState';
 import type { PackageableElement } from '../../../models/metamodels/pure/model/packageableElements/PackageableElement';
 import { Diagram } from '../../../models/metamodels/pure/model/packageableElements/diagram/Diagram';
+import type { DiagramRenderer } from '../../../components/shared/diagram-viewer/DiagramRenderer';
 
 export class DiagramEditorState extends ElementEditorState {
+  _diagramRenderer?: DiagramRenderer;
+  showHotkeyInfosModal = false;
+
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
 
     makeObservable(this, {
+      _diagramRenderer: observable,
+      showHotkeyInfosModal: observable,
+      diagramRenderer: computed,
       diagram: computed,
+      isDiagramRendererInitialized: computed,
+      setShowHotkeyInfosModal: action,
+      setDiagramRenderer: action,
       reprocess: action,
     });
   }
@@ -37,6 +50,25 @@ export class DiagramEditorState extends ElementEditorState {
       Diagram,
       'Element inside diagram editor state must be a diagram',
     );
+  }
+
+  get diagramRenderer(): DiagramRenderer {
+    return guaranteeNonNullable(
+      this._diagramRenderer,
+      `Diagram renderer must be initialized (this is likely caused by calling this method at the wrong place)`,
+    );
+  }
+
+  get isDiagramRendererInitialized(): boolean {
+    return Boolean(this._diagramRenderer);
+  }
+
+  setDiagramRenderer(val: DiagramRenderer): void {
+    this._diagramRenderer = val;
+  }
+
+  setShowHotkeyInfosModal(val: boolean): void {
+    this.showHotkeyInfosModal = val;
   }
 
   reprocess(

--- a/packages/legend-studio/style/_mixins.scss
+++ b/packages/legend-studio/style/_mixins.scss
@@ -49,3 +49,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+@mixin flexConstantDimension {
+  flex-grow: 0;
+  flex-shrink: 0;
+}

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -40,6 +40,7 @@
 
   &__header__action {
     @include flexCenter;
+    @include flexConstantDimension;
 
     height: 2.8rem;
     width: 2.8rem;
@@ -94,6 +95,8 @@
     border-left: 0.1rem solid var(--color-dark-grey-85);
 
     &__divider {
+      @include flexConstantDimension;
+
       width: 100%;
       border-radius: 0.1rem;
       height: 0.2rem;
@@ -104,6 +107,7 @@
 
   &__tool {
     @include flexCenter;
+    @include flexConstantDimension;
 
     height: 3.4rem;
     width: 3.4rem;

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -129,6 +129,8 @@
       height: 100%;
       width: 100%;
       color: var(--color-dark-grey-300);
+      padding: 2rem;
+      text-align: center;
     }
 
     &__close-btn {

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -110,7 +110,7 @@
     }
   }
 
-  &__class-panel {
+  &__side-panel {
     border-left: 0.1rem solid var(--color-light-grey-400);
 
     &__header {
@@ -121,16 +121,6 @@
 
     &__content {
       position: relative;
-    }
-
-    &__content__editor--empty {
-      @include flexCenter;
-
-      height: 100%;
-      width: 100%;
-      color: var(--color-dark-grey-300);
-      padding: 2rem;
-      text-align: center;
     }
 
     &__close-btn {
@@ -177,7 +167,7 @@
   }
 }
 
-.diagram-editor__class-panel__create-new {
+.diagram-editor__side-panel__create-new {
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -20,7 +20,68 @@
   height: 100%;
   width: 100%;
   display: flex;
-  position: relative;
+  flex-direction: column;
+  overflow: hidden;
+
+  &__header {
+    @include flexVCenter;
+
+    justify-content: flex-end;
+    height: 2.8rem;
+    background: var(--color-dark-grey-200);
+    border: 0.1rem solid var(--color-dark-grey-85);
+  }
+
+  &__header__actions {
+    @include flexVCenter;
+
+    height: 100%;
+  }
+
+  &__header__action {
+    @include flexCenter;
+
+    height: 2.8rem;
+    width: 2.8rem;
+
+    svg {
+      color: var(--color-dark-grey-400);
+    }
+
+    &--active {
+      svg {
+        color: var(--color-light-grey-300);
+      }
+    }
+  }
+
+  &__content {
+    height: calc(100% - 2.8rem);
+    width: 100%;
+    display: flex;
+    position: relative;
+    overflow: hidden;
+  }
+
+  &__stage {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    position: relative;
+  }
+
+  &__overlay {
+    position: absolute;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  &__overlay__panel-resizer,
+  &__overlay__panel {
+    pointer-events: auto;
+  }
 
   &__tools {
     @include flexVCenter;
@@ -97,6 +158,10 @@
 
     &--hotkey-info {
       font-size: 2.2rem;
+    }
+
+    &--sidebar {
+      font-size: 1.8rem;
     }
   }
 

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -173,9 +173,25 @@
     width: calc(100% - 4.4rem);
   }
 
-  &__canvas--with-cursor {
+  &__cursor {
     &--crosshair {
       cursor: crosshair;
+    }
+
+    &--text {
+      cursor: text;
+    }
+
+    &--pointer {
+      cursor: pointer;
+    }
+
+    &--resize {
+      cursor: nwse-resize;
+    }
+
+    &--add {
+      cursor: cell;
     }
   }
 

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -236,6 +236,56 @@
   }
 }
 
+.diagram-editor__inline-property-editor {
+  @include flexVCenter;
+
+  height: 2.8rem;
+  width: 23.9rem;
+  padding: 0.3rem;
+
+  &__name {
+    @include flexConstantDimension;
+
+    width: 15rem;
+    height: 2.2rem;
+    border: 0.1rem solid var(--color-dark-grey-300);
+  }
+
+  &__multiplicity-editor {
+    @include flexVCenter;
+    @include flexConstantDimension;
+
+    width: 8rem;
+    margin-left: 0.3rem;
+
+    &__bound {
+      @include flexConstantDimension;
+
+      width: 3rem;
+      padding: 0 0.5rem;
+      height: 2.2rem;
+      border: 0.1rem solid var(--color-dark-grey-300);
+    }
+
+    &__range {
+      @include flexCenter;
+      @include flexConstantDimension;
+
+      width: 2rem;
+      padding: 0 0.3rem;
+      font-size: 2rem;
+      font-weight: bold;
+      height: 2.2rem;
+      color: var(--color-dark-grey-400);
+      cursor: default;
+    }
+  }
+
+  &__close-btn {
+    display: none;
+  }
+}
+
 .diagram-editor__side-panel__create-new {
   height: 100%;
   display: flex;

--- a/packages/legend-studio/style/components/editor/uml-editor/_class-editor.scss
+++ b/packages/legend-studio/style/components/editor/uml-editor/_class-editor.scss
@@ -51,7 +51,8 @@
   }
 
   &__multiplicity {
-    display: flex;
+    @include flexVCenter;
+
     background: var(--color-light-grey-200);
     margin-left: 0.5rem;
     padding: 0.3rem;
@@ -59,11 +60,10 @@
   }
 
   &__multiplicity__range {
-    padding: 0 0.3rem;
-    font-size: 2rem;
-
     @include flexVCenter;
 
+    padding: 0 0.3rem;
+    font-size: 2rem;
     font-weight: bold;
     height: 2.2rem;
     color: var(--color-dark-grey-400);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,7 +1843,7 @@ __metadata:
     react: 17.0.2
     rimraf: 3.0.2
     typescript: 4.3.5
-    webpack: 5.44.0
+    webpack: 5.45.1
     webpack-bundle-analyzer: 4.4.2
     webpack-cli: 4.7.2
     webpack-dev-server: 4.0.0-beta.3
@@ -1915,8 +1915,8 @@ __metadata:
     jsonc-parser: 3.0.0
     micromatch: 4.0.4
     mini-css-extract-plugin: 2.1.0
-    monaco-editor: 0.26.0
-    monaco-editor-webpack-plugin: 4.1.0
+    monaco-editor: 0.26.1
+    monaco-editor-webpack-plugin: 4.1.1
     postcss: 8.3.5
     postcss-loader: 6.1.1
     react-refresh: 0.10.0
@@ -1927,7 +1927,7 @@ __metadata:
     strip-ansi: 7.0.0
     text-table: 0.2.0
     typescript: 4.3.5
-    webpack: 5.44.0
+    webpack: 5.45.1
     wrap-ansi: 8.0.0
   languageName: unknown
   linkType: soft
@@ -2027,7 +2027,7 @@ __metadata:
     jest: 27.0.6
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
-    monaco-editor: 0.26.0
+    monaco-editor: 0.26.1
     npm-run-all: 4.1.5
     react: 17.0.2
     rimraf: 3.0.2
@@ -2079,7 +2079,7 @@ __metadata:
     jest: 27.0.6
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
-    monaco-editor: 0.26.0
+    monaco-editor: 0.26.1
     npm-run-all: 4.1.5
     papaparse: 5.3.1
     react: 17.0.2
@@ -2150,7 +2150,7 @@ __metadata:
     jest-extended: 0.11.5
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
-    monaco-editor: 0.26.0
+    monaco-editor: 0.26.1
     node-diff3: 3.0.0
     npm-run-all: 4.1.5
     react: 17.0.2
@@ -3030,10 +3030,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:16.3.2":
+"@types/node@npm:*":
   version: 16.3.2
   resolution: "@types/node@npm:16.3.2"
   checksum: 242d23b6f9f93afa49eecac179444762000e99667a742c8b1de18c7875c7c952436ab319ea4fe3dca3e66bacb9e4f0ed69a25df9a155c6cedfc8cdaf52cb3453
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:16.3.3":
+  version: 16.3.3
+  resolution: "@types/node@npm:16.3.3"
+  checksum: fa885b835e57a4a2fd15571e5cbfe361d4ac48278196416aa2690ebdfb118a116249dd81475078c61fbf2d95920324f8f3a66ae7f19fac424ae74ab87a41c1e4
   languageName: node
   linkType: hard
 
@@ -9404,7 +9411,7 @@ __metadata:
     "@finos/stylelint-config-legend-studio": "workspace:*"
     "@juggle/resize-observer": 3.3.1
     "@types/jest": 26.0.24
-    "@types/node": 16.3.2
+    "@types/node": 16.3.3
     chalk: 4.1.1
     cross-env: 7.0.3
     eslint: 7.30.0
@@ -10250,22 +10257,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"monaco-editor-webpack-plugin@npm:4.1.0":
-  version: 4.1.0
-  resolution: "monaco-editor-webpack-plugin@npm:4.1.0"
+"monaco-editor-webpack-plugin@npm:4.1.1":
+  version: 4.1.1
+  resolution: "monaco-editor-webpack-plugin@npm:4.1.1"
   dependencies:
     loader-utils: ^2.0.0
   peerDependencies:
-    monaco-editor: "*"
+    monaco-editor: 0.25.x || 0.26.x
     webpack: ^4.5.0 || 5.x
-  checksum: 0a4430b22b6aba95073208b1c89b978f14ac53a841ee3d93515d7ebc94ed407511ae90018e3fb379371fc7d5ad77999aff470cb5efa830a882d6860de2f54739
+  checksum: 869edbd9b726a87facd39714e70a32957a880e63069b342fe0f931115c0ef2ae644d6c8dcbe92a3f1b1b0d24b3b096a5c50f06f5f0bff648462f1d553f4cc5f7
   languageName: node
   linkType: hard
 
-"monaco-editor@npm:0.26.0":
-  version: 0.26.0
-  resolution: "monaco-editor@npm:0.26.0"
-  checksum: d59bfd7b4f04a7560dfb5d0a6fd580b67a9ee63a70fde92f33c6d42b0275501b645b99d321d600dd2d76a8bcb9949c23f8947a38c28bf759564b5ec82727033d
+"monaco-editor@npm:0.26.1":
+  version: 0.26.1
+  resolution: "monaco-editor@npm:0.26.1"
+  checksum: 2d531aa1245c891330e398c6ddb63fa9489a3cb4c668e304aa1ead6d5e3a14ee30e601fb94d265f7f00bfb1abe197e6dfcdfbebc1e307ea8efa99b3ecb069278
   languageName: node
   linkType: hard
 
@@ -12864,7 +12871,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.0.0":
+"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.0":
   version: 3.1.0
   resolution: "schema-utils@npm:3.1.0"
   dependencies:
@@ -14880,9 +14887,9 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.44.0":
-  version: 5.44.0
-  resolution: "webpack@npm:5.44.0"
+"webpack@npm:5.45.1":
+  version: 5.45.1
+  resolution: "webpack@npm:5.45.1"
   dependencies:
     "@types/eslint-scope": ^3.7.0
     "@types/estree": ^0.0.50
@@ -14902,7 +14909,7 @@ typescript@4.3.5:
     loader-runner: ^4.2.0
     mime-types: ^2.1.27
     neo-async: ^2.6.2
-    schema-utils: ^3.0.0
+    schema-utils: ^3.1.0
     tapable: ^2.1.1
     terser-webpack-plugin: ^5.1.3
     watchpack: ^2.2.0
@@ -14912,7 +14919,7 @@ typescript@4.3.5:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: a173d875045267b5cb8ead959c1b47dc06ca191ee7cdbf6a094d5947261f1e4e167addc20eb65945078500247b74497e65270f4dbca1bcaf17327b462800c0ef
+  checksum: 7aca5a40bf95d83c89b30b7c58da70e6aba672fc97b8f8ddea18516ce026706982b3b6b5c9509a6295b87de889df64f9a08e125ba9a36a128cb84cbce742225c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Diagram editor UX improvements (see https://github.com/finos/legend-studio/issues/300):

- [x] Cleanup diagram editor state: we now can access the diagram renderer from editor state
- [x] Rework layout of diagram editor: header, side panel, etc.
- [x] Support in-place property editing
- [x] Change cursor based on edit modes and interactions with the diagram

### Other refactors
- [x] Create `PanelDisplayState` which controls the size of panels and size-related interactions, including open, close, toggle, maximize, minimize, snap, etc.