### PR TITLE
Input to ServiceTestAssertLambda is updated to regular string

### DIFF
--- a/.changeset/little-turkeys-hammer.md
+++ b/.changeset/little-turkeys-hammer.md
@@ -1,5 +1,4 @@
 ---
-'@finos/legend-graph': patch
 '@finos/legend-studio': patch
 ---
 

--- a/.changeset/little-turkeys-hammer.md
+++ b/.changeset/little-turkeys-hammer.md
@@ -1,0 +1,8 @@
+---
+'@finos/legend-graph': patch
+'@finos/legend-studio': patch
+---
+
+Due to discrepancies in the test runners for mapping and service, we don't need to do any (un)escaping for the expectedResult assertion data of the service test during its initialization and generation like what we do for mapping test assertion data. So, removing the toGrammarString & fromGrammarString pair for service test runner to avoid it adding additional escape characters. For better context:
+// See https://github.com/finos/legend-studio/issues/586
+// See https://github.com/finos/legend-engine/issues/429

--- a/.changeset/little-turkeys-hammer.md
+++ b/.changeset/little-turkeys-hammer.md
@@ -5,4 +5,3 @@
 
 Due to discrepancies in the test runners for mapping and service, we don't need to do any (un)escaping for the expectedResult assertion data of the service test during its initialization and generation like what we do for mapping test assertion data. So, removing the toGrammarString & fromGrammarString pair for service test runner to avoid it adding additional escape characters. For better context:
 // See https://github.com/finos/legend-studio/issues/586
-// See https://github.com/finos/legend-engine/issues/429

--- a/.changeset/little-turkeys-hammer.md
+++ b/.changeset/little-turkeys-hammer.md
@@ -4,4 +4,3 @@
 ---
 
 Due to discrepancies in the test runners for mapping and service, we don't need to do any (un)escaping for the expectedResult assertion data of the service test during its initialization and generation like what we do for mapping test assertion data. So, removing the toGrammarString & fromGrammarString pair for service test runner to avoid it adding additional escape characters. For better context:
-// See https://github.com/finos/legend-studio/issues/586

--- a/.changeset/little-turkeys-hammer.md
+++ b/.changeset/little-turkeys-hammer.md
@@ -3,4 +3,4 @@
 '@finos/legend-studio': patch
 ---
 
-Due to discrepancies in the test runners for mapping and service, we don't need to do any (un)escaping for the expectedResult assertion data of the service test during its initialization and generation like what we do for mapping test assertion data. So, removing the toGrammarString & fromGrammarString pair for service test runner to avoid it adding additional escape characters. For better context:
+Fix a problem with escaping of single quote character which causes service tests created in Studio fail ([#586](See https://github.com/finos/legend-studio/issues/586)), this can be considered a workaround until we figure out a strategy for the discrepancies in mapping test and service test runners in `Engine` (see [finos/legend-engine#429](https://github.com/finos/legend-engine/issues/429))

--- a/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
@@ -345,6 +345,7 @@ export abstract class AbstractPureGraphManager {
   // structurally in Studio
 
   abstract HACKY_createGetAllLambda(_class: Class): RawLambda;
+  // NOTE: Input should be a regular string, can't be escaped.
   abstract HACKY_createServiceTestAssertLambda(assertData: string): RawLambda;
   abstract HACKY_extractServiceTestAssertionData(
     query: RawLambda,

--- a/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
@@ -345,7 +345,6 @@ export abstract class AbstractPureGraphManager {
   // structurally in Studio
 
   abstract HACKY_createGetAllLambda(_class: Class): RawLambda;
-  // NOTE: Input should be a regular string, can't be escaped.
   abstract HACKY_createServiceTestAssertLambda(assertData: string): RawLambda;
   abstract HACKY_extractServiceTestAssertionData(
     query: RawLambda,

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -29,7 +29,6 @@ import {
   tryToMinifyLosslessJSONString,
   tryToFormatLosslessJSONString,
   tryToFormatJSONString,
-  fromGrammarString,
   createUrlStringFromData,
 } from '@finos/legend-shared';
 import type { EditorStore } from '../../../EditorStore';
@@ -135,6 +134,10 @@ export class TestContainerState {
       this.testContainer.assert =
         this.editorStore.graphManagerState.graphManager.HACKY_createServiceTestAssertLambda(
           /* @MARKER: Workaround for https://github.com/finos/legend-studio/issues/68 */
+          // NOTE: due to discrepancies in the test runners for mapping and service, we have don't need
+          // to do any (un)escaping here like what we do for mapping test assertion data. For better context:
+          // See https://github.com/finos/legend-studio/issues/586
+          // See https://github.com/finos/legend-engine/issues/429
           tryToMinifyLosslessJSONString(this.assertionData),
         );
     }
@@ -146,10 +149,12 @@ export class TestContainerState {
         testContainter.assert,
       );
     this.assertionData = expectedResultAssertionString
-      ? fromGrammarString(
-          /* @MARKER: Workaround for https://github.com/finos/legend-studio/issues/68 */
-          tryToFormatLosslessJSONString(expectedResultAssertionString),
-        )
+      ? /* @MARKER: Workaround for https://github.com/finos/legend-studio/issues/68 */
+        // NOTE: due to discrepancies in the test runners for mapping and service, we have don't need
+        // to do any (un)escaping here like what we do for mapping test assertion data. For better context:
+        // See https://github.com/finos/legend-studio/issues/586
+        // See https://github.com/finos/legend-engine/issues/429
+        tryToFormatLosslessJSONString(expectedResultAssertionString)
       : undefined;
   }
 

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -136,7 +136,7 @@ export class TestContainerState {
       this.testContainer.assert =
         this.editorStore.graphManagerState.graphManager.HACKY_createServiceTestAssertLambda(
           /* @MARKER: Workaround for https://github.com/finos/legend-studio/issues/68 */
-          toGrammarString(tryToMinifyLosslessJSONString(this.assertionData)),
+          tryToMinifyLosslessJSONString(this.assertionData),
         );
     }
   }

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -29,7 +29,6 @@ import {
   tryToMinifyLosslessJSONString,
   tryToFormatLosslessJSONString,
   tryToFormatJSONString,
-  toGrammarString,
   fromGrammarString,
   createUrlStringFromData,
 } from '@finos/legend-shared';


### PR DESCRIPTION


## Summary

Closes #586 

Due to discrepancies in the test runners for mapping and service, we have don't need to do any (un)escaping for service test assertion data like what we do for mapping test assertion data. For better context:
See https://github.com/finos/legend-studio/issues/586 
See https://github.com/finos/legend-engine/issues/429

## How did you test this change?

Check with the test case in the linked issue

