### PR TITLE
Update `Webpack` resolution config to work with new workspace naming pattern `legend-`

### DIFF
--- a/.changeset/giant-toes-sin.md
+++ b/.changeset/giant-toes-sin.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio-dev-utils': patch
+---
+
+Update Webpack resolution config to include workspace starting with `legend-` and `@finos/legend-` instead of `legend-studio` as we start having more non-Studio support in the codebase.

--- a/.changeset/rare-paws-unite.md
+++ b/.changeset/rare-paws-unite.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-model-storage': patch
+'@finos/legend-studio-dev-utils': patch
+---

--- a/.changeset/short-fireants-flow.md
+++ b/.changeset/short-fireants-flow.md
@@ -2,4 +2,5 @@
 '@finos/legend-studio': patch
 ---
 
-Remove 'TEMPORARY__disableSDLCProjectStructureSupport' application config flag.
+pr: #420
+Remove `TEMPORARY__disableSDLCProjectStructureSupport` application config flag.

--- a/packages/legend-model-storage/README.md
+++ b/packages/legend-model-storage/README.md
@@ -1,3 +1,1 @@
 # @finos/legend-model-storage
-
-Legend storage models: `Entity`, `ProjectDependency`

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -115,9 +115,9 @@ const getBaseWebpackConfig = (
             // The source code of the current workspace
             resolve(dirname, './src/'),
             // Packages from the same monorepo
-            /legend-studio/,
+            /legend-/,
             // Packages coming from NPM published under '@finos' scope
-            /@finos\/legend-studio/,
+            /@finos\/legend-/,
             ...extraBabelLoaderIncludePatterns,
           ],
           use: [

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -114,8 +114,6 @@ const getBaseWebpackConfig = (
           include: [
             // The source code of the current workspace
             resolve(dirname, './src/'),
-            // Packages from the same monorepo
-            /legend-/,
             // Packages coming from NPM published under '@finos' scope
             /@finos\/legend-/,
             ...extraBabelLoaderIncludePatterns,

--- a/packages/legend-studio-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-studio-dev-utils/WebpackConfigUtils.js
@@ -114,6 +114,8 @@ const getBaseWebpackConfig = (
           include: [
             // The source code of the current workspace
             resolve(dirname, './src/'),
+            // Packages from the same monorepo
+            /packages\/legend-/,
             // Packages coming from NPM published under '@finos' scope
             /@finos\/legend-/,
             ...extraBabelLoaderIncludePatterns,


### PR DESCRIPTION
Since we just introduced `@finos/legend-model-storage` which is not of the pattern `@finos/legend-studio-*` and `legend-studio-`, this module is not properly resolved by `Webpack` - See https://github.com/webpack/webpack/issues/11467