### PR TITLE
Rework release flow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.5.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@1.6.1/schema.json",
   "changelog": [
     "@finos/legend-dev-utils/ChangesetChangelogUtils",
     { "repo": "finos/legend-studio" }

--- a/.changeset/twelve-clouds-repair.md
+++ b/.changeset/twelve-clouds-repair.md
@@ -1,0 +1,12 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-application': patch
+'@finos/legend-dev-utils': patch
+'@finos/legend-manual-tests': patch
+'@finos/legend-query': patch
+'@finos/legend-query-deployment': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-deployment': patch
+'@finos/legend-studio-plugin-management': patch
+---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,26 +33,31 @@ jobs:
           node-version: 14.x
       - name: Install dependencies
         run: yarn
-      - name: Create Release Pull Request or Publish to NPM
+      - name: Create new release pull request or Publish to NPM
         id: changesets
         uses: changesets/action@master
         with:
           version: yarn version
           commit: 'chore: bump versions and release'
           title: 'New Release'
-          # NOTE: right now the prepare publish content step would run for even
-          # packages that might not get published, we can consider using NPM
-          # `prepublish` script to narrow down the scope
-          #
-          # NOTE: this is currently creating tags on Github and creating release note.
-          # This is fine except for the fact that it might be creating a lot of tags
-          # and release on our repository. We are trying to opt out by asking for a
-          # a flag to turn off this feature on changesets
-          # See https://github.com/changesets/action/issues/87
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # NOTE: this is currently creating tags on Github and creating release note.
+      # This is proper except for the fact that it might be creating a lot of tags
+      # and release on our repository. This requires substantial changes on `changesets`
+      # side and thus, we cannot rely on them doing that any time soon. Meanwhile
+      # we will do the following cleanup step and manually create a release on Github
+      # See https://github.com/changesets/action/issues/87
+      - name: Create Github release
+        # If publish never happened, there's no point in uploading this content
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAIN_PACKAGE: '@finos/legend-studio-app'
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: yarn release:github
       - name: Login to Docker Hub
         if: steps.changesets.outputs.published == 'true'
         uses: docker/login-action@v1

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -12,11 +12,14 @@ We use `changesets` to automate our versioning and release process via [github a
 Merging the PR `New Release` created by `changesets` will _effectively_ create a new release. This PR will have a fairly good summary of the changes that happen in the release. However, these are library changelogs and are meant for technical users (e.g. `@finos/legend-shared`, `@finos/legend-dev-utils`, etc.). For the applications, we need to create separate release notes, which are more user-friendly on our [documentation site](http://github.com/finos/legend).
 
 > Since this repository contains `libraries` as well as `applications`, versioning can be tricky. As such, we use `changesets` to link the application packages together so that all the apps will be versioned together. This way, we could have a version of the applications with each release, and thus, it's more clear and convenient for writing the release notes. _Also note that this is application so the versioning here does not need to follow `semver` strictly._
+>
+> By default, `changesets` create tags and Github release for each published library, this is appropriate since it links the version of the library with its source code. However, this accumulates and quickly create a lot of tags per release. With other projects like `babel` or `react`, all libraries _move_ versions together,
+> this means that they don't bump into the same problems as ours. As such, we have decided to clean all tags and releases created by `changesets` and publish a single version on Github with a version corresponding to the version of the main application package `@finos/legend-studio-app`. Since version bump is managed automatically, it's still possible to trace Git commit corresponding to a release of each library. _In the future, we will publish this as part of the changelog of the application_.
 
 For each new release, we should:
 
+- Update the release note on Github for the latest tag created by the release workflow
 - Add an entry in the root [CHANGELOG.md](../CHANGELOG.md) for the version of the application and the link to the documentation site
-- Create a release on Github that points at an application tag, here we can pick `@finos/legend-studio-app`.
 
 ## Manual Release Process
 
@@ -42,13 +45,13 @@ npm publish --tag <publish-tag>
 
 # ------------ Only if we need to push to Github -------------
 
-# 3. Create a git annotated tag
+# 3. Create a Git annotated tag for the new version
+# <!> This is the version of @finos/legend-studio-app prefixed with `v`
 # <!> Need to do this step if we wish to push this version to Github
 git -a <version> -m <version>
 git push --follow-tags
 
-# 4. Create a release for the version on Github, use the change in
-# `CHANGELOG.md` as release note
+# 4. Update the release note for the version on Github
 
 # ---------------------------- Docker ----------------------------
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint:style": "stylelint --cache --cache-location ./build/.stylelintcache \"packages/*/style/**/*.{scss,css}\"",
     "publish:prepare": "cross-env FORCE_COLOR=1 yarn build && cross-env FORCE_COLOR=1 yarn workspaces foreach --all --no-private --topological-dev --parallel --verbose run publish:prepare",
     "release": "yarn publish:prepare && changeset publish",
+    "release:github": "node ./scripts/release/createGithubVersion.js",
     "setup": "yarn install && node ./scripts/workflow/checkNodeVersion.js && yarn git:install-hooks && yarn workspaces foreach --topological-dev --verbose run setup && yarn build",
     "start": "yarn dev",
     "test": "jest",
@@ -66,7 +67,8 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@babel/core": "7.15.4",
+    "@actions/github": "5.0.0",
+    "@babel/core": "7.15.5",
     "@changesets/cli": "2.17.0",
     "@finos/babel-preset-legend-studio": "workspace:*",
     "@finos/eslint-plugin-legend-studio": "workspace:*",

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -29,7 +29,7 @@
     "publish:prepare": "node ../../scripts/release/preparePublishContent.js"
   },
   "dependencies": {
-    "@babel/core": "7.15.4",
+    "@babel/core": "7.15.5",
     "@babel/helper-plugin-utils": "7.14.5",
     "@babel/plugin-proposal-class-properties": "7.14.5",
     "@babel/plugin-transform-runtime": "7.15.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,7 +29,7 @@
     "publish:prepare": "node ../../scripts/release/preparePublishContent.js"
   },
   "dependencies": {
-    "@babel/core": "7.15.4",
+    "@babel/core": "7.15.5",
     "@babel/eslint-parser": "7.15.4",
     "@typescript-eslint/eslint-plugin": "4.30.0",
     "@typescript-eslint/parser": "4.30.0",

--- a/packages/legend-application/package.json
+++ b/packages/legend-application/package.json
@@ -55,7 +55,7 @@
     "react-icons": "4.2.0",
     "react-resize-detector": "6.7.6",
     "react-router": "5.2.1",
-    "react-router-dom": "5.2.1",
+    "react-router-dom": "5.3.0",
     "serializr": "2.0.5"
   },
   "devDependencies": {

--- a/packages/legend-dev-utils/package.json
+++ b/packages/legend-dev-utils/package.json
@@ -43,7 +43,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@babel/core": "7.15.4",
+    "@babel/core": "7.15.5",
     "@changesets/changelog-github": "0.4.1",
     "@changesets/config": "1.6.1",
     "@changesets/get-release-plan": "3.0.1",

--- a/packages/legend-dev-utils/package.json
+++ b/packages/legend-dev-utils/package.json
@@ -62,7 +62,7 @@
     "cosmiconfig": "7.0.1",
     "css-loader": "6.2.0",
     "cssnano": "5.0.8",
-    "fork-ts-checker-webpack-plugin": "6.3.2",
+    "fork-ts-checker-webpack-plugin": "6.3.3",
     "html-webpack-plugin": "5.3.2",
     "isbinaryfile": "4.0.8",
     "jest": "27.1.0",
@@ -82,7 +82,7 @@
     "strip-ansi": "7.0.0",
     "text-table": "0.2.0",
     "typescript": "4.4.2",
-    "webpack": "5.51.2",
+    "webpack": "5.52.0",
     "wrap-ansi": "8.0.0"
   },
   "devDependencies": {

--- a/packages/legend-manual-tests/package.json
+++ b/packages/legend-manual-tests/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
-    "axios": "0.21.1",
+    "axios": "0.21.3",
     "cross-env": "7.0.3",
     "eslint": "7.32.0",
     "jest": "27.1.0",

--- a/packages/legend-query-deployment/package.json
+++ b/packages/legend-query-deployment/package.json
@@ -45,7 +45,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "typescript": "4.4.2",
-    "webpack": "5.51.2",
+    "webpack": "5.52.0",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.8.0",
     "webpack-dev-server": "4.1.0"

--- a/packages/legend-query/package.json
+++ b/packages/legend-query/package.json
@@ -65,7 +65,7 @@
     "react-hotkeys": "2.0.0",
     "react-icons": "4.2.0",
     "react-router": "5.2.1",
-    "react-router-dom": "5.2.1"
+    "react-router-dom": "5.3.0"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-studio-deployment/package.json
+++ b/packages/legend-studio-deployment/package.json
@@ -45,7 +45,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "typescript": "4.4.2",
-    "webpack": "5.51.2",
+    "webpack": "5.52.0",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.8.0",
     "webpack-dev-server": "4.1.0"

--- a/packages/legend-studio-plugin-management/package.json
+++ b/packages/legend-studio-plugin-management/package.json
@@ -48,7 +48,7 @@
     "mobx-react-lite": "3.2.1",
     "react": "17.0.2",
     "react-icons": "4.2.0",
-    "react-router-dom": "5.2.1"
+    "react-router-dom": "5.3.0"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -63,7 +63,7 @@
     "react-icons": "4.2.0",
     "react-resize-detector": "6.7.6",
     "react-router": "5.2.1",
-    "react-router-dom": "5.2.1",
+    "react-router-dom": "5.3.0",
     "serializr": "2.0.5",
     "sql-formatter": "4.0.2"
   },

--- a/scripts/release/createGithubVersion.js
+++ b/scripts/release/createGithubVersion.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as github from '@actions/github';
+import { execSync } from 'child_process';
+
+/**
+ * Changesets generate tags and Github release by default, but this is cluttering the
+ * project quickly as we have a lot of libraries within the monorepo.
+ * As such, we would want to undo all of these and create a single release.
+ *
+ * Following is the list of expected environment variables:
+ *
+ * GITHUB_TOKEN - the Github token
+ * PUBLISH_PACKAGES - the list of published packages (with name and version) output by `changesets/action`
+ * MAIN_PACKAGE - the name of the package within the list of published packages. If this is available,
+ *                a new version tag and its release will be published to Github.
+ */
+const postChangesetPublishCleanup = async () => {
+  const publishedPackages = JSON.parse(process.env.PUBLISHED_PACKAGES);
+  const tagsToCleanup = publishedPackages.map(
+    (pkg) => `${pkg.name}@${pkg.version}`,
+  );
+  const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+  const mainPackageName = process.env.MAIN_PACKAGE;
+  const releaseVersion = publishedPackages.find(
+    (pkg) => pkg.name === mainPackageName,
+  )?.version;
+
+  console.log(
+    `Removing Github releases and tags created by changesets/action...`,
+  );
+  const tagsNotRemoved = [];
+  await Promise.all(
+    tagsToCleanup.map(async (tag) => {
+      try {
+        // Delete the release published on Github by `changesets/action`
+        // Check the following links for Github actions API reference
+        // See https://octokit.github.io/rest.js/v18/
+        // See https://docs.github.com/en/rest/reference/repos#releases
+        const release = await octokit.rest.repos.getReleaseByTag({
+          tag,
+          ...github.context.repo,
+        });
+        await octokit.rest.repos.deleteRelease({
+          release_id: release.data.id,
+          ...github.context.repo,
+        });
+        // Delete the tags published by `changesets/action`
+        execSync(`git push --delete origin ${tag}`, {
+          cwd: process.cwd(),
+          stdio: ['pipe', 'pipe', 'inherit'], // only print error
+        });
+        console.log(`\u2713 Removed release and tag ${tag}`);
+      } catch (error) {
+        tagsNotRemoved.push(tag);
+        console.log(
+          `\u2A2F Can't remove release and tag ${tag}. Error:\n${error.message}`,
+        );
+      }
+    }),
+  );
+
+  if (tagsNotRemoved.length) {
+    console.warn(
+      `The following tags and their respective releases are not removed from Github. Please manually remove them on Github:\n${tagsNotRemoved
+        .map((tag) => `- ${tag}`)
+        .join('\n')}`,
+    );
+  }
+
+  if (releaseVersion) {
+    try {
+      await octokit.rest.repos.createRelease({
+        tag_name: `v${releaseVersion}`,
+        name: `Version ${releaseVersion}`,
+        body: `👋  _We are crafting a release note for this version..._\n> Meanwhile, please refer to the latest \`New Release\` pull request for a summary of code changes.`,
+        ...github.context.repo,
+      });
+      console.log(
+        `\u2713 Successfully created release for tag v${releaseVersion}. Please add release note for this on Github.`,
+      );
+    } catch (error) {
+      console.log(
+        `\u2713 Failed to create release with tag v${releaseVersion}. Please manually create this release tag on Github.`,
+      );
+    }
+  }
+};
+
+postChangesetPublishCleanup();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,7 +2325,7 @@ __metadata:
     css-loader: 6.2.0
     cssnano: 5.0.8
     eslint: 7.32.0
-    fork-ts-checker-webpack-plugin: 6.3.2
+    fork-ts-checker-webpack-plugin: 6.3.3
     html-webpack-plugin: 5.3.2
     isbinaryfile: 4.0.8
     jest: 27.1.0
@@ -2346,7 +2346,7 @@ __metadata:
     strip-ansi: 7.0.0
     text-table: 0.2.0
     typescript: 4.4.2
-    webpack: 5.51.2
+    webpack: 5.52.0
     wrap-ansi: 8.0.0
   languageName: unknown
   linkType: soft
@@ -2518,7 +2518,7 @@ __metadata:
     npm-run-all: 4.1.5
     rimraf: 3.0.2
     typescript: 4.4.2
-    webpack: 5.51.2
+    webpack: 5.52.0
     webpack-bundle-analyzer: 4.4.2
     webpack-cli: 4.8.0
     webpack-dev-server: 4.1.0
@@ -2680,7 +2680,7 @@ __metadata:
     npm-run-all: 4.1.5
     rimraf: 3.0.2
     typescript: 4.4.2
-    webpack: 5.51.2
+    webpack: 5.52.0
     webpack-bundle-analyzer: 4.4.2
     webpack-cli: 4.8.0
     webpack-dev-server: 4.1.0
@@ -7551,9 +7551,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:6.3.2":
-  version: 6.3.2
-  resolution: "fork-ts-checker-webpack-plugin@npm:6.3.2"
+"fork-ts-checker-webpack-plugin@npm:6.3.3":
+  version: 6.3.3
+  resolution: "fork-ts-checker-webpack-plugin@npm:6.3.3"
   dependencies:
     "@babel/code-frame": ^7.8.3
     "@types/json-schema": ^7.0.5
@@ -7568,7 +7568,7 @@ __metadata:
     schema-utils: 2.7.0
     semver: ^7.3.2
     tapable: ^1.0.0
-  checksum: bd3e4745bbb629cf9d01c658eb4aabe9dbb5c6a959c416ec6a4bb9a4c092120f91622d8cd85a2c0af56adfbc8cf39e8815322f115dc524671cb802d1dc13c6e6
+  checksum: 22bcbf08fc6c1d31daa521e4b59495ee0e4ec51a7e5728dfd4212835f461002a92910b0bc1a1c62cfe569f7b907fdb81875f108ee922113050deca042f06df8d
   languageName: node
   linkType: hard
 
@@ -15635,9 +15635,9 @@ typescript@4.4.2:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.51.2":
-  version: 5.51.2
-  resolution: "webpack@npm:5.51.2"
+"webpack@npm:5.52.0":
+  version: 5.52.0
+  resolution: "webpack@npm:5.52.0"
   dependencies:
     "@types/eslint-scope": ^3.7.0
     "@types/estree": ^0.0.50
@@ -15668,7 +15668,7 @@ typescript@4.4.2:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: f767bf26afb89e6105757462a0d2d829583699aca0b76894339e2c60fc6dc0fbfc569fc070ef2d5e295f47b4ec649ab68db16bbc1fb593de9f5bb771afd85aca
+  checksum: fe7cbb761b251a6885d67971f8763a9675ca4777ff863be4cbe76a6ab22a3f810be2728fe7b9c31f74259001859a3915ad581f0e4aca5255cdb13ccab3472f00
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,27 @@ __metadata:
   version: 4
   cacheKey: 8
 
+"@actions/github@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@actions/github@npm:5.0.0"
+  dependencies:
+    "@actions/http-client": ^1.0.11
+    "@octokit/core": ^3.4.0
+    "@octokit/plugin-paginate-rest": ^2.13.3
+    "@octokit/plugin-rest-endpoint-methods": ^5.1.1
+  checksum: d107bca856cb1460e8bd1558a8f4e031a402fad6b662dd5c538f0cd194f13802fb3d87da52fba22ec91ec495f72658304a5c667c3c55211e95f410aa54f972be
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@actions/http-client@npm:1.0.11"
+  dependencies:
+    tunnel: 0.0.6
+  checksum: 2c72834ec36a121ae95d2cb61fd28234eae2ab265a2aefe857a9eeb788ea77b284ad727ecd3c67fefd1920d5f2800b6c1ba6916b39d44f81f293b4b0020d367c
+  languageName: node
+  linkType: hard
+
 "@ag-grid-community/client-side-row-model@npm:26.0.0":
   version: 26.0.0
   resolution: "@ag-grid-community/client-side-row-model@npm:26.0.0"
@@ -89,16 +110,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.15.4":
-  version: 7.15.4
-  resolution: "@babel/core@npm:7.15.4"
+"@babel/core@npm:7.15.5":
+  version: 7.15.5
+  resolution: "@babel/core@npm:7.15.5"
   dependencies:
     "@babel/code-frame": ^7.14.5
     "@babel/generator": ^7.15.4
     "@babel/helper-compilation-targets": ^7.15.4
     "@babel/helper-module-transforms": ^7.15.4
     "@babel/helpers": ^7.15.4
-    "@babel/parser": ^7.15.4
+    "@babel/parser": ^7.15.5
     "@babel/template": ^7.15.4
     "@babel/traverse": ^7.15.4
     "@babel/types": ^7.15.4
@@ -108,7 +129,7 @@ __metadata:
     json5: ^2.1.2
     semver: ^6.3.0
     source-map: ^0.5.0
-  checksum: fdd7db84b26e06da329a49ba9bad542113982bd3c5b8f822087859f2d7248b21c44d488cb26fa8bec96e1d206c4e4b34809e54b447ff38f5bd7a6a04a9ad0c44
+  checksum: 8121bf74040d98562b773c1e92a174cd53c99a5158ae5a9ef25645ed35d6f821c64155e394cdb04e7dc77a0871ba42a638f6703b2c44a75bc04564b21cad9e1b
   languageName: node
   linkType: hard
 
@@ -676,6 +697,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 4ab6794fc7eacf93d4792675c7ab0fb5c73e697a2ef9a85248a0797d1a0b42e97d6112983ef014ace63c2bbb49b60668793a9a334f9bd8bd9e1fc1c76a7f7ce9
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.15.5":
+  version: 7.15.5
+  resolution: "@babel/parser@npm:7.15.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: abc39a66b9bf6c861e25b07ad99830c4da6ce345135ebe08ee81a0e8d2f62cddc5f1fd825885fcd609a41b59531c856083d880f7836bd89c148136f834dfc3fe
   languageName: node
   linkType: hard
 
@@ -2186,7 +2216,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/babel-preset-legend-studio@workspace:packages/babel-preset"
   dependencies:
-    "@babel/core": 7.15.4
+    "@babel/core": 7.15.5
     "@babel/helper-plugin-utils": 7.14.5
     "@babel/plugin-proposal-class-properties": 7.14.5
     "@babel/plugin-transform-runtime": 7.15.0
@@ -2209,7 +2239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/eslint-plugin-legend-studio@workspace:packages/eslint-plugin"
   dependencies:
-    "@babel/core": 7.15.4
+    "@babel/core": 7.15.5
     "@babel/eslint-parser": 7.15.4
     "@typescript-eslint/eslint-plugin": 4.30.0
     "@typescript-eslint/parser": 4.30.0
@@ -2257,7 +2287,7 @@ __metadata:
     react-icons: 4.2.0
     react-resize-detector: 6.7.6
     react-router: 5.2.1
-    react-router-dom: 5.2.1
+    react-router-dom: 5.3.0
     rimraf: 3.0.2
     sass: 1.39.0
     serializr: 2.0.5
@@ -2304,7 +2334,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/legend-dev-utils@workspace:packages/legend-dev-utils"
   dependencies:
-    "@babel/core": 7.15.4
+    "@babel/core": 7.15.5
     "@changesets/changelog-github": 0.4.1
     "@changesets/config": 1.6.1
     "@changesets/get-release-plan": 3.0.1
@@ -2458,7 +2488,7 @@ __metadata:
     "@finos/legend-dev-utils": "workspace:*"
     "@finos/legend-graph": "workspace:*"
     "@finos/legend-shared": "workspace:*"
-    axios: 0.21.1
+    axios: 0.21.3
     cross-env: 7.0.3
     eslint: 7.32.0
     jest: 27.1.0
@@ -2563,7 +2593,7 @@ __metadata:
     react-hotkeys: 2.0.0
     react-icons: 4.2.0
     react-router: 5.2.1
-    react-router-dom: 5.2.1
+    react-router-dom: 5.3.0
     rimraf: 3.0.2
     sass: 1.39.0
     typescript: 4.4.2
@@ -2707,7 +2737,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 17.0.2
     react-icons: 4.2.0
-    react-router-dom: 5.2.1
+    react-router-dom: 5.3.0
     rimraf: 3.0.2
     sass: 1.39.0
     typescript: 4.4.2
@@ -2786,7 +2816,7 @@ __metadata:
     react-icons: 4.2.0
     react-resize-detector: 6.7.6
     react-router: 5.2.1
-    react-router-dom: 5.2.1
+    react-router-dom: 5.3.0
     rimraf: 3.0.2
     sass: 1.39.0
     serializr: 2.0.5
@@ -3323,6 +3353,116 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: c96381d4a37448ea280951e46233f7e541058cf57a57d4094dd4bdcaae43fa5872b5f2eb6bfb004591a68e29c5877abe3cdc210cb3588cbf20ab2877f31a7de7
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^2.4.4":
+  version: 2.4.5
+  resolution: "@octokit/auth-token@npm:2.4.5"
+  dependencies:
+    "@octokit/types": ^6.0.3
+  checksum: 49620119949870e63d5758be4f9065167a617b4ff343d2bf17f89497dffe17dad2a158e8a3311afc25157a83757a19835f01d66ae53a3583ccf425b60a20968b
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^3.4.0":
+  version: 3.5.1
+  resolution: "@octokit/core@npm:3.5.1"
+  dependencies:
+    "@octokit/auth-token": ^2.4.4
+    "@octokit/graphql": ^4.5.8
+    "@octokit/request": ^5.6.0
+    "@octokit/request-error": ^2.0.5
+    "@octokit/types": ^6.0.3
+    before-after-hook: ^2.2.0
+    universal-user-agent: ^6.0.0
+  checksum: 67179739fc9712b201f2400f132287a2c56a18506e00900bc9d2a3f742b74f1ba69ad998e42f28f3964c0bd1d5478232c1ec7b485c97702b821fbe22b76afa90
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^6.0.1":
+  version: 6.0.12
+  resolution: "@octokit/endpoint@npm:6.0.12"
+  dependencies:
+    "@octokit/types": ^6.0.3
+    is-plain-object: ^5.0.0
+    universal-user-agent: ^6.0.0
+  checksum: b48b29940af11c4b9bca41cf56809754bb8385d4e3a6122671799d27f0238ba575b3fde86d2d30a84f4dbbc14430940de821e56ecc6a9a92d47fc2b29a31479d
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^4.5.8":
+  version: 4.8.0
+  resolution: "@octokit/graphql@npm:4.8.0"
+  dependencies:
+    "@octokit/request": ^5.6.0
+    "@octokit/types": ^6.0.3
+    universal-user-agent: ^6.0.0
+  checksum: f68afe53f63900d4a16a0a733f2f500df2695b731f8ed32edb728d50edead7f5011437f71d069c2d2f6d656227703d0c832a3c8af58ecf82bd5dcc051f2d2d74
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "@octokit/openapi-types@npm:10.1.0"
+  checksum: 49f0084631ef0d27d3f66b3f4c8a4184793ee20c636e5f769e778a30c3cc695fda97a4ec81bba1aefdd0ad6a345c3a65da2f7aa587b4897c589c33d2613d0b4c
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^2.13.3":
+  version: 2.16.0
+  resolution: "@octokit/plugin-paginate-rest@npm:2.16.0"
+  dependencies:
+    "@octokit/types": ^6.26.0
+  peerDependencies:
+    "@octokit/core": ">=2"
+  checksum: db366cb5810005caf96862f8b8f0032aa183f4d8f8e18b8d2cdac952abf768c5e8580948eacf3b3754bfba2745fbb3101adfe893ffe3c3512640ca06db40ee89
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^5.1.1":
+  version: 5.10.0
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:5.10.0"
+  dependencies:
+    "@octokit/types": ^6.27.0
+    deprecation: ^2.3.1
+  peerDependencies:
+    "@octokit/core": ">=3"
+  checksum: 91069092f93ebccd59c0cc791984c8073e66fab5132ba6f4607c5b3b16102f225e81ad9aeebde12816b91f6d4cacfc7b0dfb5c2d15d4754747b405a0dc2f7a23
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^2.0.5, @octokit/request-error@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@octokit/request-error@npm:2.1.0"
+  dependencies:
+    "@octokit/types": ^6.0.3
+    deprecation: ^2.0.0
+    once: ^1.4.0
+  checksum: baec2b5700498be01b4d958f9472cb776b3f3b0ea52924323a07e7a88572e24cac2cdf7eb04a0614031ba346043558b47bea2d346e98f0e8385b4261f138ef18
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^5.6.0":
+  version: 5.6.1
+  resolution: "@octokit/request@npm:5.6.1"
+  dependencies:
+    "@octokit/endpoint": ^6.0.1
+    "@octokit/request-error": ^2.1.0
+    "@octokit/types": ^6.16.1
+    is-plain-object: ^5.0.0
+    node-fetch: ^2.6.1
+    universal-user-agent: ^6.0.0
+  checksum: d61e7831891bd24438a609794092b345fc7ca99900b82cd0c82792c1df6fb7019ee9cc6eb493149d0e4487657cfa7e0ad7a3ee4afb094f6337e99bfb801f98e2
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^6.0.3, @octokit/types@npm:^6.16.1, @octokit/types@npm:^6.26.0, @octokit/types@npm:^6.27.0":
+  version: 6.27.0
+  resolution: "@octokit/types@npm:6.27.0"
+  dependencies:
+    "@octokit/openapi-types": ^10.1.0
+  checksum: 81025e702bc50e70b2e81c89f334f4f3e468f0c4c8014f749d17b217b5b937c322654e724b99aa46586874bbab4b53ef667654fa0351e50209673ab7afe0c6b3
   languageName: node
   linkType: hard
 
@@ -4767,12 +4907,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.21.1":
-  version: 0.21.1
-  resolution: "axios@npm:0.21.1"
+"axios@npm:0.21.3":
+  version: 0.21.3
+  resolution: "axios@npm:0.21.3"
   dependencies:
-    follow-redirects: ^1.10.0
-  checksum: c87915fa0b18c15c63350112b6b3563a3e2ae524d7707de0a73d2e065e0d30c5d3da8563037bc29d4cc1b7424b5a350cb7274fa52525c6c04a615fe561c6ab11
+    follow-redirects: ^1.14.0
+  checksum: fdcac33adb0330e127ab0e58f8d9fb7470b49dbfb0aba251ff54f146f2fc7d9362e3300581b6c98d2ea3b8db958ed099c831c3c7832ae79b14f517d5947a029a
   languageName: node
   linkType: hard
 
@@ -4960,6 +5100,13 @@ __metadata:
   version: 0.6.1
   resolution: "batch@npm:0.6.1"
   checksum: 61f9934c7378a51dce61b915586191078ef7f1c3eca707fdd58b96ff2ff56d9e0af2bdab66b1462301a73c73374239e6542d9821c0af787f3209a23365d07e7f
+  languageName: node
+  linkType: hard
+
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.2
+  resolution: "before-after-hook@npm:2.2.2"
+  checksum: dc2e1ffe389e5afbef2a46790b1b5a50247ed57aba67649cfa9ec2552d248cc9278f222e72fb5a8ff59bbb39d78fbaa97e7234ead0c6b5e8418b67a8644ce207
   languageName: node
   linkType: hard
 
@@ -6399,6 +6546,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
+  languageName: node
+  linkType: hard
+
 "destroy@npm:~1.0.4":
   version: 1.0.4
   resolution: "destroy@npm:1.0.4"
@@ -7534,13 +7688,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.10.0":
+"follow-redirects@npm:^1.0.0":
   version: 1.14.1
   resolution: "follow-redirects@npm:1.14.1"
   peerDependenciesMeta:
     debug:
       optional: true
   checksum: 7381a55bdc6951c5c1ab73a8da99d9fa4c0496ce72dba92cd2ac2babe0e3ebde9b81c5bca889498ad95984bc773d713284ca2bb17f1b1e1416e5f6531e39a488
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.0":
+  version: 1.14.3
+  resolution: "follow-redirects@npm:1.14.3"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: b4d89339afd119b5e6fd92f0e81ae7d3621a5421af7d4a7d94539765c1d5546cf61d2f3219d40596e53c7c253307fbaf5dc772254aa9170fdfe1f9d7731732a9
   languageName: node
   linkType: hard
 
@@ -8968,6 +9132,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
 "is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
@@ -10170,7 +10341,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "legend-studio@workspace:."
   dependencies:
-    "@babel/core": 7.15.4
+    "@actions/github": 5.0.0
+    "@babel/core": 7.15.5
     "@changesets/cli": 2.17.0
     "@finos/babel-preset-legend-studio": "workspace:*"
     "@finos/eslint-plugin-legend-studio": "workspace:*"
@@ -11178,7 +11350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.5.0":
+"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.1":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
   checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
@@ -11520,7 +11692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -12959,9 +13131,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:5.2.1":
-  version: 5.2.1
-  resolution: "react-router-dom@npm:5.2.1"
+"react-router-dom@npm:5.3.0":
+  version: 5.3.0
+  resolution: "react-router-dom@npm:5.3.0"
   dependencies:
     "@babel/runtime": ^7.12.13
     history: ^4.9.0
@@ -12972,7 +13144,7 @@ __metadata:
     tiny-warning: ^1.0.0
   peerDependencies:
     react: ">=15"
-  checksum: d331c9179c291bce798ab7fb041831377a0216e680a031dbf4af6046a02bbbf2ec1215e32bbd1fc0f5a902a37c3ad679de9ae103164b56bf5848749052ac1516
+  checksum: 47584fd629ecca52398d7888cab193b8a74057cc99a7ef44410c405d4082f618c3c0399db5325bc3524f9c511404086169570013b61a94dfa6acdfdc850d7a1f
   languageName: node
   linkType: hard
 
@@ -15041,6 +15213,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tunnel@npm:0.0.6":
+  version: 0.0.6
+  resolution: "tunnel@npm:0.0.6"
+  checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -15263,6 +15442,13 @@ typescript@4.4.2:
   dependencies:
     "@types/unist": ^2.0.2
   checksum: f755cadc959f9074fe999578a1a242761296705a7fe87f333a37c00044de74ab4b184b3812989a57d4cd12211f0b14ad397b327c3a594c7af84361b1c25a7f09
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "universal-user-agent@npm:6.0.0"
+  checksum: 5092bbc80dd0d583cef0b62c17df0043193b74f425112ea6c1f69bc5eda21eeec7a08d8c4f793a277eb2202ffe9b44bec852fa3faff971234cd209874d1b79ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By default, `changesets` create tags and Github release for each published library, this is appropriate since it links the version of the library with its source code. However, this accumulates and quickly create a lot of tags per release. With other projects like `babel` or `react`, all libraries _move_ versions together, this means that they don't bump into the same problems as ours. As such, we have decided to clean all tags and releases created by `changesets` and publish a single version on Github with a version corresponding to the version of the main application package `@finos/legend-studio-app`. Since version bump is managed automatically, it's still possible to trace Git commit corresponding to a release of each library. _In the future, we will publish this as part of the changelog of the application_.