### PR TITLE
Diagram editor bug fixes and improvements

### DIFF
--- a/.changeset/chatty-deers-confess.md
+++ b/.changeset/chatty-deers-confess.md
@@ -1,0 +1,10 @@
+---
+'@finos/legend-studio': patch
+---
+
+Made several improvements to diagram editor:
+
+- Add a separate mode for pan/zoom
+- Create new basic property hotkey is not `Alt + DownArrow`
+- Fix a bug where diagram editor hotkeys not being picked up if the user hasn't clicked on the diagram editor
+- Rework class view selection behavior: single clicking a class will no-longer show classview editor; double-clicking is required instead.

--- a/.changeset/olive-worms-stare.md
+++ b/.changeset/olive-worms-stare.md
@@ -1,0 +1,10 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-components': patch
+'@finos/legend-studio-dev-utils': patch
+'@finos/legend-studio-preset-query-builder': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/.changeset/orange-pigs-train.md
+++ b/.changeset/orange-pigs-train.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Support renaming element (https://github.com/finos/legend-studio/issues/322). User can access this funtionality via the element context menu in the explorer tree. Diagram editor now also allows renaming classes.

--- a/.changeset/orange-yaks-shave.md
+++ b/.changeset/orange-yaks-shave.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Fix a bug where classes coming from immutable graphs (system, generation, dependencies) are automatically removed in diagrams (a regrssion introduced by https://github.com/finos/legend-studio/pull/351).

--- a/.changeset/smart-houses-relax.md
+++ b/.changeset/smart-houses-relax.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Fix a regression (introduced by https://github.com/finos/legend-studio/pull/350) with DnD to add class and ejecting property position in diagram editor.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@babel/core": "7.14.6",
+    "@babel/core": "7.14.8",
     "@changesets/cli": "2.16.0",
     "@finos/babel-preset-legend-studio": "workspace:*",
     "@finos/eslint-plugin-legend-studio": "workspace:*",
@@ -73,7 +73,7 @@
     "@finos/stylelint-config-legend-studio": "workspace:*",
     "@juggle/resize-observer": "3.3.1",
     "@types/jest": "26.0.24",
-    "@types/node": "16.3.3",
+    "@types/node": "16.4.0",
     "chalk": "4.1.1",
     "cross-env": "7.0.3",
     "eslint": "7.31.0",

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -29,15 +29,15 @@
     "publish:prepare": "node ../../scripts/release/preparePublishContent.js"
   },
   "dependencies": {
-    "@babel/core": "7.14.6",
+    "@babel/core": "7.14.8",
     "@babel/helper-plugin-utils": "7.14.5",
     "@babel/plugin-proposal-class-properties": "7.14.5",
     "@babel/plugin-transform-runtime": "7.14.5",
     "@babel/plugin-transform-typescript": "7.14.6",
-    "@babel/preset-env": "7.14.7",
+    "@babel/preset-env": "7.14.8",
     "@babel/preset-react": "7.14.5",
     "@babel/preset-typescript": "7.14.5",
-    "@babel/runtime": "7.14.6",
+    "@babel/runtime": "7.14.8",
     "react-refresh": "0.10.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,10 +29,10 @@
     "publish:prepare": "node ../../scripts/release/preparePublishContent.js"
   },
   "dependencies": {
-    "@babel/core": "7.14.6",
+    "@babel/core": "7.14.8",
     "@babel/eslint-parser": "7.14.7",
-    "@typescript-eslint/eslint-plugin": "4.28.3",
-    "@typescript-eslint/parser": "4.28.3",
+    "@typescript-eslint/eslint-plugin": "4.28.4",
+    "@typescript-eslint/parser": "4.28.4",
     "eslint": "7.31.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.23.4",

--- a/packages/legend-studio-app/package.json
+++ b/packages/legend-studio-app/package.json
@@ -57,6 +57,6 @@
     "webpack": "5.45.1",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.7.2",
-    "webpack-dev-server": "4.0.0-beta.3"
+    "webpack-dev-server": "4.0.0-rc.0"
   }
 }

--- a/packages/legend-studio-components/package.json
+++ b/packages/legend-studio-components/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@finos/legend-studio-shared": "workspace:*",
-    "@material-ui/core": "4.12.1",
+    "@material-ui/core": "4.12.2",
     "@types/react": "17.0.14",
     "@types/react-select": "4.0.17",
     "@types/react-window": "1.8.4",

--- a/packages/legend-studio-dev-utils/package.json
+++ b/packages/legend-studio-dev-utils/package.json
@@ -43,7 +43,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@babel/core": "7.14.6",
+    "@babel/core": "7.14.8",
     "@changesets/changelog-github": "0.4.0",
     "@changesets/config": "1.6.0",
     "@changesets/get-release-plan": "3.0.0",
@@ -60,8 +60,8 @@
     "circular-dependency-plugin": "5.2.2",
     "clean-webpack-plugin": "3.0.0",
     "cosmiconfig": "7.0.0",
-    "css-loader": "6.1.0",
-    "cssnano": "5.0.6",
+    "css-loader": "6.2.0",
+    "cssnano": "5.0.7",
     "fork-ts-checker-webpack-plugin": "6.2.12",
     "html-webpack-plugin": "5.3.2",
     "isbinaryfile": "4.0.8",
@@ -73,7 +73,7 @@
     "mini-css-extract-plugin": "2.1.0",
     "monaco-editor": "0.26.1",
     "monaco-editor-webpack-plugin": "4.1.1",
-    "postcss": "8.3.5",
+    "postcss": "8.3.6",
     "postcss-loader": "6.1.1",
     "react-refresh": "0.10.0",
     "resolve": "1.20.0",

--- a/packages/legend-studio-preset-query-builder/package.json
+++ b/packages/legend-studio-preset-query-builder/package.json
@@ -44,7 +44,7 @@
     "@finos/legend-studio": "workspace:*",
     "@finos/legend-studio-components": "workspace:*",
     "@finos/legend-studio-shared": "workspace:*",
-    "@material-ui/core": "4.12.1",
+    "@material-ui/core": "4.12.2",
     "@types/papaparse": "5.2.6",
     "@types/react": "17.0.14",
     "@types/react-dom": "17.0.9",

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -40,7 +40,7 @@
     "@finos/legend-studio-components": "workspace:*",
     "@finos/legend-studio-network": "workspace:*",
     "@finos/legend-studio-shared": "workspace:*",
-    "@material-ui/core": "4.12.1",
+    "@material-ui/core": "4.12.2",
     "@testing-library/react": "12.0.0",
     "@types/css-font-loading-module": "0.0.6",
     "@types/react": "17.0.14",

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -996,10 +996,11 @@ const DiagramEditorDiagramCanvas = observer(
           diagramEditorState.diagram,
         );
         diagramEditorState.setRenderer(renderer);
-        diagramEditorState.setupDiagramRenderer();
+        diagramEditorState.setupRenderer();
         renderer.render();
         renderer.autoRecenter();
       }
+      return diagramEditorState.cleanUp();
     }, [diagramCanvasRef, diagramEditorState]);
 
     useEffect(() => {

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -226,7 +226,6 @@ const DiagramRendererHotkeyInfosModal = observer(
               </div>
 
               <div className="diagram-editor__hotkey__groups__divider" />
-
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
                   Add simple property to selected class
@@ -237,6 +236,18 @@ const DiagramRendererHotkeyInfosModal = observer(
                     <PlusIcon />
                   </div>
                   <div className="hotkey__key">&darr;</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Eject the property
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">Alt</div>
+                  <div className="hotkey__plus">
+                    <PlusIcon />
+                  </div>
+                  <div className="hotkey__key">&rarr;</div>
                 </div>
               </div>
 
@@ -256,36 +267,6 @@ const DiagramRendererHotkeyInfosModal = observer(
                 </div>
                 <div className="hotkey__combination diagram-editor__hotkey__keys">
                   <div className="hotkey__key">&uarr;</div>
-                </div>
-              </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Eject the property
-                </div>
-                <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">Alt</div>
-                  <div className="hotkey__plus">
-                    <PlusIcon />
-                  </div>
-                  <div className="hotkey__key">&rarr;</div>
-                </div>
-              </div>
-
-              <div className="diagram-editor__hotkey__groups__divider" />
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Populate immediate supertypes of selected classes
-                </div>
-                <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">&uarr;</div>
-                </div>
-              </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Populate immediate subtypes of selected classes
-                </div>
-                <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">&darr;</div>
                 </div>
               </div>
             </div>

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -262,14 +262,6 @@ const DiagramRendererHotkeyInfosModal = observer(
                   <div className="hotkey__key">&rarr;</div>
                 </div>
               </div>
-              <div className="diagram-editor__hotkey__group">
-                <div className="diagram-editor__hotkey__annotation">
-                  Add the selected class as property of the opened class
-                </div>
-                <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">&larr;</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -55,7 +55,6 @@ import {
   MenuContentItem,
   PlusIcon,
   SquareIcon,
-  TimesIcon,
 } from '@finos/legend-studio-components';
 import { Class } from '../../../../models/metamodels/pure/model/packageableElements/domain/Class';
 import { Point } from '../../../../models/metamodels/pure/model/packageableElements/diagram/geometry/Point';
@@ -734,9 +733,7 @@ const DiagramEditorInlineClassCreatorInner = observer(
           type="submit"
           className="diagram-editor__inline-class-creator__close-btn"
           onClick={close}
-        >
-          <TimesIcon />
-        </button>
+        />
       </form>
     );
   },
@@ -941,9 +938,7 @@ const DiagramEditorInlinePropertyEditorInner = observer(
           type="submit"
           className="diagram-editor__inline-property-editor__close-btn"
           onClick={close}
-        >
-          <TimesIcon />
-        </button>
+        />
       </form>
     );
   },

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -970,11 +970,15 @@ const DiagramEditorDiagramCanvas = observer(
         if (!isReadOnly) {
           if (item instanceof ElementDragSource) {
             if (item.data.packageableElement instanceof Class) {
-              const dropPosition = monitor.getSourceClientOffset();
+              const dropPosition = monitor.getClientOffset();
               diagramEditorState.renderer.addClassView(
                 item.data.packageableElement,
                 dropPosition
-                  ? new Point(dropPosition.x, dropPosition.y)
+                  ? diagramEditorState.renderer.canvasCoordinateToModelCoordinate(
+                      diagramEditorState.renderer.eventCoordinateToCanvasCoordinate(
+                        new Point(dropPosition.x, dropPosition.y),
+                      ),
+                    )
                   : undefined,
               );
             }

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -179,7 +179,7 @@ const DiagramRendererHotkeyInfosModal = observer(
                   Add class
                 </div>
                 <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">+</div>
+                  <div className="hotkey__key">C</div>
                 </div>
               </div>
 
@@ -259,7 +259,29 @@ const DiagramRendererHotkeyInfosModal = observer(
                   Eject the property
                 </div>
                 <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">Alt</div>
+                  <div className="hotkey__plus">
+                    <PlusIcon />
+                  </div>
                   <div className="hotkey__key">&rarr;</div>
+                </div>
+              </div>
+
+              <div className="diagram-editor__hotkey__groups__divider" />
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Populate immediate supertypes of selected class
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">&uarr;</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Populate immediate subtypes of selected class
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">&darr;</div>
                 </div>
               </div>
             </div>
@@ -408,7 +430,7 @@ const DiagramEditorToolPanel = observer(
               renderer.interactionMode === DIAGRAM_INTERACTION_MODE.ADD_CLASS,
           })}
           tabIndex={-1}
-          title="New Class... (+)"
+          title="Add class tool (C)"
           disabled={isReadOnly}
           onClick={createModeSwitcher(
             DIAGRAM_INTERACTION_MODE.ADD_CLASS,
@@ -668,7 +690,7 @@ const DiagramEditorInlineClassCreatorInner = observer(
     const close = (event: React.MouseEvent<HTMLButtonElement>): void => {
       event.preventDefault();
       if (canCreateClass) {
-        diagramEditorState.setInlinePropertyEditorState(undefined);
+        diagramEditorState.setInlineClassCreatorState(undefined);
         const [packagePath, name] = resolvePackagePathAndElementName(path);
         const _class = new Class(name);
         editorStore.graphState.graph

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -62,6 +62,7 @@ import { Point } from '../../../../models/metamodels/pure/model/packageableEleme
 import type { PackageableElementSelectOption } from '../../../../models/metamodels/pure/model/packageableElements/PackageableElement';
 import {
   FiMinus,
+  FiMousePointer,
   FiMove,
   FiPlusCircle,
   FiSidebar,
@@ -143,10 +144,18 @@ const DiagramRendererHotkeyInfosModal = observer(
               <div className="diagram-editor__hotkey__groups__divider" />
               <div className="diagram-editor__hotkey__group">
                 <div className="diagram-editor__hotkey__annotation">
-                  Use layout tool
+                  Use view tool
                 </div>
                 <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">L</div>
+                  <div className="hotkey__key">V</div>
+                </div>
+              </div>
+              <div className="diagram-editor__hotkey__group">
+                <div className="diagram-editor__hotkey__annotation">
+                  Use pan tool
+                </div>
+                <div className="hotkey__combination diagram-editor__hotkey__keys">
+                  <div className="hotkey__key">M</div>
                 </div>
               </div>
               <div className="diagram-editor__hotkey__group">
@@ -301,9 +310,23 @@ const DiagramEditorToolPanel = observer(
             DIAGRAM_INTERACTION_MODE.LAYOUT,
             DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
           )}
-          title="View Tool (L)"
+          title="View Tool (V)"
         >
-          <FiMove className="diagram-editor__icon--layout" />
+          <FiMousePointer className="diagram-editor__icon--layout" />
+        </button>
+        <button
+          className={clsx('diagram-editor__tool', {
+            'diagram-editor__tool--active':
+              renderer.interactionMode === DIAGRAM_INTERACTION_MODE.PAN,
+          })}
+          tabIndex={-1}
+          onClick={createModeSwitcher(
+            DIAGRAM_INTERACTION_MODE.PAN,
+            DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
+          )}
+          title="Pan Tool (M)"
+        >
+          <FiMove className="diagram-editor__icon--pan" />
         </button>
         <button
           className={clsx('diagram-editor__tool', {

--- a/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/diagram-editor/DiagramEditor.tsx
@@ -219,7 +219,11 @@ const DiagramRendererHotkeyInfosModal = observer(
                   Add simple property to selected class
                 </div>
                 <div className="hotkey__combination diagram-editor__hotkey__keys">
-                  <div className="hotkey__key">/</div>
+                  <div className="hotkey__key">Alt</div>
+                  <div className="hotkey__plus">
+                    <PlusIcon />
+                  </div>
+                  <div className="hotkey__key">&darr;</div>
                 </div>
               </div>
 

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment, useRef, useState } from 'react';
+import React, { Fragment, useRef, useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useEditorStore } from '../../../stores/EditorStore';
 import {
@@ -73,7 +73,6 @@ import { PACKAGEABLE_ELEMENT_TYPE } from '../../../models/metamodels/pure/model/
 import { Dialog } from '@material-ui/core';
 import { isValidFullPath, isValidPath } from '../../../models/MetaModelUtils';
 import { flowResult } from 'mobx';
-import { useEffect } from 'react';
 
 const isGeneratedPackageTreeNode = (node: PackageTreeNodeData): boolean =>
   node.packageableElement.getRoot().path === ROOT_PACKAGE_NAME.MODEL_GENERATION;
@@ -154,7 +153,7 @@ const ElementRenamer = observer(() => {
             className="input-group__input input--dark explorer__element-renamer__input"
             ref={pathInputRef}
             value={path}
-            placeholder="Enter class path"
+            placeholder="Enter element path"
             onChange={changePath}
           />
           {elementRenameValidationErrorMessage && (

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -2181,7 +2181,11 @@ export class DiagramRenderer {
           ) {
             this.addClassView(
               this.mouseOverProperty.genericType.value.rawType,
-              new Point(this.cursorPosition.x, this.cursorPosition.y),
+              this.canvasCoordinateToModelCoordinate(
+                this.eventCoordinateToCanvasCoordinate(
+                  new Point(this.cursorPosition.x, this.cursorPosition.y),
+                ),
+              ),
             );
           }
         } else if (this.selectedClassProperty) {

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -572,7 +572,7 @@ export class DiagramRenderer {
           this.addRelationshipToDiagramFn = (
             startClassView: ClassView,
             targetClassView: ClassView,
-          ): PropertyView => {
+          ): PropertyView | undefined => {
             const property = new Property(
               `property_${startClassView.class.value.properties.length + 1}`,
               new Multiplicity(1, 1),
@@ -581,15 +581,21 @@ export class DiagramRenderer {
               ),
               startClassView.class.value,
             );
-            const pView = new PropertyView(
-              this.diagram,
-              PropertyExplicitReference.create(property),
-              startClassView,
-              targetClassView,
-            );
             startClassView.class.value.addProperty(property);
-            this.diagram.addPropertyView(pView);
-            return pView;
+            // only create property view if the classviews are different
+            // else we end up with a weird rendering where the property view
+            // is not targetable
+            if (startClassView !== targetClassView) {
+              const pView = new PropertyView(
+                this.diagram,
+                PropertyExplicitReference.create(property),
+                startClassView,
+                targetClassView,
+              );
+              this.diagram.addPropertyView(pView);
+              return pView;
+            }
+            return undefined;
           };
           break;
         }
@@ -2847,9 +2853,7 @@ export class DiagramRenderer {
           break;
       }
     } else {
-      this.manageVirtualScreen();
-      this.clearScreen();
-      this.drawAll();
+      this.drawScreen();
 
       const eventPointInCanvasCoordinate =
         this.eventCoordinateToCanvasCoordinate(new Point(e.x, e.y));

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -2094,10 +2094,7 @@ export class DiagramRenderer {
           this.selectedClasses.forEach((classView) => {
             classView.setHideProperties(!classView.hideProperties);
           });
-          this.clearScreen(); // draw the first time so that the virtualscreen has the right size
-          this.drawAll();
-          this.manageVirtualScreen();
-          this.drawAll();
+          this.drawScreen();
         }
       }
     }
@@ -2108,10 +2105,7 @@ export class DiagramRenderer {
           this.selectedClasses.forEach((classView) => {
             classView.setHideStereotypes(!classView.hideStereotypes);
           });
-          this.clearScreen(); // draw the first time so that the virtualscreen has the right size
-          this.drawAll();
-          this.manageVirtualScreen();
-          this.drawAll();
+          this.drawScreen();
         }
       }
     }
@@ -2122,10 +2116,7 @@ export class DiagramRenderer {
           this.selectedClasses.forEach((classView) => {
             classView.setHideTaggedValues(!classView.hideTaggedValues);
           });
-          this.clearScreen(); // draw the first time so that the virtualscreen has the right size
-          this.drawAll();
-          this.manageVirtualScreen();
-          this.drawAll();
+          this.drawScreen();
         }
       }
     }
@@ -2382,7 +2373,7 @@ export class DiagramRenderer {
     return newClasses;
   }
 
-  // DOC ???
+  // TODO: add doc
   potentiallyShiftRelationships(
     assoViews: RelationshipView[],
     selectedClasses: ClassView[],

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -2140,40 +2140,6 @@ export class DiagramRenderer {
       if (!this.isReadOnly && this.selectedClasses.length === 1) {
         this.addSimpleProperty(this.selectedClasses[0]);
       }
-    } else if (e.key === 'ArrowDown') {
-      const views = uniqBy(
-        this.selectedClasses.flatMap((x) =>
-          x.class.value._subClasses.flatMap(
-            (c) =>
-              new ClassView(
-                this.diagram,
-                uuid(),
-                PackageableElementExplicitReference.create(c),
-              ),
-          ),
-        ),
-        (cv) => cv.class.value,
-      );
-
-      if (views.length > 0) {
-        views.forEach((classView) =>
-          this.ensureClassViewMeetMinDimensions(classView),
-        );
-
-        const res = this.layoutTaxonomy(
-          [views, this.selectedClasses],
-          this.diagram,
-          false,
-          false,
-        );
-        res[0].forEach((cv) => this.diagram.addClassView(cv));
-        res[1].forEach((gv) => this.diagram.addGeneralizationView(gv));
-      }
-
-      this.clearScreen(); // draw the first time so that the virtualscreen has the right size
-      this.drawAll();
-      this.manageVirtualScreen();
-      this.drawAll();
     }
 
     // Eject the property
@@ -2219,10 +2185,41 @@ export class DiagramRenderer {
       res[0].forEach((cv) => this.diagram.addClassView(cv));
       res[1].forEach((gv) => this.diagram.addGeneralizationView(gv));
 
-      this.clearScreen(); // draw the first time so that the virtualscreen has the right size
-      this.drawAll();
-      this.manageVirtualScreen();
-      this.drawAll();
+      this.drawScreen();
+    }
+
+    // Add subtypes of selected classes to the diagram
+    else if (e.key === 'ArrowDown') {
+      const views = uniqBy(
+        this.selectedClasses.flatMap((x) =>
+          x.class.value._subClasses.flatMap(
+            (c) =>
+              new ClassView(
+                this.diagram,
+                uuid(),
+                PackageableElementExplicitReference.create(c),
+              ),
+          ),
+        ),
+        (cv) => cv.class.value,
+      );
+
+      if (views.length > 0) {
+        views.forEach((classView) =>
+          this.ensureClassViewMeetMinDimensions(classView),
+        );
+
+        const res = this.layoutTaxonomy(
+          [views, this.selectedClasses],
+          this.diagram,
+          false,
+          false,
+        );
+        res[0].forEach((cv) => this.diagram.addClassView(cv));
+        res[1].forEach((gv) => this.diagram.addGeneralizationView(gv));
+      }
+
+      this.drawScreen();
     }
   }
 
@@ -2441,9 +2438,10 @@ export class DiagramRenderer {
     // Click on a class view
     if (selectedClass) {
       this.editClassView(selectedClass);
-    } else {
-      this.onBackgroundDoubleClick(eventPointInModelCoordinate);
+      return;
     }
+    this.onBackgroundDoubleClick(eventPointInModelCoordinate);
+    return;
   }
 
   mousedown(e: MouseEvent): void {

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -218,14 +218,7 @@ export class DiagramRenderer {
   // interactions
   onAddClassViewClick: (point: Point) => void = noop();
   onBackgroundDoubleClick: (point: Point) => void = noop();
-  onSelectedClassChange: (classView: ClassView | undefined) => void = noop();
-  onSelectedPropertyOrAssociationChange: (
-    propertyHolderView: PropertyHolderView | undefined,
-  ) => void = noop();
-  onSelectedInheritanceChange: (
-    generalizationView: GeneralizationView | undefined,
-  ) => void = noop();
-  editClass: (classView: ClassView) => void = noop();
+  editClassView: (classView: ClassView) => void = noop();
   editProperty: (property: AbstractProperty, point: Point) => void = noop();
   editPropertyView: (propertyView: PropertyHolderView) => void = noop();
   addSimpleProperty: (classView: ClassView) => void = noop();
@@ -410,22 +403,14 @@ export class DiagramRenderer {
 
   setSelectedClasses(val: ClassView[]): void {
     this.selectedClasses = val;
-    this.onSelectedClassChange(undefined);
-  }
-
-  setSelectedClass(val: ClassView): void {
-    this.setSelectedClasses([val]);
-    this.onSelectedClassChange(val);
   }
 
   setSelectedPropertyOrAssociation(val: PropertyHolderView | undefined): void {
     this.selectedPropertyOrAssociation = val;
-    this.onSelectedPropertyOrAssociationChange(val);
   }
 
   setSelectedInheritance(val: GeneralizationView | undefined): void {
     this.selectedInheritance = val;
-    this.onSelectedInheritanceChange(val);
   }
 
   setRightClick(val: boolean): void {
@@ -2026,7 +2011,7 @@ export class DiagramRenderer {
         this.editPropertyView(this.selectedPropertyOrAssociation);
         e.preventDefault();
       } else if (this.selectedClasses.length === 1) {
-        this.editClass(this.selectedClasses[0]);
+        this.editClassView(this.selectedClasses[0]);
       }
     }
 
@@ -2437,7 +2422,7 @@ export class DiagramRenderer {
     );
     // Click on a class view
     if (selectedClass) {
-      this.editClass(selectedClass);
+      this.editClassView(selectedClass);
     } else {
       this.onBackgroundDoubleClick(eventPointInModelCoordinate);
     }
@@ -2514,7 +2499,7 @@ export class DiagramRenderer {
                     this.selectedClasses.indexOf(this.diagram.classViews[i]) ===
                       -1
                   ) {
-                    this.setSelectedClass(this.diagram.classViews[i]);
+                    this.setSelectedClasses([this.diagram.classViews[i]]);
                   }
                   if (!this.isReadOnly) {
                     // Bring the class view to front
@@ -2637,7 +2622,11 @@ export class DiagramRenderer {
           break;
       }
     }
-    // middle click
+
+    // NOTE: right now, in any mode, we allow to use middle click and
+    // right click to move the diagram. However, if we support context menu
+    // using right click in the future, we need to adjust to only allow
+    // middle click to move here.
     else if (e.button === 1) {
       e.returnValue = false;
       this.setMiddleClick(true);

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -223,8 +223,6 @@ export class DiagramRenderer {
   editProperty: (property: AbstractProperty, point: Point) => void = noop();
   editPropertyView: (propertyView: PropertyHolderView) => void = noop();
   addSimpleProperty: (classView: ClassView) => void = noop();
-  addSelectedClassAsPropertyOfOpenedClass: (classView: ClassView) => void =
-    noop();
 
   constructor(div: HTMLDivElement, diagram: Diagram) {
     makeObservable(this, {
@@ -2172,6 +2170,7 @@ export class DiagramRenderer {
       this.manageVirtualScreen();
       this.drawAll();
     }
+
     // Eject the property
     else if (e.key === 'ArrowRight') {
       if (!this.isReadOnly) {
@@ -2202,14 +2201,9 @@ export class DiagramRenderer {
         }
       }
     }
-    // Add currently selected class as property to the currently opened class
-    else if (e.key === 'ArrowLeft') {
-      if (!this.isReadOnly && this.selectedClasses.length !== 0) {
-        this.selectedClasses.forEach((classView) =>
-          this.addSelectedClassAsPropertyOfOpenedClass(classView),
-        );
-      }
-    } else if (e.key === 'ArrowUp') {
+
+    // Add supertypes of selected classes to the diagram
+    else if (e.key === 'ArrowUp') {
       const views = this.getSuperTypeLevels(
         this.selectedClasses,
         this.diagram,

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -2118,7 +2118,7 @@ export class DiagramRenderer {
     }
 
     // Add a new simple property to selected class
-    else if (e.key === '/') {
+    else if (e.altKey && e.key === 'ArrowDown') {
       if (!this.isReadOnly && this.selectedClasses.length === 1) {
         this.addSimpleProperty(this.selectedClasses[0]);
       }

--- a/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
+++ b/packages/legend-studio/src/components/shared/diagram-viewer/DiagramRenderer.ts
@@ -1949,7 +1949,7 @@ export class DiagramRenderer {
 
   keydown(e: KeyboardEvent): void {
     // Remove selected view(s)
-    if (e.key === 'Delete') {
+    if ('Delete' === e.key) {
       if (!this.isReadOnly) {
         this.selectedClasses.forEach((classView) => {
           this.diagram.deleteClassView(classView);
@@ -2006,7 +2006,7 @@ export class DiagramRenderer {
     // NOTE: since the current behavior when editing property is to immediately
     // focus on the property name input when the inline editor pops up
     // we need to call `preventDefault` to avoid typing `e` in the property name input
-    else if (e.key === 'e') {
+    else if ('e' === e.key) {
       if (!this.isReadOnly && this.selectedClassProperty) {
         this.editProperty(
           this.selectedClassProperty.property,
@@ -2022,7 +2022,7 @@ export class DiagramRenderer {
     }
 
     // Recenter
-    else if (e.key === 'r') {
+    else if ('r' === e.key) {
       if (this.selectedClasses.length !== 0) {
         const firstClass = getNullableFirstElement(this.selectedClasses);
         if (firstClass) {
@@ -2036,7 +2036,7 @@ export class DiagramRenderer {
       }
     }
     // Zoom
-    else if (e.key === 'z') {
+    else if ('z' === e.key) {
       this.changeMode(
         this.interactionMode !== DIAGRAM_INTERACTION_MODE.ZOOM_IN
           ? DIAGRAM_INTERACTION_MODE.ZOOM_IN
@@ -2046,21 +2046,21 @@ export class DiagramRenderer {
     }
 
     // Use View Tool
-    else if (e.key === 'v') {
+    else if ('v' === e.key) {
       this.changeMode(
         DIAGRAM_INTERACTION_MODE.LAYOUT,
         DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
       );
     }
     // Use Pan Tool
-    else if (e.key === 'm') {
+    else if ('m' === e.key) {
       this.changeMode(
         DIAGRAM_INTERACTION_MODE.PAN,
         DIAGRAM_RELATIONSHIP_EDIT_MODE.NONE,
       );
     }
     // Use Property Tool
-    else if (e.key === 'p') {
+    else if ('p' === e.key) {
       if (!this.isReadOnly) {
         this.changeMode(
           DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
@@ -2069,7 +2069,7 @@ export class DiagramRenderer {
       }
     }
     // Use Inheritance Tool
-    else if (e.key === 'i') {
+    else if ('i' === e.key) {
       if (!this.isReadOnly) {
         this.changeMode(
           DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP,
@@ -2078,7 +2078,7 @@ export class DiagramRenderer {
       }
     }
     // Add Class
-    else if (e.key === '+') {
+    else if ('c' === e.key) {
       if (!this.isReadOnly) {
         this.changeMode(
           DIAGRAM_INTERACTION_MODE.ADD_CLASS,
@@ -2088,7 +2088,7 @@ export class DiagramRenderer {
     }
 
     // Hide/show properties for selected element(s)
-    else if (e.altKey && e.code === 'KeyP') {
+    else if (e.altKey && 'KeyP' === e.code) {
       if (!this.isReadOnly) {
         if (this.selectedClasses.length !== 0) {
           this.selectedClasses.forEach((classView) => {
@@ -2099,7 +2099,7 @@ export class DiagramRenderer {
       }
     }
     // Hide/show stereotypes for selected element(s)
-    else if (e.altKey && e.code === 'KeyS') {
+    else if (e.altKey && 'KeyS' === e.code) {
       if (!this.isReadOnly) {
         if (this.selectedClasses.length !== 0) {
           this.selectedClasses.forEach((classView) => {
@@ -2110,7 +2110,7 @@ export class DiagramRenderer {
       }
     }
     // Hide/show tagged values for selected element(s)
-    else if (e.altKey && e.code === 'KeyT') {
+    else if (e.altKey && 'KeyT' === e.code) {
       if (!this.isReadOnly) {
         if (this.selectedClasses.length !== 0) {
           this.selectedClasses.forEach((classView) => {
@@ -2122,7 +2122,7 @@ export class DiagramRenderer {
     }
 
     // Add a new simple property to selected class
-    else if (e.altKey && e.key === 'ArrowDown') {
+    else if (e.altKey && 'ArrowDown' === e.key) {
       if (!this.isReadOnly && this.selectedClasses.length === 1) {
         this.addSimpleProperty(this.selectedClasses[0]);
       }
@@ -2163,7 +2163,7 @@ export class DiagramRenderer {
     }
 
     // Eject the property
-    else if (e.key === 'ArrowRight') {
+    else if (e.altKey && 'ArrowRight' === e.key) {
       if (!this.isReadOnly) {
         if (this.mouseOverProperty) {
           if (

--- a/packages/legend-studio/src/models/MetaModelUtils.ts
+++ b/packages/legend-studio/src/models/MetaModelUtils.ts
@@ -78,7 +78,11 @@ export const resolvePackagePathAndElementName = (
   ];
 };
 
+export const createPath = (packagePath: string, name: string): string =>
+  `${packagePath ? `${packagePath}${ELEMENT_PATH_DELIMITER}` : ''}${name}`;
 // TODO: we might need to support quoted identifier in the future
+export const isValidPathIdentifier = (val: string): boolean =>
+  Boolean(val.match(/^\w[\w$_-]*$/));
 export const isValidFullPath = (fullPath: string): boolean =>
   Boolean(fullPath.match(/^(?:\w[\w$_-]*)(?:::\w[\w$_-]*)+$/));
 export const isValidPath = (path: string): boolean =>

--- a/packages/legend-studio/src/models/MetaModelUtils.ts
+++ b/packages/legend-studio/src/models/MetaModelUtils.ts
@@ -78,8 +78,11 @@ export const resolvePackagePathAndElementName = (
   ];
 };
 
+// TODO: we might need to support quoted identifier in the future
 export const isValidFullPath = (fullPath: string): boolean =>
-  fullPath.split(ELEMENT_PATH_DELIMITER).filter(Boolean).length > 1;
+  Boolean(fullPath.match(/^(?:\w[\w$_-]*)(?:::\w[\w$_-]*)+$/));
+export const isValidPath = (path: string): boolean =>
+  Boolean(path.match(/^(?:\w[\w$_-]*)(?:::\w[\w$_-]*)*$/));
 
 // TODO: this is over-simplification as there could be other fields used for source information
 export const hashObjectWithoutSourceInformation = (val: object): string =>

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModelUtils.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModelUtils.test.ts
@@ -16,6 +16,8 @@
 
 import {
   hashLambda,
+  isValidFullPath,
+  isValidPath,
   resolvePackagePathAndElementName,
 } from '../../../MetaModelUtils';
 import {
@@ -129,4 +131,24 @@ test(unitTest('Resolve package path and element name'), () => {
     'somethingElse',
     'b',
   ]);
+});
+
+test(unitTest('Check valid path'), () => {
+  expect(isValidFullPath('')).toBe(false);
+  expect(isValidFullPath('something')).toBe(false);
+  expect(isValidFullPath('something::')).toBe(false);
+  expect(isValidFullPath('::')).toBe(false);
+  expect(isValidFullPath(':')).toBe(false);
+  expect(isValidFullPath('$123')).toBe(false);
+  expect(isValidFullPath('$123::something')).toBe(false);
+  expect(isValidFullPath('something::something')).toBe(true);
+
+  expect(isValidPath('')).toBe(false);
+  expect(isValidPath('asdas')).toBe(true);
+  expect(isValidPath('::')).toBe(false);
+  expect(isValidPath(':')).toBe(false);
+  expect(isValidPath(',')).toBe(false);
+  expect(isValidPath('$123')).toBe(false);
+  expect(isValidPath('$123::something')).toBe(false);
+  expect(isValidPath('something::something')).toBe(true);
 });

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModelUtils.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModelUtils.test.ts
@@ -137,7 +137,6 @@ test(unitTest('Resolve package path and element name'), () => {
 test(unitTest('Check valid path and path identifier'), () => {
   expect(isValidPathIdentifier('')).toBe(false);
   expect(isValidPathIdentifier('$')).toBe(false);
-  expect(isValidPathIdentifier('_')).toBe(false);
   expect(isValidPathIdentifier('asd')).toBe(true);
   expect(isValidPathIdentifier('asd$')).toBe(true);
 

--- a/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModelUtils.test.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/__tests__/MetaModelUtils.test.ts
@@ -18,6 +18,7 @@ import {
   hashLambda,
   isValidFullPath,
   isValidPath,
+  isValidPathIdentifier,
   resolvePackagePathAndElementName,
 } from '../../../MetaModelUtils';
 import {
@@ -133,7 +134,13 @@ test(unitTest('Resolve package path and element name'), () => {
   ]);
 });
 
-test(unitTest('Check valid path'), () => {
+test(unitTest('Check valid path and path identifier'), () => {
+  expect(isValidPathIdentifier('')).toBe(false);
+  expect(isValidPathIdentifier('$')).toBe(false);
+  expect(isValidPathIdentifier('_')).toBe(false);
+  expect(isValidPathIdentifier('asd')).toBe(true);
+  expect(isValidPathIdentifier('asd$')).toBe(true);
+
   expect(isValidFullPath('')).toBe(false);
   expect(isValidFullPath('something')).toBe(false);
   expect(isValidFullPath('something::')).toBe(false);

--- a/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
@@ -576,7 +576,6 @@ export abstract class BasicModel {
       );
       extension.deleteElement(element.path);
     }
-    this.cleanUpDeadReferences();
   }
 
   /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
@@ -736,9 +735,5 @@ export abstract class BasicModel {
     // as such `this.sectionIndicesIndex.delete(sectionIndex.path)` won't work because the path is without the package
     this.sectionIndicesIndex = new Map<string, SectionIndex>();
     this.elementSectionMap = new Map<string, Section>();
-  }
-
-  cleanUpDeadReferences(): void {
-    this.diagrams.forEach((diagram) => diagram.cleanUpDeadReferences(this));
   }
 }

--- a/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/BasicModel.ts
@@ -17,6 +17,7 @@
 import { observable, computed, action, flow, makeObservable } from 'mobx';
 import type { Clazz } from '@finos/legend-studio-shared';
 import {
+  assertNonEmptyString,
   UnsupportedOperationError,
   getClass,
   guaranteeNonNullable,
@@ -52,6 +53,11 @@ import { ServiceStore } from '../model/packageableElements/store/relational/mode
 import { PureGraphExtension } from './PureGraphExtension';
 import { PrimitiveType } from '../model/packageableElements/domain/PrimitiveType';
 import { DataType } from '../model/packageableElements/domain/DataType';
+import {
+  isValidFullPath,
+  isValidPath,
+  resolvePackagePathAndElementName,
+} from '../../../MetaModelUtils';
 
 const FORBIDDEN_EXTENSION_ELEMENT_CLASS = new Set([
   PackageableElement,
@@ -188,7 +194,8 @@ export abstract class BasicModel {
       setFileGeneration: action,
       setDiagram: action,
       allElements: computed,
-      removeElement: action,
+      deleteElement: action,
+      renameElement: action,
       setIsBuilt: action,
       deleteSectionIndex: action,
     });
@@ -478,12 +485,10 @@ export abstract class BasicModel {
       'Name is required',
     )}`;
 
-  getOrCreatePackage = (packagePath: string | undefined): Package =>
-    Package.getOrCreatePackage(
-      this.root,
-      guaranteeNonNullable(packagePath, 'Package path is required'),
-      true,
-    );
+  getOrCreatePackage = (packagePath: string | undefined): Package => {
+    assertNonEmptyString(packagePath, 'Package path is required');
+    return Package.getOrCreatePackage(this.root, packagePath, true);
+  };
 
   getNullablePackage = (path: string): Package | undefined =>
     !path
@@ -527,7 +532,7 @@ export abstract class BasicModel {
   }
 
   /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
-  removeElement(element: PackageableElement): void {
+  deleteElement(element: PackageableElement): void {
     if (element.package) {
       element.package.deleteElement(element);
     }
@@ -543,7 +548,7 @@ export abstract class BasicModel {
         }
         element.nonCanonicalUnits.forEach((unit) =>
           this.typesIndex.delete(unit.path),
-        ); // also delete all related units
+        );
       }
     } else if (element instanceof Association) {
       this.associationsIndex.delete(element.path);
@@ -564,14 +569,157 @@ export abstract class BasicModel {
     } else if (element instanceof GenerationSpecification) {
       this.generationSpecificationsIndex.delete(element.path);
     } else if (element instanceof Package) {
-      element.children.forEach((el) => this.removeElement(el));
+      element.children.forEach((el) => this.deleteElement(el));
     } else {
       const extension = this.getExtensionForElementClass(
         getClass<PackageableElement>(element),
       );
-      extension.removeElement(element.path);
+      extension.deleteElement(element.path);
     }
     this.cleanUpDeadReferences();
+  }
+
+  /* @MARKER: NEW ELEMENT TYPE SUPPORT --- consider adding new element type handler here whenever support for a new element type is added to the app */
+  renameElement(element: PackageableElement, newPath: string): void {
+    const elementCurrentPath = element.path;
+    // validation before renaming
+    if (elementCurrentPath === newPath) {
+      return;
+    }
+    if (!newPath) {
+      throw new UnsupportedOperationError(
+        `Can't rename element '${elementCurrentPath} to '${newPath}': path is empty'`,
+      );
+    }
+    if (
+      (element instanceof Package && !isValidPath(newPath)) ||
+      (!(element instanceof Package) && !isValidFullPath(newPath))
+    ) {
+      throw new UnsupportedOperationError(
+        `Can't rename element '${elementCurrentPath} to '${newPath}': invalid path'`,
+      );
+    }
+    const existingElement = this.getNullableElement(newPath, true);
+    if (existingElement) {
+      throw new UnsupportedOperationError(
+        `Can't rename element '${elementCurrentPath} to '${newPath}': element with the same path already existed'`,
+      );
+    }
+    const [packagePath, elementName] =
+      resolvePackagePathAndElementName(newPath);
+
+    // if we're not renaming package, we can simply add new package
+    // if the element new package does not exist. For renaming package
+    // it's a little bit more complicated as we need to rename its children
+    // we will handle this case later
+    if (!(element instanceof Package)) {
+      const parentPackage =
+        this.getNullablePackage(packagePath) ??
+        (packagePath !== '' ? this.getOrCreatePackage(packagePath) : this.root);
+      // update element name
+      element.setName(elementName);
+      // update element package if needed
+      if (element.package !== parentPackage) {
+        element.package?.deleteElement(element);
+        element.setPackage(parentPackage);
+        parentPackage.addChild(element);
+      }
+    }
+
+    // update index in the graph
+    if (element instanceof Mapping) {
+      this.mappingsIndex.delete(elementCurrentPath);
+      this.mappingsIndex.set(newPath, element);
+    } else if (element instanceof Store) {
+      this.storesIndex.delete(elementCurrentPath);
+      this.storesIndex.set(newPath, element);
+    } else if (element instanceof Type) {
+      this.typesIndex.delete(elementCurrentPath);
+      this.typesIndex.set(newPath, element);
+      if (element instanceof Measure) {
+        if (element.canonicalUnit) {
+          this.typesIndex.delete(element.canonicalUnit.path);
+          this.typesIndex.set(
+            element.canonicalUnit.path.replace(elementCurrentPath, newPath),
+            element.canonicalUnit,
+          );
+        }
+        element.nonCanonicalUnits.forEach((unit) => {
+          this.typesIndex.delete(unit.path);
+          this.typesIndex.set(
+            unit.path.replace(elementCurrentPath, newPath),
+            unit,
+          );
+        });
+      }
+    } else if (element instanceof Association) {
+      this.associationsIndex.delete(elementCurrentPath);
+      this.associationsIndex.set(newPath, element);
+    } else if (element instanceof Profile) {
+      this.profilesIndex.delete(elementCurrentPath);
+      this.profilesIndex.set(newPath, element);
+    } else if (element instanceof ConcreteFunctionDefinition) {
+      this.functionsIndex.delete(elementCurrentPath);
+      this.functionsIndex.set(newPath, element);
+    } else if (element instanceof Diagram) {
+      this.diagramsIndex.delete(elementCurrentPath);
+      this.diagramsIndex.set(newPath, element);
+    } else if (element instanceof Service) {
+      this.servicesIndex.delete(elementCurrentPath);
+      this.servicesIndex.set(newPath, element);
+    } else if (element instanceof PackageableRuntime) {
+      this.runtimesIndex.delete(elementCurrentPath);
+      this.runtimesIndex.set(newPath, element);
+    } else if (element instanceof PackageableConnection) {
+      this.connectionsIndex.delete(elementCurrentPath);
+      this.connectionsIndex.set(newPath, element);
+    } else if (element instanceof FileGenerationSpecification) {
+      this.fileGenerationsIndex.delete(elementCurrentPath);
+      this.fileGenerationsIndex.set(newPath, element);
+    } else if (element instanceof GenerationSpecification) {
+      this.generationSpecificationsIndex.delete(elementCurrentPath);
+      this.generationSpecificationsIndex.set(newPath, element);
+    } else if (element instanceof Package) {
+      // Since we will modify the package name, we need to first store the original
+      // paths of all of its children
+      const childElements = new Map<string, PackageableElement>();
+      element.children.forEach((childElement) => {
+        childElements.set(childElement.path, childElement);
+      });
+      // update element name
+      element.setName(elementName);
+      if (!element.package) {
+        throw new IllegalStateError(`Can't rename root package`);
+      }
+      /**
+       * Update element package if needed.
+       *
+       * NOTE: to be clean, first completely remove the package from its parent package
+       * Only then would we find or create the new parent package. This way, if we rename
+       * package `example::something` to `example::something::somethingElse`, we will not
+       * end up in a loop. If we did not first remove the package from its parent package
+       * we would end up having the `somethingElse` package containing itself as a child.
+       */
+      const currentParentPackage = element.package;
+      if (currentParentPackage !== this.getNullablePackage(packagePath)) {
+        currentParentPackage.deleteElement(element);
+        const newParentPackage =
+          packagePath !== '' ? this.getOrCreatePackage(packagePath) : this.root;
+        element.setPackage(newParentPackage);
+        newParentPackage.addChild(element);
+      }
+      childElements.forEach((childElement, childElementOriginalPath) => {
+        this.renameElement(
+          childElement,
+          childElementOriginalPath.replace(elementCurrentPath, newPath),
+        );
+      });
+    } else {
+      const extension = this.getExtensionForElementClass(
+        getClass<PackageableElement>(element),
+      );
+      extension.renameElement(elementCurrentPath, newPath);
+    }
   }
 
   setIsBuilt(built: boolean): void {

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphExtension.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureGraphExtension.ts
@@ -27,7 +27,7 @@ export class PureGraphExtension<T extends PackageableElement> {
       index: observable,
       elements: computed,
       setElement: action,
-      removeElement: action,
+      deleteElement: action,
     });
     this._class = _class;
   }
@@ -48,7 +48,15 @@ export class PureGraphExtension<T extends PackageableElement> {
     this.index.set(path, val);
   }
 
-  removeElement(path: string): void {
+  deleteElement(path: string): void {
     this.index.delete(path);
+  }
+
+  renameElement(oldPath: string, newPath: string): void {
+    const element = this.getElement(oldPath);
+    if (element) {
+      this.deleteElement(oldPath);
+      this.setElement(newPath, element);
+    }
   }
 }

--- a/packages/legend-studio/src/models/metamodels/pure/graph/PureModel.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/graph/PureModel.ts
@@ -522,4 +522,13 @@ export class PureModel extends BasicModel {
       extension.setElement(element.path, element);
     }
   }
+
+  override deleteElement(element: PackageableElement): void {
+    super.deleteElement(element);
+    this.cleanUpDeadReferences();
+  }
+
+  cleanUpDeadReferences(): void {
+    this.diagrams.forEach((diagram) => diagram.cleanUpDeadReferences(this));
+  }
 }

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElement.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/PackageableElement.ts
@@ -88,6 +88,7 @@ export abstract class PackageableElement implements Hashable, Stubable {
       _isDisposed: observable,
       _isImmutable: observable,
       name: observable,
+      package: observable,
       isReadOnly: computed,
       isDeleted: computed,
       selectOption: computed,
@@ -96,6 +97,7 @@ export abstract class PackageableElement implements Hashable, Stubable {
       // We need to enable `keepAlive` to facillitate precomutation of element hash code
       hashCode: computed({ keepAlive: true }),
       setName: action,
+      setPackage: action,
       setIsDeleted: action,
       deleteElementFromGraph: action,
       dispose: action,
@@ -108,15 +110,23 @@ export abstract class PackageableElement implements Hashable, Stubable {
   get isReadOnly(): boolean {
     return this._isImmutable;
   }
+
   get isDeleted(): boolean {
     return this._isDeleted;
   }
+
   setName(value: string): void {
     this.name = value;
   }
+
+  setPackage(val: Package | undefined): void {
+    this.package = val;
+  }
+
   setIsDeleted(value: boolean): void {
     this._isDeleted = value;
   }
+
   deleteElementFromGraph(): void {
     if (this.package) {
       this.package.deleteElement(this);
@@ -128,8 +138,9 @@ export abstract class PackageableElement implements Hashable, Stubable {
    * Get root element. In the ideal case, this method is important for finding the root package, but
    * if we do something like `this instanceof Package` that would case circular dependency.
    */
-  getRoot = (): PackageableElement =>
-    !this.package ? this : this.package.getRoot();
+  getRoot(): PackageableElement {
+    return !this.package ? this : this.package.getRoot();
+  }
 
   get selectOption(): PackageableElementSelectOption<PackageableElement> {
     return { label: this.name, value: this };

--- a/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
+++ b/packages/legend-studio/src/models/metamodels/pure/model/packageableElements/domain/Package.ts
@@ -39,7 +39,6 @@ export class Package extends PackageableElement implements Hashable {
 
     makeObservable(this, {
       children: observable,
-      setPackage: action,
       addChild: action,
       addElement: action,
       hashCode: override,
@@ -56,16 +55,13 @@ export class Package extends PackageableElement implements Hashable {
     return newPackage;
   }
 
-  setPackage(value: Package): void {
-    this.package = value;
-  }
   addChild(value: PackageableElement): void {
     addUniqueEntry(this.children, value);
   }
 
   addElement(element: PackageableElement): void {
     this.addChild(element);
-    element.package = this;
+    element.setPackage(this);
   }
 
   get fullPath(): string {
@@ -79,7 +75,9 @@ export class Package extends PackageableElement implements Hashable {
   }
 
   deleteElement(packageableElement: PackageableElement): void {
-    this.children = this.children.filter((c) => c !== packageableElement);
+    this.children = this.children.filter(
+      (child) => child !== packageableElement,
+    );
   }
 
   /**

--- a/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
+++ b/packages/legend-studio/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_GraphBuilderContext.ts
@@ -77,7 +77,20 @@ import type { V1_GraphBuilderExtensions } from './V1_GraphBuilderExtensions';
 import type { GraphBuilderOptions } from '../../../../../../metamodels/pure/graph/AbstractPureGraphManager';
 import { DataType } from '../../../../../../metamodels/pure/model/packageableElements/domain/DataType';
 
-type ResolutionResult<T> = [T, boolean];
+interface ResolutionResult<T> {
+  /**
+   * The resolved element.
+   */
+  element: T;
+  /**
+   * Flag indicating if we need to use section imports to resolve the element.
+   */
+  resolvedUsingSectionImports?: boolean;
+  /**
+   * Flag indicating if the full path is already provided when resolving the element.
+   */
+  isFullPath?: boolean;
+}
 
 export class V1_GraphBuilderContext {
   readonly logger: Logger;
@@ -105,11 +118,16 @@ export class V1_GraphBuilderContext {
     // Try the find from special types (not user-defined top level types)
     const SPECIAL_TYPES: string[] = Object.values(PRIMITIVE_TYPE).concat([]);
     if (SPECIAL_TYPES.includes(path)) {
-      return [resolverFn(path), true];
+      return {
+        element: resolverFn(path),
+      };
     }
-    // if the path is a path with package, no resolution from import is needed
+    // if the path is a path with package, no resolution from section imports is needed
     if (path.includes(ELEMENT_PATH_DELIMITER)) {
-      return [resolverFn(path), true];
+      return {
+        element: resolverFn(path),
+        isFullPath: true,
+      };
     }
     // NOTE: here we make the assumption that we have populated the indices properly so the same element
     // is not referred using 2 different paths in the same element index
@@ -119,10 +137,11 @@ export class V1_GraphBuilderContext {
         const fullPath = importPackage.path + ELEMENT_PATH_DELIMITER + path;
         const element = resolverFn(fullPath);
         if (element) {
-          results.set(fullPath, [
+          results.set(fullPath, {
             element,
-            this.graph.sectionAutoImports.includes(importPackage),
-          ]);
+            resolvedUsingSectionImports:
+              !this.graph.sectionAutoImports.includes(importPackage),
+          });
         }
       } catch {
         // do nothing
@@ -138,7 +157,10 @@ export class V1_GraphBuilderContext {
        * here we count on the `resolver` to do the validation of the type of element instead
        */
       case 0:
-        return [resolverFn(path), true];
+        return {
+          element: resolverFn(path),
+          isFullPath: true,
+        };
       case 1:
         return Array.from(results.values())[0];
       default:
@@ -165,17 +187,17 @@ export class V1_GraphBuilderContext {
     path: string,
     resolverFn: (path: string) => T,
   ): PackageableElementImplicitReference<T> => {
-    const [element, skippedSectionImportResolution] = this.resolve(
+    const { element, resolvedUsingSectionImports, isFullPath } = this.resolve(
       path,
       resolverFn,
     );
-    if (skippedSectionImportResolution) {
+    if (!resolvedUsingSectionImports && !isFullPath) {
       return PackageableElementImplicitReference.create(element, path);
     }
     return PackageableElementImplicitReference.resolveFromSection(
       element,
       path,
-      this.section,
+      resolvedUsingSectionImports ? this.section : undefined,
     );
   };
 

--- a/packages/legend-studio/src/stores/ExplorerTreeState.ts
+++ b/packages/legend-studio/src/stores/ExplorerTreeState.ts
@@ -56,6 +56,7 @@ export class ExplorerTreeState {
   dependencyTreeData?: TreeData<PackageTreeNodeData>;
   selectedNode?: PackageTreeNodeData;
   fileGenerationTreeData?: TreeData<GenerationTreeNodeData>;
+  elementToRename?: PackageableElement;
   isBuilt = false;
 
   constructor(editorStore: EditorStore) {
@@ -68,6 +69,7 @@ export class ExplorerTreeState {
       selectedNode: observable.ref,
       fileGenerationTreeData: observable.ref,
       isBuilt: observable,
+      elementToRename: observable,
       setTreeData: action,
       setGenerationTreeData: action,
       setSystemTreeData: action,
@@ -75,6 +77,7 @@ export class ExplorerTreeState {
       setDependencyTreeData: action,
       setFileGenerationTreeData: action,
       setSelectedNode: action,
+      setElementToRename: action,
       build: action,
       buildImmutableModelTrees: action,
       reprocess: action,
@@ -141,6 +144,9 @@ export class ExplorerTreeState {
   }
   setFileGenerationTreeData(data: TreeData<GenerationTreeNodeData>): void {
     this.fileGenerationTreeData = data;
+  }
+  setElementToRename(val: PackageableElement | undefined): void {
+    this.elementToRename = val;
   }
 
   setSelectedNode(node: PackageTreeNodeData | undefined): void {

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -223,7 +223,7 @@ export class DiagramEditorState extends ElementEditorState {
   // See https://css-tricks.com/using-css-cursors/
   // See https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
   get diagramCursorClass(): string {
-    if (this.isReadOnly || !this.isDiagramRendererInitialized) {
+    if (!this.isDiagramRendererInitialized) {
       return '';
     }
     if (this.renderer.middleClick || this.renderer.rightClick) {
@@ -231,7 +231,7 @@ export class DiagramEditorState extends ElementEditorState {
     }
     switch (this.renderer.interactionMode) {
       case DIAGRAM_INTERACTION_MODE.ADD_CLASS: {
-        return 'diagram-editor__cursor--add';
+        return !this.isReadOnly ? 'diagram-editor__cursor--add' : '';
       }
       case DIAGRAM_INTERACTION_MODE.PAN: {
         return this.renderer.leftClick
@@ -245,6 +245,9 @@ export class DiagramEditorState extends ElementEditorState {
         return 'diagram-editor__cursor--zoom-out';
       }
       case DIAGRAM_INTERACTION_MODE.ADD_RELATIONSHIP: {
+        if (this.isReadOnly) {
+          return '';
+        }
         if (this.renderer.mouseOverClassView && this.renderer.selectionStart) {
           return 'diagram-editor__cursor--add';
         }

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -191,6 +191,11 @@ export class DiagramEditorState extends ElementEditorState {
       case DIAGRAM_INTERACTION_MODE.ADD_CLASS: {
         return 'diagram-editor__cursor--add';
       }
+      case DIAGRAM_INTERACTION_MODE.PAN: {
+        return this.renderer.leftClick
+          ? 'diagram-editor__cursor--grabbing'
+          : 'diagram-editor__cursor--grab';
+      }
       case DIAGRAM_INTERACTION_MODE.ZOOM_IN: {
         return 'diagram-editor__cursor--zoom-in';
       }

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -261,15 +261,16 @@ export class DiagramEditorState extends ElementEditorState {
           this.renderer.selectedClassCorner
         ) {
           return 'diagram-editor__cursor--resize';
-        } else if (
-          (this.renderer.mouseOverProperty &&
-            !this.isReadOnly &&
-            !this.renderer.mouseOverProperty.owner.isReadOnly) ||
-          (this.renderer.mouseOverClassName &&
-            !this.isReadOnly &&
-            !this.renderer.mouseOverClassName.class.value.isReadOnly)
-        ) {
-          return 'diagram-editor__cursor--text';
+        } else if (this.renderer.mouseOverProperty) {
+          return this.isReadOnly ||
+            this.renderer.mouseOverProperty.owner.isReadOnly
+            ? 'diagram-editor__cursor--not-allowed'
+            : 'diagram-editor__cursor--text';
+        } else if (this.renderer.mouseOverClassName) {
+          return this.isReadOnly ||
+            this.renderer.mouseOverClassName.class.value.isReadOnly
+            ? 'diagram-editor__cursor--not-allowed'
+            : 'diagram-editor__cursor--text';
         } else if (this.renderer.mouseOverClassView) {
           return 'diagram-editor__cursor--pointer';
         }

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -61,8 +61,8 @@ const DIAGRAM_EDITOR_HOTKEY_MAP = Object.freeze({
   [DIAGRAM_EDITOR_HOTKEY.USE_PAN_TOOL]: 'm',
   [DIAGRAM_EDITOR_HOTKEY.USE_PROPERTY_TOOL]: 'p',
   [DIAGRAM_EDITOR_HOTKEY.USE_INHERITANCE_TOOL]: 'i',
-  [DIAGRAM_EDITOR_HOTKEY.ADD_CLASS]: '+',
-  [DIAGRAM_EDITOR_HOTKEY.EJECT_PROPERTY]: 'ArrowRight',
+  [DIAGRAM_EDITOR_HOTKEY.ADD_CLASS]: 'c',
+  [DIAGRAM_EDITOR_HOTKEY.EJECT_PROPERTY]: 'alt+ArrowRight',
 });
 
 export abstract class DiagramEditorSidePanelState {
@@ -398,9 +398,10 @@ export class DiagramEditorState extends ElementEditorState {
         // since we use hotkeys that can be easily in text input
         // we would need to do this check to make sure we don't accidentally
         // trigger hotkeys when the user is typing
-        !['input', 'textarea', 'select'].includes(
-          document.activeElement?.tagName.toLowerCase() ?? '',
-        )
+        (!document.activeElement ||
+          !['input', 'textarea', 'select'].includes(
+            document.activeElement.tagName.toLowerCase() ?? '',
+          ))
       ) {
         handler(event);
       }

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/DiagramEditorState.ts
@@ -273,31 +273,6 @@ export class DiagramEditorState extends ElementEditorState {
     };
     this.renderer.onBackgroundDoubleClick = createNewClassView;
     this.renderer.onAddClassViewClick = createNewClassView;
-    this.renderer.addSelectedClassAsPropertyOfOpenedClass = (
-      classView: ClassView,
-    ): void => {
-      if (
-        this.sidePanelState instanceof
-        DiagramEditorClassViewEditorSidePanelState
-      ) {
-        const _class = this.sidePanelState.classEditorState.class;
-        _class.addProperty(
-          new Property(
-            `property_${_class.properties.length + 1}`,
-            this.editorStore.graphState.graph.getTypicalMultiplicity(
-              TYPICAL_MULTIPLICITY_TYPE.ONE,
-            ),
-            GenericTypeExplicitReference.create(
-              new GenericType(classView.class.value),
-            ),
-            _class,
-          ),
-        );
-        // TODO?: should we also try to add property views between these 2 classes?
-        // we would need to scan all possible source class view(s) and potentially link them to
-        // the class view selected or all class view(s) for the class of the selected class view
-      }
-    };
     this.renderer.editProperty = (
       property: AbstractProperty,
       point: Point,

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -261,6 +261,7 @@
 
   &__side-panel {
     background: var(--color-dark-grey-85);
+    border-left: 0.1rem solid var(--color-dark-grey-85);
   }
 
   &__hotkeys__dialog .modal__body {
@@ -309,8 +310,54 @@
 .diagram-editor__class-view-editor {
   height: 100%;
   width: 100%;
-  position: relative;
-  padding: 1rem;
+
+  &__header {
+    height: 2.8rem;
+    width: 100%;
+
+    &__tabs {
+      height: 2.8rem;
+      z-index: 1;
+      display: flex;
+      overflow-x: overlay;
+      overflow-y: hidden;
+    }
+
+    &__tab {
+      height: 100%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 1rem;
+      border-right: 0.1rem solid var(--color-dark-grey-280);
+      color: var(--color-light-grey-250);
+      white-space: nowrap;
+      cursor: pointer;
+    }
+
+    &__tab--active {
+      position: relative;
+    }
+
+    &__tab--active::after {
+      content: '';
+      height: 0.4rem;
+      width: 100%;
+      position: absolute;
+      bottom: 0;
+      background: var(--color-yellow-200);
+    }
+  }
+
+  &__content {
+    position: relative;
+    height: calc(100% - 2.8rem);
+    width: 100%;
+  }
+
+  &__content__form {
+    padding: 1rem;
+  }
 }
 
 .diagram-editor__inline-property-editor {

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -185,11 +185,12 @@
   }
 
   &__icon {
-    &--layout {
-      font-size: 1.8rem;
-    }
-
-    &--add-class {
+    &--layout,
+    &--pan,
+    &--add-class,
+    &--sidebar,
+    &--zoom-in,
+    &--zoom-out {
       font-size: 1.8rem;
     }
 
@@ -209,15 +210,6 @@
 
     &--hotkey-info {
       font-size: 2.2rem;
-    }
-
-    &--sidebar {
-      font-size: 1.8rem;
-    }
-
-    &--zoom-in,
-    &--zoom-out {
-      font-size: 1.8rem;
     }
   }
 
@@ -252,6 +244,10 @@
 
     &--zoom-out {
       cursor: zoom-out;
+    }
+
+    &--grab {
+      cursor: grab;
     }
 
     &--grabbing {

--- a/packages/legend-studio/style/components/editor/_diagram-editor.scss
+++ b/packages/legend-studio/style/components/editor/_diagram-editor.scss
@@ -253,6 +253,10 @@
     &--grabbing {
       cursor: grabbing;
     }
+
+    &--not-allowed {
+      cursor: not-allowed;
+    }
   }
 
   &__side-panel {

--- a/packages/legend-studio/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-studio/style/components/editor/side-bar/_explorer.scss
@@ -147,4 +147,16 @@
   &__floating-item {
     padding-left: 1rem;
   }
+
+  &__element-renamer {
+    border: 0.1rem solid var(--color-dark-grey-85) !important;
+
+    &__input {
+      height: 2.8rem;
+    }
+
+    &__close-btn {
+      display: none;
+    }
+  }
 }

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -31,7 +31,7 @@
     "stylelint": "13.13.1",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-standard": "22.0.0",
-    "stylelint-scss": "3.20.0"
+    "stylelint-scss": "3.20.1"
   },
   "devDependencies": {
     "cross-env": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:7.14.8":
+  version: 7.14.8
+  resolution: "@babel/core@npm:7.14.8"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.8
+    "@babel/helper-compilation-targets": ^7.14.5
+    "@babel/helper-module-transforms": ^7.14.8
+    "@babel/helpers": ^7.14.8
+    "@babel/parser": ^7.14.8
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.8
+    "@babel/types": ^7.14.8
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 4c9a5b21020791659095a514f11c81159a96477037682183f23a1084732e0e3dbb58986e14ebf3a03a31230a75d8b2e1d23644ca84204eddf70018cba983035f
+  languageName: node
+  linkType: hard
+
 "@babel/eslint-parser@npm:7.14.7":
   version: 7.14.7
   resolution: "@babel/eslint-parser@npm:7.14.7"
@@ -104,6 +127,17 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: 7fcfeaf17e8e76ea91c66dc86c776d2112f52ce0315d3f4ca6a74b6eada0be1592d1ea6286d7241d3f634b63717ceef5d180d041a0b3dca9d071ba2e5fa7c77b
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/generator@npm:7.14.8"
+  dependencies:
+    "@babel/types": ^7.14.8
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 0fdec7e1991fc3973d241e4c5e7d69f8c4ab063359695e6a019e4a5a0139a768ddce91d0705d7bd8a28f3befb5abde68355e19745fcdb45c40a26cf53d879191
   languageName: node
   linkType: hard
 
@@ -258,6 +292,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/helper-module-transforms@npm:7.14.8"
+  dependencies:
+    "@babel/helper-module-imports": ^7.14.5
+    "@babel/helper-replace-supers": ^7.14.5
+    "@babel/helper-simple-access": ^7.14.8
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/helper-validator-identifier": ^7.14.8
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.8
+    "@babel/types": ^7.14.8
+  checksum: 527b3383c40788b04c815da1ded4ac8cdc21e3356517fc81bcd03b319c1b58901638bb641a6f0cd00f493c7a31a8ae7123213d59c1d4f57cec32185b5d9f79a2
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-optimise-call-expression@npm:7.14.5"
@@ -306,6 +356,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-simple-access@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/helper-simple-access@npm:7.14.8"
+  dependencies:
+    "@babel/types": ^7.14.8
+  checksum: c1dae88c956154c854bb1679d19b9158ff1c8241329a4a70026ec16c594b9637e73647e5a1a0f9b7c47b2309201f633c259fb41d06a800496283debce6a67fab
+  languageName: node
+  linkType: hard
+
 "@babel/helper-skip-transparent-expression-wrappers@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.14.5"
@@ -328,6 +387,13 @@ __metadata:
   version: 7.14.5
   resolution: "@babel/helper-validator-identifier@npm:7.14.5"
   checksum: 6366bceab4498785defc083a1bd96344f788d90a1aa7a6f18d6813c1d3d134640bfc05690453c0b79bbfc820472cf5b29110dfddaca1f8e2763dfe1bd5df0b88
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/helper-validator-identifier@npm:7.14.8"
+  checksum: f21ad9a9f0a66a02e0e5f62d505cbeb9e01a7ac5bd34be0af9f916f0b6d8d40718efaf51b656b41759e3454703090b4d386105f1f97f6598ee5a3f8eb98adc6a
   languageName: node
   linkType: hard
 
@@ -361,6 +427,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/helpers@npm:7.14.8"
+  dependencies:
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.8
+    "@babel/types": ^7.14.8
+  checksum: 2f1358c19fc1ee744c183f81b499b73977da7d3d3f7a881d457b235754394a503e4717353f29364bd5feb7fa406b1edd1aab92b5ab0765dba945fb559eeb1c65
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/highlight@npm:7.14.5"
@@ -378,6 +455,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 0d7acc8cf9c19ccd0e80ab0608953f32f4375f3867c080211270e7bb4bb94c551fd1fc3f49b3cc92a4eec356cf507801f5c93c4c72996968bdc4c28815fe0550
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/parser@npm:7.14.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 9e532b2bbe690fff8cdaf8c25cfecb684ebe9e9d50d30cd775852dd711649ddb964368b26fda55786404fadf500f944043fb0f731b765104ad857d677dd29ce5
   languageName: node
   linkType: hard
 
@@ -1234,9 +1320,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.14.7":
-  version: 7.14.7
-  resolution: "@babel/preset-env@npm:7.14.7"
+"@babel/preset-env@npm:7.14.8":
+  version: 7.14.8
+  resolution: "@babel/preset-env@npm:7.14.8"
   dependencies:
     "@babel/compat-data": ^7.14.7
     "@babel/helper-compilation-targets": ^7.14.5
@@ -1305,7 +1391,7 @@ __metadata:
     "@babel/plugin-transform-unicode-escapes": ^7.14.5
     "@babel/plugin-transform-unicode-regex": ^7.14.5
     "@babel/preset-modules": ^0.1.4
-    "@babel/types": ^7.14.5
+    "@babel/types": ^7.14.8
     babel-plugin-polyfill-corejs2: ^0.2.2
     babel-plugin-polyfill-corejs3: ^0.2.2
     babel-plugin-polyfill-regenerator: ^0.2.2
@@ -1313,7 +1399,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: ebebc20ada68c92b67375926021d576af3636a279aee7625c1e234880355c8669188483aecfff2d478c1caa9fcf18b569ea329060b479236b04baed2bdf796d5
+  checksum: b52f08b9b6ca84c6941ca6e43ab9dcddc768dd197d5921a09778429648dc8fa85cafd92293859c9349be2ec4181e91821d4c376ccfd5e25538c30f500b1b3d5c
   languageName: node
   linkType: hard
 
@@ -1371,7 +1457,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.14.6, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.14.8":
+  version: 7.14.8
+  resolution: "@babel/runtime@npm:7.14.8"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: d2dd0ce51ddab78ac93928b04042425145d0dc8cc2b70150d47934f8703f55702eb0b2894f9bd47f66794ad04d8bb03a6a847d0138fbb7aa0b970b5ccd5cc8b7
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.14.6
   resolution: "@babel/runtime@npm:7.14.6"
   dependencies:
@@ -1408,6 +1503,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/traverse@npm:7.14.8"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.8
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-hoist-variables": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/parser": ^7.14.8
+    "@babel/types": ^7.14.8
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: f635f99b1b09dfe60105bb162103346f78e058351231e33e9c11a17fabf6d56b4f87837ad14a0f82242c6dd0b97fecd90064735f1e11d47b7429a1c3e99a5ece
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.14.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.14.5
   resolution: "@babel/types@npm:7.14.5"
@@ -1415,6 +1527,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.14.5
     to-fast-properties: ^2.0.0
   checksum: 7c1ab6e8bdf438d44236034cab10f7d0f1971179bc405dca26733a9b89dd87dd692dc49a238a7495075bc41a9a17fb6f08b4d1da45ea6ddcce1e5c8593574aea
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.14.8":
+  version: 7.14.8
+  resolution: "@babel/types@npm:7.14.8"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.8
+    to-fast-properties: ^2.0.0
+  checksum: d4ebd2e0e52f05cbcb3ded434d9fb49db73c239d98c4f7bd27beaf32fcd7c81aa30618237e87d53505d5e65fd20d688cb4237b6fa927a04831129a6044f2e4b5
   languageName: node
   linkType: hard
 
@@ -1781,15 +1903,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/babel-preset-legend-studio@workspace:packages/babel-preset"
   dependencies:
-    "@babel/core": 7.14.6
+    "@babel/core": 7.14.8
     "@babel/helper-plugin-utils": 7.14.5
     "@babel/plugin-proposal-class-properties": 7.14.5
     "@babel/plugin-transform-runtime": 7.14.5
     "@babel/plugin-transform-typescript": 7.14.6
-    "@babel/preset-env": 7.14.7
+    "@babel/preset-env": 7.14.8
     "@babel/preset-react": 7.14.5
     "@babel/preset-typescript": 7.14.5
-    "@babel/runtime": 7.14.6
+    "@babel/runtime": 7.14.8
     cross-env: 7.0.3
     eslint: 7.31.0
     react-refresh: 0.10.0
@@ -1804,10 +1926,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/eslint-plugin-legend-studio@workspace:packages/eslint-plugin"
   dependencies:
-    "@babel/core": 7.14.6
+    "@babel/core": 7.14.8
     "@babel/eslint-parser": 7.14.7
-    "@typescript-eslint/eslint-plugin": 4.28.3
-    "@typescript-eslint/parser": 4.28.3
+    "@typescript-eslint/eslint-plugin": 4.28.4
+    "@typescript-eslint/parser": 4.28.4
     cross-env: 7.0.3
     eslint: 7.31.0
     eslint-config-prettier: 8.3.0
@@ -1846,7 +1968,7 @@ __metadata:
     webpack: 5.45.1
     webpack-bundle-analyzer: 4.4.2
     webpack-cli: 4.7.2
-    webpack-dev-server: 4.0.0-beta.3
+    webpack-dev-server: 4.0.0-rc.0
   languageName: unknown
   linkType: soft
 
@@ -1856,7 +1978,7 @@ __metadata:
   dependencies:
     "@finos/legend-studio-dev-utils": "workspace:*"
     "@finos/legend-studio-shared": "workspace:*"
-    "@material-ui/core": 4.12.1
+    "@material-ui/core": 4.12.2
     "@types/react": 17.0.14
     "@types/react-select": 4.0.17
     "@types/react-window": 1.8.4
@@ -1885,7 +2007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/legend-studio-dev-utils@workspace:packages/legend-studio-dev-utils"
   dependencies:
-    "@babel/core": 7.14.6
+    "@babel/core": 7.14.8
     "@changesets/changelog-github": 0.4.0
     "@changesets/config": 1.6.0
     "@changesets/get-release-plan": 3.0.0
@@ -1903,8 +2025,8 @@ __metadata:
     clean-webpack-plugin: 3.0.0
     cosmiconfig: 7.0.0
     cross-env: 7.0.3
-    css-loader: 6.1.0
-    cssnano: 5.0.6
+    css-loader: 6.2.0
+    cssnano: 5.0.7
     eslint: 7.31.0
     fork-ts-checker-webpack-plugin: 6.2.12
     html-webpack-plugin: 5.3.2
@@ -1917,7 +2039,7 @@ __metadata:
     mini-css-extract-plugin: 2.1.0
     monaco-editor: 0.26.1
     monaco-editor-webpack-plugin: 4.1.1
-    postcss: 8.3.5
+    postcss: 8.3.6
     postcss-loader: 6.1.1
     react-refresh: 0.10.0
     resolve: 1.20.0
@@ -2066,7 +2188,7 @@ __metadata:
     "@finos/legend-studio-components": "workspace:*"
     "@finos/legend-studio-dev-utils": "workspace:*"
     "@finos/legend-studio-shared": "workspace:*"
-    "@material-ui/core": 4.12.1
+    "@material-ui/core": 4.12.2
     "@testing-library/dom": 8.1.0
     "@testing-library/react": 12.0.0
     "@types/papaparse": 5.2.6
@@ -2134,7 +2256,7 @@ __metadata:
     "@finos/legend-studio-dev-utils": "workspace:*"
     "@finos/legend-studio-network": "workspace:*"
     "@finos/legend-studio-shared": "workspace:*"
-    "@material-ui/core": 4.12.1
+    "@material-ui/core": 4.12.2
     "@testing-library/dom": 8.1.0
     "@testing-library/react": 12.0.0
     "@types/css-font-loading-module": 0.0.6
@@ -2183,7 +2305,7 @@ __metadata:
     stylelint: 13.13.1
     stylelint-config-prettier: 8.0.2
     stylelint-config-standard: 22.0.0
-    stylelint-scss: 3.20.0
+    stylelint-scss: 3.20.1
   peerDependencies:
     stylelint: ^13.0.0
   languageName: unknown
@@ -2517,9 +2639,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material-ui/core@npm:4.12.1":
-  version: 4.12.1
-  resolution: "@material-ui/core@npm:4.12.1"
+"@material-ui/core@npm:4.12.2":
+  version: 4.12.2
+  resolution: "@material-ui/core@npm:4.12.2"
   dependencies:
     "@babel/runtime": ^7.4.4
     "@material-ui/styles": ^4.11.4
@@ -2540,7 +2662,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 6f612bbb75c18a9ef6746361d0736c5777c4a3a52f85bc4d0d1f6f49b2e1982dd4afc85cba1d66057f5e5d9b52ce1c6d2a9803d71592c50d96fadd74e4170201
+  checksum: daecbf812657112bfd82616ffe2add6686e80b2f0f38486108123c40cccbd0bcffb972c0d816a2b9f639f988758a86d769da6a71e6306d77b71265753786b54b
   languageName: node
   linkType: hard
 
@@ -3037,10 +3159,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.3.3":
-  version: 16.3.3
-  resolution: "@types/node@npm:16.3.3"
-  checksum: fa885b835e57a4a2fd15571e5cbfe361d4ac48278196416aa2690ebdfb118a116249dd81475078c61fbf2d95920324f8f3a66ae7f19fac424ae74ab87a41c1e4
+"@types/node@npm:16.4.0":
+  version: 16.4.0
+  resolution: "@types/node@npm:16.4.0"
+  checksum: 9107dbdd9b7ad9deacc1bcabdf7205ea512bbf5ffe982f2b8a0d8ad776296d610e7c52363f2d62ba5a87f7547619df4bd66319ac487641d519ae52d3867743b6
   languageName: node
   linkType: hard
 
@@ -3325,12 +3447,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.28.3"
+"@typescript-eslint/eslint-plugin@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.28.4"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.28.3
-    "@typescript-eslint/scope-manager": 4.28.3
+    "@typescript-eslint/experimental-utils": 4.28.4
+    "@typescript-eslint/scope-manager": 4.28.4
     debug: ^4.3.1
     functional-red-black-tree: ^1.0.1
     regexpp: ^3.1.0
@@ -3342,66 +3464,66 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 2ac7113dbb0916ee911c3cee552b31b82c3c286ce4be1d2b5b8fbbe64eb05eb8c5187a64aba2fc5d46f2bc2d391887b33e00edbb65f2f25f41342efa346776ef
+  checksum: 8de0301888e7308bca45c1cbfb28693b365780e85e0d7810ec9f004fc3f81b90871d2a55ad71d5865a93ce5d382e13ca9bbdc43d4234e0e409ef65f1348fe864
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/experimental-utils@npm:4.28.3"
+"@typescript-eslint/experimental-utils@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/experimental-utils@npm:4.28.4"
   dependencies:
     "@types/json-schema": ^7.0.7
-    "@typescript-eslint/scope-manager": 4.28.3
-    "@typescript-eslint/types": 4.28.3
-    "@typescript-eslint/typescript-estree": 4.28.3
+    "@typescript-eslint/scope-manager": 4.28.4
+    "@typescript-eslint/types": 4.28.4
+    "@typescript-eslint/typescript-estree": 4.28.4
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 09b1b196318acbf6efbb9ea93fc73b18a77c1fc04efb24bc77d941666b5a0c48828f2d788079bdfd340828045d15054a4c95fba5367e7c8b1fe53de53736a1db
+  checksum: 71eb19a55efb32b28f2cf130c6a9689ac9df18d41ac0eb0351f1bd47c2ef39e8acbc20d743830ecd2f60d2b18f38a45a588f1b6e292cacf5e55b5f57c2043583
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/parser@npm:4.28.3"
+"@typescript-eslint/parser@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/parser@npm:4.28.4"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.28.3
-    "@typescript-eslint/types": 4.28.3
-    "@typescript-eslint/typescript-estree": 4.28.3
+    "@typescript-eslint/scope-manager": 4.28.4
+    "@typescript-eslint/types": 4.28.4
+    "@typescript-eslint/typescript-estree": 4.28.4
     debug: ^4.3.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3a5d64237e7085235f3b27eece73105bd5a7b51f17c868c086a6062bd8ab6901c908270d41c055f44d9f440c6a1bb3203429693a07436905cc60d3a03cd361e9
+  checksum: 838c4fed7ad14652edd02a3649a4da2c2a0f8c3e7496657f573791114c9e0aa0278163350b349e722b2d414080c108d18e9c6571c110b229bb17ff089c8ebda3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/scope-manager@npm:4.28.3"
+"@typescript-eslint/scope-manager@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/scope-manager@npm:4.28.4"
   dependencies:
-    "@typescript-eslint/types": 4.28.3
-    "@typescript-eslint/visitor-keys": 4.28.3
-  checksum: 9ffb955581311ef46d7aebf23ac544c96164bac00f7657f963680ba7b239b1c021733318ea22ca2965ff9b8f2798dff8ae5d7add0dae4207d3dad86d5e4f0f1f
+    "@typescript-eslint/types": 4.28.4
+    "@typescript-eslint/visitor-keys": 4.28.4
+  checksum: 75ff460989d334dcef513b8ea06d8c9039731092f65790abee90f4251d1f145f9496894d5fe076b1f26612a1dce29acbddfdb73472d49fa8a0dd63451a8eb2b5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/types@npm:4.28.3"
-  checksum: 15f052f92ee429056e7bdd4b0ff3750d72a6ab6c202a46f394dcd7490da7f670d7b516fc5febc96332cced39fdf3fd20c4893ee58fb93ce9b58e2f1e1766d7bb
+"@typescript-eslint/types@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/types@npm:4.28.4"
+  checksum: be565692cc42ce387fe8a1cc9ad44edaa8dea45728a33f3ad8cc8ee664bbd3ef220d529fdc7a2165b60cd1eb5280b767fbb7f351e56f2c0b90c99d2ccf24ad06
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/typescript-estree@npm:4.28.3"
+"@typescript-eslint/typescript-estree@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/typescript-estree@npm:4.28.4"
   dependencies:
-    "@typescript-eslint/types": 4.28.3
-    "@typescript-eslint/visitor-keys": 4.28.3
+    "@typescript-eslint/types": 4.28.4
+    "@typescript-eslint/visitor-keys": 4.28.4
     debug: ^4.3.1
     globby: ^11.0.3
     is-glob: ^4.0.1
@@ -3410,17 +3532,17 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 674cdd5e3c24306f906d6479ede454d5f5a2100e22cd5aa08f9bc27953cdb4930384ad3b4434937e31e8e92e6b3cc867f8d56c3b65e2254f7042662deafef583
+  checksum: 526f41028d63ddb506586abe6ca5ffd6cee54b2773fc70e803d61988682f4528228bef8a6773ea5219e7412887e4c74732736620a4e904e51239b7acab4441b9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.28.3":
-  version: 4.28.3
-  resolution: "@typescript-eslint/visitor-keys@npm:4.28.3"
+"@typescript-eslint/visitor-keys@npm:4.28.4":
+  version: 4.28.4
+  resolution: "@typescript-eslint/visitor-keys@npm:4.28.4"
   dependencies:
-    "@typescript-eslint/types": 4.28.3
+    "@typescript-eslint/types": 4.28.4
     eslint-visitor-keys: ^2.0.0
-  checksum: b570740ae16901df85febde13b5e34b95dfa13fc51b035875bc087fef356f2db1284ff045812ace06b0e8f821171a7ddaf7606cee672d35df486989e79a0c7df
+  checksum: d0b359dc0aaf0f6c3396bf7bee31f9ec7a6d90b7f69890478a002af6eb9ab4a7be466b4ddb050af87ce5f1d01384ce41fd976d472cbe587787b2ee21d977e8f6
   languageName: node
   linkType: hard
 
@@ -5210,9 +5332,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-loader@npm:6.1.0":
-  version: 6.1.0
-  resolution: "css-loader@npm:6.1.0"
+"css-loader@npm:6.2.0":
+  version: 6.2.0
+  resolution: "css-loader@npm:6.2.0"
   dependencies:
     icss-utils: ^5.1.0
     postcss: ^8.2.15
@@ -5224,7 +5346,7 @@ __metadata:
     semver: ^7.3.5
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 5ebc5e41281625d8c20466fc5bacd56eab763173f63dcbe82a56619dd10a12d2e67dc2a08582ce4c8994516ed6440c2f6edb61d693044a82cfefd23eb3b5f784
+  checksum: 9c6e6e1eef7ab897ea1f45094a153ee82d94ef5248b54b8f8a3634c72900ec5f3cc463b3c0eca65290118c3dbfd52887ba7294b4807a0247a3c5d7cf3a63b2e6
   languageName: node
   linkType: hard
 
@@ -5332,16 +5454,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:5.0.6":
-  version: 5.0.6
-  resolution: "cssnano@npm:5.0.6"
+"cssnano@npm:5.0.7":
+  version: 5.0.7
+  resolution: "cssnano@npm:5.0.7"
   dependencies:
-    cosmiconfig: ^7.0.0
     cssnano-preset-default: ^5.1.3
     is-resolvable: ^1.1.0
+    lilconfig: ^2.0.3
+    yaml: ^1.10.2
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 0109988a37c1fe6ffa04e33f1d4365e475d77a7f661e1491344f689181fcde76a0de4ddf98f7288961fcccbf2daed749c9175ee8505d46f850c95859750b548f
+  checksum: 6058e285bc25345c3d404385300e343a1489af2b7e2d8c62161d42d46958d43a705786f887677d86cb634ed580278022a7c3d59da2f1e75694c35d3cdd9dda14
   languageName: node
   linkType: hard
 
@@ -5560,6 +5683,13 @@ __metadata:
   dependencies:
     clone: ^1.0.2
   checksum: 96e2112da6553d376afd5265ea7cbdb2a3b45535965d71ab8bb1da10c8126d168fdd5268799625324b368356d21ba2a7b3d4ec50961f11a47b7feb9de3d4413e
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "define-lazy-prop@npm:2.0.0"
+  checksum: 0115fdb065e0490918ba271d7339c42453d209d4cb619dfe635870d906731eff3e1ade8028bb461ea27ce8264ec5e22c6980612d332895977e89c1bbc80fcee2
   languageName: node
   linkType: hard
 
@@ -7576,16 +7706,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "http-proxy-middleware@npm:1.3.1"
+"http-proxy-middleware@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "http-proxy-middleware@npm:2.0.1"
   dependencies:
     "@types/http-proxy": ^1.17.5
     http-proxy: ^1.18.1
     is-glob: ^4.0.1
     is-plain-obj: ^3.0.0
     micromatch: ^4.0.2
-  checksum: c6f0fe6d5aa58f3757084f1fad8109e7384fdea1b0a5c62f58ac767c42f367a18d3819bed8cbf8b5183f17e3e14fad04322f179c569629004da5fbec9b81a88a
+  checksum: 0de65bc6644b6efae5d26cd3bec071ceaeb92f26856ffee5ecdde9c702ea1435936e7dfb09da2ac0883eada80fdc993e9925902fc10bf6625565d6365f8cb30f
   languageName: node
   linkType: hard
 
@@ -7829,7 +7959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipaddr.js@npm:^2.0.0":
+"ipaddr.js@npm:^2.0.1":
   version: 2.0.1
   resolution: "ipaddr.js@npm:2.0.1"
   checksum: dd194a394a843d470f88d17191b0948f383ed1c8e320813f850c336a0fcb5e9215d97ec26ca35ab4fbbd31392c8b3467f3e8344628029ed3710b2ff6b5d1034e
@@ -8039,7 +8169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-docker@npm:^2.0.0":
+"is-docker@npm:^2.0.0, is-docker@npm:^2.1.1":
   version: 2.2.1
   resolution: "is-docker@npm:2.2.1"
   bin:
@@ -8351,7 +8481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.1.1":
+"is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -9403,7 +9533,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "legend-studio@workspace:."
   dependencies:
-    "@babel/core": 7.14.6
+    "@babel/core": 7.14.8
     "@changesets/cli": 2.16.0
     "@finos/babel-preset-legend-studio": "workspace:*"
     "@finos/eslint-plugin-legend-studio": "workspace:*"
@@ -9411,7 +9541,7 @@ __metadata:
     "@finos/stylelint-config-legend-studio": "workspace:*"
     "@juggle/resize-observer": 3.3.1
     "@types/jest": 26.0.24
-    "@types/node": 16.3.3
+    "@types/node": 16.4.0
     chalk: 4.1.1
     cross-env: 7.0.3
     eslint: 7.31.0
@@ -9452,6 +9582,13 @@ __metadata:
     prelude-ls: ~1.1.2
     type-check: ~0.3.2
   checksum: 0d084a524231a8246bb10fec48cdbb35282099f6954838604f3c7fc66f2e16fa66fd9cc2f3f20a541a113c4dafdf181e822c887c8a319c9195444e6c64ac395e
+  languageName: node
+  linkType: hard
+
+"lilconfig@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "lilconfig@npm:2.0.3"
+  checksum: 39fcd06c9f94bec0f7be969f89abcead96cf9334682007df63e6fbe9bdb0566cf8e1ca53a8f56d2acca802f28e8acbabe8ed4e6265ed5e419b6a1397db003741
   languageName: node
   linkType: hard
 
@@ -10022,7 +10159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.30, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24":
   version: 2.1.31
   resolution: "mime-types@npm:2.1.31"
   dependencies:
@@ -10758,13 +10895,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^7.4.2":
-  version: 7.4.2
-  resolution: "open@npm:7.4.2"
+"open@npm:^8.0.9":
+  version: 8.2.1
+  resolution: "open@npm:8.2.1"
   dependencies:
-    is-docker: ^2.0.0
-    is-wsl: ^2.1.1
-  checksum: 3333900ec0e420d64c23b831bc3467e57031461d843c801f569b2204a1acc3cd7b3ec3c7897afc9dde86491dfa289708eb92bba164093d8bd88fb2c231843c91
+    define-lazy-prop: ^2.0.0
+    is-docker: ^2.1.1
+    is-wsl: ^2.2.0
+  checksum: fcde0059188dd497e080436f81c5240dad0bebd331d1c856a532d4b870808bdc5770ef7c5c4b83143fd0c0577fe2b580e54c03357d695771259aa59f64cf0f40
   languageName: node
   linkType: hard
 
@@ -11735,14 +11873,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.3.5, postcss@npm:^8.2.15":
-  version: 8.3.5
-  resolution: "postcss@npm:8.3.5"
+"postcss@npm:8.3.6":
+  version: 8.3.6
+  resolution: "postcss@npm:8.3.6"
   dependencies:
     colorette: ^1.2.2
     nanoid: ^3.1.23
     source-map-js: ^0.6.2
-  checksum: c73fc4825ed27396d453a942628cd8e34dd43c11b724f43f65f376d3900037736013b6446f1d9947ce5a847837cf96649e9a3f200ca2bd94a884e91e56ee1ceb
+  checksum: ff55b91bea21f42c2a94d77fd05c3f66dd15889c68506cf1dbb9cdee8c3b9e9d0e219bcbc6e61a107bd63e3cac0670176486e2a5794c106a4e1b9babceb79317
   languageName: node
   linkType: hard
 
@@ -11754,6 +11892,17 @@ __metadata:
     source-map: ^0.6.1
     supports-color: ^6.1.0
   checksum: 4cfc0989b9ad5d0e8971af80d87f9c5beac5c84cb89ff22ad69852edf73c0a2fa348e7e0a135b5897bf893edad0fe86c428769050431ad9b532f072ff530828d
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.2.15":
+  version: 8.3.5
+  resolution: "postcss@npm:8.3.5"
+  dependencies:
+    colorette: ^1.2.2
+    nanoid: ^3.1.23
+    source-map-js: ^0.6.2
+  checksum: c73fc4825ed27396d453a942628cd8e34dd43c11b724f43f65f376d3900037736013b6446f1d9947ce5a847837cf96649e9a3f200ca2bd94a884e91e56ee1ceb
   languageName: node
   linkType: hard
 
@@ -13789,9 +13938,9 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stylelint-scss@npm:3.20.0":
-  version: 3.20.0
-  resolution: "stylelint-scss@npm:3.20.0"
+"stylelint-scss@npm:3.20.1":
+  version: 3.20.1
+  resolution: "stylelint-scss@npm:3.20.1"
   dependencies:
     lodash: ^4.17.15
     postcss-media-query-parser: ^0.2.3
@@ -13800,7 +13949,7 @@ resolve@^2.0.0-next.3:
     postcss-value-parser: ^4.1.0
   peerDependencies:
     stylelint: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
-  checksum: 61b7448fd110b166edb8b4cfa1a42624dd94e35154ab5db5ef51b6c578c00c4f3ff9d1be1cee8a16f19aef81e755289fb3e013c4316ee4718001beaf2cdf05cd
+  checksum: 6814e6da6e5a6886d349d3cb13aaaf06496d6c00c9db2be482f0e9874ed78c3e877082f190fcb2db7f0ec725276ecf7f8b47d16174fb9bc7300f30870fe7c455
   languageName: node
   linkType: hard
 
@@ -14809,25 +14958,25 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"webpack-dev-middleware@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "webpack-dev-middleware@npm:4.3.0"
+"webpack-dev-middleware@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "webpack-dev-middleware@npm:5.0.0"
   dependencies:
     colorette: ^1.2.2
     mem: ^8.1.1
     memfs: ^3.2.2
-    mime-types: ^2.1.30
+    mime-types: ^2.1.31
     range-parser: ^1.2.1
     schema-utils: ^3.0.0
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
-  checksum: 113389f9aa488312758b329f9fdd34ff646a50822c197d0e1dc7ce171b1d826a607c92702a60439fead24e495d5b2c9959d90948fc272f7472a301d37cec1e8d
+  checksum: e5bf56a299da509d5810564790b481e599768265399777897dbbd555c6f4dfdab87f1b162e30f3dd4628a6c08097315272d1f1faa6bbb8abe82bd3ce999e261f
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:4.0.0-beta.3":
-  version: 4.0.0-beta.3
-  resolution: "webpack-dev-server@npm:4.0.0-beta.3"
+"webpack-dev-server@npm:4.0.0-rc.0":
+  version: 4.0.0-rc.0
+  resolution: "webpack-dev-server@npm:4.0.0-rc.0"
   dependencies:
     ansi-html: ^0.0.7
     bonjour: ^3.5.0
@@ -14836,26 +14985,25 @@ typescript@4.3.5:
     connect-history-api-fallback: ^1.6.0
     del: ^6.0.0
     express: ^4.17.1
-    find-cache-dir: ^3.3.1
     graceful-fs: ^4.2.6
     html-entities: ^2.3.2
-    http-proxy-middleware: ^1.3.1
+    http-proxy-middleware: ^2.0.0
     internal-ip: ^6.2.0
-    ipaddr.js: ^2.0.0
+    ipaddr.js: ^2.0.1
     is-absolute-url: ^3.0.3
     killable: ^1.0.1
-    open: ^7.4.2
+    open: ^8.0.9
     p-retry: ^4.5.0
     portfinder: ^1.0.28
-    schema-utils: ^3.0.0
+    schema-utils: ^3.1.0
     selfsigned: ^1.10.11
     serve-index: ^1.9.1
     sockjs: ^0.3.21
     spdy: ^4.0.2
-    strip-ansi: ^6.0.0
+    strip-ansi: ^7.0.0
     url: ^0.11.0
-    webpack-dev-middleware: ^4.1.0
-    ws: ^7.4.5
+    webpack-dev-middleware: ^5.0.0
+    ws: ^7.5.3
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   peerDependenciesMeta:
@@ -14863,7 +15011,7 @@ typescript@4.3.5:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 9902a5a314b12990a71063c10c6d82969610911db8387031f2a8f9ee6200201e7ff3fdc44da171b860b22f41dc0100652eb1d094db64dd77e8499361517d8da2
+  checksum: 9dc2e6f151199d050088b19f7b473e44c5cfb3e06c8572f92e71f6acf4fd6f483416a8c4bf53783bfd3093e05028394be984906b148d8e7dbb05bcbc345598be
   languageName: node
   linkType: hard
 
@@ -15104,7 +15252,7 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.3.1, ws@npm:^7.4.5":
+"ws@npm:^7.3.1, ws@npm:^7.4.5, ws@npm:^7.5.3":
   version: 7.5.3
   resolution: "ws@npm:7.5.3"
   peerDependencies:
@@ -15161,7 +15309,7 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0, yaml@npm:^1.7.2":
+"yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f


### PR DESCRIPTION
Fixes https://github.com/finos/legend-studio/issues/322

- [x] Fix class view click behaviour, remove that function for left click
- [x] New property is `Alt + DownArrow` key
- [x] New pan mode (hand) - View Tool, Change icon for selection mode back to (Pointer)
- [x] Remove `addSelectedClassAsPropertyOfOpenedClass`
- [x] Allow using hotkey in diagram editor without having to focus on the diagram canvas
- [x] Diagram - https://github.com/finos/legend-studio/issues/322 - rename element on diagram (from stash)
- [x] Allow renaming classes in diagram
- [x] Properly disable hotkeys in read-only mode or when interacting with read-only elements
- [x] Fix a bug where classes coming from immutable graphs (system, generation, dependencies, etc.) are automatically removed from the diagram (a regression introduced by https://github.com/finos/legend-studio/pull/351)

