### PR TITLE
Fix class explorer not showing properties from a class mapped using an operational set implementation

### DIFF
--- a/.changeset/odd-donkeys-dance.md
+++ b/.changeset/odd-donkeys-dance.md
@@ -2,4 +2,4 @@
 '@finos/legend-query': patch
 ---
 
-Fix class explorer not showing properties from a class mapped using an operational set implementation. Fixes [#647](https://github.com/finos/legend-studio/issues/647)
+Fix class explorer not showing properties from a class mapped using an operational set implementation ([#647](https://github.com/finos/legend-studio/issues/647)).

--- a/.changeset/odd-donkeys-dance.md
+++ b/.changeset/odd-donkeys-dance.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query': patch
+---
+
+Fix class explorer not showing properties from a class mapped using an operational set implementation. Fixes [#647](https://github.com/finos/legend-studio/issues/647)

--- a/packages/legend-query/src/stores/QueryBuilderExplorerState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderExplorerState.ts
@@ -300,11 +300,11 @@ export const getQueryBuilderPropertyNodeData = (
     property,
     parentNode.id,
     mappingData.mapped,
+    mappingData.skipMappingCheck,
     property instanceof DerivedProperty ||
       parentNode.isPartOfDerivedPropertyBranch ||
       (parentNode instanceof QueryBuilderExplorerTreePropertyNodeData &&
         parentNode.property instanceof DerivedProperty),
-    mappingData.skipMappingCheck,
     mappingData.setImpl,
   );
   if (propertyNode.type instanceof Class) {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Fix class explorer not showing properties from a class mapped using an operational set implementation.
Fixes https://github.com/finos/legend-studio/issues/647

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
