### PR TITLE
Allow configuring separate URL for query API

### DIFF
--- a/.changeset/five-lions-laugh.md
+++ b/.changeset/five-lions-laugh.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Allow configuring a separate base URL for query APIs in engine client via the settings `engine: { queryUrl?: <string> }`

--- a/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
@@ -59,7 +59,9 @@ import type { GraphPluginManager } from '../GraphPluginManager';
 export interface TEMP__EngineSetupConfig {
   env: string;
   tabSize: number;
-  clientConfig: ServerClientConfig;
+  clientConfig: ServerClientConfig & {
+    queryBaseUrl?: string;
+  };
 }
 
 export interface GraphBuilderOptions {

--- a/packages/legend-query/src/application/QueryConfig.ts
+++ b/packages/legend-query/src/application/QueryConfig.ts
@@ -29,12 +29,13 @@ export interface QueryConfigurationData
   appName: string;
   env: string;
   depot: { url: string };
-  engine: { url: string };
+  engine: { url: string; queryUrl?: string };
   extensions?: Record<PropertyKey, unknown>;
 }
 
 export class QueryConfig extends LegendApplicationConfig {
   readonly engineServerUrl: string;
+  readonly engineQueryServerUrl?: string;
   readonly depotServerUrl: string;
 
   constructor(
@@ -52,6 +53,7 @@ export class QueryConfig extends LegendApplicationConfig {
       configData.engine.url,
       `Application configuration failure: 'engine.url' field is missing or empty`,
     );
+    this.engineQueryServerUrl = configData.engine.queryUrl;
     this.depotServerUrl = guaranteeNonEmptyString(
       configData.depot.url,
       `Application configuration failure: 'depot.url' field is missing or empty`,

--- a/packages/legend-query/src/stores/QueryStore.ts
+++ b/packages/legend-query/src/stores/QueryStore.ts
@@ -620,6 +620,7 @@ export class QueryStore {
             tabSize: TAB_SIZE,
             clientConfig: {
               baseUrl: this.applicationStore.config.engineServerUrl,
+              queryBaseUrl: this.applicationStore.config.engineQueryServerUrl,
               enableCompression: true,
             },
           },

--- a/packages/legend-studio/src/application/StudioConfig.ts
+++ b/packages/legend-studio/src/application/StudioConfig.ts
@@ -147,7 +147,7 @@ export interface StudioConfigurationData
   env: string;
   sdlc: { url: string } | SDLCServerOption[];
   depot: { url: string };
-  engine: { url: string; autoReAuthenticationUrl?: string };
+  engine: { url: string };
   documentation: { url: string };
 }
 


### PR DESCRIPTION
Since we might potentially want to break down engine into multiple pieces (services, execution, generation, query, etc.) we start by allow configuring a separate route for query APIs under the application config `engine: { queryUrl?: <string>}`