### PR TITLE
enable query builder for generated/dependency elements

### DIFF
--- a/.changeset/quick-trees-clap.md
+++ b/.changeset/quick-trees-clap.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Enable query builder for generated and dependency elements.


### PR DESCRIPTION
Enable opening query builder from generated and dependency elements.
Fixes: https://github.com/finos/legend-studio/issues/302


| Q                       | A                                |
| ----------------------- | -------------------------------- |
| Fixed issues?           | <!-- e.g. Fixes #1, Fixes #2 --> |
| Tests added + passed?   | No                              |
| Changeset added?        | Yes                              |
| Documentation PR link   |                                  |
| Any dependency changes? | No                               |

<!--
Summary fill-out guides:

- Test: https://github.com/finos/legend-studio/blob/master/docs/test-strategy.md
- Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
- Documentation: Link to a PR from https://github.com/finos/legend repo
- Dependency: https://github.com/finos/legend-studio/blob/master/docs/dependencies.md

NOTE: For component/style changes: Please check out our style guide https://github.com/finos/legend-studio/tree/master/docs/ux. Also, PR involving UX/UI might take more time to discuss and review.

Last but not least, describe your changes below in as much detail as possible in the space below 🎉
-->
