### PR TITLE
More diagram editor improvements

### DIFF
--- a/.changeset/dirty-glasses-admire.md
+++ b/.changeset/dirty-glasses-admire.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Allow configuring class view in diagram editor side panel.

--- a/.changeset/dull-news-move.md
+++ b/.changeset/dull-news-move.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Make diagram editor hotkeys more systematic.

--- a/.changeset/sharp-rings-clean.md
+++ b/.changeset/sharp-rings-clean.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Allow users to align selected class views in diagram editor.

--- a/.changeset/sharp-rings-clean.md
+++ b/.changeset/sharp-rings-clean.md
@@ -1,5 +1,0 @@
----
-'@finos/legend-studio': patch
----
-
-Allow users to align selected class views in diagram editor.

--- a/.changeset/shiny-melons-dream.md
+++ b/.changeset/shiny-melons-dream.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Rework how zooming works in diagram editor. Now, upon scrolling, zoom will use the pointer location as the zoom center rather than using the canvas center. Also, we allow user to be able to choose the zoom level or do a zoom to fit.

--- a/.changeset/shiny-melons-dream.md
+++ b/.changeset/shiny-melons-dream.md
@@ -2,4 +2,4 @@
 '@finos/legend-studio': patch
 ---
 
-Rework how zooming works in diagram editor. Now, upon scrolling, zoom will use the pointer location as the zoom center rather than using the canvas center. Also, we allow user to be able to choose the zoom level or do a zoom to fit.
+Rework how zooming works in diagram editor. Now, upon scrolling, zoom will use the pointer location as the zoom center rather than using the canvas center. Also, we allow user to be able to choose the zoom level or do a zoom to fit. Also, we now disallow negative zoom level and cap at the minimum level of 5%.

--- a/.changeset/smooth-rice-listen.md
+++ b/.changeset/smooth-rice-listen.md
@@ -1,0 +1,17 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-manual-tests': patch
+'@finos/legend-studio-network': patch
+'@finos/legend-studio-plugin-management': patch
+'@finos/legend-studio-plugin-tracer-zipkin': patch
+'@finos/legend-studio-preset-dsl-text': patch
+'@finos/legend-studio-preset-external-format-json-schema': patch
+'@finos/legend-studio-preset-query-builder': patch
+'@finos/legend-studio-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/.changeset/wild-donkeys-shave.md
+++ b/.changeset/wild-donkeys-shave.md
@@ -1,0 +1,17 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-manual-tests': patch
+'@finos/legend-studio-network': patch
+'@finos/legend-studio-plugin-management': patch
+'@finos/legend-studio-plugin-tracer-zipkin': patch
+'@finos/legend-studio-preset-dsl-text': patch
+'@finos/legend-studio-preset-external-format-json-schema': patch
+'@finos/legend-studio-preset-query-builder': patch
+'@finos/legend-studio-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/node": "16.3.3",
     "chalk": "4.1.1",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "fs-extra": "10.0.0",
     "husky": "7.0.1",
     "jest": "27.0.6",

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "rimraf": "3.0.2",
     "typescript": "4.3.5"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,7 +33,7 @@
     "@babel/eslint-parser": "7.14.7",
     "@typescript-eslint/eslint-plugin": "4.28.3",
     "@typescript-eslint/parser": "4.28.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-prettier": "3.4.0",

--- a/packages/legend-studio-app/package.json
+++ b/packages/legend-studio-app/package.json
@@ -49,7 +49,7 @@
     "@finos/legend-studio-shared": "workspace:*",
     "copy-webpack-plugin": "9.0.1",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-components/package.json
+++ b/packages/legend-studio-components/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-components/src/components/BaseMuiComponents.tsx
+++ b/packages/legend-studio-components/src/components/BaseMuiComponents.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { MenuProps } from '@material-ui/core';
-import { makeStyles, Menu } from '@material-ui/core';
+import type { MenuProps, PopoverProps } from '@material-ui/core';
+import { makeStyles, Menu, Popover } from '@material-ui/core';
 
 const useBaseMenuStyles = makeStyles({
   listPadding: {
@@ -46,6 +46,33 @@ export const BaseMenu: React.FC<MenuProps> = (props: MenuProps) => {
     >
       {props.children}
     </Menu>
+  );
+};
+
+const useBasePopoverStyles = makeStyles({
+  paper: {
+    background: 'var(--color-dark-grey-100)',
+    // NOTE: this is needed in order to have elements display go beyond
+    // the boundary of the popover, e.g. elements shown with `display: relative`
+    // such as validation error for inputs
+    overflow: 'unset',
+  },
+});
+
+export const BasePopover: React.FC<PopoverProps> = (props: PopoverProps) => {
+  const classes = useBasePopoverStyles();
+  const { children, ...otherProps } = props;
+
+  return (
+    <Popover
+      classes={{
+        paper: classes.paper,
+      }}
+      transitionDuration={0}
+      {...otherProps}
+    >
+      {props.children}
+    </Popover>
   );
 };
 

--- a/packages/legend-studio-components/src/components/menu/MenuContent.tsx
+++ b/packages/legend-studio-components/src/components/menu/MenuContent.tsx
@@ -47,6 +47,13 @@ export const MenuContentItem: React.FC<{
   );
 };
 
+export const MenuContentDivider: React.FC<{
+  className?: string;
+}> = (props) => {
+  const { className, ...otherProps } = props;
+  return <div className={clsx('menu__divider', className)} {...otherProps} />;
+};
+
 export const MenuContentItemIcon: React.FC<{
   className?: string;
 }> = (props) => {

--- a/packages/legend-studio-components/style/base/_common.scss
+++ b/packages/legend-studio-components/style/base/_common.scss
@@ -37,6 +37,10 @@
 }
 
 .hotkey {
+  &__combination {
+    @include flexVCenter;
+  }
+
   &__key {
     @include flexVCenter;
 
@@ -44,16 +48,13 @@
     padding: 0 0.7rem;
     border-radius: 0.3rem;
     margin: 0 0.2rem;
+    font-size: 1.2rem;
     font-weight: 500;
+    font-family: 'Roboto Mono', monospace;
   }
 
   &__plus svg {
     font-size: 1rem;
-    margin: 0 0.2rem;
-  }
-
-  &__spacer {
-    width: 0.6rem;
     margin: 0 0.2rem;
   }
 }

--- a/packages/legend-studio-components/style/base/_menu.scss
+++ b/packages/legend-studio-components/style/base/_menu.scss
@@ -59,4 +59,13 @@
   &__item:not([disabled]):hover {
     background: var(--color-light-blue-450);
   }
+
+  &__divider {
+    @include flexConstantDimension;
+
+    border-radius: 0.1rem;
+    height: 0.2rem;
+    background: var(--color-dark-grey-300);
+    margin: 0.5rem;
+  }
 }

--- a/packages/legend-studio-components/style/base/_modal.scss
+++ b/packages/legend-studio-components/style/base/_modal.scss
@@ -97,6 +97,15 @@
   }
 }
 
+.modal.modal--scrollable {
+  height: 100%;
+
+  .modal__body {
+    height: calc(100% - 3.6rem);
+    overflow-y: auto;
+  }
+}
+
 .modal.modal--dark {
   background: var(--color-dark-grey-50);
   color: var(--color-light-grey-200);
@@ -144,6 +153,11 @@
 
   &__content {
     max-width: 100vw !important;
+  }
+
+  &__content--scrollable {
+    max-width: 100vw !important;
+    height: 100%;
   }
 
   .modal__body {

--- a/packages/legend-studio-dev-utils/package.json
+++ b/packages/legend-studio-dev-utils/package.json
@@ -60,7 +60,7 @@
     "circular-dependency-plugin": "5.2.2",
     "clean-webpack-plugin": "3.0.0",
     "cosmiconfig": "7.0.0",
-    "css-loader": "6.0.0",
+    "css-loader": "6.1.0",
     "cssnano": "5.0.6",
     "fork-ts-checker-webpack-plugin": "6.2.12",
     "html-webpack-plugin": "5.3.2",
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "rimraf": "3.0.2"
   },
   "publishConfig": {

--- a/packages/legend-studio-manual-tests/package.json
+++ b/packages/legend-studio-manual-tests/package.json
@@ -32,7 +32,7 @@
     "@finos/legend-studio-dev-utils": "workspace:*",
     "axios": "0.21.1",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-network/package.json
+++ b/packages/legend-studio-network/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "rimraf": "3.0.2",
     "typescript": "4.3.5"

--- a/packages/legend-studio-plugin-management/package.json
+++ b/packages/legend-studio-plugin-management/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-plugin-tracer-zipkin/package.json
+++ b/packages/legend-studio-plugin-tracer-zipkin/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "rimraf": "3.0.2",
     "typescript": "4.3.5"

--- a/packages/legend-studio-preset-dsl-text/package.json
+++ b/packages/legend-studio-preset-dsl-text/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-preset-external-format-json-schema/package.json
+++ b/packages/legend-studio-preset-external-format-json-schema/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-preset-query-builder/package.json
+++ b/packages/legend-studio-preset-query-builder/package.json
@@ -64,7 +64,7 @@
     "@testing-library/dom": "8.1.0",
     "@testing-library/react": "12.0.0",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-preset-query-builder/src/components/QueryBuilderResultPanel.tsx
+++ b/packages/legend-studio-preset-query-builder/src/components/QueryBuilderResultPanel.tsx
@@ -212,9 +212,9 @@ export const QueryBuilderResultPanel = observer(
             showModal={resultState.showServicePathModal}
             promoteToService={(
               name: string,
-              packageName: string,
+              packagePath: string,
             ): Promise<void> =>
-              flowResult(resultState.promoteToService(name, packageName))
+              flowResult(resultState.promoteToService(name, packagePath))
             }
           />
         )}

--- a/packages/legend-studio-preset-query-builder/src/stores/QueryBuilderResultState.ts
+++ b/packages/legend-studio-preset-query-builder/src/stores/QueryBuilderResultState.ts
@@ -145,7 +145,7 @@ export class QueryBuilderResultState {
   }
 
   *promoteToService(
-    packageName: string,
+    packagePath: string,
     serviceName: string,
   ): GeneratorFn<void> {
     try {
@@ -166,9 +166,7 @@ export class QueryBuilderResultState {
         ),
       );
       const servicePackage =
-        this.editorStore.graphState.graph.getOrCreatePackageWithPackageName(
-          packageName,
-        );
+        this.editorStore.graphState.graph.getOrCreatePackage(packagePath);
       servicePackage.addElement(service);
       this.editorStore.graphState.graph.addElement(service);
       this.editorStore.openElement(service);

--- a/packages/legend-studio-shared/package.json
+++ b/packages/legend-studio-shared/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@finos/legend-studio-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "lodash": "4.17.21",
     "rimraf": "3.0.2",

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -69,7 +69,7 @@
     "@finos/legend-studio-dev-utils": "workspace:*",
     "@testing-library/dom": "8.1.0",
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "jest": "27.0.6",
     "jest-canvas-mock": "2.3.1",
     "jest-extended": "0.11.5",

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -24,6 +24,7 @@ import { FaRegKeyboard } from 'react-icons/fa';
 import { observer } from 'mobx-react-lite';
 import {
   DiagramRenderer,
+  DIAGRAM_ALIGN_MODE,
   DIAGRAM_INTERACTION_MODE,
   DIAGRAM_RELATIONSHIP_EDIT_MODE,
   DIAGRAM_ZOOM_LEVELS,
@@ -53,6 +54,8 @@ import {
   MenuContent,
   MenuContentDivider,
   MenuContentItem,
+  MenuContentItemIcon,
+  MenuContentItemLabel,
   SquareIcon,
   TimesIcon,
 } from '@finos/legend-studio-components';
@@ -69,6 +72,14 @@ import {
   FiZoomIn,
   FiZoomOut,
 } from 'react-icons/fi';
+import {
+  CgAlignBottom,
+  CgAlignCenter,
+  CgAlignLeft,
+  CgAlignMiddle,
+  CgAlignRight,
+  CgAlignTop,
+} from 'react-icons/cg';
 import { IoResize } from 'react-icons/io5';
 import { useApplicationStore } from '../../../../stores/ApplicationStore';
 import { Dialog } from '@material-ui/core';
@@ -198,66 +209,16 @@ const DiagramEditorToolPanel = observer(
       diagramEditorState.setShowHotkeyInfosModal(true);
     const hideDiagramRendererHokeysModal = (): void =>
       diagramEditorState.setShowHotkeyInfosModal(false);
-
-    const useViewTool = (): void => {
-      if (!isReadOnly) {
-        renderer.changeMode(
-          DIAGRAM_INTERACTION_MODE.LAYOUT,
-          DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
-        );
-      }
-    };
-
-    const usePropertyTool = (): void => {
-      if (!isReadOnly) {
-        renderer.changeMode(
-          DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
-          DIAGRAM_RELATIONSHIP_EDIT_MODE.PROPERTY,
-        );
-      }
-    };
-
-    const useAssociationTool = (): void => {
-      if (!isReadOnly) {
-        applicationStore.notifyUnsupportedFeature(`Create association`);
-        // diagramRenderer.changeMode(
-        //   DIAGRAM_EDIT_MODE.RELATIONSHIP,
-        //   DIAGRAM_RELATIONSHIP_EDIT_MODE.ASSOCIATION,
-        // );
-      }
-    };
-
-    const useInheritanceTool = (): void => {
-      if (!isReadOnly) {
-        renderer.changeMode(
-          DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
-          DIAGRAM_RELATIONSHIP_EDIT_MODE.INHERITANCE,
-        );
-      }
-    };
-
-    const zoomIn = (): void => {
-      renderer.changeMode(
-        DIAGRAM_INTERACTION_MODE.ZOOM_IN,
-        DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
-      );
-    };
-
-    const zoomOut = (): void => {
-      renderer.changeMode(
-        DIAGRAM_INTERACTION_MODE.ZOOM_OUT,
-        DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
-      );
-    };
-
-    const addNewClassView = (): void => {
-      if (!isReadOnly) {
-        renderer.changeMode(
-          DIAGRAM_INTERACTION_MODE.ADD_CLASS,
-          DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
-        );
-      }
-    };
+    const createModeSwitcher =
+      (
+        editMode: DIAGRAM_INTERACTION_MODE,
+        relationshipMode: DIAGRAM_RELATIONSHIP_EDIT_MODE,
+      ): (() => void) =>
+      (): void => {
+        if (!isReadOnly) {
+          renderer.changeMode(editMode, relationshipMode);
+        }
+      };
 
     return (
       <div className="diagram-editor__tools">
@@ -267,7 +228,10 @@ const DiagramEditorToolPanel = observer(
               renderer.interactionMode === DIAGRAM_INTERACTION_MODE.LAYOUT,
           })}
           tabIndex={-1}
-          onClick={useViewTool}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.LAYOUT,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
+          )}
           title="View Tool"
         >
           <FiMove className="diagram-editor__icon--layout" />
@@ -279,7 +243,10 @@ const DiagramEditorToolPanel = observer(
           })}
           tabIndex={-1}
           title="Zoom In"
-          onClick={zoomIn}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.ZOOM_IN,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
+          )}
         >
           <FiZoomIn className="diagram-editor__icon--zoom-in" />
         </button>
@@ -290,7 +257,10 @@ const DiagramEditorToolPanel = observer(
           })}
           tabIndex={-1}
           title="Zoom Out"
-          onClick={zoomOut}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.ZOOM_OUT,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
+          )}
         >
           <FiZoomOut className="diagram-editor__icon--zoom-out" />
         </button>
@@ -305,7 +275,10 @@ const DiagramEditorToolPanel = observer(
           })}
           tabIndex={-1}
           title="Property Tool"
-          onClick={usePropertyTool}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.PROPERTY,
+          )}
         >
           <FiMinus className="diagram-editor__icon--property" />
         </button>
@@ -319,7 +292,10 @@ const DiagramEditorToolPanel = observer(
           })}
           tabIndex={-1}
           title="Inheritance Tool"
-          onClick={useInheritanceTool}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.INHERITANCE,
+          )}
         >
           <FiTriangle className="diagram-editor__icon--inheritance" />
         </button>
@@ -332,7 +308,13 @@ const DiagramEditorToolPanel = observer(
           })}
           tabIndex={-1}
           title="Association Tool"
-          onClick={useAssociationTool}
+          onClick={(): void =>
+            applicationStore.notifyUnsupportedFeature('Add association')
+          }
+          // onClick={changeMode(
+          //   DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
+          //   DIAGRAM_RELATIONSHIP_EDIT_MODE.ASSOCIATION,
+          // )}
         >
           <IoResize className="diagram-editor__icon--association" />
         </button>
@@ -343,7 +325,10 @@ const DiagramEditorToolPanel = observer(
           })}
           tabIndex={-1}
           title="New Class..."
-          onClick={addNewClassView}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.ADD_CLASS,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
+          )}
         >
           <FiPlusCircle className="diagram-editor__icon--add-class" />
         </button>
@@ -942,6 +927,7 @@ const DiagramEditorDiagramCanvas = observer(
 const DiagramEditorHeader = observer(
   (props: { diagramEditorState: DiagramEditorState }) => {
     const { diagramEditorState } = props;
+    const isReadOnly = diagramEditorState.isReadOnly;
     const createCenterZoomer =
       (zoomLevel: number): (() => void) =>
       (): void => {
@@ -956,49 +942,133 @@ const DiagramEditorHeader = observer(
       }
     };
 
+    const createAligner =
+      (alignMode: DIAGRAM_ALIGN_MODE): (() => void) =>
+      (): void => {
+        if (!isReadOnly) {
+          diagramEditorState.renderer.alignSelectedClassViews(alignMode);
+        }
+      };
+
     return (
       <>
-        <div className="diagram-editor__header__zoomer">
-          <DropdownMenu
-            className="diagram-editor__header__zoomer__dropdown"
-            content={
-              <MenuContent>
-                <MenuContentItem
-                  className="diagram-editor__header__zoomer__dropdown__menu__item"
-                  onClick={zoomToFit}
-                >
-                  Fit
-                </MenuContentItem>
-                <MenuContentDivider />
-                {DIAGRAM_ZOOM_LEVELS.map((zoomLevel) => (
-                  <MenuContentItem
-                    key={zoomLevel}
-                    className="diagram-editor__header__zoomer__dropdown__menu__item"
-                    onClick={createCenterZoomer(zoomLevel)}
-                  >
-                    {zoomLevel}%
-                  </MenuContentItem>
-                ))}
-              </MenuContent>
-            }
-            menuProps={{
-              anchorOrigin: { vertical: 'bottom', horizontal: 'right' },
-              transformOrigin: { vertical: 'top', horizontal: 'right' },
-              elevation: 7,
-            }}
+        <DropdownMenu
+          className="diagram-editor__header__dropdown"
+          content={
+            <MenuContent>
+              <MenuContentItem
+                className="diagram-editor__header__aligner__dropdown__menu__item"
+                onClick={createAligner(DIAGRAM_ALIGN_MODE.LEFT)}
+              >
+                <MenuContentItemIcon>
+                  <CgAlignLeft className="diagram-editor__icon--aligner" />
+                </MenuContentItemIcon>
+                <MenuContentItemLabel>Left</MenuContentItemLabel>
+              </MenuContentItem>
+              <MenuContentItem
+                className="diagram-editor__header__aligner__dropdown__menu__item"
+                onClick={createAligner(DIAGRAM_ALIGN_MODE.CENTER)}
+              >
+                <MenuContentItemIcon>
+                  <CgAlignCenter className="diagram-editor__icon--aligner" />
+                </MenuContentItemIcon>
+                <MenuContentItemLabel>Center</MenuContentItemLabel>
+              </MenuContentItem>
+              <MenuContentItem
+                className="diagram-editor__header__aligner__dropdown__menu__item"
+                onClick={createAligner(DIAGRAM_ALIGN_MODE.RIGHT)}
+              >
+                <MenuContentItemIcon>
+                  <CgAlignRight className="diagram-editor__icon--aligner" />
+                </MenuContentItemIcon>
+                <MenuContentItemLabel>Right</MenuContentItemLabel>
+              </MenuContentItem>
+              <MenuContentDivider />
+              <MenuContentItem
+                className="diagram-editor__header__aligner__dropdown__menu__item"
+                onClick={createAligner(DIAGRAM_ALIGN_MODE.TOP)}
+              >
+                <MenuContentItemIcon>
+                  <CgAlignTop className="diagram-editor__icon--aligner" />
+                </MenuContentItemIcon>
+                <MenuContentItemLabel>Top</MenuContentItemLabel>
+              </MenuContentItem>
+              <MenuContentItem
+                className="diagram-editor__header__aligner__dropdown__menu__item"
+                onClick={createAligner(DIAGRAM_ALIGN_MODE.MIDDLE)}
+              >
+                <MenuContentItemIcon>
+                  <CgAlignMiddle className="diagram-editor__icon--aligner" />
+                </MenuContentItemIcon>
+                <MenuContentItemLabel>Middle</MenuContentItemLabel>
+              </MenuContentItem>
+              <MenuContentItem
+                className="diagram-editor__header__aligner__dropdown__menu__item"
+                onClick={createAligner(DIAGRAM_ALIGN_MODE.BOTTOM)}
+              >
+                <MenuContentItemIcon>
+                  <CgAlignBottom className="diagram-editor__icon--aligner" />
+                </MenuContentItemIcon>
+                <MenuContentItemLabel>Bottom</MenuContentItemLabel>
+              </MenuContentItem>
+            </MenuContent>
+          }
+          menuProps={{
+            anchorOrigin: { vertical: 'bottom', horizontal: 'right' },
+            transformOrigin: { vertical: 'top', horizontal: 'right' },
+            elevation: 7,
+          }}
+        >
+          <button
+            className="diagram-editor__header__dropdown__label diagram-editor__header__aligner__dropdown__label"
+            tabIndex={-1}
+            title="Align..."
           >
-            <button
-              className="diagram-editor__header__zoomer__dropdown__label"
-              tabIndex={-1}
-              title="Zoom..."
-            >
-              {Math.round(diagramEditorState.renderer.zoom * 100)}%
-            </button>
-            <div className="diagram-editor__header__zoomer__dropdown__trigger">
-              <CaretDownIcon />
-            </div>
-          </DropdownMenu>
-        </div>
+            <CgAlignLeft className="diagram-editor__icon--aligner" /> Align
+          </button>
+          <div className="diagram-editor__header__dropdown__trigger diagram-editor__header__aligner__dropdown__trigger">
+            <CaretDownIcon />
+          </div>
+        </DropdownMenu>
+        <DropdownMenu
+          className="diagram-editor__header__dropdown"
+          content={
+            <MenuContent>
+              <MenuContentItem
+                className="diagram-editor__header__zoomer__dropdown__menu__item"
+                onClick={zoomToFit}
+              >
+                Fit
+              </MenuContentItem>
+              <MenuContentDivider />
+              {DIAGRAM_ZOOM_LEVELS.map((zoomLevel) => (
+                <MenuContentItem
+                  key={zoomLevel}
+                  className="diagram-editor__header__zoomer__dropdown__menu__item"
+                  onClick={createCenterZoomer(zoomLevel)}
+                >
+                  {zoomLevel}%
+                </MenuContentItem>
+              ))}
+            </MenuContent>
+          }
+          menuProps={{
+            anchorOrigin: { vertical: 'bottom', horizontal: 'right' },
+            transformOrigin: { vertical: 'top', horizontal: 'right' },
+            elevation: 7,
+          }}
+        >
+          <button
+            className="diagram-editor__header__dropdown__label diagram-editor__header__zoomer__dropdown__label"
+            tabIndex={-1}
+            title="Zoom..."
+          >
+            {Math.round(diagramEditorState.renderer.zoom * 100)}%
+          </button>
+          <div className="diagram-editor__header__dropdown__trigger diagram-editor__header__zoomer__dropdown__trigger">
+            <CaretDownIcon />
+          </div>
+        </DropdownMenu>
         <div className="diagram-editor__header__actions">
           <button
             className={clsx('diagram-editor__header__action', {

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -33,6 +33,7 @@ import type {
   DiagramEditorInlinePropertyEditorState,
 } from '../../../../stores/editor-state/element-editor-state/DiagramEditorState';
 import {
+  DiagramEditorClassViewEditorSidePanelState,
   DiagramEditorClassEditorSidePanelState,
   DiagramEditorState,
 } from '../../../../stores/editor-state/element-editor-state/DiagramEditorState';
@@ -42,7 +43,9 @@ import {
 } from '../../../../stores/shared/DnDUtil';
 import {
   BaseMenu,
+  BlankPanelContent,
   CaretDownIcon,
+  CheckSquareIcon,
   clsx,
   createFilter,
   CustomSelectorInput,
@@ -50,6 +53,7 @@ import {
   MenuContent,
   MenuContentDivider,
   MenuContentItem,
+  SquareIcon,
   TimesIcon,
 } from '@finos/legend-studio-components';
 import { guaranteeType } from '@finos/legend-studio-shared';
@@ -361,40 +365,136 @@ const DiagramEditorToolPanel = observer(
   },
 );
 
-const DiagramEditorOverlay = observer(() => {
-  const editorStore = useEditorStore();
-  const diagramEditorState =
-    editorStore.getCurrentEditorState(DiagramEditorState);
-  const sidePanelState = diagramEditorState.sidePanelState;
+const DiagramEditorClassViewEditor = observer(
+  (props: {
+    classViewEditorState: DiagramEditorClassViewEditorSidePanelState;
+  }) => {
+    const { classViewEditorState } = props;
+    const classView = classViewEditorState.classView;
+    const diagramEditorState = classViewEditorState.diagramEditorState;
+    const toggleHideProperties = (): void => {
+      classView.setHideProperties(!classView.hideProperties);
+      diagramEditorState.renderer.render();
+    };
+    const toggleHideTaggedValues = (): void => {
+      classView.setHideTaggedValues(!classView.hideTaggedValues);
+      diagramEditorState.renderer.render();
+    };
+    const toggleHideStereotypes = (): void => {
+      classView.setHideStereotypes(!classView.hideStereotypes);
+      diagramEditorState.renderer.render();
+    };
 
-  const resizeSidePanel = (handleProps: HandlerProps): void =>
-    diagramEditorState.sidePanelDisplayState.setSize(
-      (handleProps.domElement as HTMLDivElement).getBoundingClientRect().width,
+    return (
+      <div className="diagram-editor__class-view-editor">
+        <div className="panel__content__form">
+          <div className="panel__content__form__section">
+            {/* Hide properties */}
+            <div
+              className={clsx('panel__content__form__section__toggler')}
+              onClick={toggleHideProperties}
+            >
+              <button
+                className={clsx('panel__content__form__section__toggler__btn', {
+                  'panel__content__form__section__toggler__btn--toggled':
+                    classView.hideProperties,
+                })}
+              >
+                {classView.hideProperties ? (
+                  <CheckSquareIcon />
+                ) : (
+                  <SquareIcon />
+                )}
+              </button>
+              <div className="panel__content__form__section__toggler__prompt">
+                Specifies if properties should be hidden
+              </div>
+            </div>
+            {/* Hide tagged-values */}
+            <div
+              className={clsx('panel__content__form__section__toggler')}
+              onClick={toggleHideTaggedValues}
+            >
+              <button
+                className={clsx('panel__content__form__section__toggler__btn', {
+                  'panel__content__form__section__toggler__btn--toggled':
+                    classView.hideTaggedValues,
+                })}
+              >
+                {classView.hideTaggedValues ? (
+                  <CheckSquareIcon />
+                ) : (
+                  <SquareIcon />
+                )}
+              </button>
+              <div className="panel__content__form__section__toggler__prompt">
+                Specifies if tagged values should be hidden
+              </div>
+            </div>
+            {/* Hide stereotypes */}
+            <div
+              className={clsx('panel__content__form__section__toggler')}
+              onClick={toggleHideStereotypes}
+            >
+              <button
+                className={clsx('panel__content__form__section__toggler__btn', {
+                  'panel__content__form__section__toggler__btn--toggled':
+                    classView.hideStereotypes,
+                })}
+              >
+                {classView.hideStereotypes ? (
+                  <CheckSquareIcon />
+                ) : (
+                  <SquareIcon />
+                )}
+              </button>
+              <div className="panel__content__form__section__toggler__prompt">
+                Specifies if stereotypes should be hidden
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     );
+  },
+);
 
-  const redrawOnClassChange = useCallback((): void => {
-    diagramEditorState.diagram.deadReferencesCleanUp(
-      editorStore.graphState.graph,
-    );
-    diagramEditorState.renderer.start();
-  }, [diagramEditorState, editorStore]);
+const DiagramEditorOverlay = observer(
+  (props: { diagramEditorState: DiagramEditorState }) => {
+    const { diagramEditorState } = props;
+    const editorStore = useEditorStore();
+    const sidePanelState = diagramEditorState.sidePanelState;
 
-  return (
-    <ReflexContainer className="diagram-editor__overlay" orientation="vertical">
-      <ReflexElement direction={1}>
-        <div className="diagram-editor__view-finder" />
-      </ReflexElement>
-      <ReflexSplitter className="diagram-editor__overlay__panel-resizer" />
-      <ReflexElement
-        className="diagram-editor__overlay__panel"
-        flex={0}
-        size={diagramEditorState.sidePanelDisplayState.size}
-        direction={-1}
-        onStopResize={resizeSidePanel}
+    const resizeSidePanel = (handleProps: HandlerProps): void =>
+      diagramEditorState.sidePanelDisplayState.setSize(
+        (handleProps.domElement as HTMLDivElement).getBoundingClientRect()
+          .width,
+      );
+
+    const redrawOnClassChange = useCallback((): void => {
+      diagramEditorState.diagram.deadReferencesCleanUp(
+        editorStore.graphState.graph,
+      );
+      diagramEditorState.renderer.render();
+    }, [diagramEditorState, editorStore]);
+
+    return (
+      <ReflexContainer
+        className="diagram-editor__overlay"
+        orientation="vertical"
       >
-        <div className="panel diagram-editor__side-panel">
-          <div className="panel__header diagram-editor__side-panel__header"></div>
-          <div className="panel__content diagram-editor__side-panel__content">
+        <ReflexElement direction={1}>
+          <div className="diagram-editor__view-finder" />
+        </ReflexElement>
+        <ReflexSplitter className="diagram-editor__overlay__panel-resizer" />
+        <ReflexElement
+          className="diagram-editor__overlay__panel"
+          flex={0}
+          size={diagramEditorState.sidePanelDisplayState.size}
+          direction={-1}
+          onStopResize={resizeSidePanel}
+        >
+          <div className="panel diagram-editor__side-panel">
             {sidePanelState instanceof
               DiagramEditorClassEditorSidePanelState && (
               <ClassFormEditor
@@ -403,13 +503,21 @@ const DiagramEditorOverlay = observer(() => {
                 onHashChange={redrawOnClassChange}
               />
             )}
-            {/* TODO: handle cases where we select views */}
+            {sidePanelState instanceof
+              DiagramEditorClassViewEditorSidePanelState && (
+              <DiagramEditorClassViewEditor
+                classViewEditorState={sidePanelState}
+              />
+            )}
+            {!sidePanelState && (
+              <BlankPanelContent>No element selected</BlankPanelContent>
+            )}
           </div>
-        </div>
-      </ReflexElement>
-    </ReflexContainer>
-  );
-});
+        </ReflexElement>
+      </ReflexContainer>
+    );
+  },
+);
 
 const DiagramEditorInlineClassCreatorInner = observer(
   (props: {
@@ -624,16 +732,14 @@ const DiagramEditorInlinePropertyEditorInner = observer(
     ) => {
       if (property instanceof DerivedProperty || property instanceof Property) {
         property.setName(event.target.value);
-        // redraw diagram
-        diagramEditorState.renderer.start();
+        diagramEditorState.renderer.render();
       }
     };
 
     const changeMultiplicity = (val: Multiplicity): void => {
       if (property instanceof DerivedProperty || property instanceof Property) {
         property.setMultiplicity(val);
-        // redraw diagram
-        diagramEditorState.renderer.start();
+        diagramEditorState.renderer.render();
       }
     };
 
@@ -778,7 +884,7 @@ const DiagramEditorDiagramCanvas = observer(
         );
         diagramEditorState.setRenderer(renderer);
         diagramEditorState.setupDiagramRenderer();
-        renderer.start();
+        renderer.render();
         renderer.autoRecenter();
       }
     }, [diagramCanvasRef, diagramEditorState]);
@@ -925,7 +1031,7 @@ export const DiagramEditor = observer(() => {
       </div>
       <div className="diagram-editor__content">
         {diagramEditorState.isDiagramRendererInitialized && (
-          <DiagramEditorOverlay />
+          <DiagramEditorOverlay diagramEditorState={diagramEditorState} />
         )}
         <div className="diagram-editor__stage">
           {diagramEditorState.isDiagramRendererInitialized && (

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -442,7 +442,7 @@ const DiagramEditorOverlay = observer(
       );
 
     const redrawOnClassChange = useCallback((): void => {
-      diagramEditorState.diagram.deadReferencesCleanUp(
+      diagramEditorState.diagram.cleanUpDeadReferences(
         editorStore.graphState.graph,
       );
       diagramEditorState.renderer.render();

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -24,7 +24,6 @@ import { FaRegKeyboard } from 'react-icons/fa';
 import { observer } from 'mobx-react-lite';
 import {
   DiagramRenderer,
-  DIAGRAM_ALIGN_MODE,
   DIAGRAM_INTERACTION_MODE,
   DIAGRAM_RELATIONSHIP_EDIT_MODE,
   DIAGRAM_ZOOM_LEVELS,
@@ -54,8 +53,6 @@ import {
   MenuContent,
   MenuContentDivider,
   MenuContentItem,
-  MenuContentItemIcon,
-  MenuContentItemLabel,
   SquareIcon,
   TimesIcon,
 } from '@finos/legend-studio-components';
@@ -72,14 +69,6 @@ import {
   FiZoomIn,
   FiZoomOut,
 } from 'react-icons/fi';
-import {
-  CgAlignBottom,
-  CgAlignCenter,
-  CgAlignLeft,
-  CgAlignMiddle,
-  CgAlignRight,
-  CgAlignTop,
-} from 'react-icons/cg';
 import { IoResize } from 'react-icons/io5';
 import { Dialog } from '@material-ui/core';
 import type { HandlerProps } from 'react-reflex';
@@ -940,7 +929,6 @@ const DiagramEditorDiagramCanvas = observer(
 const DiagramEditorHeader = observer(
   (props: { diagramEditorState: DiagramEditorState }) => {
     const { diagramEditorState } = props;
-    const isReadOnly = diagramEditorState.isReadOnly;
     const createCenterZoomer =
       (zoomLevel: number): (() => void) =>
       (): void => {
@@ -955,94 +943,8 @@ const DiagramEditorHeader = observer(
       }
     };
 
-    const createAligner =
-      (alignMode: DIAGRAM_ALIGN_MODE): (() => void) =>
-      (): void => {
-        if (!isReadOnly) {
-          diagramEditorState.renderer.alignSelectedClassViews(alignMode);
-        }
-      };
-
     return (
       <>
-        <DropdownMenu
-          className="diagram-editor__header__dropdown"
-          content={
-            <MenuContent>
-              <MenuContentItem
-                className="diagram-editor__header__aligner__dropdown__menu__item"
-                onClick={createAligner(DIAGRAM_ALIGN_MODE.LEFT)}
-              >
-                <MenuContentItemIcon>
-                  <CgAlignLeft className="diagram-editor__icon--aligner" />
-                </MenuContentItemIcon>
-                <MenuContentItemLabel>Left</MenuContentItemLabel>
-              </MenuContentItem>
-              <MenuContentItem
-                className="diagram-editor__header__aligner__dropdown__menu__item"
-                onClick={createAligner(DIAGRAM_ALIGN_MODE.CENTER)}
-              >
-                <MenuContentItemIcon>
-                  <CgAlignCenter className="diagram-editor__icon--aligner" />
-                </MenuContentItemIcon>
-                <MenuContentItemLabel>Center</MenuContentItemLabel>
-              </MenuContentItem>
-              <MenuContentItem
-                className="diagram-editor__header__aligner__dropdown__menu__item"
-                onClick={createAligner(DIAGRAM_ALIGN_MODE.RIGHT)}
-              >
-                <MenuContentItemIcon>
-                  <CgAlignRight className="diagram-editor__icon--aligner" />
-                </MenuContentItemIcon>
-                <MenuContentItemLabel>Right</MenuContentItemLabel>
-              </MenuContentItem>
-              <MenuContentDivider />
-              <MenuContentItem
-                className="diagram-editor__header__aligner__dropdown__menu__item"
-                onClick={createAligner(DIAGRAM_ALIGN_MODE.TOP)}
-              >
-                <MenuContentItemIcon>
-                  <CgAlignTop className="diagram-editor__icon--aligner" />
-                </MenuContentItemIcon>
-                <MenuContentItemLabel>Top</MenuContentItemLabel>
-              </MenuContentItem>
-              <MenuContentItem
-                className="diagram-editor__header__aligner__dropdown__menu__item"
-                onClick={createAligner(DIAGRAM_ALIGN_MODE.MIDDLE)}
-              >
-                <MenuContentItemIcon>
-                  <CgAlignMiddle className="diagram-editor__icon--aligner" />
-                </MenuContentItemIcon>
-                <MenuContentItemLabel>Middle</MenuContentItemLabel>
-              </MenuContentItem>
-              <MenuContentItem
-                className="diagram-editor__header__aligner__dropdown__menu__item"
-                onClick={createAligner(DIAGRAM_ALIGN_MODE.BOTTOM)}
-              >
-                <MenuContentItemIcon>
-                  <CgAlignBottom className="diagram-editor__icon--aligner" />
-                </MenuContentItemIcon>
-                <MenuContentItemLabel>Bottom</MenuContentItemLabel>
-              </MenuContentItem>
-            </MenuContent>
-          }
-          menuProps={{
-            anchorOrigin: { vertical: 'bottom', horizontal: 'right' },
-            transformOrigin: { vertical: 'top', horizontal: 'right' },
-            elevation: 7,
-          }}
-        >
-          <button
-            className="diagram-editor__header__dropdown__label diagram-editor__header__aligner__dropdown__label"
-            tabIndex={-1}
-            title="Align..."
-          >
-            <CgAlignLeft className="diagram-editor__icon--aligner" /> Align
-          </button>
-          <div className="diagram-editor__header__dropdown__trigger diagram-editor__header__aligner__dropdown__trigger">
-            <CaretDownIcon />
-          </div>
-        </DropdownMenu>
         <DropdownMenu
           className="diagram-editor__header__dropdown"
           content={

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -53,6 +53,7 @@ import {
   MenuContent,
   MenuContentDivider,
   MenuContentItem,
+  PlusIcon,
   SquareIcon,
   TimesIcon,
 } from '@finos/legend-studio-components';
@@ -98,10 +99,10 @@ const DiagramRendererHotkeyInfosModal = observer(
         classes={{
           root: 'editor-modal__root-container',
           container: 'editor-modal__container',
-          paper: 'editor-modal__content',
+          paper: 'editor-modal__content--scrollable',
         }}
       >
-        <div className="modal modal--dark diagram-editor__hotkeys__dialog">
+        <div className="modal modal--dark modal--scrollable diagram-editor__hotkeys__dialog">
           <div className="modal__header">
             <div className="modal__title">Diagram Hotkeys</div>
           </div>
@@ -111,72 +112,130 @@ const DiagramRendererHotkeyInfosModal = observer(
                 <div className="diagram-editor__hotkey__annotation">
                   Remove selected element(s)
                 </div>
-                <div className="diagram-editor__hotkey__keys">
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
                   <div className="hotkey__key">Delete</div>
-                </div>
-              </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Toggle display for properties of selected element(s)
-                </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">h</div>
-                </div>
-              </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Toggle display for stereotypes of selected element(s)
-                </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">s</div>
-                </div>
-              </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Toggle display for tagged values of selected element(s)
-                </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">t</div>
                 </div>
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
                   Edit the selected element
                 </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">e</div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">E</div>
+                </div>
+              </div>
+
+              <div className="diagram-editor__hotkey__groups__divider" />
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Recenter
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">R</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">Zoom</div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">Z</div>
+                </div>
+              </div>
+
+              <div className="diagram-editor__hotkey__groups__divider" />
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Use layout tool
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">L</div>
                 </div>
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
+                  Use property tool
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">P</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Use inheritance tool
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">I</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Add class
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">+</div>
+                </div>
+              </div>
+
+              <div className="diagram-editor__hotkey__groups__divider" />
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Toggle display for properties of selected element(s)
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">Alt</div>
+                  <div className="hotkey__plus">
+                    <PlusIcon />
+                  </div>
+                  <div className="hotkey__key">P</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Toggle display for tagged values of selected element(s)
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">Alt</div>
+                  <div className="hotkey__plus">
+                    <PlusIcon />
+                  </div>
+                  <div className="hotkey__key">T</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Toggle display for stereotypes of selected element(s)
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">Alt</div>
+                  <div className="hotkey__plus">
+                    <PlusIcon />
+                  </div>
+                  <div className="hotkey__key">S</div>
+                </div>
+              </div>
+
+              <div className="diagram-editor__hotkey__groups__divider" />
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
                   Add simple property to selected class
                 </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">b</div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">&darr;</div>
                 </div>
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
                   Eject the property
                 </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">a</div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">&rarr;</div>
                 </div>
               </div>
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
                   Add the selected class as property of the opened class
                 </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">p</div>
-                </div>
-              </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Recenter
-                </div>
-                <div className="diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">c</div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">&larr;</div>
                 </div>
               </div>
             </div>
@@ -219,7 +278,7 @@ const DiagramEditorToolPanel = observer(
             DIAGRAM_INTERACTION_MODE.LAYOUT,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
           )}
-          title="View Tool"
+          title="View Tool (L)"
         >
           <FiMove className="diagram-editor__icon--layout" />
         </button>
@@ -229,7 +288,7 @@ const DiagramEditorToolPanel = observer(
               renderer.interactionMode === DIAGRAM_INTERACTION_MODE.ZOOM_IN,
           })}
           tabIndex={-1}
-          title="Zoom In"
+          title="Zoom In (Z)"
           onClick={createModeSwitcher(
             DIAGRAM_INTERACTION_MODE.ZOOM_IN,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
@@ -243,7 +302,7 @@ const DiagramEditorToolPanel = observer(
               renderer.interactionMode === DIAGRAM_INTERACTION_MODE.ZOOM_OUT,
           })}
           tabIndex={-1}
-          title="Zoom Out"
+          title="Zoom Out (Z)"
           onClick={createModeSwitcher(
             DIAGRAM_INTERACTION_MODE.ZOOM_OUT,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
@@ -261,7 +320,8 @@ const DiagramEditorToolPanel = observer(
                 DIAGRAM_RELATIONSHIP_EDIT_MODE.PROPERTY,
           })}
           tabIndex={-1}
-          title="Property Tool"
+          title="Property Tool (P)"
+          disabled={isReadOnly}
           onClick={createModeSwitcher(
             DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.PROPERTY,
@@ -278,7 +338,8 @@ const DiagramEditorToolPanel = observer(
                 DIAGRAM_RELATIONSHIP_EDIT_MODE.INHERITANCE,
           })}
           tabIndex={-1}
-          title="Inheritance Tool"
+          title="Inheritance Tool (I)"
+          disabled={isReadOnly}
           onClick={createModeSwitcher(
             DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.INHERITANCE,
@@ -309,7 +370,8 @@ const DiagramEditorToolPanel = observer(
               renderer.interactionMode === DIAGRAM_INTERACTION_MODE.ADD_CLASS,
           })}
           tabIndex={-1}
-          title="New Class..."
+          title="New Class... (+)"
+          disabled={isReadOnly}
           onClick={createModeSwitcher(
             DIAGRAM_INTERACTION_MODE.ADD_CLASS,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementGenerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/ElementGenerationEditor.tsx
@@ -20,7 +20,7 @@ import SplitPane from 'react-split-pane';
 import { observer } from 'mobx-react-lite';
 import { useEditorStore } from '../../../../stores/EditorStore';
 import { ELEMENT_PATH_DELIMITER } from '../../../../models/MetaModelConst';
-import { resolvePackageNameAndElementName } from '../../../../models/MetaModelUtils';
+import { resolvePackagePathAndElementName } from '../../../../models/MetaModelUtils';
 import type { ElementFileGenerationState } from '../../../../stores/editor-state/element-editor-state/ElementFileGenerationState';
 import type { ElementEditorState } from '../../../../stores/editor-state/element-editor-state/ElementEditorState';
 import { guaranteeType } from '@finos/legend-studio-shared';
@@ -47,9 +47,9 @@ const NewFileGenerationModal = observer(
     const [servicePath, setServicePath] = useState<string>(
       defaultFileGenerationName,
     );
-    const [packageName, serviceName] = resolvePackageNameAndElementName(
-      mappingPackage.path,
+    const [packagePath, serviceName] = resolvePackagePathAndElementName(
       servicePath,
+      mappingPackage.path,
     );
     const close = (): void =>
       elementGenerationState.setShowNewFileGenerationModal(false);
@@ -57,7 +57,7 @@ const NewFileGenerationModal = observer(
     const handleSubmit = (): void => {
       if (servicePath && !isReadOnly) {
         elementGenerationState.promoteToFileGeneration(
-          packageName,
+          packagePath,
           serviceName,
         );
         close();
@@ -71,7 +71,7 @@ const NewFileGenerationModal = observer(
       setServicePath(event.target.value);
     const elementAlreadyExists = editorStore.graphState.graph.allElements
       .map((el) => el.path)
-      .includes(packageName + ELEMENT_PATH_DELIMITER + serviceName);
+      .includes(packagePath + ELEMENT_PATH_DELIMITER + serviceName);
 
     return (
       <Dialog

--- a/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/FileGenerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/element-generation-editor/FileGenerationEditor.tsx
@@ -80,7 +80,7 @@ import {
 } from '../../../../models/metamodels/pure/model/packageableElements/PackageableElementReference';
 import {
   isValidFullPath,
-  resolvePackageNameAndElementName,
+  resolvePackagePathAndElementName,
 } from '../../../../models/MetaModelUtils';
 
 export const FileGenerationTreeNodeContainer: React.FC<
@@ -688,7 +688,7 @@ const GenerationEnumPropertyEditor = observer(
     const { property, fileGeneration, isReadOnly, update } = props;
     const getEnumLabel = (_enum: string): string =>
       isValidFullPath(_enum)
-        ? resolvePackageNameAndElementName('', _enum)[1]
+        ? resolvePackagePathAndElementName(_enum)[1]
         : _enum;
     const options = guaranteeNonNullable(
       property.items,

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExecutionBuilder.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExecutionBuilder.tsx
@@ -736,9 +736,9 @@ export const MappingExecutionBuilder = observer(
           showModal={executionState.showServicePathModal}
           promoteToService={(
             name: string,
-            packageName: string,
+            packagePath: string,
           ): Promise<void> =>
-            executionState.promoteToService(name, packageName)
+            executionState.promoteToService(name, packagePath)
           }
           isReadOnly={mappingEditorState.isReadOnly}
         />

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/NewServiceModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/NewServiceModal.tsx
@@ -19,7 +19,7 @@ import { observer } from 'mobx-react-lite';
 import { useEditorStore } from '../../../../stores/EditorStore';
 import { useApplicationStore } from '../../../../stores/ApplicationStore';
 import { ELEMENT_PATH_DELIMITER } from '../../../../models/MetaModelConst';
-import { resolvePackageNameAndElementName } from '../../../../models/MetaModelUtils';
+import { resolvePackagePathAndElementName } from '../../../../models/MetaModelUtils';
 import { guaranteeType } from '@finos/legend-studio-shared';
 import Dialog from '@material-ui/core/Dialog';
 import type { Mapping } from '../../../../models/metamodels/pure/model/packageableElements/mapping/Mapping';
@@ -31,7 +31,7 @@ export const NewServiceModal = observer(
     close: () => void;
     showModal: boolean;
     promoteToService: (
-      packageName: string,
+      packagePath: string,
       serviceName: string,
     ) => Promise<void>;
     isReadOnly?: boolean;
@@ -43,15 +43,15 @@ export const NewServiceModal = observer(
     const nameRef = useRef<HTMLInputElement>(null);
     const defaultServiceName = `${mapping.path}Service`;
     const [servicePath, setServicePath] = useState<string>(defaultServiceName);
-    const [packageName, serviceName] = resolvePackageNameAndElementName(
-      mappingPackage.path,
+    const [packagePath, serviceName] = resolvePackagePathAndElementName(
       servicePath,
+      mappingPackage.path,
     );
     const handleEnter = (): void => nameRef.current?.focus();
     const onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
       event.preventDefault();
       if (servicePath && !isReadOnly) {
-        promoteToService(packageName, serviceName)
+        promoteToService(packagePath, serviceName)
           .then(() => close())
           .catch(applicationStore.alertIllegalUnhandledError);
       }
@@ -60,7 +60,7 @@ export const NewServiceModal = observer(
       setServicePath(event.target.value);
     const elementAlreadyExists = editorStore.graphState.graph.allElements
       .map((s) => s.path)
-      .includes(packageName + ELEMENT_PATH_DELIMITER + serviceName);
+      .includes(packagePath + ELEMENT_PATH_DELIMITER + serviceName);
     return (
       <Dialog
         open={showModal}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -1365,7 +1365,7 @@ export const ClassEditor = observer((props: { _class: Class }) => {
         setDiagramRenderer(newRender);
         currentRenderer = newRender;
       }
-      currentRenderer.start();
+      currentRenderer.render();
       currentRenderer.autoRecenter();
     }
   }, [diagramRenderer, _class]);
@@ -1373,7 +1373,7 @@ export const ClassEditor = observer((props: { _class: Class }) => {
   useEffect(() => {
     if (diagramRenderer) {
       diagramRenderer.loadClass(_class);
-      diagramRenderer.start();
+      diagramRenderer.render();
       diagramRenderer.autoRecenter();
     }
   }, [_class, classHash, diagramRenderer]);

--- a/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -352,13 +352,13 @@ export const CreateNewElementModal = observer(() => {
     newElementState.setElementType(val.value);
   // Submit button
   const closeModal = (): void => newElementState.closeModal();
-  const [packageName, elementName] = resolvePackageAndElementName(
+  const [packagePath, elementName] = resolvePackageAndElementName(
     selectedPackage,
     editorStore.graphState.graph.isRoot(selectedPackage),
     name,
   );
   const resolvedPackage =
-    editorStore.graphState.graph.getNullablePackage(packageName);
+    editorStore.graphState.graph.getNullablePackage(packagePath);
   const needsToOverride = Boolean(
     resolvedPackage?.children.find((child) => child.name === elementName),
   );

--- a/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
@@ -30,7 +30,7 @@ import { CORE_TEST_ID } from '../../../../const';
 import type { EditorStore } from '../../../../stores/EditorStore';
 import { PACKAGEABLE_ELEMENT_TYPE } from '../../../../models/metamodels/pure/model/packageableElements/PackageableElement';
 
-const addRootPackage = (packageName: string, result: RenderResult): void => {
+const addRootPackage = (packagePath: string, result: RenderResult): void => {
   fireEvent.click(result.getByTitle('New Element...', { exact: false }));
   const contextMenu = result.getByRole('menu');
   fireEvent.click(getByText(contextMenu, 'New Package...'));
@@ -38,7 +38,7 @@ const addRootPackage = (packageName: string, result: RenderResult): void => {
   const packageInput = getByPlaceholderText(modal, 'Enter a name', {
     exact: false,
   });
-  fireEvent.change(packageInput, { target: { value: packageName } });
+  fireEvent.change(packageInput, { target: { value: packagePath } });
   fireEvent.click(getByText(modal, 'Create'));
 };
 

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -489,6 +489,24 @@ export class DiagramRenderer {
     this.drawAll();
   }
 
+  autoRecenter(): void {
+    this.recenter(
+      this.virtualScreen.position.x + this.virtualScreen.rectangle.width / 2,
+      this.virtualScreen.position.y + this.virtualScreen.rectangle.height / 2,
+    );
+  }
+
+  /**
+   * Reset the screen offset
+   */
+  private recenter(x: number, y: number): void {
+    this.screenOffset = new Point(
+      -x + this.canvasCenter.x,
+      -y + this.canvasCenter.y,
+    );
+    this.refresh();
+  }
+
   changeMode(
     editMode: DIAGRAM_INTERACTION_MODE,
     relationshipMode: DIAGRAM_RELATIONSHIP_EDIT_MODE,
@@ -600,22 +618,108 @@ export class DiagramRenderer {
     }
   }
 
-  autoRecenter(): void {
-    this.recenter(
-      this.virtualScreen.position.x + this.virtualScreen.rectangle.width / 2,
-      this.virtualScreen.position.y + this.virtualScreen.rectangle.height / 2,
-    );
-  }
-
-  /**
-   * Reset the screen offset
-   */
-  recenter(x: number, y: number): void {
-    this.screenOffset = new Point(
-      -x + this.canvasCenter.x,
-      -y + this.canvasCenter.y,
-    );
-    this.refresh();
+  alignSelectedClassViews(alignMode: DIAGRAM_ALIGN_MODE): void {
+    if (!this.isReadOnly && this.selectedClasses.length > 1) {
+      switch (alignMode) {
+        case DIAGRAM_ALIGN_MODE.LEFT: {
+          let minX = Number.MAX_VALUE;
+          this.selectedClasses.forEach((classView) => {
+            minX = Math.min(minX, classView.position.x);
+          });
+          this.selectedClasses.forEach((classView) => {
+            classView.setPosition(new Point(minX, classView.position.y));
+          });
+          return;
+        }
+        case DIAGRAM_ALIGN_MODE.CENTER: {
+          let minX = Number.MAX_VALUE;
+          let maxX = Number.MIN_VALUE;
+          this.selectedClasses.forEach((classView) => {
+            minX = Math.min(minX, classView.position.x);
+            maxX = Math.max(
+              maxX,
+              classView.position.x + classView.rectangle.width,
+            );
+          });
+          this.selectedClasses.forEach((classView) => {
+            classView.setPosition(
+              new Point(
+                (minX + maxX - classView.rectangle.width) / 2,
+                classView.position.y,
+              ),
+            );
+          });
+          return;
+        }
+        case DIAGRAM_ALIGN_MODE.RIGHT: {
+          let maxX = Number.MIN_VALUE;
+          this.selectedClasses.forEach((classView) => {
+            maxX = Math.max(
+              maxX,
+              classView.position.x + classView.rectangle.width,
+            );
+          });
+          this.selectedClasses.forEach((classView) => {
+            classView.setPosition(
+              new Point(maxX - classView.rectangle.width, classView.position.y),
+            );
+          });
+          return;
+        }
+        case DIAGRAM_ALIGN_MODE.TOP: {
+          let minY = Number.MAX_VALUE;
+          this.selectedClasses.forEach((classView) => {
+            minY = Math.min(minY, classView.position.y);
+          });
+          this.selectedClasses.forEach((classView) => {
+            classView.setPosition(new Point(classView.position.x, minY));
+          });
+          return;
+        }
+        case DIAGRAM_ALIGN_MODE.MIDDLE: {
+          let minY = Number.MAX_VALUE;
+          let maxY = Number.MIN_VALUE;
+          this.selectedClasses.forEach((classView) => {
+            minY = Math.min(minY, classView.position.y);
+            maxY = Math.max(
+              maxY,
+              classView.position.y + classView.rectangle.height,
+            );
+          });
+          this.selectedClasses.forEach((classView) => {
+            classView.setPosition(
+              new Point(
+                classView.position.x,
+                (minY + maxY - classView.rectangle.height) / 2,
+              ),
+            );
+          });
+          return;
+        }
+        case DIAGRAM_ALIGN_MODE.BOTTOM: {
+          let maxY = Number.MIN_VALUE;
+          this.selectedClasses.forEach((classView) => {
+            maxY = Math.max(
+              maxY,
+              classView.position.y + classView.rectangle.height,
+            );
+          });
+          this.selectedClasses.forEach((classView) => {
+            classView.setPosition(
+              new Point(
+                classView.position.x,
+                maxY - classView.rectangle.height,
+              ),
+            );
+          });
+          return;
+        }
+        default:
+          throw new UnsupportedOperationError(
+            `Can't align class view(s) with mode '${alignMode}': unsupported mode`,
+          );
+      }
+    }
   }
 
   truncateTextWithEllipsis(val: string, limit = this.maxLineLength): string {

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -205,6 +205,7 @@ export class DiagramRenderer {
   cursorPosition: Point;
 
   leftClick: boolean;
+  middleClick: boolean;
   rightClick: boolean;
   clickX: number;
   clickY: number;
@@ -234,6 +235,8 @@ export class DiagramRenderer {
       selectedClasses: observable,
       selectedPropertyOrAssociation: observable,
       selectedInheritance: observable,
+      rightClick: observable,
+      middleClick: observable,
       changeMode: action,
       setIsReadOnly: action,
       setMouseOverClassCorner: action,
@@ -244,6 +247,8 @@ export class DiagramRenderer {
       setSelectedClasses: action,
       setSelectedPropertyOrAssociation: action,
       setSelectedInheritance: action,
+      setRightClick: action,
+      setMiddleClick: action,
       setZoomLevel: action,
     });
 
@@ -355,6 +360,7 @@ export class DiagramRenderer {
     this._selectedClassesInitialPositions = [];
     this.cursorPosition = new Point(0, 0);
     this.leftClick = false;
+    this.middleClick = false;
     this.rightClick = false;
     this.clickX = 0;
     this.clickY = 0;
@@ -401,6 +407,14 @@ export class DiagramRenderer {
 
   setSelectedInheritance(val: GeneralizationView | undefined): void {
     this.selectedInheritance = val;
+  }
+
+  setRightClick(val: boolean): void {
+    this.rightClick = val;
+  }
+
+  setMiddleClick(val: boolean): void {
+    this.middleClick = val;
   }
 
   setZoomLevel(val: number): void {
@@ -2228,7 +2242,8 @@ export class DiagramRenderer {
       }
     }
     this.leftClick = false;
-    this.rightClick = false;
+    this.setMiddleClick(false);
+    this.setRightClick(false);
 
     this.setSelectedClassCorner(undefined);
     this.setSelectionStart(undefined);
@@ -2496,10 +2511,17 @@ export class DiagramRenderer {
           break;
       }
     }
+    // middle click
+    else if (e.button === 1) {
+      e.returnValue = false;
+      this.setMiddleClick(true);
+      this.positionBeforeLastMove = new Point(e.x, e.y);
+      return;
+    }
     // right click
     else if (e.button === 2) {
       e.returnValue = false;
-      this.rightClick = true;
+      this.setRightClick(true);
       this.positionBeforeLastMove = new Point(e.x, e.y);
       return;
     }
@@ -2516,7 +2538,7 @@ export class DiagramRenderer {
 
   mousemove(e: MouseEvent): void {
     this.cursorPosition = new Point(e.x, e.y);
-    if (this.rightClick) {
+    if (this.rightClick || this.middleClick) {
       this.screenOffset = new Point(
         this.screenOffset.x + (e.x - this.positionBeforeLastMove.x) / this.zoom,
         this.screenOffset.y + (e.y - this.positionBeforeLastMove.y) / this.zoom,

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -231,6 +231,9 @@ export class DiagramRenderer {
       mouseOverProperty: observable,
       selectionStart: observable,
       selectedClassCorner: observable,
+      selectedClasses: observable,
+      selectedPropertyOrAssociation: observable,
+      selectedInheritance: observable,
       changeMode: action,
       setIsReadOnly: action,
       setMouseOverClassCorner: action,
@@ -238,6 +241,9 @@ export class DiagramRenderer {
       setMouseOverProperty: action,
       setSelectionStart: action,
       setSelectedClassCorner: action,
+      setSelectedClasses: action,
+      setSelectedPropertyOrAssociation: action,
+      setSelectedInheritance: action,
       setZoomLevel: action,
     });
 
@@ -383,6 +389,18 @@ export class DiagramRenderer {
 
   setSelectedClassCorner(val: ClassView | undefined): void {
     this.selectedClassCorner = val;
+  }
+
+  setSelectedClasses(val: ClassView[]): void {
+    this.selectedClasses = val;
+  }
+
+  setSelectedPropertyOrAssociation(val: PropertyHolderView | undefined): void {
+    this.selectedPropertyOrAssociation = val;
+  }
+
+  setSelectedInheritance(val: GeneralizationView | undefined): void {
+    this.selectedInheritance = val;
   }
 
   setZoomLevel(val: number): void {
@@ -2287,11 +2305,11 @@ export class DiagramRenderer {
   mousedown(e: MouseEvent): void {
     this.setSelectionStart(undefined);
     this.setSelectedClassCorner(undefined);
+    this.setSelectedPropertyOrAssociation(undefined);
+    this.setSelectedInheritance(undefined);
     this.selection = undefined;
     this.selectedClassProperty = undefined;
     this.selectedPoint = undefined;
-    this.selectedPropertyOrAssociation = undefined;
-    this.selectedInheritance = undefined;
     this.startClassView = undefined;
 
     // left click
@@ -2315,7 +2333,7 @@ export class DiagramRenderer {
                   eventPointInModelCoordinate.y,
                 )
             ) {
-              this.selectedClasses = [];
+              this.setSelectedClasses([]);
               this.setSelectedClassCorner(this.diagram.classViews[i]);
               if (!this.isReadOnly) {
                 // Bring the class view to front
@@ -2337,7 +2355,7 @@ export class DiagramRenderer {
                 property: this.mouseOverProperty,
                 selectionPoint: eventPointInModelCoordinate,
               };
-              this.selectedClasses = [];
+              this.setSelectedClasses([]);
             } else {
               // Check for selection of class view(s)
 
@@ -2355,7 +2373,7 @@ export class DiagramRenderer {
                     this.selectedClasses.indexOf(this.diagram.classViews[i]) ===
                       -1
                   ) {
-                    this.selectedClasses = [this.diagram.classViews[i]];
+                    this.setSelectedClasses([this.diagram.classViews[i]]);
                   }
                   if (!this.isReadOnly) {
                     // Bring the class view to front
@@ -2385,7 +2403,7 @@ export class DiagramRenderer {
                 }
               }
               if (!anyClassesSelected) {
-                this.selectedClasses = [];
+                this.setSelectedClasses([]);
               }
 
               if (!this.selectedClasses.length) {
@@ -2405,7 +2423,7 @@ export class DiagramRenderer {
                   );
                   if (val) {
                     this.selectedPoint = val;
-                    this.selectedInheritance = generalizationView;
+                    this.setSelectedInheritance(generalizationView);
                     break;
                   }
                 }
@@ -2421,7 +2439,7 @@ export class DiagramRenderer {
                     );
                     if (val) {
                       this.selectedPoint = val;
-                      this.selectedPropertyOrAssociation = associationView;
+                      this.setSelectedPropertyOrAssociation(associationView);
                       break;
                     }
                   }
@@ -2438,7 +2456,7 @@ export class DiagramRenderer {
                     );
                     if (val) {
                       this.selectedPoint = val;
-                      this.selectedPropertyOrAssociation = propertyView;
+                      this.setSelectedPropertyOrAssociation(propertyView);
                       break;
                     }
                   }
@@ -2642,13 +2660,13 @@ export class DiagramRenderer {
                 Math.abs(selectionBoxHeight),
               ),
             );
-            this.selectedClasses = [];
+            this.setSelectedClasses([]);
             for (const classView of this.diagram.classViews) {
               if (
                 this.selection.boxContains(classView) ||
                 classView.boxContains(this.selection)
               ) {
-                this.selectedClasses = [...this.selectedClasses, classView];
+                this.setSelectedClasses([...this.selectedClasses, classView]);
               }
             }
           }

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -65,15 +65,6 @@ export enum DIAGRAM_RELATIONSHIP_EDIT_MODE {
   NONE,
 }
 
-export enum DIAGRAM_ALIGN_MODE {
-  TOP,
-  MIDDLE,
-  BOTTOM,
-  LEFT,
-  CENTER,
-  RIGHT,
-}
-
 const MIN_ZOOM_LEVEL = 0.05; // 5%
 const FIT_ZOOM_PADDING = 10;
 export const DIAGRAM_ZOOM_LEVELS = [
@@ -613,110 +604,6 @@ export class DiagramRenderer {
         default:
           throw new UnsupportedOperationError(
             `Can't switch to relationship mode '${relationshipMode}': unsupported mode`,
-          );
-      }
-    }
-  }
-
-  alignSelectedClassViews(alignMode: DIAGRAM_ALIGN_MODE): void {
-    if (!this.isReadOnly && this.selectedClasses.length > 1) {
-      switch (alignMode) {
-        case DIAGRAM_ALIGN_MODE.LEFT: {
-          let minX = Number.MAX_VALUE;
-          this.selectedClasses.forEach((classView) => {
-            minX = Math.min(minX, classView.position.x);
-          });
-          this.selectedClasses.forEach((classView) => {
-            classView.setPosition(new Point(minX, classView.position.y));
-          });
-          return;
-        }
-        case DIAGRAM_ALIGN_MODE.CENTER: {
-          let minX = Number.MAX_VALUE;
-          let maxX = Number.MIN_VALUE;
-          this.selectedClasses.forEach((classView) => {
-            minX = Math.min(minX, classView.position.x);
-            maxX = Math.max(
-              maxX,
-              classView.position.x + classView.rectangle.width,
-            );
-          });
-          this.selectedClasses.forEach((classView) => {
-            classView.setPosition(
-              new Point(
-                (minX + maxX - classView.rectangle.width) / 2,
-                classView.position.y,
-              ),
-            );
-          });
-          return;
-        }
-        case DIAGRAM_ALIGN_MODE.RIGHT: {
-          let maxX = Number.MIN_VALUE;
-          this.selectedClasses.forEach((classView) => {
-            maxX = Math.max(
-              maxX,
-              classView.position.x + classView.rectangle.width,
-            );
-          });
-          this.selectedClasses.forEach((classView) => {
-            classView.setPosition(
-              new Point(maxX - classView.rectangle.width, classView.position.y),
-            );
-          });
-          return;
-        }
-        case DIAGRAM_ALIGN_MODE.TOP: {
-          let minY = Number.MAX_VALUE;
-          this.selectedClasses.forEach((classView) => {
-            minY = Math.min(minY, classView.position.y);
-          });
-          this.selectedClasses.forEach((classView) => {
-            classView.setPosition(new Point(classView.position.x, minY));
-          });
-          return;
-        }
-        case DIAGRAM_ALIGN_MODE.MIDDLE: {
-          let minY = Number.MAX_VALUE;
-          let maxY = Number.MIN_VALUE;
-          this.selectedClasses.forEach((classView) => {
-            minY = Math.min(minY, classView.position.y);
-            maxY = Math.max(
-              maxY,
-              classView.position.y + classView.rectangle.height,
-            );
-          });
-          this.selectedClasses.forEach((classView) => {
-            classView.setPosition(
-              new Point(
-                classView.position.x,
-                (minY + maxY - classView.rectangle.height) / 2,
-              ),
-            );
-          });
-          return;
-        }
-        case DIAGRAM_ALIGN_MODE.BOTTOM: {
-          let maxY = Number.MIN_VALUE;
-          this.selectedClasses.forEach((classView) => {
-            maxY = Math.max(
-              maxY,
-              classView.position.y + classView.rectangle.height,
-            );
-          });
-          this.selectedClasses.forEach((classView) => {
-            classView.setPosition(
-              new Point(
-                classView.position.x,
-                maxY - classView.rectangle.height,
-              ),
-            );
-          });
-          return;
-        }
-        default:
-          throw new UnsupportedOperationError(
-            `Can't align class view(s) with mode '${alignMode}': unsupported mode`,
           );
       }
     }

--- a/packages/legend-studio/src/components/shared/diagram-viewer/InheritanceDiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/InheritanceDiagramRenderer.ts
@@ -44,7 +44,7 @@ export class InheritanceDiagramRenderer extends DiagramRenderer {
   buildLevels(classViews: ClassView[]): ClassView[][] {
     if (classViews.length) {
       classViews.forEach((classView) =>
-        this.computeClassViewMinDimensions(classView),
+        this.ensureClassViewMeetMinDimensions(classView),
       );
       const res = classViews.flatMap((classView) =>
         classView.class.value.generalizations.map(

--- a/packages/legend-studio/src/components/shared/diagram-viewer/something.d.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/something.d.ts
@@ -1,0 +1,1 @@
+declare module 'canvas2svg';

--- a/packages/legend-studio/src/components/shared/diagram-viewer/something.d.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/something.d.ts
@@ -1,1 +1,0 @@
-declare module 'canvas2svg';

--- a/packages/legend-studio/src/models/MetaModelUtils.ts
+++ b/packages/legend-studio/src/models/MetaModelUtils.ts
@@ -64,17 +64,18 @@ export const matchFunctionName = (
  * This method concatenate 2 fully-qualified elementh paths to form a single one
  * and then extracts the name and package part from it.
  */
-export const resolvePackageNameAndElementName = (
-  defaultPath: string,
+export const resolvePackagePathAndElementName = (
   path: string,
+  defaultPath?: string,
 ): [string, string] => {
   const index = path.lastIndexOf(ELEMENT_PATH_DELIMITER);
-  const elementName =
-    index === -1
-      ? path
-      : path.substring(index + ELEMENT_PATH_DELIMITER.length, path.length);
-  const packageName = index === -1 ? defaultPath : path.substring(0, index);
-  return [packageName, elementName];
+  if (index === -1) {
+    return [defaultPath ?? '', path];
+  }
+  return [
+    path.substring(0, index),
+    path.substring(index + ELEMENT_PATH_DELIMITER.length, path.length),
+  ];
 };
 
 export const isValidFullPath = (fullPath: string): boolean =>

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
@@ -114,19 +114,18 @@ test(unitTest('JSON Object input data should be minified'), () => {
 });
 
 test(unitTest('Resolve package path and element name'), () => {
-  expect(resolvePackagePathAndElementName('something::somethingElse')).toBe([
+  expect(resolvePackagePathAndElementName('something::somethingElse')).toEqual([
     'something',
     'somethingElse',
   ]);
-  expect(resolvePackagePathAndElementName('something::a::somethingElse')).toBe([
-    'something::a',
-    'somethingElse',
-  ]);
-  expect(resolvePackagePathAndElementName('b')).toBe(['', 'b']);
+  expect(
+    resolvePackagePathAndElementName('something::a::somethingElse'),
+  ).toEqual(['something::a', 'somethingElse']);
+  expect(resolvePackagePathAndElementName('b')).toEqual(['', 'b']);
   expect(
     resolvePackagePathAndElementName('something::b', 'somethingElse'),
-  ).toBe(['something', 'b']);
-  expect(resolvePackagePathAndElementName('b', 'somethingElse')).toBe([
+  ).toEqual(['something', 'b']);
+  expect(resolvePackagePathAndElementName('b', 'somethingElse')).toEqual([
     'somethingElse',
     'b',
   ]);

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModel.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { hashLambda } from '../../../MetaModelUtils';
+import {
+  hashLambda,
+  resolvePackagePathAndElementName,
+} from '../../../MetaModelUtils';
 import {
   losslessParse,
   losslessStringify,
@@ -31,8 +34,8 @@ import { PackageableElementExplicitReference } from '../model/packageableElement
 
 test(unitTest('Create valid and invalid packages on a root package'), () => {
   const _root = new Package(ROOT_PACKAGE_NAME.MAIN);
-  const createPackage = (packageName: string): void => {
-    Package.getOrCreatePackage(_root, packageName, true);
+  const createPackage = (packagePath: string): void => {
+    Package.getOrCreatePackage(_root, packagePath, true);
   };
   const validPackage = 'model::myPackage';
   createPackage(validPackage);
@@ -108,4 +111,23 @@ test(unitTest('JSON Object input data should be minified'), () => {
   expect(test1.data === losslessStringify(losslessParse(test1.data)));
   expect(test2.data === losslessStringify(losslessParse(test2.data)));
   expect(test3.data === losslessStringify(losslessParse(test3.data)));
+});
+
+test(unitTest('Resolve package path and element name'), () => {
+  expect(resolvePackagePathAndElementName('something::somethingElse')).toBe([
+    'something',
+    'somethingElse',
+  ]);
+  expect(resolvePackagePathAndElementName('something::a::somethingElse')).toBe([
+    'something::a',
+    'somethingElse',
+  ]);
+  expect(resolvePackagePathAndElementName('b')).toBe(['', 'b']);
+  expect(
+    resolvePackagePathAndElementName('something::b', 'somethingElse'),
+  ).toBe(['something', 'b']);
+  expect(resolvePackagePathAndElementName('b', 'somethingElse')).toBe([
+    'somethingElse',
+    'b',
+  ]);
 });

--- a/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
@@ -571,7 +571,7 @@ export abstract class BasicModel {
       );
       extension.removeElement(element.path);
     }
-    this.deadReferencesCleanUp();
+    this.cleanUpDeadReferences();
   }
 
   setIsBuilt(built: boolean): void {
@@ -590,7 +590,7 @@ export abstract class BasicModel {
     this.elementSectionMap = new Map<string, Section>();
   }
 
-  deadReferencesCleanUp(): void {
-    this.diagrams.forEach((diagram) => diagram.deadReferencesCleanUp(this));
+  cleanUpDeadReferences(): void {
+    this.diagrams.forEach((diagram) => diagram.cleanUpDeadReferences(this));
   }
 }

--- a/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
@@ -478,12 +478,10 @@ export abstract class BasicModel {
       'Name is required',
     )}`;
 
-  getOrCreatePackageWithPackageName = (
-    packageName: string | undefined,
-  ): Package =>
+  getOrCreatePackage = (packagePath: string | undefined): Package =>
     Package.getOrCreatePackage(
       this.root,
-      guaranteeNonNullable(packageName, 'Package name is required'),
+      guaranteeNonNullable(packagePath, 'Package path is required'),
       true,
     );
 

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/Diagram.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/diagram/Diagram.ts
@@ -59,7 +59,7 @@ export class Diagram extends PackageableElement implements Hashable {
     });
   }
 
-  deadReferencesCleanUp(pureModel: BasicModel): void {
+  cleanUpDeadReferences(graph: BasicModel): void {
     // Delete orphan property views
     const propertyViewsToRemove = this.propertyViews.filter(
       (p) =>
@@ -71,7 +71,7 @@ export class Diagram extends PackageableElement implements Hashable {
       this.deletePropertyView(propertyView),
     );
 
-    const classesSet = new Set(pureModel.classes);
+    const classesSet = new Set(graph.classes);
 
     // Fix orphan class views
     const classViewsRoRemove = this.classViews.filter(

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
@@ -88,11 +88,11 @@ export class Package extends PackageableElement implements Hashable {
    */
   static getOrCreatePackage(
     parent: Package,
-    packageName: string,
+    packagePath: string,
     insert: boolean,
   ): Package {
-    const index = packageName.indexOf(ELEMENT_PATH_DELIMITER);
-    const str = index === -1 ? packageName : packageName.substring(0, index);
+    const index = packagePath.indexOf(ELEMENT_PATH_DELIMITER);
+    const str = index === -1 ? packagePath : packagePath.substring(0, index);
     let node: Package | undefined;
     node = parent.children.find(
       (child: PackageableElement): child is Package =>
@@ -101,7 +101,7 @@ export class Package extends PackageableElement implements Hashable {
     if (!node) {
       if (!insert) {
         throw new GraphError(
-          `Can't find packageable element '${str}' in package '${packageName}'`,
+          `Can't find packageable element '${str}' in package '${packagePath}'`,
         );
       }
       // create the node if it is not in parent package
@@ -111,7 +111,7 @@ export class Package extends PackageableElement implements Hashable {
     if (index !== -1) {
       return Package.getOrCreatePackage(
         node,
-        packageName.substring(index + 2),
+        packagePath.substring(index + 2),
         insert,
       );
     }

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ElementBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ElementBuilder.ts
@@ -113,7 +113,7 @@ export class V1_ElementBuilder<T extends V1_PackageableElement> {
     );
     const element = this.firstPass(elementProtocol, context);
     context.currentSubGraph
-      .getOrCreatePackageWithPackageName(elementProtocol.package)
+      .getOrCreatePackage(elementProtocol.package)
       .addElement(element);
     return element;
   }

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassBuilder.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassBuilder.ts
@@ -105,7 +105,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(profile);
     this.context.currentSubGraph.setProfile(path, profile);
     return profile;
@@ -124,7 +124,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(pureEnumeration);
     this.context.currentSubGraph.setType(path, pureEnumeration);
     return pureEnumeration;
@@ -143,7 +143,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(pureMeasure);
     this.context.currentSubGraph.setType(path, pureMeasure);
     return pureMeasure;
@@ -162,7 +162,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(_class);
     this.context.currentSubGraph.setType(path, _class);
     return _class;
@@ -181,7 +181,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(association);
     this.context.currentSubGraph.setAssociation(path, association);
     return association;
@@ -210,7 +210,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(func);
     this.context.currentSubGraph.setFunction(path, func);
     return func;
@@ -229,7 +229,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(flatData);
     this.context.currentSubGraph.setStore(path, flatData);
     return flatData;
@@ -248,7 +248,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(database);
     this.context.currentSubGraph.setStore(path, database);
     return database;
@@ -267,7 +267,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(serviceStore);
     this.context.currentSubGraph.setStore(path, serviceStore);
     return serviceStore;
@@ -286,7 +286,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(pureMapping);
     this.context.currentSubGraph.setMapping(path, pureMapping);
     return pureMapping;
@@ -305,7 +305,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(service);
     this.context.currentSubGraph.setService(path, service);
     return service;
@@ -324,7 +324,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(diagram);
     this.context.currentSubGraph.setDiagram(path, diagram);
     return diagram;
@@ -351,7 +351,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(fileGeneration);
     this.context.currentSubGraph.setFileGeneration(path, fileGeneration);
     return fileGeneration;
@@ -379,7 +379,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(generationSpec);
     this.context.currentSubGraph.setGenerationSpecification(
       path,
@@ -401,7 +401,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(runtime);
     this.context.currentSubGraph.setRuntime(path, runtime);
     return runtime;
@@ -422,7 +422,7 @@ export class V1_ProtocolToMetaModelGraphFirstPassBuilder
       `Element '${path}' already exists`,
     );
     this.context.currentSubGraph
-      .getOrCreatePackageWithPackageName(element.package)
+      .getOrCreatePackage(element.package)
       .addElement(connection);
     this.context.currentSubGraph.setConnection(path, connection);
     return connection;

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DomainBuilderHelper.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DomainBuilderHelper.ts
@@ -127,9 +127,7 @@ export const V1_buildUnit = (
     !currentGraph.getNullableElement(path),
     `Element '${path}' already exists`,
   );
-  currentGraph
-    .getOrCreatePackageWithPackageName(unit.package)
-    .addElement(pureUnit);
+  currentGraph.getOrCreatePackage(unit.package).addElement(pureUnit);
   currentGraph.setType(path, pureUnit);
   return pureUnit;
 };

--- a/packages/legend-studio/src/stores/EditorStore.tsx
+++ b/packages/legend-studio/src/stores/EditorStore.tsx
@@ -1030,7 +1030,7 @@ export class EditorStore {
     );
     this.graphState.graph.removeElement(element);
     if (this.currentEditorState instanceof DiagramEditorState) {
-      this.currentEditorState.diagramRenderer.start();
+      this.currentEditorState.renderer.render();
     }
     this.explorerTreeState.reprocess();
     // re-compile after deletion

--- a/packages/legend-studio/src/stores/ExplorerTreeState.ts
+++ b/packages/legend-studio/src/stores/ExplorerTreeState.ts
@@ -341,14 +341,14 @@ export class ExplorerTreeState {
         element,
       );
     }
-    const packageName = element.getRoot().path;
+    const packagePath = element.getRoot().path;
     let opened = false;
-    if (packageName === ROOT_PACKAGE_NAME.MAIN && this.treeData) {
+    if (packagePath === ROOT_PACKAGE_NAME.MAIN && this.treeData) {
       const openingNode = openNode(this.editorStore, element, this.treeData);
       this.setSelectedNode(openingNode);
       opened = true;
     } else if (
-      packageName === ROOT_PACKAGE_NAME.MODEL_GENERATION &&
+      packagePath === ROOT_PACKAGE_NAME.MODEL_GENERATION &&
       this.generationTreeData
     ) {
       const openingNode = openNode(
@@ -359,7 +359,7 @@ export class ExplorerTreeState {
       this.setSelectedNode(openingNode);
       opened = true;
     } else if (
-      packageName === ROOT_PACKAGE_NAME.SYSTEM &&
+      packagePath === ROOT_PACKAGE_NAME.SYSTEM &&
       this.systemTreeData
     ) {
       const openingNode = openNode(
@@ -370,7 +370,7 @@ export class ExplorerTreeState {
       this.setSelectedNode(openingNode);
       opened = true;
     } else if (
-      packageName === ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT &&
+      packagePath === ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT &&
       this.dependencyTreeData
     ) {
       const openingNode = openNode(
@@ -384,7 +384,7 @@ export class ExplorerTreeState {
     if (!opened) {
       this.editorStore.applicationStore.logger.error(
         CORE_LOG_EVENT.PACKAGE_TREE_PROBLEM,
-        `Can't open package tree node for element '${element.path}' with package root '${packageName}'`,
+        `Can't open package tree node for element '${element.path}' with package root '${packagePath}'`,
       );
     }
   }

--- a/packages/legend-studio/src/stores/NewElementState.tsx
+++ b/packages/legend-studio/src/stores/NewElementState.tsx
@@ -87,7 +87,7 @@ export const resolvePackageAndElementName = (
     index === -1 ? name : name.substring(index + 2, name.length);
   const additionalPackageName = index === -1 ? '' : name.substring(0, index);
   const selectedPackageName = isPackageRoot ? '' : _package.path;
-  const packageName =
+  const packagePath =
     !selectedPackageName && !additionalPackageName
       ? ''
       : selectedPackageName
@@ -97,7 +97,7 @@ export const resolvePackageAndElementName = (
             : ''
         }`
       : additionalPackageName;
-  return [packageName, elementName];
+  return [packagePath, elementName];
 };
 
 export abstract class NewElementDriver<T extends PackageableElement> {
@@ -527,10 +527,10 @@ export class NewElementState {
 
   save(): void {
     if (this.name && this.isValid) {
-      const [packageName, elementName] = this.elementAndPackageName;
+      const [packagePath, elementName] = this.elementAndPackageName;
       if (
         this.editorStore.graphState.graph.isRoot(
-          this.editorStore.graphState.graph.getNullablePackage(packageName),
+          this.editorStore.graphState.graph.getNullablePackage(packagePath),
         ) &&
         this.type !== PACKAGEABLE_ELEMENT_TYPE.PACKAGE
       ) {
@@ -539,10 +539,8 @@ export class NewElementState {
         );
       } else {
         const element = this.createElement(elementName);
-        (packageName
-          ? this.editorStore.graphState.graph.getOrCreatePackageWithPackageName(
-              packageName,
-            )
+        (packagePath
+          ? this.editorStore.graphState.graph.getOrCreatePackage(packagePath)
           : this.editorStore.graphState.graph.root
         ).addElement(element);
         this.editorStore.graphState.graph.addElement(element);

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -126,15 +126,18 @@ export class DiagramEditorInlinePropertyEditorState {
   diagramEditorState: DiagramEditorState;
   property: PropertyReference;
   point: Point;
+  isEditingPropertyView: boolean;
 
   constructor(
     diagramEditorState: DiagramEditorState,
     property: AbstractProperty,
     point: Point,
+    isEditingPropertyView: boolean,
   ) {
     this.diagramEditorState = diagramEditorState;
     this.property = PropertyExplicitReference.create(property);
     this.point = point;
+    this.isEditingPropertyView = isEditingPropertyView;
   }
 }
 
@@ -315,7 +318,12 @@ export class DiagramEditorState extends ElementEditorState {
       point: Point,
     ): void => {
       this.setInlinePropertyEditorState(
-        new DiagramEditorInlinePropertyEditorState(this, property, point),
+        new DiagramEditorInlinePropertyEditorState(
+          this,
+          property,
+          point,
+          false,
+        ),
       );
     };
     this.renderer.editPropertyView = (
@@ -328,6 +336,7 @@ export class DiagramEditorState extends ElementEditorState {
           propertyHolderView.path.length
             ? propertyHolderView.path[0]
             : propertyHolderView.from.classView.value.center(),
+          true,
         ),
       );
     };

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -196,6 +196,9 @@ export class DiagramEditorState extends ElementEditorState {
     if (this.isReadOnly || !this.isDiagramRendererInitialized) {
       return '';
     }
+    if (this.renderer.middleClick || this.renderer.rightClick) {
+      return 'diagram-editor__cursor--grabbing';
+    }
     switch (this.renderer.interactionMode) {
       case DIAGRAM_INTERACTION_MODE.ADD_CLASS: {
         return 'diagram-editor__cursor--add';

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -122,6 +122,16 @@ export class DiagramEditorNewClassSidePanelState extends DiagramEditorSidePanelS
   }
 }
 
+export class DiagramEditorInlineClassCreatorState {
+  diagramEditorState: DiagramEditorState;
+  point: Point;
+
+  constructor(diagramEditorState: DiagramEditorState, point: Point) {
+    this.diagramEditorState = diagramEditorState;
+    this.point = point;
+  }
+}
+
 export class DiagramEditorInlinePropertyEditorState {
   diagramEditorState: DiagramEditorState;
   property: PropertyReference;
@@ -151,6 +161,7 @@ export class DiagramEditorState extends ElementEditorState {
   });
   sidePanelState?: DiagramEditorSidePanelState;
   inlinePropertyEditorState?: DiagramEditorInlinePropertyEditorState;
+  inlineClassCreatorState?: DiagramEditorInlineClassCreatorState;
 
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
@@ -161,6 +172,7 @@ export class DiagramEditorState extends ElementEditorState {
       sidePanelDisplayState: observable,
       sidePanelState: observable,
       inlinePropertyEditorState: observable,
+      inlineClassCreatorState: observable,
       renderer: computed,
       diagram: computed,
       isDiagramRendererInitialized: computed,
@@ -168,6 +180,7 @@ export class DiagramEditorState extends ElementEditorState {
       setRenderer: action,
       setSidePanelState: action,
       setInlinePropertyEditorState: action,
+      setInlineClassCreatorState: action,
       reprocess: action,
     });
   }
@@ -256,6 +269,12 @@ export class DiagramEditorState extends ElementEditorState {
     this.inlinePropertyEditorState = val;
   }
 
+  setInlineClassCreatorState(
+    val: DiagramEditorInlineClassCreatorState | undefined,
+  ): void {
+    this.inlineClassCreatorState = val;
+  }
+
   setupDiagramRenderer(): void {
     this.renderer.setIsReadOnly(this.isReadOnly);
     this.renderer.editClass = (classView: ClassView): void => {
@@ -275,16 +294,11 @@ export class DiagramEditorState extends ElementEditorState {
       );
       this.sidePanelDisplayState.open();
     };
-    const createNewClassView = (mouseEvent: MouseEvent): void => {
+    const createNewClassView = (point: Point): void => {
       if (!this.isReadOnly) {
-        this.setSidePanelState(
-          new DiagramEditorNewClassSidePanelState(
-            this.editorStore,
-            this,
-            mouseEvent,
-          ),
+        this.setInlineClassCreatorState(
+          new DiagramEditorInlineClassCreatorState(this, point),
         );
-        this.sidePanelDisplayState.open();
       }
     };
     this.renderer.onBackgroundDoubleClick = createNewClassView;
@@ -298,7 +312,7 @@ export class DiagramEditorState extends ElementEditorState {
         const _class = this.sidePanelState.classEditorState.class;
         _class.addProperty(
           new Property(
-            `newProperty_${_class.properties.length}`,
+            `property_${_class.properties.length + 1}`,
             this.editorStore.graphState.graph.getTypicalMultiplicity(
               TYPICAL_MULTIPLICITY_TYPE.ONE,
             ),
@@ -344,7 +358,7 @@ export class DiagramEditorState extends ElementEditorState {
       const _class = classView.class.value;
       _class.addProperty(
         new Property(
-          `newProperty_${_class.properties.length}`,
+          `property_${_class.properties.length + 1}`,
           this.editorStore.graphState.graph.getTypicalMultiplicity(
             TYPICAL_MULTIPLICITY_TYPE.ONE,
           ),

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
@@ -51,11 +51,9 @@ export class ElementFileGenerationState {
     this.showNewFileGenerationModal = show;
   }
 
-  promoteToFileGeneration(packageName: string, name: string): void {
+  promoteToFileGeneration(packagePath: string, name: string): void {
     const fileGenerationPackage =
-      this.editorStore.graphState.graph.getOrCreatePackageWithPackageName(
-        packageName,
-      );
+      this.editorStore.graphState.graph.getOrCreatePackage(packagePath);
     const fileGeneration = this.fileGenerationState.fileGeneration;
     fileGeneration.name = name;
     fileGenerationPackage.addElement(fileGeneration);

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
@@ -38,7 +38,7 @@ import type { Schema } from '../../../../models/metamodels/pure/model/packageabl
 import type { Table } from '../../../../models/metamodels/pure/model/packageableElements/store/relational/model/Table';
 import {
   isValidFullPath,
-  resolvePackageNameAndElementName,
+  resolvePackagePathAndElementName,
 } from '../../../../models/MetaModelUtils';
 import type { Entity } from '../../../../models/sdlc/models/entity/Entity';
 import { CORE_LOG_EVENT } from '../../../../utils/Logger';
@@ -204,9 +204,9 @@ export class DatabaseBuilderState {
     schema?: string,
   ): DatabaseBuilderInput {
     const databaseBuilderInput = new DatabaseBuilderInput(this.connection);
-    const [packageName, databaseName] = this.getDatabasePackageAndName();
+    const [packagePath, databaseName] = this.getDatabasePackageAndName();
     databaseBuilderInput.targetDatabase = new TargetDatabase(
-      packageName,
+      packagePath,
       databaseName,
     );
     databaseBuilderInput.config.maxTables = undefined;
@@ -307,12 +307,11 @@ export class DatabaseBuilderState {
   ): GeneratorFn<void> {
     try {
       const databaseBuilderInput = new DatabaseBuilderInput(this.connection);
-      const [packageName, databaseName] = resolvePackageNameAndElementName(
-        this.targetDatabasePath,
+      const [packagePath, databaseName] = resolvePackagePathAndElementName(
         this.targetDatabasePath,
       );
       databaseBuilderInput.targetDatabase = new TargetDatabase(
-        packageName,
+        packagePath,
         databaseName,
       );
       const config = databaseBuilderInput.config;
@@ -391,7 +390,7 @@ export class DatabaseBuilderState {
       isValidFullPath(this.targetDatabasePath),
       'Invalid database path',
     );
-    return resolvePackageNameAndElementName(
+    return resolvePackagePathAndElementName(
       this.targetDatabasePath,
       this.targetDatabasePath,
     );
@@ -403,9 +402,9 @@ export class DatabaseBuilderState {
         const dbTreeData = this.treeData;
         this.isBuildingDatabase = true;
         const databaseBuilderInput = new DatabaseBuilderInput(this.connection);
-        const [packageName, databaseName] = this.getDatabasePackageAndName();
+        const [packagePath, databaseName] = this.getDatabasePackageAndName();
         databaseBuilderInput.targetDatabase = new TargetDatabase(
-          packageName,
+          packagePath,
           databaseName,
         );
         const config = databaseBuilderInput.config;
@@ -520,7 +519,7 @@ export class DatabaseBuilderState {
       this.isSavingDatabase = true;
       assertNonEmptyString(
         this.databaseGrammarCode,
-        'Database Grammar cannot be empty',
+        'Database grammar is empty',
       );
       const database = (yield this.buildDatabaseGrammar(
         this.databaseGrammarCode,
@@ -532,14 +531,12 @@ export class DatabaseBuilderState {
         this.connection.setStore(
           PackageableElementExplicitReference.create(newDatabase),
         );
-        const packageName = guaranteeNonNullable(
+        const PackagePath = guaranteeNonNullable(
           database.package?.name,
-          'database must have package defined',
+          'Database package is missing',
         );
         const databasePackage =
-          this.editorStore.graphState.graph.getOrCreatePackageWithPackageName(
-            packageName,
-          );
+          this.editorStore.graphState.graph.getOrCreatePackage(PackagePath);
         databasePackage.addElement(newDatabase);
         this.editorStore.graphState.graph.addElement(newDatabase);
         currentDatabase = newDatabase;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
@@ -576,7 +576,7 @@ export class MappingExecutionState {
 
   promoteToService = flow(function* (
     this: MappingExecutionState,
-    packageName: string,
+    packagePath: string,
     serviceName: string,
   ) {
     try {
@@ -612,9 +612,7 @@ export class MappingExecutionState {
           );
           singleExecutionTest.asserts.push(testContainer);
           const servicePackage =
-            this.editorStore.graphState.graph.getOrCreatePackageWithPackageName(
-              packageName,
-            );
+            this.editorStore.graphState.graph.getOrCreatePackage(packagePath);
           service.test = singleExecutionTest;
           servicePackage.addElement(service);
           this.editorStore.graphState.graph.addElement(service);

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -252,21 +252,7 @@
   }
 
   &__side-panel {
-    border-left: 0.1rem solid var(--color-light-grey-400);
-
-    &__header {
-      display: flex;
-      justify-content: flex-end;
-      padding: 0 1rem;
-    }
-
-    &__content {
-      position: relative;
-    }
-
-    &__close-btn {
-      cursor: pointer;
-    }
+    background: var(--color-dark-grey-85);
   }
 
   &__hotkeys__dialog .modal__body {
@@ -306,6 +292,13 @@
       }
     }
   }
+}
+
+.diagram-editor__class-view-editor {
+  height: 100%;
+  width: 100%;
+  position: relative;
+  padding: 1rem;
 }
 
 .diagram-editor__inline-property-editor {

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -245,6 +245,10 @@
     &--zoom-out {
       cursor: zoom-out;
     }
+
+    &--grabbing {
+      cursor: grabbing;
+    }
   }
 
   &__side-panel {

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -56,6 +56,45 @@
     }
   }
 
+  &__header__zoomer {
+    &__dropdown {
+      @include flexVCenter;
+
+      height: 1.8rem;
+      border: 0.1rem solid var(--color-dark-grey-300);
+    }
+
+    &__dropdown__label {
+      @include flexCenter;
+      @include flexConstantDimension;
+
+      height: 100%;
+      width: 5rem;
+      color: var(--color-dark-grey-500);
+      font-weight: 500;
+      font-size: 1.2rem;
+    }
+
+    &__dropdown__trigger {
+      @include flexCenter;
+      @include flexConstantDimension;
+
+      height: 100%;
+      width: 2rem;
+      cursor: pointer;
+
+      svg {
+        color: var(--color-dark-grey-500);
+      }
+    }
+
+    &__dropdown__menu__item {
+      @include flexCenter;
+
+      width: 7rem;
+    }
+  }
+
   &__content {
     height: calc(100% - 2.8rem);
     width: 100%;
@@ -167,6 +206,11 @@
     &--sidebar {
       font-size: 1.8rem;
     }
+
+    &--zoom-in,
+    &--zoom-out {
+      font-size: 1.8rem;
+    }
   }
 
   &__canvas {
@@ -192,6 +236,14 @@
 
     &--add {
       cursor: cell;
+    }
+
+    &--zoom-in {
+      cursor: zoom-in;
+    }
+
+    &--zoom-out {
+      cursor: zoom-out;
     }
   }
 

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -364,48 +364,22 @@
   }
 }
 
-.diagram-editor__side-panel__create-new {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  padding: 2rem;
+.diagram-editor__inline-class-creator {
+  @include flexVCenter;
 
-  &__title {
-    font-size: 2rem;
-    font-weight: bold;
-    margin-bottom: 1rem;
+  height: 2.8rem;
+  width: 25.6rem;
+  padding: 0.3rem;
+
+  &__path {
+    @include flexConstantDimension;
+
+    width: 25rem;
+    height: 2.2rem;
+    border: 0.1rem solid var(--color-dark-grey-300);
   }
 
-  &__name {
-    width: 100%;
-  }
-
-  &__package-tree {
-    flex: 1 0 auto;
-    padding: 0.5rem;
-    border: 0.1rem solid var(--color-light-grey-300);
-    background: var(--color-light-grey-0);
-    margin: 0.5rem 0;
-  }
-}
-
-.package-tree {
-  &__node__container--selected {
-    background: var(--color-yellow-200);
-  }
-
-  &__node__icon {
-    width: 4rem;
-  }
-
-  &__expand-icon,
-  &__type-icon {
-    @include flexHCenter;
-
-    width: 2rem;
-  }
-
-  &__expand-icon svg {
-    font-size: 1rem;
+  &__close-btn {
+    display: none;
   }
 }

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -49,6 +49,7 @@
       color: var(--color-dark-grey-400);
     }
 
+    &:hover,
     &--active {
       svg {
         color: var(--color-light-grey-300);
@@ -56,39 +57,68 @@
     }
   }
 
-  &__header__zoomer {
-    &__dropdown {
-      @include flexVCenter;
+  &__header__dropdown {
+    @include flexVCenter;
 
-      height: 1.8rem;
-      border: 0.1rem solid var(--color-dark-grey-300);
-    }
+    margin-left: 0.3rem;
+    height: 1.8rem;
+    border: 0.1rem solid var(--color-dark-grey-300);
 
-    &__dropdown__label {
+    &__label {
       @include flexCenter;
       @include flexConstantDimension;
 
       height: 100%;
-      width: 5rem;
       color: var(--color-dark-grey-500);
       font-weight: 500;
       font-size: 1.2rem;
     }
 
-    &__dropdown__trigger {
+    &__trigger {
       @include flexCenter;
       @include flexConstantDimension;
 
       height: 100%;
-      width: 2rem;
       cursor: pointer;
 
       svg {
         color: var(--color-dark-grey-500);
       }
     }
+  }
 
-    &__dropdown__menu__item {
+  &__header__aligner__dropdown {
+    &__label {
+      width: 7rem;
+    }
+
+    &__trigger {
+      width: 2rem;
+    }
+
+    &__menu__item {
+      @include flexCenter;
+
+      width: 9rem;
+      padding: 0.5rem;
+      justify-content: left;
+
+      .menu__item__label {
+        margin-left: 0.5rem;
+      }
+    }
+  }
+
+  &__header__zoomer__dropdown {
+    &__label {
+      width: 5rem;
+    }
+
+    &__trigger {
+      width: 2rem;
+    }
+
+    &__menu__item {
       @include flexCenter;
 
       width: 7rem;
@@ -209,6 +239,10 @@
 
     &--zoom-in,
     &--zoom-out {
+      font-size: 1.8rem;
+    }
+
+    &--aligner {
       font-size: 1.8rem;
     }
   }

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -267,9 +267,13 @@
     padding: 3rem;
   }
 
-  &__hotkey__groups {
-    height: 100%;
+  &__hotkey__groups__divider {
+    @include flexConstantDimension;
+
     width: 100%;
+    height: 0.1rem;
+    background: var(--color-dark-grey-100);
+    margin: 0.7rem 0;
   }
 
   &__hotkey__group {

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -87,28 +87,6 @@
     }
   }
 
-  &__header__aligner__dropdown {
-    &__label {
-      width: 7rem;
-    }
-
-    &__trigger {
-      width: 2rem;
-    }
-
-    &__menu__item {
-      @include flexCenter;
-
-      width: 9rem;
-      padding: 0.5rem;
-      justify-content: left;
-
-      .menu__item__label {
-        margin-left: 0.5rem;
-      }
-    }
-  }
-
   &__header__zoomer__dropdown {
     &__label {
       width: 5rem;
@@ -239,10 +217,6 @@
 
     &--zoom-in,
     &--zoom-out {
-      font-size: 1.8rem;
-    }
-
-    &--aligner {
       font-size: 1.8rem;
     }
   }

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -312,7 +312,7 @@
   @include flexVCenter;
 
   height: 2.8rem;
-  width: 23.9rem;
+  width: 39.2rem;
   padding: 0.3rem;
 
   &__name {
@@ -323,12 +323,18 @@
     border: 0.1rem solid var(--color-dark-grey-300);
   }
 
+  &__type {
+    @include flexConstantDimension;
+
+    width: 15rem;
+    margin: 0 0.3rem;
+  }
+
   &__multiplicity-editor {
     @include flexVCenter;
     @include flexConstantDimension;
 
     width: 8rem;
-    margin-left: 0.3rem;
 
     &__bound {
       @include flexConstantDimension;

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -31,11 +31,11 @@
     "stylelint": "13.13.1",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-standard": "22.0.0",
-    "stylelint-scss": "3.19.0"
+    "stylelint-scss": "3.20.0"
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "eslint": "7.30.0",
+    "eslint": "7.31.0",
     "rimraf": "3.0.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,9 +1760,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@eslint/eslintrc@npm:0.4.2"
+"@eslint/eslintrc@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "@eslint/eslintrc@npm:0.4.3"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.1.1
@@ -1773,7 +1773,7 @@ __metadata:
     js-yaml: ^3.13.1
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
-  checksum: 17f90cf07988dd2a5e4f510687c81334141977b8e0fa1b63ef0318b0578466e368fc988c101ddc7df55b6124dff8ecd1be67292c27901265761758ad22608e12
+  checksum: 03a7704150b868c318aab6a94d87a33d30dc2ec579d27374575014f06237ba1370ae11178db772f985ef680d469dc237e7b16a1c5d8edaaeb8c3733e7a95a6d3
   languageName: node
   linkType: hard
 
@@ -1791,7 +1791,7 @@ __metadata:
     "@babel/preset-typescript": 7.14.5
     "@babel/runtime": 7.14.6
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     react-refresh: 0.10.0
     rimraf: 3.0.2
     typescript: 4.3.5
@@ -1809,7 +1809,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 4.28.3
     "@typescript-eslint/parser": 4.28.3
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     eslint-config-prettier: 8.3.0
     eslint-plugin-import: 2.23.4
     eslint-plugin-prettier: 3.4.0
@@ -1837,7 +1837,7 @@ __metadata:
     "@types/react": 17.0.14
     copy-webpack-plugin: 9.0.1
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     npm-run-all: 4.1.5
     react: 17.0.2
@@ -1862,7 +1862,7 @@ __metadata:
     "@types/react-window": 1.8.4
     clsx: 1.1.1
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
@@ -1903,9 +1903,9 @@ __metadata:
     clean-webpack-plugin: 3.0.0
     cosmiconfig: 7.0.0
     cross-env: 7.0.3
-    css-loader: 6.0.0
+    css-loader: 6.1.0
     cssnano: 5.0.6
-    eslint: 7.30.0
+    eslint: 7.31.0
     fork-ts-checker-webpack-plugin: 6.2.12
     html-webpack-plugin: 5.3.2
     isbinaryfile: 4.0.8
@@ -1942,7 +1942,7 @@ __metadata:
     "@types/react": 17.0.14
     axios: 0.21.1
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     npm-run-all: 4.1.5
     react: 17.0.2
@@ -1958,7 +1958,7 @@ __metadata:
     "@finos/legend-studio-dev-utils": "workspace:*"
     "@finos/legend-studio-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     rimraf: 3.0.2
     typescript: 4.3.5
@@ -1976,7 +1976,7 @@ __metadata:
     "@types/react": 17.0.14
     "@types/react-router-dom": 5.1.8
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
@@ -2002,7 +2002,7 @@ __metadata:
     "@finos/legend-studio-shared": "workspace:*"
     "@types/zipkin-javascript-opentracing": 1.6.0
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     opentracing: 0.14.5
     rimraf: 3.0.2
@@ -2023,7 +2023,7 @@ __metadata:
     "@finos/legend-studio-shared": "workspace:*"
     "@types/react": 17.0.14
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
@@ -2047,7 +2047,7 @@ __metadata:
     "@finos/legend-studio-dev-utils": "workspace:*"
     "@finos/legend-studio-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     npm-run-all: 4.1.5
     rimraf: 3.0.2
@@ -2075,7 +2075,7 @@ __metadata:
     "@types/react-router-dom": 5.1.8
     cross-env: 7.0.3
     date-fns: 2.22.1
-    eslint: 7.30.0
+    eslint: 7.31.0
     jest: 27.0.6
     mobx: 6.3.2
     mobx-react-lite: 3.2.0
@@ -2106,7 +2106,7 @@ __metadata:
     "@types/seedrandom": 3.0.1
     "@types/uuid": 8.3.1
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     hash.js: 1.1.7
     http-status-codes: 2.1.4
     jest: 27.0.6
@@ -2143,7 +2143,7 @@ __metadata:
     "@types/react-router-dom": 5.1.8
     cross-env: 7.0.3
     date-fns: 2.22.1
-    eslint: 7.30.0
+    eslint: 7.31.0
     history: 5.0.0
     jest: 27.0.6
     jest-canvas-mock: 2.3.1
@@ -2178,12 +2178,12 @@ __metadata:
   resolution: "@finos/stylelint-config-legend-studio@workspace:packages/stylelint-config"
   dependencies:
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     rimraf: 3.0.2
     stylelint: 13.13.1
     stylelint-config-prettier: 8.0.2
     stylelint-config-standard: 22.0.0
-    stylelint-scss: 3.19.0
+    stylelint-scss: 3.20.0
   peerDependencies:
     stylelint: ^13.0.0
   languageName: unknown
@@ -5210,9 +5210,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-loader@npm:6.0.0":
-  version: 6.0.0
-  resolution: "css-loader@npm:6.0.0"
+"css-loader@npm:6.1.0":
+  version: 6.1.0
+  resolution: "css-loader@npm:6.1.0"
   dependencies:
     icss-utils: ^5.1.0
     postcss: ^8.2.15
@@ -5224,7 +5224,7 @@ __metadata:
     semver: ^7.3.5
   peerDependencies:
     webpack: ^5.0.0
-  checksum: d0d0ec6f13b0df5591d8d881297adf7756889b91defb6bb0ce3b5a407f69a8163695063a4f7ec644e14a274058c75b5ac1d21565c770f3d896d941c78662b34a
+  checksum: 5ebc5e41281625d8c20466fc5bacd56eab763173f63dcbe82a56619dd10a12d2e67dc2a08582ce4c8994516ed6440c2f6edb61d693044a82cfefd23eb3b5f784
   languageName: node
   linkType: hard
 
@@ -6272,12 +6272,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:7.30.0":
-  version: 7.30.0
-  resolution: "eslint@npm:7.30.0"
+"eslint@npm:7.31.0":
+  version: 7.31.0
+  resolution: "eslint@npm:7.31.0"
   dependencies:
     "@babel/code-frame": 7.12.11
-    "@eslint/eslintrc": ^0.4.2
+    "@eslint/eslintrc": ^0.4.3
     "@humanwhocodes/config-array": ^0.5.0
     ajv: ^6.10.0
     chalk: ^4.0.0
@@ -6318,7 +6318,7 @@ __metadata:
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 872f90844b164dd61ec1bb949d2e33e7fbd189e0652fabe2cbbd0bdce1e4cd7ed08e72fa213795a453ae39fe24460771800608e765febb9e778deb28b9db3cc1
+  checksum: fd73d07ce0b73e5ea950b295a6eaf8d45914b4e56cba4ef49e55a36dc7e965a4865f63f618c0a096a01d089752d9e44180b80ba8657039b8e631dd40e0af1663
   languageName: node
   linkType: hard
 
@@ -9414,7 +9414,7 @@ __metadata:
     "@types/node": 16.3.3
     chalk: 4.1.1
     cross-env: 7.0.3
-    eslint: 7.30.0
+    eslint: 7.31.0
     fs-extra: 10.0.0
     husky: 7.0.1
     jest: 27.0.6
@@ -13789,9 +13789,9 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stylelint-scss@npm:3.19.0":
-  version: 3.19.0
-  resolution: "stylelint-scss@npm:3.19.0"
+"stylelint-scss@npm:3.20.0":
+  version: 3.20.0
+  resolution: "stylelint-scss@npm:3.20.0"
   dependencies:
     lodash: ^4.17.15
     postcss-media-query-parser: ^0.2.3
@@ -13800,7 +13800,7 @@ resolve@^2.0.0-next.3:
     postcss-value-parser: ^4.1.0
   peerDependencies:
     stylelint: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
-  checksum: 5ce72106f5a99800ce463715d9ff7c59eb2169c8c046b5f5ff0dcf8cdfadc7c6f67a02a2a9f2c2be376cebdae5dcfc467f07c7a71a2a919444226705cea9fc44
+  checksum: 61b7448fd110b166edb8b4cfa1a42624dd94e35154ab5db5ef51b6c578c00c4f3ff9d1be1cee8a16f19aef81e755289fb3e013c4316ee4718001beaf2cdf05cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to https://github.com/finos/legend-studio/issues/300

Improvements for diagram editor:
- [x] Better zoom interactions
- [x] More systematic hotkey
- [x] Dynamic cursor
- [x] Allow editing property type in property inline-editor
- [x] Allow creating class inline
- [x] Allow editing class view attributes: `hideProperties`, `hideStereotypes`, `hideTaggedValues`, etc.
- [x] ~~Allow aligning selected elements~~ - add but then removed as we deem it less useful than we thought.