### PR TITLE
Add round trip tests for BigQuery connections

### DIFF
--- a/.changeset/seven-foxes-pretend.md
+++ b/.changeset/seven-foxes-pretend.md
@@ -1,0 +1,19 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-manual-tests': patch
+'@finos/legend-studio-network': patch
+'@finos/legend-studio-plugin-management': patch
+'@finos/legend-studio-plugin-tracer-zipkin': patch
+'@finos/legend-studio-preset-dsl-text': patch
+'@finos/legend-studio-preset-external-format-json-schema': patch
+'@finos/legend-studio-preset-query-builder': patch
+'@finos/legend-studio-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---
+
+Add roundtrip tests for BigQuery connection

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/store/relational/connection/DatasourceSpecification.ts
@@ -266,10 +266,17 @@ export class BigQueryDatasourceSpecification
   }
 
   get hashCode(): string {
-    return hashArray([
-      CORE_HASH_STRUCTURE.BIGQUERY_DATASOURCE_SPECIFICATION,
-      this.projectId,
-      this.defaultDataset,
-    ]);
+    if (this.defaultDataset === undefined || this.defaultDataset === null) {
+      return hashArray([
+        CORE_HASH_STRUCTURE.BIGQUERY_DATASOURCE_SPECIFICATION,
+        this.projectId,
+      ]);
+    } else {
+      return hashArray([
+        CORE_HASH_STRUCTURE.BIGQUERY_DATASOURCE_SPECIFICATION,
+        this.projectId,
+        this.defaultDataset,
+      ]);
+    }
   }
 }

--- a/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
+++ b/packages/legend-studio/src/stores/__tests__/roundtrip/RelationalRoundtripTestData.ts
@@ -3982,6 +3982,49 @@ export const testRelationalDatabaseConnectionRoundtrip = [
     },
     classifierPath: 'meta::pure::runtime::PackageableConnection',
   },
+  {
+    path: 'simple::BigQueryConnectionWithDefaultDataset',
+    content: {
+      _type: 'connection',
+      connectionValue: {
+        _type: 'RelationalDatabaseConnection',
+        authenticationStrategy: {
+          _type: 'gcpApplicationDefaultCredentials',
+        },
+        datasourceSpecification: {
+          _type: 'bigQuery',
+          projectId: 'project1',
+          defaultDataset: 'dataset1',
+        },
+        element: 'apps::pure::studio::relational::tests::dbInc',
+        type: 'BigQuery',
+      },
+      name: 'BigQueryConnectionWithDefaultDataset',
+      package: 'simple',
+    },
+    classifierPath: 'meta::pure::runtime::PackageableConnection',
+  },
+  {
+    path: 'simple::BigQueryConnectionWithoutDefaultDataset',
+    content: {
+      _type: 'connection',
+      connectionValue: {
+        _type: 'RelationalDatabaseConnection',
+        authenticationStrategy: {
+          _type: 'gcpApplicationDefaultCredentials',
+        },
+        datasourceSpecification: {
+          _type: 'bigQuery',
+          projectId: 'project1',
+        },
+        element: 'apps::pure::studio::relational::tests::dbInc',
+        type: 'BigQuery',
+      },
+      name: 'BigQueryConnectionWithoutDefaultDataset',
+      package: 'simple',
+    },
+    classifierPath: 'meta::pure::runtime::PackageableConnection',
+  },
 ];
 
 export const testRelationalInputData = [


### PR DESCRIPTION
| Q                       | A                                |
| ----------------------- | -------------------------------- |
| Fixed issues?           | <!-- e.g. Fixes #1, Fixes #2 --> |
| Tests added + passed?   | Yes                              |
| Changeset added?        | No|
| Documentation PR link   |                                  |
| Any dependency changes? | No                               |

This PR adds round trip tests for BigQuery connections. The tests identified the absence of null/undefined check for the optional defaultDataset property. 
