### PR TITLE
reorganize and rename plugin and extension-related classes

### DIFF
--- a/.changeset/quick-rats-push.md
+++ b/.changeset/quick-rats-push.md
@@ -1,0 +1,17 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-art': patch
+'@finos/legend-dev-utils': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-extension-dsl-diagram': patch
+'@finos/legend-extension-dsl-serializer': patch
+'@finos/legend-extension-dsl-text': patch
+'@finos/legend-extension-external-format-json-schema': patch
+'@finos/legend-extension-external-store-service': patch
+'@finos/legend-query': patch
+'@finos/legend-query-app': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-extension-management-toolkit': patch
+'@finos/legend-studio-extension-query-builder': patch
+---

--- a/.changeset/stale-dolls-dance.md
+++ b/.changeset/stale-dolls-dance.md
@@ -2,4 +2,4 @@
 '@finos/legend-studio': patch
 ---
 
-**BREAKING CHANGE:** Change `StudioPlugin` to `LegendStudioPlugin`.
+**BREAKING CHANGE:** Change `StudioPlugin` to `LegendStudioPlugin`. This change applies for other extension-related classes as well, e.g. `LegendStudioPluginManager`, `*_LegendStudioPreset`, `*_LegendStudioPlugin`, etc.

--- a/.changeset/stale-dolls-dance.md
+++ b/.changeset/stale-dolls-dance.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+**BREAKING CHANGE:** Change `StudioPlugin` to `LegendStudioPlugin`.

--- a/.changeset/tall-moons-do.md
+++ b/.changeset/tall-moons-do.md
@@ -2,4 +2,4 @@
 '@finos/legend-query': patch
 ---
 
-**BREAKING CHANGE:** Change `QueryPlugin` to `LegendQueryPlugin`.
+**BREAKING CHANGE:** Change `QueryPlugin` to `LegendQueryPlugin`. This change applies for other extension-related classes as well, e.g. `LegendQueryPluginManager`, `*_LegendQueryPreset`, `*_LegendQueryPlugin`, etc.

--- a/.changeset/tall-moons-do.md
+++ b/.changeset/tall-moons-do.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query': patch
+---
+
+**BREAKING CHANGE:** Change `QueryPlugin` to `LegendQueryPlugin`.

--- a/packages/legend-application/.npmignore
+++ b/packages/legend-application/.npmignore
@@ -4,4 +4,3 @@
 **/__tests__/**
 /*.*
 !tsconfig.json
-!tsconfig.package.json

--- a/packages/legend-application/_package.config.js
+++ b/packages/legend-application/_package.config.js
@@ -18,7 +18,6 @@ export default {
   publish: {
     typescript: {
       main: './tsconfig.build.json',
-      others: ['./tsconfig.package.json'],
     },
   },
 };

--- a/packages/legend-application/package.json
+++ b/packages/legend-application/package.json
@@ -44,7 +44,7 @@
     "@material-ui/core": "4.12.3",
     "@testing-library/react": "12.1.2",
     "@types/css-font-loading-module": "0.0.7",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "@types/react-dom": "17.0.11",
     "@types/react-router-dom": "5.3.2",
     "history": "5.1.0",

--- a/packages/legend-application/tsconfig.build.json
+++ b/packages/legend-application/tsconfig.build.json
@@ -9,6 +9,5 @@
     "src/**/__tests__/**/*.tsx",
     "src/**/__mocks__/**/*.ts",
     "src/**/__mocks__/**/*.tsx"
-  ],
-  "references": [{ "path": "./tsconfig.package.json" }]
+  ]
 }

--- a/packages/legend-application/tsconfig.json
+++ b/packages/legend-application/tsconfig.json
@@ -8,7 +8,6 @@
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
   "references": [
-    { "path": "./tsconfig.package.json" },
     { "path": "../legend-shared" },
     { "path": "../legend-art" },
     { "path": "../legend-graph" }

--- a/packages/legend-application/tsconfig.package.json
+++ b/packages/legend-application/tsconfig.package.json
@@ -1,9 +1,0 @@
-{
-  "extends": "@finos/legend-dev-utils/tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "lib",
-    "tsBuildInfoFile": "build/package.tsbuildinfo",
-    "rootDir": "."
-  },
-  "include": ["package.json"]
-}

--- a/packages/legend-art/package.json
+++ b/packages/legend-art/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@finos/legend-shared": "workspace:*",
     "@material-ui/core": "4.12.3",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "@types/react-select": "4.0.18",
     "@types/react-window": "1.8.5",
     "clsx": "1.1.1",

--- a/packages/legend-dev-utils/package.json
+++ b/packages/legend-dev-utils/package.json
@@ -67,7 +67,7 @@
     "circular-dependency-plugin": "5.2.2",
     "clean-webpack-plugin": "4.0.0",
     "css-loader": "6.5.1",
-    "cssnano": "5.0.10",
+    "cssnano": "5.0.11",
     "html-webpack-plugin": "5.5.0",
     "isbinaryfile": "4.0.8",
     "jest": "27.3.1",

--- a/packages/legend-extension-dsl-data-space/package.json
+++ b/packages/legend-extension-dsl-data-space/package.json
@@ -47,7 +47,7 @@
     "@finos/legend-server-depot": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "@types/react-router-dom": "5.3.2",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",

--- a/packages/legend-extension-dsl-data-space/src/DSLDataSpace_Extension.ts
+++ b/packages/legend-extension-dsl-data-space/src/DSLDataSpace_Extension.ts
@@ -19,11 +19,11 @@ import { AbstractPreset } from '@finos/legend-shared';
 import { DSLDataSpace_PureGraphManagerPlugin } from './graphManager/DSLDataSpace_PureGraphManagerPlugin';
 import { DSLDataSpace_PureProtocolProcessorPlugin } from './models/protocols/pure/DSLDataSpace_PureProtocolProcessorPlugin';
 import type { GraphPluginManager } from '@finos/legend-graph';
-import type { StudioPluginManager } from '@finos/legend-studio';
-import { DSLDataSpace_StudioPlugin } from './components/studio/DSLDataSpace_StudioPlugin';
+import type { LegendStudioPluginManager } from '@finos/legend-studio';
+import { DSLDataSpace_LegendStudioPlugin } from './components/studio/DSLDataSpace_LegendStudioPlugin';
 import { DSLDataSpace_PureGraphPlugin } from './graph/DSLDataSpace_PureGraphPlugin';
-import type { QueryPluginManager } from '@finos/legend-query';
-import { DSLDataSpace_QueryPlugin } from './components/query/DSLDataSpace_QueryPlugin';
+import type { LegendQueryPluginManager } from '@finos/legend-query';
+import { DSLDataSpace_LegendQueryPlugin } from './components/query/DSLDataSpace_LegendQueryPlugin';
 
 export class DSLDataSpace_GraphPreset extends AbstractPreset {
   constructor() {
@@ -37,26 +37,26 @@ export class DSLDataSpace_GraphPreset extends AbstractPreset {
   }
 }
 
-export class DSLDataSpace_StudioPreset extends AbstractPreset {
+export class DSLDataSpace_LegendStudioPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
-    new DSLDataSpace_StudioPlugin().install(pluginManager);
+  install(pluginManager: LegendStudioPluginManager): void {
+    new DSLDataSpace_LegendStudioPlugin().install(pluginManager);
     new DSLDataSpace_PureGraphPlugin().install(pluginManager);
     new DSLDataSpace_PureGraphManagerPlugin().install(pluginManager);
     new DSLDataSpace_PureProtocolProcessorPlugin().install(pluginManager);
   }
 }
 
-export class DSLDataSpace_QueryPreset extends AbstractPreset {
+export class DSLDataSpace_LegendQueryPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: QueryPluginManager): void {
-    new DSLDataSpace_QueryPlugin().install(pluginManager);
+  install(pluginManager: LegendQueryPluginManager): void {
+    new DSLDataSpace_LegendQueryPlugin().install(pluginManager);
     new DSLDataSpace_PureGraphPlugin().install(pluginManager);
     new DSLDataSpace_PureGraphManagerPlugin().install(pluginManager);
     new DSLDataSpace_PureProtocolProcessorPlugin().install(pluginManager);

--- a/packages/legend-extension-dsl-data-space/src/components/query/DSLDataSpace_LegendQueryPlugin.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/query/DSLDataSpace_LegendQueryPlugin.tsx
@@ -16,7 +16,7 @@
 
 import packageJson from '../../../package.json';
 import type {
-  QueryPluginManager,
+  LegendQueryPluginManager,
   QuerySetupOptionRendererConfiguration,
   QuerySetupRenderer,
   QuerySetupState,
@@ -27,12 +27,12 @@ import { SquareIcon } from '@finos/legend-art';
 import { DataSpaceQuerySetupState } from '../../stores/query/DataSpaceQuerySetupState';
 import { DataspaceQuerySetup } from './DataSpaceQuerySetup';
 
-export class DSLDataSpace_QueryPlugin extends LegendQueryPlugin {
+export class DSLDataSpace_LegendQueryPlugin extends LegendQueryPlugin {
   constructor() {
     super(packageJson.extensions.queryPlugin, packageJson.version);
   }
 
-  install(pluginManager: QueryPluginManager): void {
+  install(pluginManager: LegendQueryPluginManager): void {
     pluginManager.registerQueryPlugin(this);
   }
 

--- a/packages/legend-extension-dsl-data-space/src/components/query/DSLDataSpace_QueryPlugin.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/query/DSLDataSpace_QueryPlugin.tsx
@@ -22,12 +22,12 @@ import type {
   QuerySetupState,
   QuerySetupStore,
 } from '@finos/legend-query';
-import { QueryPlugin } from '@finos/legend-query';
+import { LegendQueryPlugin } from '@finos/legend-query';
 import { SquareIcon } from '@finos/legend-art';
 import { DataSpaceQuerySetupState } from '../../stores/query/DataSpaceQuerySetupState';
 import { DataspaceQuerySetup } from './DataSpaceQuerySetup';
 
-export class DSLDataSpace_QueryPlugin extends QueryPlugin {
+export class DSLDataSpace_QueryPlugin extends LegendQueryPlugin {
   constructor() {
     super(packageJson.extensions.queryPlugin, packageJson.version);
   }

--- a/packages/legend-extension-dsl-data-space/src/components/query/DataSpaceQuerySetup.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/query/DataSpaceQuerySetup.tsx
@@ -27,7 +27,7 @@ import {
   CustomSelectorInput,
   SearchIcon,
 } from '@finos/legend-art';
-import { useQuerySetupStore, useQueryStore } from '@finos/legend-query';
+import { useQuerySetupStore, useLegendQueryStore } from '@finos/legend-query';
 import { generateGAVCoordinates } from '@finos/legend-server-depot';
 import { debounce } from '@finos/legend-shared';
 import { flowResult } from 'mobx';
@@ -50,7 +50,7 @@ export const DataspaceQuerySetup = observer(
     const { querySetupState } = props;
     const applicationStore = useApplicationStore();
     const setupStore = useQuerySetupStore();
-    const queryStore = useQueryStore();
+    const queryStore = useLegendQueryStore();
     const dataSpaceSearchRef = useRef<SelectComponent>(null);
     const [searchText, setSearchText] = useState('');
 

--- a/packages/legend-extension-dsl-data-space/src/components/studio/DSLDataSpace_LegendStudioPlugin.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/studio/DSLDataSpace_LegendStudioPlugin.tsx
@@ -16,12 +16,12 @@
 
 import packageJson from '../../../package.json';
 import type {
-  StudioPluginManager,
+  LegendStudioPluginManager,
   NewElementFromStateCreator,
   ElementTypeGetter,
   ElementProjectExplorerDnDTypeGetter,
   ElementIconGetter,
-  DSL_StudioPlugin_Extension,
+  DSL_LegendStudioPlugin_Extension,
   NewElementState,
   ElementEditorStateCreator,
   EditorStore,
@@ -46,15 +46,15 @@ const DATA_SPACE_ELEMENT_TYPE = 'DATA SPACE';
 const DATA_SPACE_ELEMENT_PROJECT_EXPLORER_DND_TYPE =
   'PROJECT_EXPLORER_DATA_SPACE';
 
-export class DSLDataSpace_StudioPlugin
+export class DSLDataSpace_LegendStudioPlugin
   extends LegendStudioPlugin
-  implements DSL_StudioPlugin_Extension
+  implements DSL_LegendStudioPlugin_Extension
 {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 

--- a/packages/legend-extension-dsl-data-space/src/components/studio/DSLDataSpace_StudioPlugin.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/studio/DSLDataSpace_StudioPlugin.tsx
@@ -30,7 +30,7 @@ import type {
 } from '@finos/legend-studio';
 import {
   UnsupportedElementEditorState,
-  StudioPlugin,
+  LegendStudioPlugin,
 } from '@finos/legend-studio';
 import { SquareIcon } from '@finos/legend-art';
 import type { PackageableElement } from '@finos/legend-graph';
@@ -47,7 +47,7 @@ const DATA_SPACE_ELEMENT_PROJECT_EXPLORER_DND_TYPE =
   'PROJECT_EXPLORER_DATA_SPACE';
 
 export class DSLDataSpace_StudioPlugin
-  extends StudioPlugin
+  extends LegendStudioPlugin
   implements DSL_StudioPlugin_Extension
 {
   constructor() {

--- a/packages/legend-extension-dsl-data-space/src/components/studio/EnterpriseModelExplorerStoreProvider.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/studio/EnterpriseModelExplorerStoreProvider.tsx
@@ -21,8 +21,8 @@ import { guaranteeNonNullable } from '@finos/legend-shared';
 import { useDepotServerClient } from '@finos/legend-server-depot';
 import { useGraphManagerState } from '@finos/legend-graph';
 import { EnterpriseModelExplorerStore } from '../../stores/studio/EnterpriseModelExplorerStore';
-import type { StudioConfig } from '@finos/legend-studio';
-import { useStudioStore } from '@finos/legend-studio';
+import type { LegendStudioConfig } from '@finos/legend-studio';
+import { useLegendStudioStore } from '@finos/legend-studio';
 
 const EnterpriseModelExplorerStoreContext = createContext<
   EnterpriseModelExplorerStore | undefined
@@ -33,10 +33,10 @@ export const EnterpriseModelExplorerStoreProvider = ({
 }: {
   children: React.ReactNode;
 }): React.ReactElement => {
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const depotServerClient = useDepotServerClient();
   const graphManagerState = useGraphManagerState();
-  const studioStore = useStudioStore();
+  const studioStore = useLegendStudioStore();
   const store = useLocalObservable(
     () =>
       new EnterpriseModelExplorerStore(

--- a/packages/legend-extension-dsl-data-space/src/stores/studio/EnterpriseModelExplorerStore.tsx
+++ b/packages/legend-extension-dsl-data-space/src/stores/studio/EnterpriseModelExplorerStore.tsx
@@ -39,7 +39,10 @@ import {
   ActionState,
   assertErrorThrown,
 } from '@finos/legend-shared';
-import type { StudioConfig, StudioPluginManager } from '@finos/legend-studio';
+import type {
+  LegendStudioConfig,
+  LegendStudioPluginManager,
+} from '@finos/legend-studio';
 import { makeObservable, flow, observable, action, flowResult } from 'mobx';
 import { generatePath } from 'react-router';
 import {
@@ -279,10 +282,10 @@ export class TaxonomyViewerState {
 }
 
 export class EnterpriseModelExplorerStore {
-  applicationStore: ApplicationStore<StudioConfig>;
+  applicationStore: ApplicationStore<LegendStudioConfig>;
   depotServerClient: DepotServerClient;
   graphManagerState: GraphManagerState;
-  pluginManager: StudioPluginManager;
+  pluginManager: LegendStudioPluginManager;
 
   sideBarDisplayState = new PanelDisplayState({
     initial: 300,
@@ -300,10 +303,10 @@ export class EnterpriseModelExplorerStore {
   currentTaxonomyViewerState?: TaxonomyViewerState | undefined;
 
   constructor(
-    applicationStore: ApplicationStore<StudioConfig>,
+    applicationStore: ApplicationStore<LegendStudioConfig>,
     depotServerClient: DepotServerClient,
     graphManagerState: GraphManagerState,
-    pluginManager: StudioPluginManager,
+    pluginManager: LegendStudioPluginManager,
   ) {
     makeObservable(this, {
       isInExpandedMode: observable,

--- a/packages/legend-extension-dsl-diagram/package.json
+++ b/packages/legend-extension-dsl-diagram/package.json
@@ -45,7 +45,7 @@
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
     "@material-ui/core": "4.12.3",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",
     "react": "17.0.2",

--- a/packages/legend-extension-dsl-diagram/src/DSLDiagram_Extension.ts
+++ b/packages/legend-extension-dsl-diagram/src/DSLDiagram_Extension.ts
@@ -19,8 +19,8 @@ import { AbstractPreset } from '@finos/legend-shared';
 import { DSLDiagram_PureGraphManagerPlugin } from './graphManager/DSLDiagram_PureGraphManagerPlugin';
 import { DSLDiagram_PureProtocolProcessorPlugin } from './models/protocols/pure/DSLDiagram_PureProtocolProcessorPlugin';
 import type { GraphPluginManager } from '@finos/legend-graph';
-import type { StudioPluginManager } from '@finos/legend-studio';
-import { DSLDiagram_StudioPlugin } from './components/studio/DSLDiagram_StudioPlugin';
+import type { LegendStudioPluginManager } from '@finos/legend-studio';
+import { DSLDiagram_LegendStudioPlugin } from './components/studio/DSLDiagram_LegendStudioPlugin';
 import { DSLDiagram_PureGraphPlugin } from './graph/DSLDiagram_PureGraphPlugin';
 
 export class DSLDiagram_GraphPreset extends AbstractPreset {
@@ -35,13 +35,13 @@ export class DSLDiagram_GraphPreset extends AbstractPreset {
   }
 }
 
-export class DSLDiagram_StudioPreset extends AbstractPreset {
+export class DSLDiagram_LegendStudioPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
-    new DSLDiagram_StudioPlugin().install(pluginManager);
+  install(pluginManager: LegendStudioPluginManager): void {
+    new DSLDiagram_LegendStudioPlugin().install(pluginManager);
     new DSLDiagram_PureGraphPlugin().install(pluginManager);
     new DSLDiagram_PureGraphManagerPlugin().install(pluginManager);
     new DSLDiagram_PureProtocolProcessorPlugin().install(pluginManager);

--- a/packages/legend-extension-dsl-diagram/src/components/studio/DSLDiagram_LegendStudioPlugin.tsx
+++ b/packages/legend-extension-dsl-diagram/src/components/studio/DSLDiagram_LegendStudioPlugin.tsx
@@ -16,7 +16,7 @@
 
 import packageJson from '../../../package.json';
 import type {
-  StudioPluginManager,
+  LegendStudioPluginManager,
   NewElementFromStateCreator,
   EditorStore,
   ElementEditorState,
@@ -25,7 +25,7 @@ import type {
   ElementProjectExplorerDnDTypeGetter,
   ElementIconGetter,
   ElementEditorRenderer,
-  DSL_StudioPlugin_Extension,
+  DSL_LegendStudioPlugin_Extension,
   NewElementState,
   ElementEditorPostDeleteAction,
   ElementEditorPostRenameAction,
@@ -42,15 +42,15 @@ import { ClassDiagramPreview } from './ClassDiagramPreview';
 const DIAGRAM_ELEMENT_TYPE = 'DIAGRAM';
 const DIAGRAM_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_DIAGRAM';
 
-export class DSLDiagram_StudioPlugin
+export class DSLDiagram_LegendStudioPlugin
   extends LegendStudioPlugin
-  implements DSL_StudioPlugin_Extension
+  implements DSL_LegendStudioPlugin_Extension
 {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 

--- a/packages/legend-extension-dsl-diagram/src/components/studio/DSLDiagram_LegendStudioPlugin_Extension.tsx
+++ b/packages/legend-extension-dsl-diagram/src/components/studio/DSLDiagram_LegendStudioPlugin_Extension.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from '@finos/legend-studio';
+import type { DSL_LegendStudioPlugin_Extension } from '@finos/legend-studio';
 import type { ClassView } from '../../models/metamodels/pure/packageableElements/diagram/ClassView';
 import type { DiagramEditorState } from '../../stores/studio/DiagramEditorState';
 
@@ -26,8 +26,8 @@ export type ClassViewContextMenuItemRendererConfiguration = {
   ) => React.ReactNode | undefined;
 };
 
-export interface DSLDiagram_StudioPlugin_Extension
-  extends DSL_StudioPlugin_Extension {
+export interface DSLDiagram_LegendStudioPlugin_Extension
+  extends DSL_LegendStudioPlugin_Extension {
   /**
    * Get the list of items to be rendered in the context menu of a class view.
    */

--- a/packages/legend-extension-dsl-diagram/src/components/studio/DSLDiagram_StudioPlugin.tsx
+++ b/packages/legend-extension-dsl-diagram/src/components/studio/DSLDiagram_StudioPlugin.tsx
@@ -31,7 +31,7 @@ import type {
   ElementEditorPostRenameAction,
   ClassPreviewRenderer,
 } from '@finos/legend-studio';
-import { StudioPlugin } from '@finos/legend-studio';
+import { LegendStudioPlugin } from '@finos/legend-studio';
 import { ShapesIcon } from '@finos/legend-art';
 import type { Class, PackageableElement } from '@finos/legend-graph';
 import { Diagram } from '../../models/metamodels/pure/packageableElements/diagram/Diagram';
@@ -43,7 +43,7 @@ const DIAGRAM_ELEMENT_TYPE = 'DIAGRAM';
 const DIAGRAM_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_DIAGRAM';
 
 export class DSLDiagram_StudioPlugin
-  extends StudioPlugin
+  extends LegendStudioPlugin
   implements DSL_StudioPlugin_Extension
 {
   constructor() {

--- a/packages/legend-extension-dsl-diagram/src/components/studio/DiagramEditor.tsx
+++ b/packages/legend-extension-dsl-diagram/src/components/studio/DiagramEditor.tsx
@@ -99,7 +99,7 @@ import {
 } from '@finos/legend-studio';
 import { cleanUpDeadReferencesInDiagram } from '../../helpers/DiagramHelper';
 import { Point } from '../../models/metamodels/pure/packageableElements/diagram/geometry/Point';
-import type { DSLDiagram_StudioPlugin_Extension } from './DSLDiagram_StudioPlugin_Extension';
+import type { DSLDiagram_LegendStudioPlugin_Extension } from './DSLDiagram_LegendStudioPlugin_Extension';
 
 const DiagramEditorContextMenu = observer(
   (
@@ -117,7 +117,7 @@ const DiagramEditorContextMenu = observer(
             .flatMap(
               (plugin) =>
                 (
-                  plugin as DSLDiagram_StudioPlugin_Extension
+                  plugin as DSLDiagram_LegendStudioPlugin_Extension
                 ).getExtraClassViewContextMenuItemRendererConfigurations?.() ??
                 [],
             )

--- a/packages/legend-extension-dsl-diagram/src/components/studio/__tests__/ClassDiagramPreview.test.tsx
+++ b/packages/legend-extension-dsl-diagram/src/components/studio/__tests__/ClassDiagramPreview.test.tsx
@@ -20,9 +20,9 @@ import {
   TEST__provideMockedEditorStore,
   TEST__setUpEditorWithDefaultSDLCData,
   TEST__openElementFromExplorerTree,
-  StudioPluginManager,
+  LegendStudioPluginManager,
 } from '@finos/legend-studio';
-import { DSLDiagram_StudioPreset } from '../../../DSLDiagram_Extension';
+import { DSLDiagram_LegendStudioPreset } from '../../../DSLDiagram_Extension';
 import { DSL_DIAGRAM_TEST_ID } from '../DSLDiagram_TestID';
 
 const TEST_DATA__dummyModel = [
@@ -47,8 +47,8 @@ const TEST_DATA__dummyModel = [
   },
 ];
 
-const pluginManager = StudioPluginManager.create();
-pluginManager.usePresets([new DSLDiagram_StudioPreset()]).install();
+const pluginManager = LegendStudioPluginManager.create();
+pluginManager.usePresets([new DSLDiagram_LegendStudioPreset()]).install();
 
 test(integrationTest('Class diagram preview shows up properly'), async () => {
   const mockedEditorStore = TEST__provideMockedEditorStore({ pluginManager });

--- a/packages/legend-extension-dsl-diagram/src/index.ts
+++ b/packages/legend-extension-dsl-diagram/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export * from './DSLDiagram_Extension';
-export * from './components/studio/DSLDiagram_StudioPlugin_Extension';
+export * from './components/studio/DSLDiagram_LegendStudioPlugin_Extension';
 export { DiagramEditorState } from './stores/studio/DiagramEditorState';
 
 export { DiagramRenderer, DIAGRAM_INTERACTION_MODE } from './DiagramRenderer';

--- a/packages/legend-extension-dsl-serializer/package.json
+++ b/packages/legend-extension-dsl-serializer/package.json
@@ -46,7 +46,7 @@
     "@finos/legend-model-storage": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",
     "monaco-editor": "0.30.1",

--- a/packages/legend-extension-dsl-serializer/src/DSLSerializer_Extension.ts
+++ b/packages/legend-extension-dsl-serializer/src/DSLSerializer_Extension.ts
@@ -19,8 +19,8 @@ import type { GraphPluginManager } from '@finos/legend-graph';
 import { AbstractPreset } from '@finos/legend-shared';
 import { DSLSerializer_PureGraphManagerPlugin } from './graphManager/DSLSerializer_PureGraphManagerPlugin';
 import { DSLSerializer_PureProtocolProcessorPlugin } from './models/protocols/pure/DSLSerializer_PureProtocolProcessorPlugin';
-import type { StudioPluginManager } from '@finos/legend-studio';
-import { DSLSerializer_StudioPlugin } from './components/studio/DSLSerializer_StudioPlugin';
+import type { LegendStudioPluginManager } from '@finos/legend-studio';
+import { DSLSerializer_LegendStudioPlugin } from './components/studio/DSLSerializer_LegendStudioPlugin';
 import { DSLSerializer_PureGraphPlugin } from './graph/DSLSerializer_PureGraphPlugin';
 
 export class DSLSerializer_GraphPreset extends AbstractPreset {
@@ -35,13 +35,13 @@ export class DSLSerializer_GraphPreset extends AbstractPreset {
   }
 }
 
-export class DSLSerializer_StudioPreset extends AbstractPreset {
+export class DSLSerializer_LegendStudioPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
-    new DSLSerializer_StudioPlugin().install(pluginManager);
+  install(pluginManager: LegendStudioPluginManager): void {
+    new DSLSerializer_LegendStudioPlugin().install(pluginManager);
     new DSLSerializer_PureGraphPlugin().install(pluginManager);
     new DSLSerializer_PureGraphManagerPlugin().install(pluginManager);
     new DSLSerializer_PureProtocolProcessorPlugin().install(pluginManager);

--- a/packages/legend-extension-dsl-serializer/src/components/studio/DSLSerializer_LegendStudioPlugin.tsx
+++ b/packages/legend-extension-dsl-serializer/src/components/studio/DSLSerializer_LegendStudioPlugin.tsx
@@ -20,7 +20,7 @@ import type {
   ConnectionValueEditorStateBuilder,
   ConnectionValueState,
   DefaultConnectionValueBuilder,
-  DSLMapping_StudioPlugin_Extension,
+  DSLMapping_LegendStudioPlugin_Extension,
   EditorStore,
   ElementEditorRenderer,
   ElementEditorState,
@@ -33,7 +33,7 @@ import type {
   NewElementFromStateCreator,
   NewElementState,
   RuntimeConnectionTooltipTextBuilder,
-  StudioPluginManager,
+  LegendStudioPluginManager,
 } from '@finos/legend-studio';
 import { LegendStudioPlugin } from '@finos/legend-studio';
 import { FaBuffer, FaSitemap } from 'react-icons/fa';
@@ -73,15 +73,15 @@ const SCHEMA_SET_ELEMENT_PROJECT_EXPLORER_DND_TYPE =
 const BINDING_ELEMENT_TYPE = 'BINDING';
 const BINDING_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_BINDING';
 
-export class DSLSerializer_StudioPlugin
+export class DSLSerializer_LegendStudioPlugin
   extends LegendStudioPlugin
-  implements DSLMapping_StudioPlugin_Extension
+  implements DSLMapping_LegendStudioPlugin_Extension
 {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 

--- a/packages/legend-extension-dsl-serializer/src/components/studio/DSLSerializer_StudioPlugin.tsx
+++ b/packages/legend-extension-dsl-serializer/src/components/studio/DSLSerializer_StudioPlugin.tsx
@@ -35,7 +35,7 @@ import type {
   RuntimeConnectionTooltipTextBuilder,
   StudioPluginManager,
 } from '@finos/legend-studio';
-import { StudioPlugin } from '@finos/legend-studio';
+import { LegendStudioPlugin } from '@finos/legend-studio';
 import { FaBuffer, FaSitemap } from 'react-icons/fa';
 import { SchemaSetEditor } from './SchemaSetElementEditor';
 import { SchemaSetEditorState } from '../../stores/studio/SchemaSetEditorState';
@@ -74,7 +74,7 @@ const BINDING_ELEMENT_TYPE = 'BINDING';
 const BINDING_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_BINDING';
 
 export class DSLSerializer_StudioPlugin
-  extends StudioPlugin
+  extends LegendStudioPlugin
   implements DSLMapping_StudioPlugin_Extension
 {
   constructor() {

--- a/packages/legend-extension-dsl-text/package.json
+++ b/packages/legend-extension-dsl-text/package.json
@@ -44,7 +44,7 @@
     "@finos/legend-model-storage": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",
     "monaco-editor": "0.30.1",

--- a/packages/legend-extension-dsl-text/src/DSLText_Extension.ts
+++ b/packages/legend-extension-dsl-text/src/DSLText_Extension.ts
@@ -19,8 +19,8 @@ import { AbstractPreset } from '@finos/legend-shared';
 import { DSLText_PureGraphManagerPlugin } from './graphManager/DSLText_PureGraphManagerPlugin';
 import { DSLText_PureProtocolProcessorPlugin } from './models/protocols/pure/DSLText_PureProtocolProcessorPlugin';
 import type { GraphPluginManager } from '@finos/legend-graph';
-import type { StudioPluginManager } from '@finos/legend-studio';
-import { DSLText_StudioPlugin } from './components/studio/DSLText_StudioPlugin';
+import type { LegendStudioPluginManager } from '@finos/legend-studio';
+import { DSLText_LegendStudioPlugin } from './components/studio/DSLText_LegendStudioPlugin';
 import { DSLText_PureGraphPlugin } from './graph/DSLText_PureGraphPlugin';
 
 export class DSLText_GraphPreset extends AbstractPreset {
@@ -35,13 +35,13 @@ export class DSLText_GraphPreset extends AbstractPreset {
   }
 }
 
-export class DSLText_StudioPreset extends AbstractPreset {
+export class DSLText_LegendStudioPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
-    new DSLText_StudioPlugin().install(pluginManager);
+  install(pluginManager: LegendStudioPluginManager): void {
+    new DSLText_LegendStudioPlugin().install(pluginManager);
     new DSLText_PureGraphPlugin().install(pluginManager);
     new DSLText_PureGraphManagerPlugin().install(pluginManager);
     new DSLText_PureProtocolProcessorPlugin().install(pluginManager);

--- a/packages/legend-extension-dsl-text/src/components/studio/DSLText_LegendStudioPlugin.tsx
+++ b/packages/legend-extension-dsl-text/src/components/studio/DSLText_LegendStudioPlugin.tsx
@@ -17,7 +17,7 @@
 import packageJson from '../../../package.json';
 import { LegendStudioPlugin } from '@finos/legend-studio';
 import type {
-  StudioPluginManager,
+  LegendStudioPluginManager,
   NewElementFromStateCreator,
   EditorStore,
   ElementEditorState,
@@ -26,7 +26,7 @@ import type {
   ElementProjectExplorerDnDTypeGetter,
   ElementIconGetter,
   ElementEditorRenderer,
-  DSL_StudioPlugin_Extension,
+  DSL_LegendStudioPlugin_Extension,
   NewElementState,
 } from '@finos/legend-studio';
 import { FileIcon } from '@finos/legend-art';
@@ -38,15 +38,15 @@ import { Text } from '../../models/metamodels/pure/model/packageableElements/tex
 const TEXT_ELEMENT_TYPE = 'TEXT';
 const TEXT_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_TEXT';
 
-export class DSLText_StudioPlugin
+export class DSLText_LegendStudioPlugin
   extends LegendStudioPlugin
-  implements DSL_StudioPlugin_Extension
+  implements DSL_LegendStudioPlugin_Extension
 {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 

--- a/packages/legend-extension-dsl-text/src/components/studio/DSLText_StudioPlugin.tsx
+++ b/packages/legend-extension-dsl-text/src/components/studio/DSLText_StudioPlugin.tsx
@@ -15,7 +15,7 @@
  */
 
 import packageJson from '../../../package.json';
-import { StudioPlugin } from '@finos/legend-studio';
+import { LegendStudioPlugin } from '@finos/legend-studio';
 import type {
   StudioPluginManager,
   NewElementFromStateCreator,
@@ -39,7 +39,7 @@ const TEXT_ELEMENT_TYPE = 'TEXT';
 const TEXT_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_TEXT';
 
 export class DSLText_StudioPlugin
-  extends StudioPlugin
+  extends LegendStudioPlugin
   implements DSL_StudioPlugin_Extension
 {
   constructor() {

--- a/packages/legend-extension-external-format-json-schema/_package.config.js
+++ b/packages/legend-extension-external-format-json-schema/_package.config.js
@@ -16,6 +16,9 @@
 
 export default {
   publish: {
-    tsConfigPath: './tsconfig.build.json',
+    typescript: {
+      main: './tsconfig.build.json',
+      others: ['./tsconfig.package.json'],
+    },
   },
 };

--- a/packages/legend-extension-external-store-service/package.json
+++ b/packages/legend-extension-external-store-service/package.json
@@ -43,7 +43,7 @@
     "@finos/legend-model-storage": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",
     "monaco-editor": "0.30.1",

--- a/packages/legend-extension-external-store-service/src/ESService_Extension.ts
+++ b/packages/legend-extension-external-store-service/src/ESService_Extension.ts
@@ -19,9 +19,9 @@ import type { GraphPluginManager } from '@finos/legend-graph';
 import { AbstractPreset } from '@finos/legend-shared';
 import { ESService_PureGraphManagerPlugin } from './graphManager/ESService_PureGraphManagerPlugin';
 import { ESService_PureProtocolProcessorPlugin } from './models/protocols/pure/ESService_PureProtocolProcessorPlugin';
-import type { StudioPluginManager } from '@finos/legend-studio';
+import type { LegendStudioPluginManager } from '@finos/legend-studio';
 import { ESService_PureGraphPlugin } from './graph/ESService_PureGraphPlugin';
-import { ESService_StudioPlugin } from './components/ESService_StudioPlugin';
+import { ESService_LegendStudioPlugin } from './components/ESService_LegendStudioPlugin';
 
 export class ESService_GraphPreset extends AbstractPreset {
   constructor() {
@@ -35,13 +35,13 @@ export class ESService_GraphPreset extends AbstractPreset {
   }
 }
 
-export class ESService_StudioPreset extends AbstractPreset {
+export class ESService_LegendStudioPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
-    new ESService_StudioPlugin().install(pluginManager);
+  install(pluginManager: LegendStudioPluginManager): void {
+    new ESService_LegendStudioPlugin().install(pluginManager);
     new ESService_PureGraphPlugin().install(pluginManager);
     new ESService_PureGraphManagerPlugin().install(pluginManager);
     new ESService_PureProtocolProcessorPlugin().install(pluginManager);

--- a/packages/legend-extension-external-store-service/src/components/ESService_LegendStudioPlugin.tsx
+++ b/packages/legend-extension-external-store-service/src/components/ESService_LegendStudioPlugin.tsx
@@ -21,7 +21,7 @@ import {
   UnsupportedInstanceSetImplementationState,
 } from '@finos/legend-studio';
 import type {
-  StudioPluginManager,
+  LegendStudioPluginManager,
   NewElementFromStateCreator,
   RuntimeConnectionTooltipTextBuilder,
   EditorStore,
@@ -30,7 +30,7 @@ import type {
   ElementTypeGetter,
   ElementProjectExplorerDnDTypeGetter,
   NewElementState,
-  DSLMapping_StudioPlugin_Extension,
+  DSLMapping_LegendStudioPlugin_Extension,
   SetImplemtationClassifier,
   MappingElementStateCreator,
   MappingElement,
@@ -52,15 +52,15 @@ const SERVICE_STORE_ELEMENT_PROJECT_EXPLORER_DND_TYPE =
   'PROJECT_EXPLORER_SERVICE_STORE';
 const SERVICE_STORE_MAPPING_TYPE = 'serviceStore';
 
-export class ESService_StudioPlugin
+export class ESService_LegendStudioPlugin
   extends LegendStudioPlugin
-  implements DSLMapping_StudioPlugin_Extension
+  implements DSLMapping_LegendStudioPlugin_Extension
 {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 

--- a/packages/legend-extension-external-store-service/src/components/ESService_StudioPlugin.tsx
+++ b/packages/legend-extension-external-store-service/src/components/ESService_StudioPlugin.tsx
@@ -16,7 +16,7 @@
 
 import packageJson from '../../package.json';
 import {
-  StudioPlugin,
+  LegendStudioPlugin,
   UnsupportedElementEditorState,
   UnsupportedInstanceSetImplementationState,
 } from '@finos/legend-studio';
@@ -53,7 +53,7 @@ const SERVICE_STORE_ELEMENT_PROJECT_EXPLORER_DND_TYPE =
 const SERVICE_STORE_MAPPING_TYPE = 'serviceStore';
 
 export class ESService_StudioPlugin
-  extends StudioPlugin
+  extends LegendStudioPlugin
   implements DSLMapping_StudioPlugin_Extension
 {
   constructor() {

--- a/packages/legend-query-app/.npmignore
+++ b/packages/legend-query-app/.npmignore
@@ -4,4 +4,3 @@
 **/__tests__/**
 /*.*
 !tsconfig.json
-!tsconfig.package.json

--- a/packages/legend-query-app/_package.config.js
+++ b/packages/legend-query-app/_package.config.js
@@ -18,7 +18,6 @@ export default {
   publish: {
     typescript: {
       main: './tsconfig.build.json',
-      others: ['./tsconfig.package.json'],
     },
   },
 };

--- a/packages/legend-query-app/package.json
+++ b/packages/legend-query-app/package.json
@@ -48,7 +48,7 @@
     "@finos/legend-extension-external-store-service": "workspace:*",
     "@finos/legend-query": "workspace:*",
     "@finos/legend-shared": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "react": "17.0.2"
   },
   "devDependencies": {

--- a/packages/legend-query-app/src/index.tsx
+++ b/packages/legend-query-app/src/index.tsx
@@ -21,7 +21,7 @@ import { BrowserConsole } from '@finos/legend-shared';
 import { DSLDiagram_GraphPreset } from '@finos/legend-extension-dsl-diagram';
 import { DSLSerializer_GraphPreset } from '@finos/legend-extension-dsl-serializer';
 import { ESService_GraphPreset } from '@finos/legend-extension-external-store-service';
-import { DSLDataSpace_QueryPreset } from '@finos/legend-extension-dsl-data-space';
+import { DSLDataSpace_LegendQueryPreset } from '@finos/legend-extension-dsl-data-space';
 
 export class LegendQueryApplication {
   static run(baseUrl: string): void {
@@ -30,7 +30,7 @@ export class LegendQueryApplication {
       .withPresets([
         new DSLText_GraphPreset(),
         new DSLDiagram_GraphPreset(),
-        new DSLDataSpace_QueryPreset(),
+        new DSLDataSpace_LegendQueryPreset(),
         new EFJSONSchema_GraphPreset(),
         new DSLSerializer_GraphPreset(),
         new ESService_GraphPreset(),

--- a/packages/legend-query/_package.config.js
+++ b/packages/legend-query/_package.config.js
@@ -16,6 +16,9 @@
 
 export default {
   publish: {
-    tsConfigPath: './tsconfig.build.json',
+    typescript: {
+      main: './tsconfig.build.json',
+      others: ['./tsconfig.package.json'],
+    },
   },
 };

--- a/packages/legend-query/package.json
+++ b/packages/legend-query/package.json
@@ -50,7 +50,7 @@
     "@material-ui/core": "4.12.3",
     "@testing-library/react": "12.1.2",
     "@types/papaparse": "5.3.1",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "@types/react-dom": "17.0.11",
     "@types/react-router-dom": "5.3.2",
     "date-fns": "2.25.0",

--- a/packages/legend-query/src/application/LegendQuery.tsx
+++ b/packages/legend-query/src/application/LegendQuery.tsx
@@ -29,12 +29,12 @@ import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-mod
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { LegendQueryApplication } from '../components/LegendQueryApplication';
-import { QueryPluginManager } from './QueryPluginManager';
+import { LegendQueryPluginManager } from './LegendQueryPluginManager';
 import { Query_GraphPreset } from '../models/Query_GraphPreset';
 import { getRootElement } from '@finos/legend-art';
 import { CorePureGraphManagerPlugin } from '@finos/legend-graph';
-import type { QueryConfigurationData } from './QueryConfig';
-import { QueryConfig } from './QueryConfig';
+import type { LegendQueryConfigurationData } from './LegendQueryConfig';
+import { LegendQueryConfig } from './LegendQueryConfig';
 
 export const setupLegendQueryUILibrary = async (): Promise<void> => {
   // Register module extensions for `ag-grid`
@@ -49,22 +49,22 @@ export const setupLegendQueryUILibrary = async (): Promise<void> => {
 };
 
 export class LegendQuery extends LegendApplication {
-  declare config: QueryConfig;
-  declare pluginManager: QueryPluginManager;
+  declare config: LegendQueryConfig;
+  declare pluginManager: LegendQueryPluginManager;
 
   static create(): LegendQuery {
-    const application = new LegendQuery(QueryPluginManager.create());
+    const application = new LegendQuery(LegendQueryPluginManager.create());
     application.withBasePlugins([new CorePureGraphManagerPlugin()]);
     application.withBasePresets([new Query_GraphPreset()]);
     return application;
   }
 
   async configureApplication(
-    configData: QueryConfigurationData,
+    configData: LegendQueryConfigurationData,
     versionData: LegendApplicationVersionData,
     baseUrl: string,
   ): Promise<LegendApplicationConfig> {
-    return new QueryConfig(configData, versionData, baseUrl);
+    return new LegendQueryConfig(configData, versionData, baseUrl);
   }
 
   async loadApplication(): Promise<void> {

--- a/packages/legend-query/src/application/LegendQueryConfig.ts
+++ b/packages/legend-query/src/application/LegendQueryConfig.ts
@@ -24,7 +24,7 @@ import type {
 } from '@finos/legend-application';
 import { LegendApplicationConfig } from '@finos/legend-application';
 
-export interface QueryConfigurationData
+export interface LegendQueryConfigurationData
   extends LegendApplicationConfigurationData {
   appName: string;
   env: string;
@@ -42,7 +42,7 @@ export interface QueryConfigurationData
   extensions?: Record<PropertyKey, unknown>;
 }
 
-export class QueryConfig extends LegendApplicationConfig {
+export class LegendQueryConfig extends LegendApplicationConfig {
   readonly engineServerUrl: string;
   readonly engineQueryServerUrl?: string | undefined;
   readonly depotServerUrl: string;
@@ -50,7 +50,7 @@ export class QueryConfig extends LegendApplicationConfig {
   readonly TEMP__useLegacyDepotServerAPIRoutes?: boolean | undefined;
 
   constructor(
-    configData: QueryConfigurationData,
+    configData: LegendQueryConfigurationData,
     versionData: LegendApplicationVersionData,
     baseUrl: string,
   ) {

--- a/packages/legend-query/src/application/LegendQueryPluginManager.ts
+++ b/packages/legend-query/src/application/LegendQueryPluginManager.ts
@@ -29,7 +29,7 @@ import type {
 import { AbstractPluginManager } from '@finos/legend-shared';
 import type { LegendQueryPlugin } from '../stores/LegendQueryPlugin';
 
-export class QueryPluginManager
+export class LegendQueryPluginManager
   extends AbstractPluginManager
   implements
     GraphPluginManager,
@@ -47,8 +47,8 @@ export class QueryPluginManager
     super();
   }
 
-  static create(): QueryPluginManager {
-    return new QueryPluginManager();
+  static create(): LegendQueryPluginManager {
+    return new LegendQueryPluginManager();
   }
 
   registerTelemetryServicePlugin(plugin: TelemetryServicePlugin): void {

--- a/packages/legend-query/src/application/QueryPluginManager.ts
+++ b/packages/legend-query/src/application/QueryPluginManager.ts
@@ -27,7 +27,7 @@ import type {
   TracerServicePluginManager,
 } from '@finos/legend-shared';
 import { AbstractPluginManager } from '@finos/legend-shared';
-import type { QueryPlugin } from '../stores/QueryPlugin';
+import type { LegendQueryPlugin } from '../stores/LegendQueryPlugin';
 
 export class QueryPluginManager
   extends AbstractPluginManager
@@ -41,7 +41,7 @@ export class QueryPluginManager
   private pureProtocolProcessorPlugins: PureProtocolProcessorPlugin[] = [];
   private pureGraphManagerPlugins: PureGraphManagerPlugin[] = [];
   private pureGraphPlugins: PureGraphPlugin[] = [];
-  private queryPlugins: QueryPlugin[] = [];
+  private queryPlugins: LegendQueryPlugin[] = [];
 
   private constructor() {
     super();
@@ -73,7 +73,7 @@ export class QueryPluginManager
     this.pureGraphPlugins.push(plugin);
   }
 
-  registerQueryPlugin(plugin: QueryPlugin): void {
+  registerQueryPlugin(plugin: LegendQueryPlugin): void {
     this.queryPlugins.push(plugin);
   }
 
@@ -97,7 +97,7 @@ export class QueryPluginManager
     return [...this.pureGraphPlugins];
   }
 
-  getQueryPlugins(): QueryPlugin[] {
+  getQueryPlugins(): LegendQueryPlugin[] {
     return [...this.queryPlugins];
   }
 }

--- a/packages/legend-query/src/components/LegendQueryApplication.tsx
+++ b/packages/legend-query/src/components/LegendQueryApplication.tsx
@@ -31,7 +31,10 @@ import {
   PanelLoadingIndicator,
 } from '@finos/legend-art';
 import type { Log } from '@finos/legend-shared';
-import { QueryStoreProvider, useQueryStore } from './QueryStoreProvider';
+import {
+  LegendQueryStoreProvider,
+  useLegendQueryStore,
+} from './LegendQueryStoreProvider';
 import { DepotServerClientProvider } from '@finos/legend-server-depot';
 import { GraphManagerStateProvider } from '@finos/legend-graph';
 import {
@@ -42,11 +45,11 @@ import {
   useApplicationStore,
   useWebApplicationNavigator,
 } from '@finos/legend-application';
-import type { QueryPluginManager } from '../application/QueryPluginManager';
-import type { QueryConfig } from '../application/QueryConfig';
+import type { LegendQueryPluginManager } from '../application/LegendQueryPluginManager';
+import type { LegendQueryConfig } from '../application/LegendQueryConfig';
 
 const LegendQueryApplicationInner = observer(() => {
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const applicationStore = useApplicationStore();
 
   useEffect(() => {
@@ -92,8 +95,8 @@ const LegendQueryApplicationInner = observer(() => {
 
 export const LegendQueryApplication = observer(
   (props: {
-    config: QueryConfig;
-    pluginManager: QueryPluginManager;
+    config: LegendQueryConfig;
+    pluginManager: LegendQueryPluginManager;
     log: Log;
   }) => {
     const { config, pluginManager, log } = props;
@@ -109,11 +112,11 @@ export const LegendQueryApplication = observer(
           }}
         >
           <GraphManagerStateProvider pluginManager={pluginManager} log={log}>
-            <QueryStoreProvider pluginManager={pluginManager}>
+            <LegendQueryStoreProvider pluginManager={pluginManager}>
               <ThemeProvider theme={LegendMaterialUITheme}>
                 <LegendQueryApplicationInner />
               </ThemeProvider>
-            </QueryStoreProvider>
+            </LegendQueryStoreProvider>
           </GraphManagerStateProvider>
         </DepotServerClientProvider>
       </ApplicationStoreProvider>

--- a/packages/legend-query/src/components/LegendQueryStoreProvider.tsx
+++ b/packages/legend-query/src/components/LegendQueryStoreProvider.tsx
@@ -16,29 +16,31 @@
 
 import { createContext, useContext } from 'react';
 import { useLocalObservable } from 'mobx-react-lite';
-import { QueryStore } from '../stores/QueryStore';
+import { LegendQueryStore } from '../stores/LegendQueryStore';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { useDepotServerClient } from '@finos/legend-server-depot';
 import { useGraphManagerState } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
-import type { QueryPluginManager } from '../application/QueryPluginManager';
-import type { QueryConfig } from '../application/QueryConfig';
+import type { LegendQueryPluginManager } from '../application/LegendQueryPluginManager';
+import type { LegendQueryConfig } from '../application/LegendQueryConfig';
 
-const QueryStoreContext = createContext<QueryStore | undefined>(undefined);
+const LegendQueryStoreContext = createContext<LegendQueryStore | undefined>(
+  undefined,
+);
 
-export const QueryStoreProvider = ({
+export const LegendQueryStoreProvider = ({
   children,
   pluginManager,
 }: {
   children: React.ReactNode;
-  pluginManager: QueryPluginManager;
+  pluginManager: LegendQueryPluginManager;
 }): React.ReactElement => {
-  const applicationStore = useApplicationStore<QueryConfig>();
+  const applicationStore = useApplicationStore<LegendQueryConfig>();
   const depotServerClient = useDepotServerClient();
   const graphManagerState = useGraphManagerState();
   const store = useLocalObservable(
     () =>
-      new QueryStore(
+      new LegendQueryStore(
         applicationStore,
         depotServerClient,
         graphManagerState,
@@ -46,14 +48,14 @@ export const QueryStoreProvider = ({
       ),
   );
   return (
-    <QueryStoreContext.Provider value={store}>
+    <LegendQueryStoreContext.Provider value={store}>
       {children}
-    </QueryStoreContext.Provider>
+    </LegendQueryStoreContext.Provider>
   );
 };
 
-export const useQueryStore = (): QueryStore =>
+export const useLegendQueryStore = (): LegendQueryStore =>
   guaranteeNonNullable(
-    useContext(QueryStoreContext),
-    `Can't find Query store in context`,
+    useContext(LegendQueryStoreContext),
+    `Can't find Legend Query store in context`,
   );

--- a/packages/legend-query/src/components/QueryComponentTestUtils.tsx
+++ b/packages/legend-query/src/components/QueryComponentTestUtils.tsx
@@ -42,175 +42,52 @@ import {
   TEST__getTestApplicationStore,
   WebApplicationNavigator,
 } from '@finos/legend-application';
-import { QueryStore } from '../stores/QueryStore';
+import { LegendQueryStore } from '../stores/LegendQueryStore';
 import { TEST__getTestQueryConfig } from '../stores/QueryStoreTestUtils';
-import { QueryStoreProvider } from './QueryStoreProvider';
-import { QueryPluginManager } from '../application/QueryPluginManager';
+import { LegendQueryStoreProvider } from './LegendQueryStoreProvider';
+import { LegendQueryPluginManager } from '../application/LegendQueryPluginManager';
 import { ExistingQueryLoader } from './QueryEditor';
 import { generateExistingQueryRoute } from '../stores/LegendQueryRouter';
 import { flowResult } from 'mobx';
 import { QUERY_BUILDER_TEST_ID } from './QueryBuilder_TestID';
-import type { QueryConfig } from '../application/QueryConfig';
+import type { LegendQueryConfig } from '../application/LegendQueryConfig';
 import type { Entity } from '@finos/legend-model-storage';
-
-// const TEST_DATA__simpleModelEntities = [
-//   {
-//     path: 'model::Person',
-//     content: {
-//       _type: 'class',
-//       name: 'Person',
-//       package: 'model',
-//       properties: [
-//         {
-//           multiplicity: {
-//             lowerBound: 1,
-//             upperBound: 1,
-//           },
-//           name: 'name',
-//           type: 'String',
-//         },
-//       ],
-//     },
-//     classifierPath: 'meta::pure::metamodel::type::Class',
-//   },
-//   {
-//     path: 'model::MyMapping',
-//     content: {
-//       _type: 'mapping',
-//       classMappings: [
-//         {
-//           _type: 'pureInstance',
-//           class: 'model::Person',
-//           propertyMappings: [
-//             {
-//               _type: 'purePropertyMapping',
-//               property: {
-//                 class: 'model::Person',
-//                 property: 'name',
-//               },
-//               source: '',
-//               transform: {
-//                 _type: 'lambda',
-//                 body: [
-//                   {
-//                     _type: 'property',
-//                     parameters: [
-//                       {
-//                         _type: 'var',
-//                         name: 'src',
-//                       },
-//                     ],
-//                     property: 'name',
-//                   },
-//                 ],
-//                 parameters: [],
-//               },
-//             },
-//           ],
-//           root: true,
-//           srcClass: 'model::Person',
-//         },
-//       ],
-//       enumerationMappings: [],
-//       includedMappings: [],
-//       name: 'MyMapping',
-//       package: 'model',
-//       tests: [],
-//     },
-//     classifierPath: 'meta::pure::mapping::Mapping',
-//   },
-//   {
-//     path: 'model::MyRuntime',
-//     content: {
-//       _type: 'runtime',
-//       name: 'MyRuntime',
-//       package: 'model',
-//       runtimeValue: {
-//         _type: 'engineRuntime',
-//         connections: [
-//           {
-//             store: {
-//               path: 'ModelStore',
-//               type: 'STORE',
-//             },
-//             storeConnections: [
-//               {
-//                 connection: {
-//                   _type: 'JsonModelConnection',
-//                   class: 'model::Person',
-//                   url: 'data:application/json,%7B%7D',
-//                 },
-//                 id: 'connection_1',
-//               },
-//             ],
-//           },
-//         ],
-//         mappings: [
-//           {
-//             path: 'model::MyMapping',
-//             type: 'MAPPING',
-//           },
-//         ],
-//       },
-//     },
-//     classifierPath: 'meta::pure::runtime::PackageableRuntime',
-//   },
-// ];
-
-// const TEST_DATA__simpleQuery = {
-//   _type: 'lambda',
-//   body: [
-//     {
-//       _type: 'func',
-//       function: 'getAll',
-//       parameters: [
-//         {
-//           _type: 'packageableElementPtr',
-//           fullPath: 'model::Person',
-//         },
-//       ],
-//     },
-//   ],
-//   parameters: [],
-// };
-
-// const TEST_DATA__simpleQueryGrammarText = 'model::Person.all()';
 
 export const TEST__QueryStoreProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }): React.ReactElement => (
-  <QueryStoreProvider pluginManager={QueryPluginManager.create()}>
+  <LegendQueryStoreProvider pluginManager={LegendQueryPluginManager.create()}>
     {children}
-  </QueryStoreProvider>
+  </LegendQueryStoreProvider>
 );
 
 export const TEST__provideMockedQueryStore = (customization?: {
-  mock?: QueryStore;
-  applicationStore?: ApplicationStore<QueryConfig>;
+  mock?: LegendQueryStore;
+  applicationStore?: ApplicationStore<LegendQueryConfig>;
   depotServerClient?: DepotServerClient;
   graphManagerState?: GraphManagerState;
-  pluginManager?: QueryPluginManager;
-}): QueryStore => {
+  pluginManager?: LegendQueryPluginManager;
+}): LegendQueryStore => {
   const value =
     customization?.mock ??
-    new QueryStore(
+    new LegendQueryStore(
       customization?.applicationStore ??
         TEST__getTestApplicationStore(TEST__getTestQueryConfig()),
       customization?.depotServerClient ?? TEST__getTestDepotServerClient(),
       customization?.graphManagerState ??
         TEST__getTestGraphManagerState(customization?.pluginManager),
-      customization?.pluginManager ?? QueryPluginManager.create(),
+      customization?.pluginManager ?? LegendQueryPluginManager.create(),
     );
-  const MockedQueryStoreProvider = require('./QueryStoreProvider'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-  MockedQueryStoreProvider.useQueryStore = jest.fn();
-  MockedQueryStoreProvider.useQueryStore.mockReturnValue(value);
+  const MockedQueryStoreProvider = require('./LegendQueryStoreProvider'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+  MockedQueryStoreProvider.useLegendQueryStore = jest.fn();
+  MockedQueryStoreProvider.useLegendQueryStore.mockReturnValue(value);
   return value;
 };
 
 export const TEST__setUpQueryEditor = async (
-  mockedQueryStore: QueryStore,
+  mockedQueryStore: LegendQueryStore,
   entities: Entity[],
   lambda: RawLambda,
   mappingPath: string,

--- a/packages/legend-query/src/components/QueryEditor.tsx
+++ b/packages/legend-query/src/components/QueryEditor.tsx
@@ -40,14 +40,14 @@ import {
   LEGEND_QUERY_ROUTE_PATTERN,
   generateCreateQueryRoute,
 } from '../stores/LegendQueryRouter';
-import type { QueryExportState } from '../stores/QueryStore';
+import type { QueryExportState } from '../stores/LegendQueryStore';
 import {
   ExistingQueryInfoState,
   ServiceQueryInfoState,
   CreateQueryInfoState,
-} from '../stores/QueryStore';
+} from '../stores/LegendQueryStore';
 import { QueryBuilder } from './QueryBuilder';
-import { useQueryStore } from './QueryStoreProvider';
+import { useLegendQueryStore } from './LegendQueryStoreProvider';
 import { RuntimePointer } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
 
@@ -112,7 +112,7 @@ const QueryExportInner = observer(
 );
 
 const QueryExport = observer(() => {
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const queryExportState = queryStore.queryExportState;
   const close = (): void => queryStore.setQueryExportState(undefined);
 
@@ -139,7 +139,7 @@ const QueryExport = observer(() => {
 });
 
 const QueryEditorHeader = observer(() => {
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const queryInfoState = queryStore.queryInfoState;
   const applicationStore = useApplicationStore();
   const backToMainMenu = (): void =>
@@ -222,7 +222,7 @@ const QueryEditorHeader = observer(() => {
 });
 
 const QueryEditorInner = observer(() => {
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const isLoadingEditor =
     !queryStore.graphManagerState.graph.buildState.hasCompleted ||
     !queryStore.editorInitState.hasCompleted;
@@ -247,7 +247,7 @@ const QueryEditor: React.FC = () => (
 );
 
 export const ExistingQueryLoader = observer(() => {
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const params = useParams<ExistingQueryPathParams>();
 
   useEffect(() => {
@@ -259,7 +259,7 @@ export const ExistingQueryLoader = observer(() => {
 
 export const ServiceQueryLoader = observer(() => {
   const applicationStore = useApplicationStore();
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const params = useParams<ServiceQueryPathParams>();
   const queryParams = getQueryParameters<ServiceQueryQueryParams>(
     applicationStore.navigator.getCurrentLocation(),
@@ -275,7 +275,7 @@ export const ServiceQueryLoader = observer(() => {
 
 export const CreateQueryLoader = observer(() => {
   const applicationStore = useApplicationStore();
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const params = useParams<CreateQueryPathParams>();
   const currentMapping = queryStore.queryBuilderState.querySetupState.mapping;
   const currentRuntime =

--- a/packages/legend-query/src/components/QuerySetup.tsx
+++ b/packages/legend-query/src/components/QuerySetup.tsx
@@ -51,12 +51,12 @@ import {
   CreateQueryInfoState,
   ExistingQueryInfoState,
   ServiceQueryInfoState,
-} from '../stores/QueryStore';
+} from '../stores/LegendQueryStore';
 import {
   QuerySetupStoreProvider,
   useQuerySetupStore,
 } from './QuerySetupStoreProvider';
-import { useQueryStore } from './QueryStoreProvider';
+import { useLegendQueryStore } from './LegendQueryStoreProvider';
 import type { ProjectData } from '@finos/legend-server-depot';
 import {
   LATEST_VERSION_ALIAS,
@@ -81,7 +81,7 @@ const ExistingQuerySetup = observer(
     const { querySetupState } = props;
     const applicationStore = useApplicationStore();
     const setupStore = useQuerySetupStore();
-    const queryStore = useQueryStore();
+    const queryStore = useLegendQueryStore();
     const querySearchRef = useRef<SelectComponent>(null);
     const [searchText, setSearchText] = useState('');
     const back = (): void => {
@@ -286,7 +286,7 @@ const ServiceQuerySetup = observer(
     const { querySetupState } = props;
     const applicationStore = useApplicationStore();
     const setupStore = useQuerySetupStore();
-    const queryStore = useQueryStore();
+    const queryStore = useLegendQueryStore();
     const back = (): void => {
       setupStore.setSetupState(undefined);
       querySetupState.setCurrentVersionId(undefined);
@@ -527,7 +527,7 @@ const CreateQuerySetup = observer(
     const { querySetupState } = props;
     const applicationStore = useApplicationStore();
     const setupStore = useQuerySetupStore();
-    const queryStore = useQueryStore();
+    const queryStore = useLegendQueryStore();
     const back = (): void => {
       setupStore.setSetupState(undefined);
       querySetupState.setCurrentVersionId(undefined);
@@ -808,7 +808,7 @@ const CreateQuerySetup = observer(
 
 const QuerySetupLandingPage = observer(() => {
   const setupStore = useQuerySetupStore();
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const extraQuerySetupOptions = queryStore.pluginManager
     .getQueryPlugins()
     .flatMap(
@@ -881,7 +881,7 @@ const QuerySetupLandingPage = observer(() => {
 
 const QuerySetupInner = observer(() => {
   const setupStore = useQuerySetupStore();
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const querySetupState = setupStore.querySetupState;
   const renderQuerySetupScreen = (
     setupState: QuerySetupState,

--- a/packages/legend-query/src/components/QuerySetupStoreProvider.tsx
+++ b/packages/legend-query/src/components/QuerySetupStoreProvider.tsx
@@ -17,7 +17,7 @@
 import { createContext, useContext } from 'react';
 import { useLocalObservable } from 'mobx-react-lite';
 import { QuerySetupStore } from '../stores/QuerySetupStore';
-import { useQueryStore } from './QueryStoreProvider';
+import { useLegendQueryStore } from './LegendQueryStoreProvider';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 
 const QuerySetupStoreContext = createContext<QuerySetupStore | undefined>(
@@ -29,7 +29,7 @@ export const QuerySetupStoreProvider = ({
 }: {
   children: React.ReactNode;
 }): React.ReactElement => {
-  const queryStore = useQueryStore();
+  const queryStore = useLegendQueryStore();
   const store = useLocalObservable(() => new QuerySetupStore(queryStore));
   return (
     <QuerySetupStoreContext.Provider value={store}>

--- a/packages/legend-query/src/components/__tests__/QueryBuilder_FetchStructure.test.tsx
+++ b/packages/legend-query/src/components/__tests__/QueryBuilder_FetchStructure.test.tsx
@@ -46,7 +46,7 @@ import { QUERY_BUILDER_TEST_ID } from '../QueryBuilder_TestID';
 import { QueryBuilderExplorerTreeRootNodeData } from '../../stores/QueryBuilderExplorerState';
 import { QueryBuilderSimpleProjectionColumnState } from '../../stores/QueryBuilderProjectionState';
 import { COLUMN_SORT_TYPE } from '../../stores/QueryResultSetModifierState';
-import { QueryPluginManager } from '../../application/QueryPluginManager';
+import { LegendQueryPluginManager } from '../../application/LegendQueryPluginManager';
 import { Query_GraphPreset } from '../../models/Query_GraphPreset';
 import { FETCH_STRUCTURE_MODE } from '../../stores/QueryBuilderFetchStructureState';
 
@@ -60,7 +60,7 @@ test(
     'Query builder state is properly set after processing a projection lambda',
   ),
   async () => {
-    const pluginManager = QueryPluginManager.create();
+    const pluginManager = LegendQueryPluginManager.create();
     pluginManager.usePresets([new Query_GraphPreset()]).install();
     const mockedQueryStore = TEST__provideMockedQueryStore({
       pluginManager,
@@ -348,7 +348,7 @@ test(
     'Query builder state is properly set after processing a graph-fetch lambda',
   ),
   async () => {
-    const pluginManager = QueryPluginManager.create();
+    const pluginManager = LegendQueryPluginManager.create();
     pluginManager.usePresets([new Query_GraphPreset()]).install();
     const mockedQueryStore = TEST__provideMockedQueryStore({
       pluginManager,

--- a/packages/legend-query/src/index.ts
+++ b/packages/legend-query/src/index.ts
@@ -26,7 +26,7 @@ export { useQueryStore } from './components/QueryStoreProvider';
 
 export { QueryPluginManager } from './application/QueryPluginManager';
 
-export * from './stores/QueryPlugin';
+export * from './stores/LegendQueryPlugin';
 export * from './stores/LegendQueryRouter';
 export { QuerySetupState, QuerySetupStore } from './stores/QuerySetupStore';
 export { QueryStore, CreateQueryInfoState } from './stores/QueryStore';

--- a/packages/legend-query/src/index.ts
+++ b/packages/legend-query/src/index.ts
@@ -22,14 +22,17 @@ export { QueryBuilder_PureProtocolProcessorPlugin } from './models/protocols/pur
 
 export { QueryBuilder } from './components/QueryBuilder';
 export { useQuerySetupStore } from './components/QuerySetupStoreProvider';
-export { useQueryStore } from './components/QueryStoreProvider';
+export { useLegendQueryStore } from './components/LegendQueryStoreProvider';
 
-export { QueryPluginManager } from './application/QueryPluginManager';
+export { LegendQueryPluginManager } from './application/LegendQueryPluginManager';
 
 export * from './stores/LegendQueryPlugin';
 export * from './stores/LegendQueryRouter';
 export { QuerySetupState, QuerySetupStore } from './stores/QuerySetupStore';
-export { QueryStore, CreateQueryInfoState } from './stores/QueryStore';
+export {
+  LegendQueryStore,
+  CreateQueryInfoState,
+} from './stores/LegendQueryStore';
 export {
   QueryBuilderMode,
   StandardQueryBuilderMode,

--- a/packages/legend-query/src/stores/LegendQueryPlugin.ts
+++ b/packages/legend-query/src/stores/LegendQueryPlugin.ts
@@ -26,8 +26,8 @@ export type QuerySetupRenderer = (
   setupState: QuerySetupState,
 ) => React.ReactNode | undefined;
 
-export abstract class QueryPlugin extends AbstractPlugin {
-  private readonly _$nominalTypeBrand!: 'QueryPlugin';
+export abstract class LegendQueryPlugin extends AbstractPlugin {
+  private readonly _$nominalTypeBrand!: 'LegendQueryPlugin';
 
   /**
    * Get the list of renderer configurations for the query setup option.

--- a/packages/legend-query/src/stores/LegendQueryStore.ts
+++ b/packages/legend-query/src/stores/LegendQueryStore.ts
@@ -76,13 +76,13 @@ import {
 } from '@finos/legend-server-depot';
 import type { ApplicationStore } from '@finos/legend-application';
 import { APPLICATION_LOG_EVENT, TAB_SIZE } from '@finos/legend-application';
-import type { QueryPluginManager } from '../application/QueryPluginManager';
-import type { QueryConfig } from '../application/QueryConfig';
+import type { LegendQueryPluginManager } from '../application/LegendQueryPluginManager';
+import type { LegendQueryConfig } from '../application/LegendQueryConfig';
 
 export abstract class QueryInfoState {
-  queryStore: QueryStore;
+  queryStore: LegendQueryStore;
 
-  constructor(queryStore: QueryStore) {
+  constructor(queryStore: LegendQueryStore) {
     this.queryStore = queryStore;
   }
 
@@ -98,7 +98,7 @@ export class CreateQueryInfoState extends QueryInfoState {
   class?: Class | undefined;
 
   constructor(
-    queryStore: QueryStore,
+    queryStore: LegendQueryStore,
     project: ProjectData,
     versionId: string,
     mapping: Mapping,
@@ -150,7 +150,7 @@ export class ServiceQueryInfoState extends QueryInfoState {
   key?: string | undefined;
 
   constructor(
-    queryStore: QueryStore,
+    queryStore: LegendQueryStore,
     project: ProjectData,
     versionId: string,
     service: Service,
@@ -183,7 +183,7 @@ export class ServiceQueryInfoState extends QueryInfoState {
 export class ExistingQueryInfoState extends QueryInfoState {
   query: LightQuery;
 
-  constructor(queryStore: QueryStore, query: LightQuery) {
+  constructor(queryStore: LegendQueryStore, query: LightQuery) {
     super(queryStore);
 
     makeObservable(this, {
@@ -215,14 +215,14 @@ export class ExistingQueryInfoState extends QueryInfoState {
 }
 
 export class QueryExportState {
-  queryStore: QueryStore;
+  queryStore: LegendQueryStore;
   lambda: RawLambda;
   persistQueryState = ActionState.create();
   queryName = 'My New Query';
   allowUpdate = false;
 
   constructor(
-    queryStore: QueryStore,
+    queryStore: LegendQueryStore,
     lambda: RawLambda,
     allowUpdate: boolean,
     queryName: string | undefined,
@@ -328,11 +328,11 @@ export class QueryExportState {
   }
 }
 
-export class QueryStore {
-  applicationStore: ApplicationStore<QueryConfig>;
+export class LegendQueryStore {
+  applicationStore: ApplicationStore<LegendQueryConfig>;
   depotServerClient: DepotServerClient;
   graphManagerState: GraphManagerState;
-  pluginManager: QueryPluginManager;
+  pluginManager: LegendQueryPluginManager;
 
   queryInfoState?: QueryInfoState | undefined;
   queryBuilderState: QueryBuilderState;
@@ -343,10 +343,10 @@ export class QueryStore {
   onSaveQuery?: ((lambda: RawLambda) => Promise<void>) | undefined;
 
   constructor(
-    applicationStore: ApplicationStore<QueryConfig>,
+    applicationStore: ApplicationStore<LegendQueryConfig>,
     depotServerClient: DepotServerClient,
     graphManagerState: GraphManagerState,
-    pluginManager: QueryPluginManager,
+    pluginManager: LegendQueryPluginManager,
   ) {
     makeAutoObservable(this, {
       applicationStore: false,

--- a/packages/legend-query/src/stores/QuerySetupStore.ts
+++ b/packages/legend-query/src/stores/QuerySetupStore.ts
@@ -36,13 +36,13 @@ import type {
   Service,
 } from '@finos/legend-graph';
 import { PureSingleExecution, PureMultiExecution } from '@finos/legend-graph';
-import type { QueryStore } from './QueryStore';
+import type { LegendQueryStore } from './LegendQueryStore';
 import { ProjectData } from '@finos/legend-server-depot';
 import type { PackageableElementOption } from '@finos/legend-application';
 
 export abstract class QuerySetupState {
   setupStore: QuerySetupStore;
-  queryStore: QueryStore;
+  queryStore: LegendQueryStore;
 
   constructor(setupStore: QuerySetupStore) {
     this.setupStore = setupStore;
@@ -271,10 +271,10 @@ export class ServiceQuerySetupState extends QuerySetupState {
 }
 
 export class QuerySetupStore {
-  queryStore: QueryStore;
+  queryStore: LegendQueryStore;
   querySetupState?: QuerySetupState | undefined;
 
-  constructor(queryStore: QueryStore) {
+  constructor(queryStore: LegendQueryStore) {
     makeAutoObservable(this, {
       queryStore: false,
       setSetupState: action,

--- a/packages/legend-query/src/stores/QueryStoreTestUtils.ts
+++ b/packages/legend-query/src/stores/QueryStoreTestUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { QueryConfig } from '../application/QueryConfig';
+import { LegendQueryConfig } from '../application/LegendQueryConfig';
 import { TEST_DATA__applicationVersion } from '@finos/legend-application';
 
 export const TEST_DATA__queryConfig = {
@@ -31,8 +31,10 @@ export const TEST_DATA__queryConfig = {
   },
 };
 
-export const TEST__getTestQueryConfig = (extraConfigData = {}): QueryConfig => {
-  const config = new QueryConfig(
+export const TEST__getTestQueryConfig = (
+  extraConfigData = {},
+): LegendQueryConfig => {
+  const config = new LegendQueryConfig(
     {
       ...TEST_DATA__queryConfig,
       ...extraConfigData,

--- a/packages/legend-query/src/stores/__tests__/QueryBuilder_BuildLambdaFailure.test.tsx
+++ b/packages/legend-query/src/stores/__tests__/QueryBuilder_BuildLambdaFailure.test.tsx
@@ -29,7 +29,7 @@ import {
   TEST__buildGraphWithEntities,
   TEST__getTestGraphManagerState,
 } from '@finos/legend-graph';
-import { QueryPluginManager } from '../../application/QueryPluginManager';
+import { LegendQueryPluginManager } from '../../application/LegendQueryPluginManager';
 import { Query_GraphPreset } from '../../models/Query_GraphPreset';
 import { TEST__getTestApplicationStore } from '@finos/legend-application';
 import {
@@ -98,7 +98,7 @@ describe(
       '%s',
       async (testName, context, lambdaJson, errorMessage) => {
         const { entities } = context;
-        const pluginManager = QueryPluginManager.create();
+        const pluginManager = LegendQueryPluginManager.create();
         pluginManager.usePresets([new Query_GraphPreset()]).install();
         const applicationStore = TEST__getTestApplicationStore(
           TEST__getTestQueryConfig(),

--- a/packages/legend-query/src/stores/__tests__/QueryBuilder_BuildLambdaRoundtrip.test.tsx
+++ b/packages/legend-query/src/stores/__tests__/QueryBuilder_BuildLambdaRoundtrip.test.tsx
@@ -65,7 +65,7 @@ import {
   QueryBuilderState,
   StandardQueryBuilderMode,
 } from '../QueryBuilderState';
-import { QueryPluginManager } from '../../application/QueryPluginManager';
+import { LegendQueryPluginManager } from '../../application/LegendQueryPluginManager';
 import { Query_GraphPreset } from '../../models/Query_GraphPreset';
 import { TEST__getTestQueryConfig } from '../QueryStoreTestUtils';
 
@@ -230,7 +230,7 @@ describe(
   () => {
     test.each(cases)('%s', async (testName, context, lambda, inputLambda) => {
       const { entities } = context;
-      const pluginManager = QueryPluginManager.create();
+      const pluginManager = LegendQueryPluginManager.create();
       pluginManager.usePresets([new Query_GraphPreset()]).install();
       const applicationStore = TEST__getTestApplicationStore(
         TEST__getTestQueryConfig(),

--- a/packages/legend-query/src/stores/__tests__/QueryBuilder_ExplorerState.test.ts
+++ b/packages/legend-query/src/stores/__tests__/QueryBuilder_ExplorerState.test.ts
@@ -29,7 +29,7 @@ import {
   getPropertyNodeMappingData,
   getRootMappingData,
 } from '../../stores/QueryBuilderExplorerState';
-import { QueryPluginManager } from '../../application/QueryPluginManager';
+import { LegendQueryPluginManager } from '../../application/LegendQueryPluginManager';
 import { Query_GraphPreset } from '../../models/Query_GraphPreset';
 import { TEST__provideMockedQueryStore } from '../../components/QueryComponentTestUtils';
 import { flowResult } from 'mobx';
@@ -177,7 +177,7 @@ const transformToTestPropertyMappingData = (
 describe(integrationTest('Build property mapping data'), () => {
   test.each(cases)('%s', async (testName, testCase) => {
     const { mapping, rootClass, expectedMappingData, entities } = testCase;
-    const pluginManager = QueryPluginManager.create();
+    const pluginManager = LegendQueryPluginManager.create();
     pluginManager.usePresets([new Query_GraphPreset()]).install();
     const mockedQueryStore = TEST__provideMockedQueryStore({
       pluginManager,

--- a/packages/legend-query/src/stores/__tests__/QueryBuilder_LambdaProcessingRoundtrip.test.ts
+++ b/packages/legend-query/src/stores/__tests__/QueryBuilder_LambdaProcessingRoundtrip.test.ts
@@ -39,9 +39,9 @@ import {
   TEST__getTestGraphManagerState,
 } from '@finos/legend-graph';
 import { Query_GraphPreset } from '../../models/Query_GraphPreset';
-import { QueryPluginManager } from '../../application/QueryPluginManager';
+import { LegendQueryPluginManager } from '../../application/LegendQueryPluginManager';
 
-const pluginManager = QueryPluginManager.create();
+const pluginManager = LegendQueryPluginManager.create();
 pluginManager.usePresets([new Query_GraphPreset()]).install();
 
 type RoundtripTestCase = [
@@ -102,7 +102,7 @@ const cases: RoundtripTestCase[] = [
 describe(unitTest('Lambda processing roundtrip test'), () => {
   test.each(cases)('%s', async (testName, context, lambdaJson) => {
     const { entities } = context;
-    const pluginManager = QueryPluginManager.create();
+    const pluginManager = LegendQueryPluginManager.create();
     pluginManager.usePresets([new Query_GraphPreset()]).install();
     const graphManagerState = TEST__getTestGraphManagerState(pluginManager);
     await TEST__buildGraphWithEntities(graphManagerState, entities);

--- a/packages/legend-studio-app/.npmignore
+++ b/packages/legend-studio-app/.npmignore
@@ -4,4 +4,3 @@
 **/__tests__/**
 /*.*
 !tsconfig.json
-!tsconfig.package.json

--- a/packages/legend-studio-app/_package.config.js
+++ b/packages/legend-studio-app/_package.config.js
@@ -18,7 +18,6 @@ export default {
   publish: {
     typescript: {
       main: './tsconfig.build.json',
-      others: ['./tsconfig.package.json'],
     },
   },
 };

--- a/packages/legend-studio-app/package.json
+++ b/packages/legend-studio-app/package.json
@@ -49,7 +49,7 @@
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
     "@finos/legend-studio-extension-query-builder": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "react": "17.0.2"
   },
   "devDependencies": {

--- a/packages/legend-studio-app/src/index.tsx
+++ b/packages/legend-studio-app/src/index.tsx
@@ -15,27 +15,27 @@
  */
 
 import { LegendStudio } from '@finos/legend-studio';
-import { QueryBuilder_StudioPreset } from '@finos/legend-studio-extension-query-builder';
-import { DSLText_StudioPreset } from '@finos/legend-extension-dsl-text';
+import { QueryBuilder_LegendStudioPreset } from '@finos/legend-studio-extension-query-builder';
+import { DSLText_LegendStudioPreset } from '@finos/legend-extension-dsl-text';
 import { EFJSONSchema_GraphPreset } from '@finos/legend-extension-external-format-json-schema';
 import { BrowserConsole } from '@finos/legend-shared';
-import { DSLDiagram_StudioPreset } from '@finos/legend-extension-dsl-diagram';
-import { DSLSerializer_StudioPreset } from '@finos/legend-extension-dsl-serializer';
-import { DSLDataSpace_StudioPreset } from '@finos/legend-extension-dsl-data-space';
-import { ESService_StudioPreset } from '@finos/legend-extension-external-store-service';
+import { DSLDiagram_LegendStudioPreset } from '@finos/legend-extension-dsl-diagram';
+import { DSLSerializer_LegendStudioPreset } from '@finos/legend-extension-dsl-serializer';
+import { DSLDataSpace_LegendStudioPreset } from '@finos/legend-extension-dsl-data-space';
+import { ESService_LegendStudioPreset } from '@finos/legend-extension-external-store-service';
 
 export class LegendStudioApplication {
   static run(baseUrl: string): void {
     LegendStudio.create()
       .setup({ baseUrl })
       .withPresets([
-        new DSLText_StudioPreset(),
-        new DSLDiagram_StudioPreset(),
-        new DSLDataSpace_StudioPreset(),
+        new DSLText_LegendStudioPreset(),
+        new DSLDiagram_LegendStudioPreset(),
+        new DSLDataSpace_LegendStudioPreset(),
         new EFJSONSchema_GraphPreset(),
-        new QueryBuilder_StudioPreset(),
-        new DSLSerializer_StudioPreset(),
-        new ESService_StudioPreset(),
+        new QueryBuilder_LegendStudioPreset(),
+        new DSLSerializer_LegendStudioPreset(),
+        new ESService_LegendStudioPreset(),
       ])
       .withLoggers([new BrowserConsole()])
       .start()

--- a/packages/legend-studio-extension-management-toolkit/package.json
+++ b/packages/legend-studio-extension-management-toolkit/package.json
@@ -45,7 +45,7 @@
     "@finos/legend-server-sdlc": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "@types/react-router-dom": "5.3.2",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",

--- a/packages/legend-studio-extension-management-toolkit/src/components/Management_LegendStudioPlugin.tsx
+++ b/packages/legend-studio-extension-management-toolkit/src/components/Management_LegendStudioPlugin.tsx
@@ -16,7 +16,7 @@
 
 import packageJson from '../../package.json';
 import type {
-  StudioPluginManager,
+  LegendStudioPluginManager,
   ApplicationPageRenderEntry,
 } from '@finos/legend-studio';
 import {
@@ -25,12 +25,12 @@ import {
 } from '@finos/legend-studio';
 import { PATH_PARAM_TOKEN_REDIRECT_URL, URLRedirector } from './URLRedirector';
 
-export class Management_StudioPlugin extends LegendStudioPlugin {
+export class Management_LegendStudioPlugin extends LegendStudioPlugin {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 

--- a/packages/legend-studio-extension-management-toolkit/src/components/Management_StudioPlugin.tsx
+++ b/packages/legend-studio-extension-management-toolkit/src/components/Management_StudioPlugin.tsx
@@ -21,11 +21,11 @@ import type {
 } from '@finos/legend-studio';
 import {
   generateRoutePatternWithSDLCServerKey,
-  StudioPlugin,
+  LegendStudioPlugin,
 } from '@finos/legend-studio';
 import { PATH_PARAM_TOKEN_REDIRECT_URL, URLRedirector } from './URLRedirector';
 
-export class Management_StudioPlugin extends StudioPlugin {
+export class Management_StudioPlugin extends LegendStudioPlugin {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }

--- a/packages/legend-studio-extension-management-toolkit/src/components/URLRedirector.tsx
+++ b/packages/legend-studio-extension-management-toolkit/src/components/URLRedirector.tsx
@@ -19,7 +19,11 @@ import { observer } from 'mobx-react-lite';
 import { PanelLoadingIndicator } from '@finos/legend-art';
 import { getQueryParameters } from '@finos/legend-shared';
 import { useParams } from 'react-router-dom';
-import { useStudioStore, AppHeader, AppHeaderMenu } from '@finos/legend-studio';
+import {
+  useLegendStudioStore,
+  AppHeader,
+  AppHeaderMenu,
+} from '@finos/legend-studio';
 import { useApplicationStore } from '@finos/legend-application';
 
 const EVENT_MARKETING_LINK_ACCESS = 'Marketing link accessed';
@@ -42,7 +46,7 @@ interface RedirectPathParams {
  */
 export const URLRedirector = observer(() => {
   const applicationStore = useApplicationStore();
-  const studioStore = useStudioStore();
+  const studioStore = useLegendStudioStore();
   const params = useParams<RedirectPathParams>();
 
   useEffect(() => {

--- a/packages/legend-studio-extension-management-toolkit/src/index.ts
+++ b/packages/legend-studio-extension-management-toolkit/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './components/Management_StudioPlugin';
+export * from './components/Management_LegendStudioPlugin';

--- a/packages/legend-studio-extension-query-builder/_package.config.js
+++ b/packages/legend-studio-extension-query-builder/_package.config.js
@@ -16,6 +16,9 @@
 
 export default {
   publish: {
-    tsConfigPath: './tsconfig.build.json',
+    typescript: {
+      main: './tsconfig.build.json',
+      others: ['./tsconfig.package.json'],
+    },
   },
 };

--- a/packages/legend-studio-extension-query-builder/package.json
+++ b/packages/legend-studio-extension-query-builder/package.json
@@ -50,7 +50,7 @@
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
     "@material-ui/core": "4.12.3",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "mobx": "6.3.7",
     "mobx-react-lite": "3.2.2",
     "react": "17.0.2",

--- a/packages/legend-studio-extension-query-builder/src/QueryBuilder_LegendStudioPreset.ts
+++ b/packages/legend-studio-extension-query-builder/src/QueryBuilder_LegendStudioPreset.ts
@@ -15,18 +15,18 @@
  */
 
 import packageJson from '../package.json';
-import type { StudioPluginManager } from '@finos/legend-studio';
+import type { LegendStudioPluginManager } from '@finos/legend-studio';
 import { AbstractPreset } from '@finos/legend-shared';
-import { QueryBuilder_StudioPlugin } from './components/QueryBuilder_StudioPlugin';
+import { QueryBuilder_LegendStudioPlugin } from './components/QueryBuilder_LegendStudioPlugin';
 import { QueryBuilder_PureProtocolProcessorPlugin } from '@finos/legend-query';
 
-export class QueryBuilder_StudioPreset extends AbstractPreset {
+export class QueryBuilder_LegendStudioPreset extends AbstractPreset {
   constructor() {
     super(packageJson.extensions.studioPreset, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
-    new QueryBuilder_StudioPlugin().install(pluginManager);
+  install(pluginManager: LegendStudioPluginManager): void {
+    new QueryBuilder_LegendStudioPlugin().install(pluginManager);
     new QueryBuilder_PureProtocolProcessorPlugin().install(pluginManager);
   }
 }

--- a/packages/legend-studio-extension-query-builder/src/components/QueryBuilder_LegendStudioPlugin.tsx
+++ b/packages/legend-studio-extension-query-builder/src/components/QueryBuilder_LegendStudioPlugin.tsx
@@ -19,13 +19,13 @@ import type {
   ClassView,
   ClassViewContextMenuItemRendererConfiguration,
   DiagramEditorState,
-  DSLDiagram_StudioPlugin_Extension,
+  DSLDiagram_LegendStudioPlugin_Extension,
 } from '@finos/legend-extension-dsl-diagram';
 import type {
   EditorExtensionState,
   EditorExtensionStateCreator,
   EditorStore,
-  StudioPluginManager,
+  LegendStudioPluginManager,
   EditorExtensionComponentRendererConfiguration,
   ExplorerContextMenuItemRendererConfiguration,
   TEMP__ServiceQueryEditorActionConfiguration,
@@ -155,21 +155,21 @@ const PromoteToServiceQueryBuilderAction = observer(() => {
   );
 });
 
-export class QueryBuilder_StudioPlugin
+export class QueryBuilder_LegendStudioPlugin
   extends LegendStudioPlugin
-  implements DSLDiagram_StudioPlugin_Extension
+  implements DSLDiagram_LegendStudioPlugin_Extension
 {
   constructor() {
     super(packageJson.extensions.studioPlugin, packageJson.version);
   }
 
-  install(pluginManager: StudioPluginManager): void {
+  install(pluginManager: LegendStudioPluginManager): void {
     pluginManager.registerStudioPlugin(this);
   }
 
   override getExtraApplicationSetups(): ApplicationSetup[] {
     return [
-      async (pluginManager: StudioPluginManager): Promise<void> => {
+      async (pluginManager: LegendStudioPluginManager): Promise<void> => {
         await setupLegendQueryUILibrary();
       },
     ];

--- a/packages/legend-studio-extension-query-builder/src/components/QueryBuilder_StudioPlugin.tsx
+++ b/packages/legend-studio-extension-query-builder/src/components/QueryBuilder_StudioPlugin.tsx
@@ -39,7 +39,7 @@ import type {
 import {
   NewServiceModal,
   useEditorStore,
-  StudioPlugin,
+  LegendStudioPlugin,
 } from '@finos/legend-studio';
 import { MenuContentItem } from '@finos/legend-art';
 import { QueryBuilderDialog } from './QueryBuilderDialog';
@@ -156,7 +156,7 @@ const PromoteToServiceQueryBuilderAction = observer(() => {
 });
 
 export class QueryBuilder_StudioPlugin
-  extends StudioPlugin
+  extends LegendStudioPlugin
   implements DSLDiagram_StudioPlugin_Extension
 {
   constructor() {

--- a/packages/legend-studio-extension-query-builder/src/components/__tests__/QueryBuilder_StudioPlugin.test.tsx
+++ b/packages/legend-studio-extension-query-builder/src/components/__tests__/QueryBuilder_StudioPlugin.test.tsx
@@ -23,7 +23,7 @@ import {
 import { waitFor } from '@testing-library/dom';
 import type { EditorStore } from '@finos/legend-studio';
 import {
-  StudioPluginManager,
+  LegendStudioPluginManager,
   STUDIO_TEST_ID,
   TEST__openElementFromExplorerTree,
   TEST__getTestStudioConfig,
@@ -32,13 +32,13 @@ import {
 } from '@finos/legend-studio';
 import { QUERY_BUILDER_TEST_ID } from '@finos/legend-query';
 import { TEST__provideMockedGraphManagerState } from '@finos/legend-graph';
-import { QueryBuilder_StudioPreset } from '../../QueryBuilder_StudioPreset';
+import { QueryBuilder_LegendStudioPreset } from '../../QueryBuilder_LegendStudioPreset';
 import { TEST__provideMockedApplicationStore } from '@finos/legend-application';
 import { MockedMonacoEditorInstance } from '@finos/legend-art';
 
 const TEST__buildQueryBuilderMockedEditorStore = (): EditorStore => {
-  const pluginManager = StudioPluginManager.create();
-  pluginManager.usePresets([new QueryBuilder_StudioPreset()]).install();
+  const pluginManager = LegendStudioPluginManager.create();
+  pluginManager.usePresets([new QueryBuilder_LegendStudioPreset()]).install();
 
   return TEST__provideMockedEditorStore({
     applicationStore: TEST__provideMockedApplicationStore(

--- a/packages/legend-studio-extension-query-builder/src/index.ts
+++ b/packages/legend-studio-extension-query-builder/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './QueryBuilder_StudioPreset';
+export * from './QueryBuilder_LegendStudioPreset';

--- a/packages/legend-studio/.npmignore
+++ b/packages/legend-studio/.npmignore
@@ -4,4 +4,3 @@
 **/__tests__/**
 /*.*
 !tsconfig.json
-!tsconfig.package.json

--- a/packages/legend-studio/_package.config.js
+++ b/packages/legend-studio/_package.config.js
@@ -18,7 +18,6 @@ export default {
   publish: {
     typescript: {
       main: './tsconfig.build.json',
-      others: ['./tsconfig.package.json'],
     },
   },
 };

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -47,7 +47,7 @@
     "@finos/legend-shared": "workspace:*",
     "@material-ui/core": "4.12.3",
     "@testing-library/react": "12.1.2",
-    "@types/react": "17.0.34",
+    "@types/react": "17.0.35",
     "@types/react-dom": "17.0.11",
     "@types/react-router-dom": "5.3.2",
     "date-fns": "2.25.0",

--- a/packages/legend-studio/src/application/LegendStudio.tsx
+++ b/packages/legend-studio/src/application/LegendStudio.tsx
@@ -18,7 +18,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { configure as configureReactHotkeys } from 'react-hotkeys';
 import { LegendStudioApplication } from '../components/LegendStudioApplication';
-import { StudioPluginManager } from './StudioPluginManager';
+import { LegendStudioPluginManager } from './LegendStudioPluginManager';
 import type {
   LegendApplicationConfig,
   LegendApplicationVersionData,
@@ -31,11 +31,11 @@ import {
 import type { Log } from '@finos/legend-shared';
 import { CorePureGraphManagerPlugin } from '@finos/legend-graph';
 import { getRootElement } from '@finos/legend-art';
-import type { StudioConfigurationData } from './StudioConfig';
-import { StudioConfig } from './StudioConfig';
+import type { LegendStudioConfigurationData } from './LegendStudioConfig';
+import { LegendStudioConfig } from './LegendStudioConfig';
 
 const setupLegendStudioUILibrary = async (
-  pluginManager: StudioPluginManager,
+  pluginManager: LegendStudioPluginManager,
   log: Log,
 ): Promise<void> => {
   await setupLegendApplicationUILibrary(pluginManager, log);
@@ -56,21 +56,21 @@ const setupLegendStudioUILibrary = async (
 };
 
 export class LegendStudio extends LegendApplication {
-  declare config: StudioConfig;
-  declare pluginManager: StudioPluginManager;
+  declare config: LegendStudioConfig;
+  declare pluginManager: LegendStudioPluginManager;
 
   static create(): LegendStudio {
-    const application = new LegendStudio(StudioPluginManager.create());
+    const application = new LegendStudio(LegendStudioPluginManager.create());
     application.withBasePlugins([new CorePureGraphManagerPlugin()]);
     return application;
   }
 
   async configureApplication(
-    configData: StudioConfigurationData,
+    configData: LegendStudioConfigurationData,
     versionData: LegendApplicationVersionData,
     baseUrl: string,
   ): Promise<LegendApplicationConfig> {
-    return new StudioConfig(configData, versionData, baseUrl);
+    return new LegendStudioConfig(configData, versionData, baseUrl);
   }
 
   async loadApplication(): Promise<void> {

--- a/packages/legend-studio/src/application/LegendStudioConfig.ts
+++ b/packages/legend-studio/src/application/LegendStudioConfig.ts
@@ -150,7 +150,7 @@ export class SDLCServerOption {
   );
 }
 
-export interface StudioConfigurationData
+export interface LegendStudioConfigurationData
   extends LegendApplicationConfigurationData {
   appName: string;
   env: string;
@@ -160,7 +160,7 @@ export interface StudioConfigurationData
   documentation: { url: string };
 }
 
-export class StudioConfig extends LegendApplicationConfig {
+export class LegendStudioConfig extends LegendApplicationConfig {
   readonly options = new ApplicationCoreOptions();
 
   readonly documentationUrl: string;
@@ -171,7 +171,7 @@ export class StudioConfig extends LegendApplicationConfig {
   readonly depotServerUrl: string;
 
   constructor(
-    configData: StudioConfigurationData,
+    configData: LegendStudioConfigurationData,
     versionData: LegendApplicationVersionData,
     baseUrl: string,
   ) {

--- a/packages/legend-studio/src/application/LegendStudioPluginManager.ts
+++ b/packages/legend-studio/src/application/LegendStudioPluginManager.ts
@@ -29,7 +29,7 @@ import type {
 import { AbstractPluginManager } from '@finos/legend-shared';
 import type { LegendStudioPlugin } from '../stores/LegendStudioPlugin';
 
-export class StudioPluginManager
+export class LegendStudioPluginManager
   extends AbstractPluginManager
   implements
     GraphPluginManager,
@@ -47,8 +47,8 @@ export class StudioPluginManager
     super();
   }
 
-  static create(): StudioPluginManager {
-    return new StudioPluginManager();
+  static create(): LegendStudioPluginManager {
+    return new LegendStudioPluginManager();
   }
 
   registerTelemetryServicePlugin(plugin: TelemetryServicePlugin): void {

--- a/packages/legend-studio/src/application/StudioPluginManager.ts
+++ b/packages/legend-studio/src/application/StudioPluginManager.ts
@@ -27,7 +27,7 @@ import type {
   TracerServicePluginManager,
 } from '@finos/legend-shared';
 import { AbstractPluginManager } from '@finos/legend-shared';
-import type { StudioPlugin } from '../stores/StudioPlugin';
+import type { LegendStudioPlugin } from '../stores/LegendStudioPlugin';
 
 export class StudioPluginManager
   extends AbstractPluginManager
@@ -41,7 +41,7 @@ export class StudioPluginManager
   private pureProtocolProcessorPlugins: PureProtocolProcessorPlugin[] = [];
   private pureGraphManagerPlugins: PureGraphManagerPlugin[] = [];
   private pureGraphPlugins: PureGraphPlugin[] = [];
-  private studioPlugins: StudioPlugin[] = [];
+  private studioPlugins: LegendStudioPlugin[] = [];
 
   private constructor() {
     super();
@@ -73,7 +73,7 @@ export class StudioPluginManager
     this.pureGraphPlugins.push(plugin);
   }
 
-  registerStudioPlugin(plugin: StudioPlugin): void {
+  registerStudioPlugin(plugin: LegendStudioPlugin): void {
     this.studioPlugins.push(plugin);
   }
 
@@ -97,7 +97,7 @@ export class StudioPluginManager
     return [...this.pureGraphPlugins];
   }
 
-  getStudioPlugins(): StudioPlugin[] {
+  getStudioPlugins(): LegendStudioPlugin[] {
     return [...this.studioPlugins];
   }
 }

--- a/packages/legend-studio/src/components/EditorComponentTestUtils.tsx
+++ b/packages/legend-studio/src/components/EditorComponentTestUtils.tsx
@@ -27,7 +27,7 @@ import {
   MOBX__disableSpyOrMock,
   MOBX__enableSpyOrMock,
 } from '@finos/legend-shared';
-import { StudioPluginManager } from '../application/StudioPluginManager';
+import { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
 import type { Entity } from '@finos/legend-model-storage';
 import type {
   Project,
@@ -64,7 +64,7 @@ import {
   TEST__DepotServerClientProvider,
   TEST__getTestDepotServerClient,
 } from '@finos/legend-server-depot';
-import { StudioStoreProvider } from './StudioStoreProvider';
+import { LegendStudioStoreProvider } from './LegendStudioStoreProvider';
 import type { ApplicationStore } from '@finos/legend-application';
 import {
   TEST__ApplicationStoreProvider,
@@ -72,7 +72,7 @@ import {
   WebApplicationNavigator,
 } from '@finos/legend-application';
 import { TEST__getTestStudioConfig } from '../stores/EditorStoreTestUtils';
-import type { StudioConfig } from '../application/StudioConfig';
+import type { LegendStudioConfig } from '../application/LegendStudioConfig';
 
 export const TEST_DATA__DefaultSDLCInfo = {
   project: {
@@ -141,23 +141,23 @@ export const TEST_DATA__DefaultSDLCInfo = {
   ],
 };
 
-export const TEST__StudioStoreProvider = ({
+export const TEST__LegendStudioStoreProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }): React.ReactElement => (
-  <StudioStoreProvider pluginManager={StudioPluginManager.create()}>
+  <LegendStudioStoreProvider pluginManager={LegendStudioPluginManager.create()}>
     {children}
-  </StudioStoreProvider>
+  </LegendStudioStoreProvider>
 );
 
 export const TEST__provideMockedEditorStore = (customization?: {
   mock?: EditorStore;
-  applicationStore?: ApplicationStore<StudioConfig>;
+  applicationStore?: ApplicationStore<LegendStudioConfig>;
   sdlcServerClient?: SDLCServerClient;
   depotServerClient?: DepotServerClient;
   graphManagerState?: GraphManagerState;
-  pluginManager?: StudioPluginManager;
+  pluginManager?: LegendStudioPluginManager;
 }): EditorStore => {
   const value =
     customization?.mock ??
@@ -168,7 +168,7 @@ export const TEST__provideMockedEditorStore = (customization?: {
       customization?.depotServerClient ?? TEST__getTestDepotServerClient(),
       customization?.graphManagerState ??
         TEST__getTestGraphManagerState(customization?.pluginManager),
-      customization?.pluginManager ?? StudioPluginManager.create(),
+      customization?.pluginManager ?? LegendStudioPluginManager.create(),
     );
   const MockedEditorStoreProvider = require('./editor/EditorStoreProvider'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
   MockedEditorStoreProvider.useEditorStore = jest.fn();
@@ -350,9 +350,9 @@ export const TEST__setUpEditor = async (
         <TEST__SDLCServerClientProvider>
           <TEST__DepotServerClientProvider>
             <TEST__GraphManagerStateProvider>
-              <TEST__StudioStoreProvider>
+              <TEST__LegendStudioStoreProvider>
                 <Editor />
-              </TEST__StudioStoreProvider>
+              </TEST__LegendStudioStoreProvider>
             </TEST__GraphManagerStateProvider>
           </TEST__DepotServerClientProvider>
         </TEST__SDLCServerClientProvider>

--- a/packages/legend-studio/src/components/LegendStudioApplication.tsx
+++ b/packages/legend-studio/src/components/LegendStudioApplication.tsx
@@ -35,12 +35,15 @@ import {
 import { AppHeader } from './shared/AppHeader';
 import { AppHeaderMenu } from './editor/header/AppHeaderMenu';
 import { ThemeProvider } from '@material-ui/core/styles';
-import type { StudioPluginManager } from '../application/StudioPluginManager';
+import type { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
 import type { Log } from '@finos/legend-shared';
 import { flowResult } from 'mobx';
 import { SDLCServerClientProvider } from '@finos/legend-server-sdlc';
 import { DepotServerClientProvider } from '@finos/legend-server-depot';
-import { StudioStoreProvider, useStudioStore } from './StudioStoreProvider';
+import {
+  LegendStudioStoreProvider,
+  useLegendStudioStore,
+} from './LegendStudioStoreProvider';
 import { GraphManagerStateProvider } from '@finos/legend-graph';
 import {
   ActionAlert,
@@ -50,11 +53,11 @@ import {
   useApplicationStore,
   useWebApplicationNavigator,
 } from '@finos/legend-application';
-import type { StudioConfig } from '../application/StudioConfig';
+import type { LegendStudioConfig } from '../application/LegendStudioConfig';
 
 export const LegendStudioApplicationRoot = observer(() => {
-  const studioStore = useStudioStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const studioStore = useLegendStudioStore();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const extraApplicationPageRenderEntries = studioStore.pluginManager
     .getStudioPlugins()
     .flatMap((plugin) => plugin.getExtraApplicationPageRenderEntries?.() ?? []);
@@ -139,8 +142,8 @@ export const LegendStudioApplicationRoot = observer(() => {
 
 export const LegendStudioApplication = observer(
   (props: {
-    config: StudioConfig;
-    pluginManager: StudioPluginManager;
+    config: LegendStudioConfig;
+    pluginManager: LegendStudioPluginManager;
     log: Log;
   }) => {
     const { config, pluginManager, log } = props;
@@ -205,11 +208,11 @@ export const LegendStudioApplication = observer(
             }}
           >
             <GraphManagerStateProvider pluginManager={pluginManager} log={log}>
-              <StudioStoreProvider pluginManager={pluginManager}>
+              <LegendStudioStoreProvider pluginManager={pluginManager}>
                 <ThemeProvider theme={LegendMaterialUITheme}>
                   <LegendStudioApplicationRoot />
                 </ThemeProvider>
-              </StudioStoreProvider>
+              </LegendStudioStoreProvider>
             </GraphManagerStateProvider>
           </DepotServerClientProvider>
         </SDLCServerClientProvider>

--- a/packages/legend-studio/src/components/LegendStudioStoreProvider.tsx
+++ b/packages/legend-studio/src/components/LegendStudioStoreProvider.tsx
@@ -18,27 +18,29 @@ import { createContext, useContext } from 'react';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { useSDLCServerClient } from '@finos/legend-server-sdlc';
 import { useDepotServerClient } from '@finos/legend-server-depot';
-import { StudioStore } from '../stores/StudioStore';
-import type { StudioPluginManager } from '../application/StudioPluginManager';
+import { LegendStudioStore } from '../stores/StudioStore';
+import type { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
 import { useLocalObservable } from 'mobx-react-lite';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../application/StudioConfig';
+import type { LegendStudioConfig } from '../application/LegendStudioConfig';
 
-const StudioStoreContext = createContext<StudioStore | undefined>(undefined);
+const LegendStudioStoreContext = createContext<LegendStudioStore | undefined>(
+  undefined,
+);
 
-export const StudioStoreProvider = ({
+export const LegendStudioStoreProvider = ({
   pluginManager,
   children,
 }: {
-  pluginManager: StudioPluginManager;
+  pluginManager: LegendStudioPluginManager;
   children: React.ReactNode;
 }): React.ReactElement => {
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcServerClient = useSDLCServerClient();
   const depotServerClient = useDepotServerClient();
   const studioStore = useLocalObservable(
     () =>
-      new StudioStore(
+      new LegendStudioStore(
         applicationStore,
         sdlcServerClient,
         depotServerClient,
@@ -46,14 +48,14 @@ export const StudioStoreProvider = ({
       ),
   );
   return (
-    <StudioStoreContext.Provider value={studioStore}>
+    <LegendStudioStoreContext.Provider value={studioStore}>
       {children}
-    </StudioStoreContext.Provider>
+    </LegendStudioStoreContext.Provider>
   );
 };
 
-export const useStudioStore = (): StudioStore =>
+export const useLegendStudioStore = (): LegendStudioStore =>
   guaranteeNonNullable(
-    useContext(StudioStoreContext),
-    `Can't find Studio store in context`,
+    useContext(LegendStudioStoreContext),
+    `Can't find Legend Studio store in context`,
   );

--- a/packages/legend-studio/src/components/__tests__/LegendStudioApplication.test.tsx
+++ b/packages/legend-studio/src/components/__tests__/LegendStudioApplication.test.tsx
@@ -26,7 +26,7 @@ import {
   TEST__provideMockedApplicationStore,
   TEST__ApplicationStoreProvider,
 } from '@finos/legend-application';
-import { TEST__StudioStoreProvider } from '../EditorComponentTestUtils';
+import { TEST__LegendStudioStoreProvider } from '../EditorComponentTestUtils';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
@@ -57,9 +57,9 @@ test(integrationTest('App header is displayed properly'), async () => {
       <TEST__ApplicationStoreProvider config={TEST__getTestStudioConfig()}>
         <TEST__SDLCServerClientProvider>
           <TEST__DepotServerClientProvider>
-            <TEST__StudioStoreProvider>
+            <TEST__LegendStudioStoreProvider>
               <LegendStudioApplicationRoot />
-            </TEST__StudioStoreProvider>
+            </TEST__LegendStudioStoreProvider>
           </TEST__DepotServerClientProvider>
         </TEST__SDLCServerClientProvider>
       </TEST__ApplicationStoreProvider>
@@ -96,9 +96,9 @@ test(integrationTest('Failed to authorize SDLC will redirect'), async () => {
       <TEST__ApplicationStoreProvider config={TEST__getTestStudioConfig()}>
         <TEST__SDLCServerClientProvider>
           <TEST__DepotServerClientProvider>
-            <TEST__StudioStoreProvider>
+            <TEST__LegendStudioStoreProvider>
               <LegendStudioApplicationRoot />
-            </TEST__StudioStoreProvider>
+            </TEST__LegendStudioStoreProvider>
           </TEST__DepotServerClientProvider>
         </TEST__SDLCServerClientProvider>
       </TEST__ApplicationStoreProvider>
@@ -136,9 +136,9 @@ test(
         <TEST__ApplicationStoreProvider config={TEST__getTestStudioConfig()}>
           <TEST__SDLCServerClientProvider>
             <TEST__DepotServerClientProvider>
-              <TEST__StudioStoreProvider>
+              <TEST__LegendStudioStoreProvider>
                 <LegendStudioApplicationRoot />
-              </TEST__StudioStoreProvider>
+              </TEST__LegendStudioStoreProvider>
             </TEST__DepotServerClientProvider>
           </TEST__SDLCServerClientProvider>
         </TEST__ApplicationStoreProvider>

--- a/packages/legend-studio/src/components/__tests__/MultiSDLCServerConfiguration.test.tsx
+++ b/packages/legend-studio/src/components/__tests__/MultiSDLCServerConfiguration.test.tsx
@@ -38,14 +38,14 @@ import {
   updateRouteWithNewSDLCServerOption,
 } from '../../stores/LegendStudioRouter';
 import { TEST__provideMockedSDLCServerClient } from '@finos/legend-server-sdlc';
-import { StudioPluginManager } from '../../application/StudioPluginManager';
+import { LegendStudioPluginManager } from '../../application/LegendStudioPluginManager';
 import { TEST_DATA__studioConfig } from '../../stores/EditorStoreTestUtils';
-import { StudioConfig } from '../../application/StudioConfig';
+import { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const getTestStudioConfigWithMultiSDLCServer = (
   extraConfigData = {},
-): StudioConfig =>
-  new StudioConfig(
+): LegendStudioConfig =>
+  new LegendStudioConfig(
     {
       ...TEST_DATA__studioConfig,
       ...extraConfigData,
@@ -104,7 +104,7 @@ test(
           <CaptureNavigator />
           <LegendStudioApplication
             config={config}
-            pluginManager={StudioPluginManager.create()}
+            pluginManager={LegendStudioPluginManager.create()}
             log={new Log()}
           />
         </WebApplicationNavigatorProvider>
@@ -158,7 +158,7 @@ test(integrationTest('SDLC server can be specified via URL'), async () => {
       <WebApplicationNavigatorProvider>
         <LegendStudioApplication
           config={config}
-          pluginManager={StudioPluginManager.create()}
+          pluginManager={LegendStudioPluginManager.create()}
           log={new Log()}
         />
       </WebApplicationNavigatorProvider>
@@ -201,7 +201,7 @@ test(
           <CaptureNavigator />
           <LegendStudioApplication
             config={config}
-            pluginManager={StudioPluginManager.create()}
+            pluginManager={LegendStudioPluginManager.create()}
             log={new Log()}
           />
         </WebApplicationNavigatorProvider>
@@ -244,7 +244,7 @@ test(
           <CaptureNavigator />
           <LegendStudioApplication
             config={config}
-            pluginManager={StudioPluginManager.create()}
+            pluginManager={LegendStudioPluginManager.create()}
             log={new Log()}
           />
         </WebApplicationNavigatorProvider>
@@ -265,7 +265,7 @@ test(
 );
 
 test(unitTest('Route update with SDLC server option changes'), async () => {
-  const config = new StudioConfig(
+  const config = new LegendStudioConfig(
     {
       ...TEST_DATA__studioConfig,
       ...{

--- a/packages/legend-studio/src/components/editor/EditorStoreProvider.tsx
+++ b/packages/legend-studio/src/components/editor/EditorStoreProvider.tsx
@@ -21,9 +21,9 @@ import { useApplicationStore } from '@finos/legend-application';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { useSDLCServerClient } from '@finos/legend-server-sdlc';
 import { useDepotServerClient } from '@finos/legend-server-depot';
-import { useStudioStore } from '../StudioStoreProvider';
+import { useLegendStudioStore } from '../LegendStudioStoreProvider';
 import { useGraphManagerState } from '@finos/legend-graph';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const EditorStoreContext = createContext<EditorStore | undefined>(undefined);
 
@@ -32,11 +32,11 @@ export const EditorStoreProvider = ({
 }: {
   children: React.ReactNode;
 }): React.ReactElement => {
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcServerClient = useSDLCServerClient();
   const depotServerClient = useDepotServerClient();
   const graphManagerState = useGraphManagerState();
-  const studioStore = useStudioStore();
+  const studioStore = useLegendStudioStore();
   const store = useLocalObservable(
     () =>
       new EditorStore(

--- a/packages/legend-studio/src/components/editor/StatusBar.tsx
+++ b/packages/legend-studio/src/components/editor/StatusBar.tsx
@@ -36,14 +36,14 @@ import { generateSetupRoute } from '../../stores/LegendStudioRouter';
 import { flowResult } from 'mobx';
 import { useEditorStore } from './EditorStoreProvider';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 import { WorkspaceType } from '@finos/legend-server-sdlc';
 
 export const StatusBar = observer((props: { actionsDisabled: boolean }) => {
   const { actionsDisabled } = props;
   const params = useParams<EditorPathParams | GroupEditorPathParams>();
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const isInConflictResolutionMode = editorStore.isInConflictResolutionMode;
   // SDLC
   const projectId = params.projectId;

--- a/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
@@ -64,7 +64,7 @@ import { GenerationSpecificationEditorState } from '../../../stores/editor-state
 import { GenerationSpecificationEditor } from './GenerationSpecificationEditor';
 import { FileGenerationViewerState } from '../../../stores/editor-state/FileGenerationViewerState';
 import { FileGenerationViewer } from '../../editor/edit-panel/FileGenerationViewer';
-import type { DSL_StudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
 import { useEditorStore } from '../EditorStoreProvider';
 
 export const ViewerEditPanelSplashScreen: React.FC = () => {
@@ -278,7 +278,7 @@ export const EditPanel = observer(() => {
             .flatMap(
               (plugin) =>
                 (
-                  plugin as DSL_StudioPlugin_Extension
+                  plugin as DSL_LegendStudioPlugin_Extension
                 ).getExtraElementEditorRenderers?.() ?? [],
             );
           for (const elementEditorCreators of extraElementEditorCreators) {

--- a/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/EditPanel.tsx
@@ -64,7 +64,7 @@ import { GenerationSpecificationEditorState } from '../../../stores/editor-state
 import { GenerationSpecificationEditor } from './GenerationSpecificationEditor';
 import { FileGenerationViewerState } from '../../../stores/editor-state/FileGenerationViewerState';
 import { FileGenerationViewer } from '../../editor/edit-panel/FileGenerationViewer';
-import type { DSL_StudioPlugin_Extension } from '../../../stores/StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
 import { useEditorStore } from '../EditorStoreProvider';
 
 export const ViewerEditPanelSplashScreen: React.FC = () => {

--- a/packages/legend-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
@@ -46,7 +46,7 @@ import { CORE_DND_TYPE } from '../../../stores/shared/DnDUtil';
 import type { PackageableElementOption } from '../../../stores/shared/PackageableElementOptionUtil';
 import { buildElementOption } from '../../../stores/shared/PackageableElementOptionUtil';
 import { getNullableFirstElement } from '@finos/legend-shared';
-import type { DSLGenerationSpecification_StudioPlugin_Extension } from '../../../stores/DSLGenerationSpecification_StudioPlugin_Extension';
+import type { DSLGenerationSpecification_LegendStudioPlugin_Extension } from '../../../stores/DSLGenerationSpecification_LegendStudioPlugin_Extension';
 import { flowResult } from 'mobx';
 import { useEditorStore } from '../EditorStoreProvider';
 import type {
@@ -270,7 +270,7 @@ const ModelGenerationSpecifications = observer(
         .flatMap(
           (plugin) =>
             (
-              plugin as DSLGenerationSpecification_StudioPlugin_Extension
+              plugin as DSLGenerationSpecification_LegendStudioPlugin_Extension
             ).getExtraModelGenerationSpecificationElementDnDTypes?.() ?? [],
         );
     const modelGenerationElementOptions =

--- a/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
@@ -43,7 +43,7 @@ import type { ElementDragSource } from '../../../stores/shared/DnDUtil';
 import { CORE_DND_TYPE } from '../../../stores/shared/DnDUtil';
 import type { DropTargetMonitor } from 'react-dnd';
 import { useDrop } from 'react-dnd';
-import type { DSL_StudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
 import { flowResult } from 'mobx';
 import { useEditorStore } from '../EditorStoreProvider';
 import { guaranteeNonNullable } from '@finos/legend-shared';
@@ -140,7 +140,7 @@ export const GrammarTextEditor = observer(() => {
     .flatMap(
       (plugin) =>
         (
-          plugin as DSL_StudioPlugin_Extension
+          plugin as DSL_LegendStudioPlugin_Extension
         ).getExtraGrammarTextEditorDnDTypes?.() ?? [],
     );
   const handleDrop = useCallback(

--- a/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
@@ -43,7 +43,7 @@ import type { ElementDragSource } from '../../../stores/shared/DnDUtil';
 import { CORE_DND_TYPE } from '../../../stores/shared/DnDUtil';
 import type { DropTargetMonitor } from 'react-dnd';
 import { useDrop } from 'react-dnd';
-import type { DSL_StudioPlugin_Extension } from '../../../stores/StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
 import { flowResult } from 'mobx';
 import { useEditorStore } from '../EditorStoreProvider';
 import { guaranteeNonNullable } from '@finos/legend-shared';

--- a/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
@@ -93,7 +93,7 @@ import {
   PackageableElementExplicitReference,
 } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../stores/DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../stores/DSLMapping_LegendStudioPlugin_Extension';
 
 const getConnectionTooltipText = (
   connection: Connection,
@@ -117,7 +117,7 @@ const getConnectionTooltipText = (
     .flatMap(
       (plugin) =>
         (
-          plugin as DSLMapping_StudioPlugin_Extension
+          plugin as DSLMapping_LegendStudioPlugin_Extension
         ).getExtraRuntimeConnectionTooltipTextBuilders?.() ?? [],
     );
   for (const builder of extraConnectionToolTipTexts) {

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/ConnectionEditor.tsx
@@ -29,7 +29,7 @@ import type { Class } from '@finos/legend-graph';
 import { FaLock } from 'react-icons/fa';
 import { CustomSelectorInput } from '@finos/legend-art';
 import { useEditorStore } from '../../EditorStoreProvider';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../../stores/DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../../stores/DSLMapping_LegendStudioPlugin_Extension';
 
 const ModelConnectionEditor = observer(
   (props: {
@@ -135,7 +135,7 @@ export const ConnectionEditor = observer(
         const extraConnectionEditorRenderers = plugins.flatMap(
           (plugin) =>
             (
-              plugin as DSLMapping_StudioPlugin_Extension
+              plugin as DSLMapping_LegendStudioPlugin_Extension
             ).getExtraConnectionEditorRenderers?.() ?? [],
         );
         for (const editorRenderer of extraConnectionEditorRenderers) {

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor.tsx
@@ -53,7 +53,7 @@ import {
 import { runInAction } from 'mobx';
 import { buildElementOption } from '../../../../stores/shared/PackageableElementOptionUtil';
 import type { PackageableElementOption } from '../../../../stores/shared/PackageableElementOptionUtil';
-import type { StudioPlugin } from '../../../../stores/StudioPlugin';
+import type { LegendStudioPlugin } from '../../../../stores/LegendStudioPlugin';
 import type { StoreRelational_StudioPlugin_Extension } from '../../../../stores/StoreRelational_StudioPlugin_Extension';
 import { DatabaseBuilder } from './DatabaseBuilder';
 import { useEditorStore } from '../../EditorStoreProvider';
@@ -839,7 +839,7 @@ const RelationalConnectionStoreEditor = observer(
 const renderDatasourceSpecificationEditor = (
   connection: RelationalDatabaseConnection,
   isReadOnly: boolean,
-  plugins: StudioPlugin[],
+  plugins: LegendStudioPlugin[],
 ): React.ReactNode => {
   const sourceSpec = connection.datasourceSpecification;
   if (sourceSpec instanceof StaticDatasourceSpecification) {
@@ -905,7 +905,7 @@ const renderDatasourceSpecificationEditor = (
 const renderAuthenticationStrategyEditor = (
   connection: RelationalDatabaseConnection,
   isReadOnly: boolean,
-  plugins: StudioPlugin[],
+  plugins: LegendStudioPlugin[],
 ): React.ReactNode => {
   const authSpec = connection.authenticationStrategy;
   if (authSpec instanceof DelegatedKerberosAuthenticationStrategy) {

--- a/packages/legend-studio/src/components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor.tsx
@@ -54,7 +54,7 @@ import { runInAction } from 'mobx';
 import { buildElementOption } from '../../../../stores/shared/PackageableElementOptionUtil';
 import type { PackageableElementOption } from '../../../../stores/shared/PackageableElementOptionUtil';
 import type { LegendStudioPlugin } from '../../../../stores/LegendStudioPlugin';
-import type { StoreRelational_StudioPlugin_Extension } from '../../../../stores/StoreRelational_StudioPlugin_Extension';
+import type { StoreRelational_LegendStudioPlugin_Extension } from '../../../../stores/StoreRelational_LegendStudioPlugin_Extension';
 import { DatabaseBuilder } from './DatabaseBuilder';
 import { useEditorStore } from '../../EditorStoreProvider';
 import { EDITOR_LANGUAGE } from '@finos/legend-application';
@@ -888,7 +888,7 @@ const renderDatasourceSpecificationEditor = (
     const extraDatasourceSpecificationEditorRenderers = plugins.flatMap(
       (plugin) =>
         (
-          plugin as StoreRelational_StudioPlugin_Extension
+          plugin as StoreRelational_LegendStudioPlugin_Extension
         ).getExtraDatasourceSpecificationEditorRenderers?.() ?? [],
     );
     for (const editorRenderer of extraDatasourceSpecificationEditorRenderers) {
@@ -940,7 +940,7 @@ const renderAuthenticationStrategyEditor = (
     const extraAuthenticationStrategyEditorRenderers = plugins.flatMap(
       (plugin) =>
         (
-          plugin as StoreRelational_StudioPlugin_Extension
+          plugin as StoreRelational_LegendStudioPlugin_Extension
         ).getExtraAuthenticationStrategyEditorRenderers?.() ?? [],
     );
     for (const editorRenderer of extraAuthenticationStrategyEditorRenderers) {
@@ -986,7 +986,7 @@ const RelationalConnectionGeneralEditor = observer(
         plugins.flatMap(
           (plugin) =>
             (
-              plugin as StoreRelational_StudioPlugin_Extension
+              plugin as StoreRelational_LegendStudioPlugin_Extension
             ).getExtraDatasourceSpecificationTypes?.() ?? [],
         ),
       )
@@ -1014,7 +1014,7 @@ const RelationalConnectionGeneralEditor = observer(
         plugins.flatMap(
           (plugin) =>
             (
-              plugin as StoreRelational_StudioPlugin_Extension
+              plugin as StoreRelational_LegendStudioPlugin_Extension
             ).getExtraAuthenticationStrategyTypes?.() ?? [],
         ),
       )

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExecutionBuilder.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExecutionBuilder.tsx
@@ -73,7 +73,7 @@ import {
   RelationalInputType,
 } from '@finos/legend-graph';
 import { StudioTextInputEditor } from '../../../shared/StudioTextInputEditor';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../../stores/DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../../stores/DSLMapping_LegendStudioPlugin_Extension';
 
 interface ClassMappingSelectOption {
   label: string;
@@ -172,7 +172,7 @@ const MappingExecutionQueryEditor = observer(
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraMappingExecutionQueryEditorActionConfigurations?.() ?? [],
       )
       .filter(isNonNullable)

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestEditor.tsx
@@ -79,7 +79,7 @@ import {
   RelationalInputType,
 } from '@finos/legend-graph';
 import { StudioTextInputEditor } from '../../../shared/StudioTextInputEditor';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../../stores/DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../../stores/DSLMapping_LegendStudioPlugin_Extension';
 
 const MappingTestQueryEditor = observer(
   (props: { testState: MappingTestState; isReadOnly: boolean }) => {
@@ -93,7 +93,7 @@ const MappingTestQueryEditor = observer(
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraMappingTestQueryEditorActionConfigurations?.() ?? [],
       )
       .filter(isNonNullable)

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceEditor.tsx
@@ -38,7 +38,7 @@ import { ServiceRegistrationModalEditor } from '../../../editor/edit-panel/servi
 import { useEditorStore } from '../../EditorStoreProvider';
 import { useApplicationStore } from '@finos/legend-application';
 import { validateServicePattern } from '@finos/legend-graph';
-import type { StudioConfig } from '../../../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../../../application/LegendStudioConfig';
 
 const ServiceGeneralEditor = observer(() => {
   const editorStore = useEditorStore();
@@ -389,7 +389,7 @@ const ServiceGeneralEditor = observer(() => {
 
 export const ServiceEditor = observer(() => {
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const serviceState = editorStore.getCurrentEditorState(ServiceEditorState);
   const service = serviceState.service;
   const isReadOnly = serviceState.isReadOnly;

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionQueryEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionQueryEditor.tsx
@@ -41,7 +41,7 @@ import {
 } from '@finos/legend-application';
 import { StudioTextInputEditor } from '../../../shared/StudioTextInputEditor';
 import type { LightQuery } from '@finos/legend-graph';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../../stores/DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../../stores/DSLMapping_LegendStudioPlugin_Extension';
 
 const ServiceExecutionResultViewer = observer(
   (props: { executionState: ServicePureExecutionState }) => {
@@ -234,7 +234,7 @@ export const ServiceExecutionQueryEditor = observer(
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).TEMP__getExtraServiceQueryEditorActionConfigurations?.() ?? [],
       )
       .filter(isNonNullable)

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -81,7 +81,7 @@ import {
 import { StudioLambdaEditor } from '../../../shared/StudioLambdaEditor';
 import { useApplicationStore } from '@finos/legend-application';
 import { getElementIcon } from '../../../shared/ElementIconUtils';
-import type { ClassPreviewRenderer } from '../../../../stores/StudioPlugin';
+import type { ClassPreviewRenderer } from '../../../../stores/LegendStudioPlugin';
 
 const PropertyBasicEditor = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/header/AppHeaderMenu.tsx
+++ b/packages/legend-studio/src/components/editor/header/AppHeaderMenu.tsx
@@ -28,8 +28,8 @@ import Dialog from '@material-ui/core/Dialog';
 import { useApplicationStore } from '@finos/legend-application';
 import type {
   SDLCServerOption,
-  StudioConfig,
-} from '../../../application/StudioConfig';
+  LegendStudioConfig,
+} from '../../../application/LegendStudioConfig';
 import { updateRouteWithNewSDLCServerOption } from '../../../stores/LegendStudioRouter';
 
 const AboutModal: React.FC<{
@@ -37,7 +37,7 @@ const AboutModal: React.FC<{
   closeModal: () => void;
 }> = (props) => {
   const { open, closeModal } = props;
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const config = applicationStore.config;
 
   return (
@@ -112,7 +112,7 @@ const AboutModal: React.FC<{
 };
 
 export const AppHeaderMenu: React.FC = () => {
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const config = applicationStore.config;
 
   // menu

--- a/packages/legend-studio/src/components/editor/header/ShareProjectHeaderAction.tsx
+++ b/packages/legend-studio/src/components/editor/header/ShareProjectHeaderAction.tsx
@@ -26,13 +26,13 @@ import { FiShare } from 'react-icons/fi';
 import type { Version } from '@finos/legend-server-sdlc';
 import { useEditorStore } from '../EditorStoreProvider';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../../application/LegendStudioConfig';
 
 const ShareModal = observer(
   (props: { open: boolean; closeModal: () => void }) => {
     const { open, closeModal } = props;
     const editorStore = useEditorStore();
-    const applicationStore = useApplicationStore<StudioConfig>();
+    const applicationStore = useApplicationStore<LegendStudioConfig>();
     const versions = editorStore.sdlcState.projectVersions;
     const isDispatchingAction = editorStore.sdlcState.isFetchingProjectVersions;
     const isFetchingProject = editorStore.sdlcState.isFetchingProject;

--- a/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -30,7 +30,7 @@ import { compareLabelFn, CustomSelectorInput } from '@finos/legend-art';
 import type { EditorStore } from '../../../stores/EditorStore';
 import { prettyCONSTName } from '@finos/legend-shared';
 import type { PackageableElementOption } from '../../../stores/shared/PackageableElementOptionUtil';
-import type { DSL_StudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
 import { useEditorStore } from '../EditorStoreProvider';
 import type { Mapping, Store, Class } from '@finos/legend-graph';
 import {
@@ -73,7 +73,7 @@ export const getElementTypeLabel = (
           .flatMap(
             (plugin) =>
               (
-                plugin as DSL_StudioPlugin_Extension
+                plugin as DSL_LegendStudioPlugin_Extension
               ).getExtraElementTypeLabelGetters?.() ?? [],
           );
         for (const typeLabelGetter of extraElementTypeLabelGetters) {
@@ -306,7 +306,7 @@ const renderNewElementDriver = (
         .flatMap(
           (plugin) =>
             (
-              plugin as DSL_StudioPlugin_Extension
+              plugin as DSL_LegendStudioPlugin_Extension
             ).getExtraNewElementDriverEditorRenderers?.() ?? [],
         );
       for (const creator of extraNewElementDriverEditorCreators) {

--- a/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -30,7 +30,7 @@ import { compareLabelFn, CustomSelectorInput } from '@finos/legend-art';
 import type { EditorStore } from '../../../stores/EditorStore';
 import { prettyCONSTName } from '@finos/legend-shared';
 import type { PackageableElementOption } from '../../../stores/shared/PackageableElementOptionUtil';
-import type { DSL_StudioPlugin_Extension } from '../../../stores/StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from '../../../stores/LegendStudioPlugin';
 import { useEditorStore } from '../EditorStoreProvider';
 import type { Mapping, Store, Class } from '@finos/legend-graph';
 import {

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -74,7 +74,7 @@ import {
   isValidPath,
 } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../../application/LegendStudioConfig';
 
 const isGeneratedPackageTreeNode = (node: PackageTreeNodeData): boolean =>
   node.packageableElement.getRoot().path === ROOT_PACKAGE_NAME.MODEL_GENERATION;
@@ -182,7 +182,7 @@ const ExplorerContextMenu = observer(
   ) => {
     const { node, nodeIsImmutable } = props;
     const editorStore = useEditorStore();
-    const applicationStore = useApplicationStore<StudioConfig>();
+    const applicationStore = useApplicationStore<LegendStudioConfig>();
     const extraExplorerContextMenuItems = editorStore.pluginManager
       .getStudioPlugins()
       .flatMap(

--- a/packages/legend-studio/src/components/editor/side-bar/ProjectOverview.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/ProjectOverview.tsx
@@ -37,7 +37,7 @@ import {
 } from '@finos/legend-server-sdlc';
 import { useEditorStore } from '../EditorStoreProvider';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../../application/LegendStudioConfig';
 
 const WorkspaceViewerContextMenu = observer<
   {
@@ -70,7 +70,7 @@ const WorkspaceViewerContextMenu = observer<
 const WorkspaceViewer = observer((props: { workspace: Workspace }) => {
   const { workspace } = props;
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const isActive = areWorkspacesEquivalent(
     editorStore.sdlcState.activeWorkspace,
     workspace,
@@ -173,7 +173,7 @@ const WorkspacesViewer = observer(() => {
 
 const ReleaseEditor = observer(() => {
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const projectOverviewState = editorStore.projectOverviewState;
   const sdlcState = editorStore.sdlcState;
   const commitedReviews =
@@ -368,7 +368,7 @@ const ReleaseEditor = observer(() => {
 
 const VersionsViewer = observer(() => {
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const versions = editorStore.sdlcState.projectVersions;
   const isDispatchingAction = editorStore.sdlcState.isFetchingProjectVersions;
 

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceReview.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceReview.tsx
@@ -41,7 +41,7 @@ import {
   ActionAlertActionType,
   useApplicationStore,
 } from '@finos/legend-application';
-import type { StudioConfig } from '../../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../../application/LegendStudioConfig';
 
 export const WorkspaceReviewDiffs = observer(() => {
   const editorStore = useEditorStore();
@@ -95,7 +95,7 @@ export const WorkspaceReviewDiffs = observer(() => {
 
 export const WorkspaceReview = observer(() => {
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const workspaceReviewState = editorStore.workspaceReviewState;
   const workspaceReview = workspaceReviewState.workspaceReview;
   // Review Title

--- a/packages/legend-studio/src/components/editor/side-bar/WorkspaceUpdater.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/WorkspaceUpdater.tsx
@@ -46,11 +46,11 @@ import {
   ActionAlertActionType,
   useApplicationStore,
 } from '@finos/legend-application';
-import type { StudioConfig } from '../../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../../application/LegendStudioConfig';
 
 export const WorkspaceUpdater = observer(() => {
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcState = editorStore.sdlcState;
   const currentEditorState = editorStore.currentEditorState;
   const workspaceUpdaterState = editorStore.workspaceUpdaterState;

--- a/packages/legend-studio/src/components/review/Review.tsx
+++ b/packages/legend-studio/src/components/review/Review.tsx
@@ -54,12 +54,12 @@ import {
   NotificationSnackbar,
   useApplicationStore,
 } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const ReviewStatusBar = observer(() => {
   const reviewStore = useReviewStore();
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const currentUserId =
     editorStore.sdlcServerClient.currentUser?.userId ?? '(unknown)';
   const currentProject = reviewStore.currentProject

--- a/packages/legend-studio/src/components/setup/ProjectSelector.tsx
+++ b/packages/legend-studio/src/components/setup/ProjectSelector.tsx
@@ -24,7 +24,7 @@ import { generateSetupRoute } from '../../stores/LegendStudioRouter';
 import { flowResult } from 'mobx';
 import { useSetupStore } from './SetupStoreProvider';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const formatOptionLabel = (option: ProjectOption): React.ReactNode => (
   <div className="setup__project__label">
@@ -50,7 +50,7 @@ export const ProjectSelector = observer(
   ) => {
     const { onChange, create } = props;
     const setupStore = useSetupStore();
-    const applicationStore = useApplicationStore<StudioConfig>();
+    const applicationStore = useApplicationStore<LegendStudioConfig>();
     const currentProjectId = setupStore.currentProjectId;
     const options = setupStore.projectOptions.sort(compareLabelFn);
     const selectedOption =

--- a/packages/legend-studio/src/components/setup/Setup.tsx
+++ b/packages/legend-studio/src/components/setup/Setup.tsx
@@ -48,11 +48,11 @@ import {
   useApplicationStore,
   NotificationSnackbar,
 } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const CreateProjectModal = observer(() => {
   const setupStore = useSetupStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const importProjectSuccessReport = setupStore.importProjectSuccessReport;
   const projectNameInputRef = useRef<HTMLInputElement>(null);
   const defaultType = applicationStore.config.options
@@ -642,7 +642,7 @@ const CreateWorkspaceModal = observer(() => {
 
 const SetupSelection = observer(() => {
   const setupStore = useSetupStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const config = applicationStore.config;
   const projectSelectorRef = useRef<SelectComponent>(null);
   const workspaceSelectorRef = useRef<SelectComponent>(null);

--- a/packages/legend-studio/src/components/setup/SetupStoreProvider.tsx
+++ b/packages/legend-studio/src/components/setup/SetupStoreProvider.tsx
@@ -20,7 +20,7 @@ import { SetupStore } from '../../stores/SetupStore';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { useApplicationStore } from '@finos/legend-application';
 import { useSDLCServerClient } from '@finos/legend-server-sdlc';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const SetupStoreContext = createContext<SetupStore | undefined>(undefined);
 
@@ -29,7 +29,7 @@ export const SetupStoreProvider = ({
 }: {
   children: React.ReactNode;
 }): React.ReactElement => {
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcServerClient = useSDLCServerClient();
   const store = useLocalObservable(
     () => new SetupStore(applicationStore, sdlcServerClient),

--- a/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
+++ b/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
@@ -24,7 +24,7 @@ import { FaPlus, FaUserFriends, FaUser } from 'react-icons/fa';
 import { generateSetupRoute } from '../../stores/LegendStudioRouter';
 import { useSetupStore } from './SetupStoreProvider';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const formatOptionLabel = (option: WorkspaceOption): React.ReactNode => (
   <div className="setup__workspace__label">
@@ -49,7 +49,7 @@ export const WorkspaceSelector = observer(
   ) => {
     const { onChange, create } = props;
     const setupStore = useSetupStore();
-    const applicationStore = useApplicationStore<StudioConfig>();
+    const applicationStore = useApplicationStore<LegendStudioConfig>();
     const currentWorkspaceCompositeId = setupStore.currentWorkspaceCompositeId;
     const options =
       setupStore.currentProjectWorkspaceOptions.sort(compareLabelFn);

--- a/packages/legend-studio/src/components/shared/AppHeader.tsx
+++ b/packages/legend-studio/src/components/shared/AppHeader.tsx
@@ -17,7 +17,7 @@
 import { Link } from 'react-router-dom';
 import { LegendLogo } from '@finos/legend-art';
 import { useApplicationStore } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 export const AppHeader: React.FC<{
   children?: React.ReactNode;
@@ -48,7 +48,7 @@ export const AppHeader: React.FC<{
 };
 
 export const BasicAppHeader: React.FC<{
-  config: StudioConfig;
+  config: LegendStudioConfig;
 }> = (props) => {
   const { config } = props;
 

--- a/packages/legend-studio/src/components/shared/ElementIconUtils.tsx
+++ b/packages/legend-studio/src/components/shared/ElementIconUtils.tsx
@@ -16,7 +16,7 @@
 
 import { returnUndefOnError } from '@finos/legend-shared';
 import type { EditorStore } from '../../stores/EditorStore';
-import type { DSL_StudioPlugin_Extension } from '../../stores/LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from '../../stores/LegendStudioPlugin';
 import type { PackageableElement, Type } from '@finos/legend-graph';
 import {
   Class,
@@ -108,7 +108,7 @@ export const getElementTypeIcon = (
           .flatMap(
             (plugin) =>
               (
-                plugin as DSL_StudioPlugin_Extension
+                plugin as DSL_LegendStudioPlugin_Extension
               ).getExtraElementIconGetters?.() ?? [],
           );
         for (const iconGetter of extraElementIconGetters) {

--- a/packages/legend-studio/src/components/shared/ElementIconUtils.tsx
+++ b/packages/legend-studio/src/components/shared/ElementIconUtils.tsx
@@ -16,7 +16,7 @@
 
 import { returnUndefOnError } from '@finos/legend-shared';
 import type { EditorStore } from '../../stores/EditorStore';
-import type { DSL_StudioPlugin_Extension } from '../../stores/StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from '../../stores/LegendStudioPlugin';
 import type { PackageableElement, Type } from '@finos/legend-graph';
 import {
   Class,

--- a/packages/legend-studio/src/components/viewer/Viewer.tsx
+++ b/packages/legend-studio/src/components/viewer/Viewer.tsx
@@ -60,13 +60,13 @@ import {
   NotificationSnackbar,
   useApplicationStore,
 } from '@finos/legend-application';
-import type { StudioConfig } from '../../application/StudioConfig';
+import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const ViewerStatusBar = observer(() => {
   const params = useParams<ViewerPathParams>();
   const viewerStore = useViewerStore();
   const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore<StudioConfig>();
+  const applicationStore = useApplicationStore<LegendStudioConfig>();
   const latestVersion = viewerStore.onLatestVersion;
   const currentRevision = viewerStore.onCurrentRevision;
   const extraSDLCInfo = params.revisionId ?? params.versionId ?? 'HEAD';

--- a/packages/legend-studio/src/index.ts
+++ b/packages/legend-studio/src/index.ts
@@ -26,7 +26,7 @@ export {
 export { STUDIO_LOG_EVENT } from './stores/StudioLogEvent';
 
 // stores
-export * from './stores/StudioPlugin';
+export * from './stores/LegendStudioPlugin';
 export * from './stores/EditorStore';
 export * from './stores/EditorConfig';
 export { ClassEditorState } from './stores/editor-state/element-editor-state/ClassEditorState';

--- a/packages/legend-studio/src/index.ts
+++ b/packages/legend-studio/src/index.ts
@@ -15,10 +15,10 @@
  */
 
 // application
-export * from './components/StudioStoreProvider';
+export * from './components/LegendStudioStoreProvider';
 export * from './application/LegendStudio';
-export * from './application/StudioConfig';
-export * from './application/StudioPluginManager';
+export * from './application/LegendStudioConfig';
+export * from './application/LegendStudioPluginManager';
 export {
   LEGEND_STUDIO_PATH_PARAM_TOKEN,
   generateRoutePatternWithSDLCServerKey,
@@ -40,7 +40,7 @@ export {
   TypeDragSource,
 } from './stores/shared/DnDUtil';
 export { ExplorerTreeRootPackageLabel } from './stores/ExplorerTreeState';
-export * from './stores/DSLMapping_StudioPlugin_Extension';
+export * from './stores/DSLMapping_LegendStudioPlugin_Extension';
 
 // components
 export * from './components/editor/EditorStoreProvider';
@@ -77,9 +77,9 @@ export {
   ConnectionEditor_BooleanEditor,
   ConnectionEditor_ArrayEditor,
 } from './components/editor/edit-panel/connection-editor/RelationalDatabaseConnectionEditor';
-export * from './stores/DSLGenerationSpecification_StudioPlugin_Extension';
+export * from './stores/DSLGenerationSpecification_LegendStudioPlugin_Extension';
 
-export * from './stores/StoreRelational_StudioPlugin_Extension';
+export * from './stores/StoreRelational_LegendStudioPlugin_Extension';
 
 export { ServicePureExecutionState } from './stores/editor-state/element-editor-state/service/ServiceExecutionState';
 export { NewServiceModal } from './components/editor/edit-panel/service-editor/NewServiceModal';

--- a/packages/legend-studio/src/stores/DSLGenerationSpecification_LegendStudioPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/DSLGenerationSpecification_LegendStudioPlugin_Extension.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from './LegendStudioPlugin';
 
-export interface DSLGenerationSpecification_StudioPlugin_Extension
-  extends DSL_StudioPlugin_Extension {
+export interface DSLGenerationSpecification_LegendStudioPlugin_Extension
+  extends DSL_LegendStudioPlugin_Extension {
   /**
    * Get drag-and-drop type specifier for model generation specification elements.
    */

--- a/packages/legend-studio/src/stores/DSLGenerationSpecification_StudioPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/DSLGenerationSpecification_StudioPlugin_Extension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from './StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
 
 export interface DSLGenerationSpecification_StudioPlugin_Extension
   extends DSL_StudioPlugin_Extension {

--- a/packages/legend-studio/src/stores/DSLMapping_LegendStudioPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/DSLMapping_LegendStudioPlugin_Extension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from './LegendStudioPlugin';
 import type { ConnectionValueState } from './editor-state/element-editor-state/connection/ConnectionEditorState';
 import type { EditorStore } from './EditorStore';
 import type {
@@ -113,8 +113,8 @@ export type TEMP__ServiceTestRuntimeConnectionBuilder = (
   testData: string,
 ) => Connection | undefined;
 
-export interface DSLMapping_StudioPlugin_Extension
-  extends DSL_StudioPlugin_Extension {
+export interface DSLMapping_LegendStudioPlugin_Extension
+  extends DSL_LegendStudioPlugin_Extension {
   /**
    * Get the list of extra set implementation decorators.
    */

--- a/packages/legend-studio/src/stores/DSLMapping_StudioPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/DSLMapping_StudioPlugin_Extension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from './StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
 import type { ConnectionValueState } from './editor-state/element-editor-state/connection/ConnectionEditorState';
 import type { EditorStore } from './EditorStore';
 import type {

--- a/packages/legend-studio/src/stores/EditorGraphState.ts
+++ b/packages/legend-studio/src/stores/EditorGraphState.ts
@@ -32,7 +32,7 @@ import type { EditorStore } from './EditorStore';
 import { ElementEditorState } from './editor-state/element-editor-state/ElementEditorState';
 import { GraphGenerationState } from './editor-state/GraphGenerationState';
 import { MODEL_UPDATER_INPUT_TYPE } from './editor-state/ModelLoaderState';
-import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from './LegendStudioPlugin';
 import type { Entity } from '@finos/legend-model-storage';
 import type {
   EntityChange,
@@ -93,7 +93,7 @@ import {
   ActionAlertType,
 } from '@finos/legend-application';
 import { CONFIGURATION_EDITOR_TAB } from './editor-state/ProjectConfigurationEditorState';
-import type { DSLMapping_StudioPlugin_Extension } from './DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from './DSLMapping_LegendStudioPlugin_Extension';
 
 export enum GraphBuilderStatus {
   SUCCEEDED = 'SUCCEEDED',
@@ -1091,7 +1091,7 @@ export class EditorGraphState {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSL_StudioPlugin_Extension
+            plugin as DSL_LegendStudioPlugin_Extension
           ).getExtraElementTypeGetters?.() ?? [],
       );
     for (const labelGetter of extraElementTypeLabelGetters) {
@@ -1130,7 +1130,7 @@ export class EditorGraphState {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraSetImplementationClassifiers?.() ?? [],
       );
     for (const Classifier of extraSetImplementationClassifiers) {

--- a/packages/legend-studio/src/stores/EditorGraphState.ts
+++ b/packages/legend-studio/src/stores/EditorGraphState.ts
@@ -32,7 +32,7 @@ import type { EditorStore } from './EditorStore';
 import { ElementEditorState } from './editor-state/element-editor-state/ElementEditorState';
 import { GraphGenerationState } from './editor-state/GraphGenerationState';
 import { MODEL_UPDATER_INPUT_TYPE } from './editor-state/ModelLoaderState';
-import type { DSL_StudioPlugin_Extension } from './StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
 import type { Entity } from '@finos/legend-model-storage';
 import type {
   EntityChange,

--- a/packages/legend-studio/src/stores/EditorStore.ts
+++ b/packages/legend-studio/src/stores/EditorStore.ts
@@ -78,7 +78,7 @@ import {
 import { NonBlockingDialogState, PanelDisplayState } from '@finos/legend-art';
 import type { PackageableElementOption } from './shared/PackageableElementOptionUtil';
 import { buildElementOption } from './shared/PackageableElementOptionUtil';
-import type { DSL_StudioPlugin_Extension } from './StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
 import type { Entity } from '@finos/legend-model-storage';
 import type {
   SDLCServerClient,

--- a/packages/legend-studio/src/stores/EditorStore.ts
+++ b/packages/legend-studio/src/stores/EditorStore.ts
@@ -78,7 +78,7 @@ import {
 import { NonBlockingDialogState, PanelDisplayState } from '@finos/legend-art';
 import type { PackageableElementOption } from './shared/PackageableElementOptionUtil';
 import { buildElementOption } from './shared/PackageableElementOptionUtil';
-import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from './LegendStudioPlugin';
 import type { Entity } from '@finos/legend-model-storage';
 import type {
   SDLCServerClient,
@@ -113,7 +113,7 @@ import {
   Package,
 } from '@finos/legend-graph';
 import type { DepotServerClient } from '@finos/legend-server-depot';
-import type { StudioPluginManager } from '../application/StudioPluginManager';
+import type { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
 import type {
   ActionAlertInfo,
   ApplicationStore,
@@ -126,7 +126,7 @@ import {
   TAB_SIZE,
 } from '@finos/legend-application';
 import { STUDIO_LOG_EVENT } from './StudioLogEvent';
-import type { StudioConfig } from '../application/StudioConfig';
+import type { LegendStudioConfig } from '../application/LegendStudioConfig';
 import type { EditorMode } from './editor/EditorMode';
 import { StandardEditorMode } from './editor/StandardEditorMode';
 
@@ -151,10 +151,10 @@ export class EditorHotkey {
 }
 
 export class EditorStore {
-  applicationStore: ApplicationStore<StudioConfig>;
+  applicationStore: ApplicationStore<LegendStudioConfig>;
   sdlcServerClient: SDLCServerClient;
   depotServerClient: DepotServerClient;
-  pluginManager: StudioPluginManager;
+  pluginManager: LegendStudioPluginManager;
 
   editorMode: EditorMode;
   setEditorMode(val: EditorMode): void {
@@ -233,11 +233,11 @@ export class EditorStore {
   isDevToolEnabled = true;
 
   constructor(
-    applicationStore: ApplicationStore<StudioConfig>,
+    applicationStore: ApplicationStore<LegendStudioConfig>,
     sdlcServerClient: SDLCServerClient,
     depotServerClient: DepotServerClient,
     graphManagerState: GraphManagerState,
-    pluginManager: StudioPluginManager,
+    pluginManager: LegendStudioPluginManager,
   ) {
     makeAutoObservable(this, {
       applicationStore: false,
@@ -1060,7 +1060,7 @@ export class EditorStore {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSL_StudioPlugin_Extension
+            plugin as DSL_LegendStudioPlugin_Extension
           ).getExtraElementEditorStateCreators?.() ?? [],
       );
     for (const creator of extraElementEditorStateCreators) {
@@ -1128,7 +1128,7 @@ export class EditorStore {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSL_StudioPlugin_Extension
+            plugin as DSL_LegendStudioPlugin_Extension
           ).getExtraElementEditorPostDeleteActions?.() ?? [],
       );
     for (const action of extraElementEditorPostDeleteActions) {
@@ -1159,7 +1159,7 @@ export class EditorStore {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSL_StudioPlugin_Extension
+            plugin as DSL_LegendStudioPlugin_Extension
           ).getExtraElementEditorPostRenameActions?.() ?? [],
       );
     for (const action of extraElementEditorPostRenameActions) {
@@ -1412,7 +1412,7 @@ export class EditorStore {
         .flatMap(
           (plugin) =>
             (
-              plugin as DSL_StudioPlugin_Extension
+              plugin as DSL_LegendStudioPlugin_Extension
             ).getExtraSupportedElementTypes?.() ?? [],
         ),
     );

--- a/packages/legend-studio/src/stores/EditorStoreTestUtils.ts
+++ b/packages/legend-studio/src/stores/EditorStoreTestUtils.ts
@@ -15,7 +15,7 @@
  */
 
 import { EditorStore } from './EditorStore';
-import { StudioPluginManager } from '../application/StudioPluginManager';
+import { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
 import { TEST__getTestGraphManagerState } from '@finos/legend-graph';
 import { TEST__getTestSDLCServerClient } from '@finos/legend-server-sdlc';
 import { TEST__getTestDepotServerClient } from '@finos/legend-server-depot';
@@ -23,7 +23,7 @@ import {
   TEST_DATA__applicationVersion,
   TEST__getTestApplicationStore,
 } from '@finos/legend-application';
-import { StudioConfig } from '../application/StudioConfig';
+import { LegendStudioConfig } from '../application/LegendStudioConfig';
 
 export const TEST_DATA__studioConfig = {
   appName: 'test-studio-app',
@@ -44,8 +44,8 @@ export const TEST_DATA__studioConfig = {
 
 export const TEST__getTestStudioConfig = (
   extraConfigData = {},
-): StudioConfig => {
-  const config = new StudioConfig(
+): LegendStudioConfig => {
+  const config = new LegendStudioConfig(
     {
       ...TEST_DATA__studioConfig,
       ...extraConfigData,
@@ -57,7 +57,7 @@ export const TEST__getTestStudioConfig = (
 };
 
 export const TEST__getTestEditorStore = (
-  pluginManager = StudioPluginManager.create(),
+  pluginManager = LegendStudioPluginManager.create(),
 ): EditorStore => {
   const applicationStore = TEST__getTestApplicationStore(
     TEST__getTestStudioConfig(),

--- a/packages/legend-studio/src/stores/LegendStudioPlugin.ts
+++ b/packages/legend-studio/src/stores/LegendStudioPlugin.ts
@@ -15,14 +15,14 @@
  */
 
 import { AbstractPlugin } from '@finos/legend-shared';
-import type { StudioPluginManager } from '../application/StudioPluginManager';
+import type { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
 import type { ElementEditorState } from './editor-state/element-editor-state/ElementEditorState';
 import type { EditorExtensionState, EditorStore } from './EditorStore';
 import type { NewElementDriver, NewElementState } from './NewElementState';
 import type { Class, PackageableElement } from '@finos/legend-graph';
 
 export type ApplicationSetup = (
-  pluginManager: StudioPluginManager,
+  pluginManager: LegendStudioPluginManager,
 ) => Promise<void>;
 
 export type ApplicationPageRenderEntry = {
@@ -145,7 +145,7 @@ export type ElementProjectExplorerDnDTypeGetter = (
 /**
  * Studio plugins for new DSL extension.
  */
-export interface DSL_StudioPlugin_Extension extends LegendStudioPlugin {
+export interface DSL_LegendStudioPlugin_Extension extends LegendStudioPlugin {
   /**
    * Get the list of the supported packageable element type specifiers.
    */

--- a/packages/legend-studio/src/stores/LegendStudioPlugin.ts
+++ b/packages/legend-studio/src/stores/LegendStudioPlugin.ts
@@ -52,8 +52,8 @@ export type ClassPreviewRenderer = (
   _class: Class,
 ) => React.ReactNode | undefined;
 
-export abstract class StudioPlugin extends AbstractPlugin {
-  private readonly _$nominalTypeBrand!: 'StudioPlugin';
+export abstract class LegendStudioPlugin extends AbstractPlugin {
+  private readonly _$nominalTypeBrand!: 'LegendStudioPlugin';
 
   /**
    * Get the list of setup procedures to be run when booting up the application.
@@ -145,7 +145,7 @@ export type ElementProjectExplorerDnDTypeGetter = (
 /**
  * Studio plugins for new DSL extension.
  */
-export interface DSL_StudioPlugin_Extension extends StudioPlugin {
+export interface DSL_StudioPlugin_Extension extends LegendStudioPlugin {
   /**
    * Get the list of the supported packageable element type specifiers.
    */

--- a/packages/legend-studio/src/stores/LegendStudioRouter.ts
+++ b/packages/legend-studio/src/stores/LegendStudioRouter.ts
@@ -18,7 +18,7 @@ import { generateGAVCoordinates } from '@finos/legend-server-depot';
 import { WorkspaceType } from '@finos/legend-server-sdlc';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { generatePath, matchPath } from 'react-router-dom';
-import type { SDLCServerOption } from '../application/StudioConfig';
+import type { SDLCServerOption } from '../application/LegendStudioConfig';
 
 export enum LEGEND_STUDIO_PATH_PARAM_TOKEN {
   SDLC_SERVER_KEY = 'sdlcServerKey',

--- a/packages/legend-studio/src/stores/NewElementState.tsx
+++ b/packages/legend-studio/src/stores/NewElementState.tsx
@@ -30,7 +30,7 @@ import {
   guaranteeNonNullable,
 } from '@finos/legend-shared';
 import { decorateRuntimeWithNewMapping } from './editor-state/element-editor-state/RuntimeEditorState';
-import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from './LegendStudioPlugin';
 import type { FileGenerationTypeOption } from './editor-state/GraphGenerationState';
 import { DEFAULT_GENERATION_SPECIFICATION_NAME } from './editor-state/GraphGenerationState';
 import type {
@@ -72,7 +72,7 @@ import {
   DefaultH2AuthenticationStrategy,
   ModelGenerationSpecification,
 } from '@finos/legend-graph';
-import type { DSLMapping_StudioPlugin_Extension } from './DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from './DSLMapping_LegendStudioPlugin_Extension';
 
 export const resolvePackageAndElementName = (
   _package: Package,
@@ -312,7 +312,7 @@ export class NewPackageableConnectionDriver extends NewElementDriver<Packageable
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraNewConnectionDriverCreators?.() ?? [],
       );
     for (const creator of extraNewConnectionDriverCreators) {
@@ -502,7 +502,7 @@ export class NewElementState {
             .flatMap(
               (plugin) =>
                 (
-                  plugin as DSL_StudioPlugin_Extension
+                  plugin as DSL_LegendStudioPlugin_Extension
                 ).getExtraNewElementDriverCreators?.() ?? [],
             );
           for (const creator of extraNewElementDriverCreators) {
@@ -597,7 +597,7 @@ export class NewElementState {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSL_StudioPlugin_Extension
+            plugin as DSL_LegendStudioPlugin_Extension
           ).getExtraElementEditorPostCreateActions?.() ?? [],
       );
     for (const action of extraElementEditorPostCreateActions) {
@@ -703,7 +703,7 @@ export class NewElementState {
           .flatMap(
             (plugin) =>
               (
-                plugin as DSL_StudioPlugin_Extension
+                plugin as DSL_LegendStudioPlugin_Extension
               ).getExtraNewElementFromStateCreators?.() ?? [],
           );
         for (const creator of extraNewElementFromStateCreators) {

--- a/packages/legend-studio/src/stores/NewElementState.tsx
+++ b/packages/legend-studio/src/stores/NewElementState.tsx
@@ -30,7 +30,7 @@ import {
   guaranteeNonNullable,
 } from '@finos/legend-shared';
 import { decorateRuntimeWithNewMapping } from './editor-state/element-editor-state/RuntimeEditorState';
-import type { DSL_StudioPlugin_Extension } from './StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
 import type { FileGenerationTypeOption } from './editor-state/GraphGenerationState';
 import { DEFAULT_GENERATION_SPECIFICATION_NAME } from './editor-state/GraphGenerationState';
 import type {

--- a/packages/legend-studio/src/stores/SetupStore.ts
+++ b/packages/legend-studio/src/stores/SetupStore.ts
@@ -30,7 +30,7 @@ import {
   Workspace,
   WorkspaceAccessType,
 } from '@finos/legend-server-sdlc';
-import type { StudioConfig } from '../application/StudioConfig';
+import type { LegendStudioConfig } from '../application/LegendStudioConfig';
 
 interface ImportProjectSuccessReport {
   projectId: string;
@@ -69,7 +69,7 @@ export interface WorkspaceIdentifier {
 }
 
 export class SetupStore {
-  applicationStore: ApplicationStore<StudioConfig>;
+  applicationStore: ApplicationStore<LegendStudioConfig>;
   sdlcServerClient: SDLCServerClient;
 
   currentProjectId?: string | undefined;
@@ -85,7 +85,7 @@ export class SetupStore {
   importProjectSuccessReport?: ImportProjectSuccessReport | undefined;
 
   constructor(
-    applicationStore: ApplicationStore<StudioConfig>,
+    applicationStore: ApplicationStore<LegendStudioConfig>,
     sdlcServerClient: SDLCServerClient,
   ) {
     makeAutoObservable(this, {

--- a/packages/legend-studio/src/stores/StoreRelational_LegendStudioPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/StoreRelational_LegendStudioPlugin_Extension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from './LegendStudioPlugin';
 import type {
   DatasourceSpecification,
   AuthenticationStrategy,
@@ -50,8 +50,8 @@ export type AuthenticationStrategyEditorRenderer = (
   isReadOnly: boolean,
 ) => React.ReactNode | undefined;
 
-export interface StoreRelational_StudioPlugin_Extension
-  extends DSL_StudioPlugin_Extension {
+export interface StoreRelational_LegendStudioPlugin_Extension
+  extends DSL_LegendStudioPlugin_Extension {
   // --------------------- relational database connection datasource specification ------------------
 
   /**

--- a/packages/legend-studio/src/stores/StoreRelational_StudioPlugin_Extension.ts
+++ b/packages/legend-studio/src/stores/StoreRelational_StudioPlugin_Extension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DSL_StudioPlugin_Extension } from './StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from './LegendStudioPlugin';
 import type {
   DatasourceSpecification,
   AuthenticationStrategy,

--- a/packages/legend-studio/src/stores/StudioStore.ts
+++ b/packages/legend-studio/src/stores/StudioStore.ts
@@ -38,16 +38,16 @@ import {
 import { User, SDLCMode, SDLCServerClient } from '@finos/legend-server-sdlc';
 import { STUDIO_LOG_EVENT } from '../stores/StudioLogEvent';
 import type { DepotServerClient } from '@finos/legend-server-depot';
-import type { StudioPluginManager } from '../application/StudioPluginManager';
-import type { StudioConfig } from '../application/StudioConfig';
+import type { LegendStudioPluginManager } from '../application/LegendStudioPluginManager';
+import type { LegendStudioConfig } from '../application/LegendStudioConfig';
 
 const UNKNOWN_USER_ID = '(unknown)';
 
-export class StudioStore {
-  applicationStore: ApplicationStore<StudioConfig>;
+export class LegendStudioStore {
+  applicationStore: ApplicationStore<LegendStudioConfig>;
   sdlcServerClient: SDLCServerClient;
   depotServerClient: DepotServerClient;
-  pluginManager: StudioPluginManager;
+  pluginManager: LegendStudioPluginManager;
 
   telemetryService = new TelemetryService();
   initState = ActionState.create();
@@ -56,12 +56,12 @@ export class StudioStore {
   SDLCServerTermsOfServicesUrlsToView: string[] = [];
 
   constructor(
-    applicationStore: ApplicationStore<StudioConfig>,
+    applicationStore: ApplicationStore<LegendStudioConfig>,
     sdlcServerClient: SDLCServerClient,
     depotServerClient: DepotServerClient,
-    pluginManager: StudioPluginManager,
+    pluginManager: LegendStudioPluginManager,
   ) {
-    makeObservable<StudioStore, 'checkSDLCAuthorization'>(this, {
+    makeObservable<LegendStudioStore, 'checkSDLCAuthorization'>(this, {
       isSDLCAuthorized: observable,
       SDLCServerTermsOfServicesUrlsToView: observable,
       needsToAcceptSDLCServerTermsOfServices: computed,

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
@@ -63,7 +63,7 @@ import {
   StaticDatasourceSpecification,
   DefaultH2AuthenticationStrategy,
 } from '@finos/legend-graph';
-import type { DSLMapping_StudioPlugin_Extension } from '../../DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../DSLMapping_LegendStudioPlugin_Extension';
 
 /* @MARKER: NEW CLASS MAPPING TYPE SUPPORT --- consider adding class mapping type handler here whenever support for a new one is added to the app */
 export const getClassMappingStore = (
@@ -461,7 +461,7 @@ export class IdentifiedConnectionsPerStoreEditorTabState extends IdentifiedConne
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraDefaultConnectionValueBuilders?.() ?? [],
       );
 

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/ConnectionEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/ConnectionEditorState.ts
@@ -22,7 +22,7 @@ import {
   UnsupportedOperationError,
 } from '@finos/legend-shared';
 import { ElementEditorState } from './../ElementEditorState';
-import type { StoreRelational_StudioPlugin_Extension } from '../../../StoreRelational_StudioPlugin_Extension';
+import type { StoreRelational_LegendStudioPlugin_Extension } from '../../../StoreRelational_LegendStudioPlugin_Extension';
 import { DatabaseBuilderState } from './DatabaseBuilderState';
 import type {
   PackageableElement,
@@ -49,7 +49,7 @@ import {
   RedshiftDatasourceSpecification,
   createValidationError,
 } from '@finos/legend-graph';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../DSLMapping_LegendStudioPlugin_Extension';
 
 export abstract class ConnectionValueState {
   editorStore: EditorStore;
@@ -144,7 +144,7 @@ export class RelationalDatabaseConnectionValueState extends ConnectionValueState
         .flatMap(
           (plugin) =>
             (
-              plugin as StoreRelational_StudioPlugin_Extension
+              plugin as StoreRelational_LegendStudioPlugin_Extension
             ).getExtraDatasourceSpecificationTypeGetters?.() ?? [],
         );
     for (const typeGetter of extraDatasourceSpecificationTypeGetters) {
@@ -204,7 +204,7 @@ export class RelationalDatabaseConnectionValueState extends ConnectionValueState
             .flatMap(
               (plugin) =>
                 (
-                  plugin as StoreRelational_StudioPlugin_Extension
+                  plugin as StoreRelational_LegendStudioPlugin_Extension
                 ).getExtraDatasourceSpecificationCreators?.() ?? [],
             );
         for (const creator of extraDatasourceSpecificationCreators) {
@@ -246,7 +246,7 @@ export class RelationalDatabaseConnectionValueState extends ConnectionValueState
         .flatMap(
           (plugin) =>
             (
-              plugin as StoreRelational_StudioPlugin_Extension
+              plugin as StoreRelational_LegendStudioPlugin_Extension
             ).getExtraAuthenticationStrategyTypeGetters?.() ?? [],
         );
     for (const typeGetter of extraAuthenticationStrategyTypeGetters) {
@@ -311,7 +311,7 @@ export class RelationalDatabaseConnectionValueState extends ConnectionValueState
             .flatMap(
               (plugin) =>
                 (
-                  plugin as StoreRelational_StudioPlugin_Extension
+                  plugin as StoreRelational_LegendStudioPlugin_Extension
                 ).getExtraAuthenticationStrategyCreators?.() ?? [],
             );
         for (const creator of extraAuthenticationStrategyCreators) {
@@ -391,7 +391,7 @@ export class ConnectionEditorState {
           .flatMap(
             (plugin) =>
               (
-                plugin as DSLMapping_StudioPlugin_Extension
+                plugin as DSLMapping_LegendStudioPlugin_Extension
               ).getExtraConnectionValueEditorStateBuilders?.() ?? [],
           );
       for (const stateBuilder of extraConnectionValueEditorStateBuilders) {

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -107,7 +107,7 @@ import {
 } from '@finos/legend-graph';
 import { LambdaEditorState } from '@finos/legend-application';
 import type { DSLMapping_StudioPlugin_Extension } from '../../../DSLMapping_StudioPlugin_Extension';
-import type { StudioPlugin } from '../../../StudioPlugin';
+import type { LegendStudioPlugin } from '../../../LegendStudioPlugin';
 
 export interface MappingExplorerTreeNodeData extends TreeNodeData {
   mappingElement: MappingElement;
@@ -177,7 +177,7 @@ export const getMappingElementTarget = (
 
 export const getMappingElementSource = (
   mappingElement: MappingElement,
-  plugins: StudioPlugin[],
+  plugins: LegendStudioPlugin[],
 ): MappingElementSource | undefined => {
   if (mappingElement instanceof OperationSetImplementation) {
     // NOTE: we don't need to resolve operation union because at the end of the day, it uses other class mappings

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -106,7 +106,7 @@ import {
   updateRootSetImplementationOnDelete,
 } from '@finos/legend-graph';
 import { LambdaEditorState } from '@finos/legend-application';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../DSLMapping_LegendStudioPlugin_Extension';
 import type { LegendStudioPlugin } from '../../../LegendStudioPlugin';
 
 export interface MappingExplorerTreeNodeData extends TreeNodeData {
@@ -216,7 +216,7 @@ export const getMappingElementSource = (
   const extraMappingElementSourceGetters = plugins.flatMap(
     (plugin) =>
       (
-        plugin as DSLMapping_StudioPlugin_Extension
+        plugin as DSLMapping_LegendStudioPlugin_Extension
       ).getExtraMappingElementSourceGetters?.() ?? [],
   );
   for (const sourceGetter of extraMappingElementSourceGetters) {
@@ -1031,7 +1031,7 @@ export class MappingEditorState extends ElementEditorState {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraMappingElementStateCreators?.() ?? [],
       );
     for (const elementStateCreator of extraMappingElementStateCreators) {

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementDecorator.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementDecorator.ts
@@ -56,7 +56,7 @@ import {
   EmbeddedRelationalInstanceSetImplementation,
   getEnumerationMappingsByEnumeration,
 } from '@finos/legend-graph';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../DSLMapping_LegendStudioPlugin_Extension';
 import type { EditorStore } from '../../../EditorStore';
 
 /* @MARKER: ACTION ANALYTICS */
@@ -494,7 +494,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
       .flatMap(
         (plugin) =>
           (
-            plugin as DSLMapping_StudioPlugin_Extension
+            plugin as DSLMapping_LegendStudioPlugin_Extension
           ).getExtraSetImplementationDecorators?.() ?? [],
       );
     for (const decorator of extraSetImplementationDecorators) {
@@ -603,7 +603,7 @@ export class MappingElementDecorationCleaner
         .flatMap(
           (plugin) =>
             (
-              plugin as DSLMapping_StudioPlugin_Extension
+              plugin as DSLMapping_LegendStudioPlugin_Extension
             ).getExtraSetImplementationDecorationCleaners?.() ?? [],
         );
     for (const decorationCleaner of extraSetImplementationDecorationCleaners) {

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceRegistrationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceRegistrationState.ts
@@ -33,7 +33,7 @@ import { STUDIO_LOG_EVENT } from '../../../../stores/StudioLogEvent';
 import { Version } from '@finos/legend-server-sdlc';
 import type { ServiceRegistrationResult } from '@finos/legend-graph';
 import { ServiceExecutionMode } from '@finos/legend-graph';
-import { ServiceRegistrationEnvInfo } from '../../../../application/StudioConfig';
+import { ServiceRegistrationEnvInfo } from '../../../../application/LegendStudioConfig';
 
 export const LATEST_PROJECT_REVISION = 'Latest Project Revision';
 

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceTestState.ts
@@ -60,7 +60,7 @@ import {
   PureClientVersion,
 } from '@finos/legend-graph';
 import { TAB_SIZE } from '@finos/legend-application';
-import type { DSLMapping_StudioPlugin_Extension } from '../../../DSLMapping_StudioPlugin_Extension';
+import type { DSLMapping_LegendStudioPlugin_Extension } from '../../../DSLMapping_LegendStudioPlugin_Extension';
 
 interface ServiceTestExecutionResult {
   expected: string;
@@ -250,7 +250,7 @@ export class TestContainerState {
               .flatMap(
                 (plugin) =>
                   (
-                    plugin as DSLMapping_StudioPlugin_Extension
+                    plugin as DSLMapping_LegendStudioPlugin_Extension
                   ).TEMP__getExtraServiceTestRuntimeConnectionBuilders?.() ??
                   [],
               );

--- a/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
@@ -19,7 +19,7 @@ import type { PackageTreeNodeData } from './TreeUtil';
 import type { TreeNodeData, TreeData } from '@finos/legend-art';
 import type { EditorStore } from '../EditorStore';
 import { CORE_DND_TYPE } from './DnDUtil';
-import type { DSL_StudioPlugin_Extension } from '../StudioPlugin';
+import type { DSL_StudioPlugin_Extension } from '../LegendStudioPlugin';
 import type { PackageableElement } from '@finos/legend-graph';
 import {
   ROOT_PACKAGE_NAME,

--- a/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
+++ b/packages/legend-studio/src/stores/shared/PackageTreeUtil.ts
@@ -19,7 +19,7 @@ import type { PackageTreeNodeData } from './TreeUtil';
 import type { TreeNodeData, TreeData } from '@finos/legend-art';
 import type { EditorStore } from '../EditorStore';
 import { CORE_DND_TYPE } from './DnDUtil';
-import type { DSL_StudioPlugin_Extension } from '../LegendStudioPlugin';
+import type { DSL_LegendStudioPlugin_Extension } from '../LegendStudioPlugin';
 import type { PackageableElement } from '@finos/legend-graph';
 import {
   ROOT_PACKAGE_NAME,
@@ -81,7 +81,7 @@ const getElementProjectExplorerDnDType = (
     .flatMap(
       (plugin) =>
         (
-          plugin as DSL_StudioPlugin_Extension
+          plugin as DSL_LegendStudioPlugin_Extension
         ).getExtraElementProjectExplorerDnDTypeGetters?.() ?? [],
     );
   for (const dndTypeGetter of extraElementProjectExplorerDnDTypeGetters) {

--- a/packages/legend-studio/tsconfig.build.json
+++ b/packages/legend-studio/tsconfig.build.json
@@ -9,6 +9,5 @@
     "src/**/__tests__/**/*.tsx",
     "src/**/__mocks__/**/*.ts",
     "src/**/__mocks__/**/*.tsx"
-  ],
-  "references": [{ "path": "./tsconfig.package.json" }]
+  ]
 }

--- a/packages/legend-studio/tsconfig.json
+++ b/packages/legend-studio/tsconfig.json
@@ -8,7 +8,6 @@
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
   "references": [
-    { "path": "./tsconfig.package.json" },
     { "path": "../legend-shared" },
     { "path": "../legend-model-storage" },
     { "path": "../legend-server-depot" },

--- a/packages/legend-studio/tsconfig.package.json
+++ b/packages/legend-studio/tsconfig.package.json
@@ -1,9 +1,0 @@
-{
-  "extends": "@finos/legend-dev-utils/tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "lib",
-    "tsBuildInfoFile": "build/package.tsbuildinfo",
-    "rootDir": "."
-  },
-  "include": ["package.json"]
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,7 +1859,7 @@ __metadata:
     "@testing-library/dom": 8.11.1
     "@testing-library/react": 12.1.2
     "@types/css-font-loading-module": 0.0.7
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     "@types/react-dom": 17.0.11
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
@@ -1892,7 +1892,7 @@ __metadata:
     "@finos/legend-dev-utils": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@material-ui/core": 4.12.3
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     "@types/react-select": 4.0.18
     "@types/react-window": 1.8.5
     clsx: 1.1.1
@@ -1942,7 +1942,7 @@ __metadata:
     clean-webpack-plugin: 4.0.0
     cross-env: 7.0.3
     css-loader: 6.5.1
-    cssnano: 5.0.10
+    cssnano: 5.0.11
     eslint: 8.2.0
     html-webpack-plugin: 5.5.0
     isbinaryfile: 4.0.8
@@ -1980,7 +1980,7 @@ __metadata:
     "@finos/legend-server-depot": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
     eslint: 8.2.0
@@ -2016,7 +2016,7 @@ __metadata:
     "@finos/legend-studio": "workspace:*"
     "@material-ui/core": 4.12.3
     "@testing-library/react": 12.1.2
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     jest: 27.3.1
@@ -2049,7 +2049,7 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     jest: 27.3.1
@@ -2080,7 +2080,7 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     jest: 27.3.1
@@ -2125,7 +2125,7 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     jest: 27.3.1
@@ -2239,7 +2239,7 @@ __metadata:
     "@finos/legend-extension-external-store-service": "workspace:*"
     "@finos/legend-query": "workspace:*"
     "@finos/legend-shared": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     npm-run-all: 4.1.5
@@ -2287,7 +2287,7 @@ __metadata:
     "@testing-library/dom": 8.11.1
     "@testing-library/react": 12.1.2
     "@types/papaparse": 5.3.1
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     "@types/react-dom": 17.0.11
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
@@ -2404,7 +2404,7 @@ __metadata:
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
     "@finos/legend-studio-extension-query-builder": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     npm-run-all: 4.1.5
@@ -2444,7 +2444,7 @@ __metadata:
     "@finos/legend-server-sdlc": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
     eslint: 8.2.0
@@ -2480,7 +2480,7 @@ __metadata:
     "@material-ui/core": 4.12.3
     "@testing-library/dom": 8.11.1
     "@testing-library/react": 12.1.2
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     cross-env: 7.0.3
     eslint: 8.2.0
     jest: 27.3.1
@@ -2513,7 +2513,7 @@ __metadata:
     "@material-ui/core": 4.12.3
     "@testing-library/dom": 8.11.1
     "@testing-library/react": 12.1.2
-    "@types/react": 17.0.34
+    "@types/react": 17.0.35
     "@types/react-dom": 17.0.11
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
@@ -3597,7 +3597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
+"@types/react@npm:*, @types/react@npm:17.0.35":
   version: 17.0.35
   resolution: "@types/react@npm:17.0.35"
   dependencies:
@@ -3605,17 +3605,6 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: 33e2bf8068ccc5330f089f5d4bee54649c2d5b512edee4a9e44c113271a69ea8c71ddbd3103b205eb971fd4c358e9f69d707df08bec90b3c33492db374614eb7
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:17.0.34":
-  version: 17.0.34
-  resolution: "@types/react@npm:17.0.34"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: 16729ad7d50922ccbf8eb93874d7781dc2f1c64edc78134b5edc7154839d41e9fe320eb1c11ad2d1c9bf28b99cb1febda344509c1fda025955a5c2b43c688c8f
   languageName: node
   linkType: hard
 
@@ -5436,13 +5425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-color-names@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "css-color-names@npm:1.0.1"
-  checksum: 7a3cdeb9e3311dc508c2f59872ba40b4c0af70304e942d638956fc4103afc3d62784c17aa8703ab42180653e0079734919a6c436143f12c8baf63035bb8d187d
-  languageName: node
-  linkType: hard
-
 "css-declaration-sorter@npm:^6.0.3":
   version: 6.1.3
   resolution: "css-declaration-sorter@npm:6.1.3"
@@ -5528,9 +5510,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-default@npm:^5.1.6":
-  version: 5.1.6
-  resolution: "cssnano-preset-default@npm:5.1.6"
+"cssnano-preset-default@npm:^5.1.7":
+  version: 5.1.7
+  resolution: "cssnano-preset-default@npm:5.1.7"
   dependencies:
     css-declaration-sorter: ^6.0.3
     cssnano-utils: ^2.0.1
@@ -5541,11 +5523,11 @@ __metadata:
     postcss-discard-duplicates: ^5.0.1
     postcss-discard-empty: ^5.0.1
     postcss-discard-overridden: ^5.0.1
-    postcss-merge-longhand: ^5.0.3
-    postcss-merge-rules: ^5.0.2
+    postcss-merge-longhand: ^5.0.4
+    postcss-merge-rules: ^5.0.3
     postcss-minify-font-values: ^5.0.1
     postcss-minify-gradients: ^5.0.3
-    postcss-minify-params: ^5.0.1
+    postcss-minify-params: ^5.0.2
     postcss-minify-selectors: ^5.1.0
     postcss-normalize-charset: ^5.0.1
     postcss-normalize-display-values: ^5.0.1
@@ -5554,16 +5536,16 @@ __metadata:
     postcss-normalize-string: ^5.0.1
     postcss-normalize-timing-functions: ^5.0.1
     postcss-normalize-unicode: ^5.0.1
-    postcss-normalize-url: ^5.0.2
+    postcss-normalize-url: ^5.0.3
     postcss-normalize-whitespace: ^5.0.1
     postcss-ordered-values: ^5.0.2
     postcss-reduce-initial: ^5.0.1
     postcss-reduce-transforms: ^5.0.1
     postcss-svgo: ^5.0.3
-    postcss-unique-selectors: ^5.0.1
+    postcss-unique-selectors: ^5.0.2
   peerDependencies:
     postcss: ^8.2.15
-  checksum: e8826ce075648a3ef3865595c9aa189c39a8a672e941d400596bedfd9df4d176a5d462caf21a8bf711bebcfa10b12cfe1d283190423825ba6ee3664fc6eec341
+  checksum: 179b9a113d5e7fc887eb5ce4841ec83834e95afc85a28c767b34a8736fe0fe098a5963c225b18a1b553d566c7a74908951a0ceed97f2fbf5cdfafcce10db37ff
   languageName: node
   linkType: hard
 
@@ -5576,17 +5558,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:5.0.10":
-  version: 5.0.10
-  resolution: "cssnano@npm:5.0.10"
+"cssnano@npm:5.0.11":
+  version: 5.0.11
+  resolution: "cssnano@npm:5.0.11"
   dependencies:
-    cssnano-preset-default: ^5.1.6
+    cssnano-preset-default: ^5.1.7
     is-resolvable: ^1.1.0
     lilconfig: ^2.0.3
     yaml: ^1.10.2
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 65fa38069925b9ac5b97b05e04c1ad4c9ede580f402e58bef4a15eae14d8cdb8c834b76091b6d4319c1986025221f29ce57b89ae32f63a13f66625df44e12db9
+  checksum: 9b7d6a4a796175e73a019ec94e112dbf1fb66173716e099116fa8b33568fb1875d7cc1bf728033f4c2861c65d92b66be15618127182dd1f9872387d2d55fddcd
   languageName: node
   linkType: hard
 
@@ -11030,31 +11012,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-merge-longhand@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "postcss-merge-longhand@npm:5.0.3"
+"postcss-merge-longhand@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-merge-longhand@npm:5.0.4"
   dependencies:
-    css-color-names: ^1.0.1
     postcss-value-parser: ^4.1.0
     stylehacks: ^5.0.1
   peerDependencies:
     postcss: ^8.2.15
-  checksum: a0982ac3533fc2cf24077917050154dd7a9f7d2ad3994e5c9a4a7495192a65fa172997923b7119ec64b7eadfb99630fa11a5d3ee555d95822a02f881d627b0aa
+  checksum: 6c5ff2ae0e9def05a59cbb432b5cbbdb968816b83c4e38fdf14fa596ef21e36442f61b53984d56dca6165d91e74eadc720270b2887a4a1ef5e25ee171b7d7ea0
   languageName: node
   linkType: hard
 
-"postcss-merge-rules@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "postcss-merge-rules@npm:5.0.2"
+"postcss-merge-rules@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-merge-rules@npm:5.0.3"
   dependencies:
     browserslist: ^4.16.6
     caniuse-api: ^3.0.0
     cssnano-utils: ^2.0.1
     postcss-selector-parser: ^6.0.5
-    vendors: ^1.0.3
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 04b2be8e9def9822182aeb1362d25ef1bee9d4a5be6715fc9bec7aa4c7e885fb1b22d2d8a4438d58952952d2d3957e423ef8adcd7d5339d8bd046c9bae8c1639
+  checksum: 2e701693c6086cc88ac9e4d30a64471bd8da2e33b7e788b7bcbb4e91ecf87bbddc73529a1308a77953e0a2969f57f22714028547b8469db364b3d0d26b39eae2
   languageName: node
   linkType: hard
 
@@ -11082,18 +11062,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-minify-params@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-minify-params@npm:5.0.1"
+"postcss-minify-params@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "postcss-minify-params@npm:5.0.2"
   dependencies:
     alphanum-sort: ^1.0.2
-    browserslist: ^4.16.0
+    browserslist: ^4.16.6
     cssnano-utils: ^2.0.1
     postcss-value-parser: ^4.1.0
-    uniqs: ^2.0.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 52f210c5240c17d21bf4d1fec6477c929e74b047d084d5bf0f8e388534cc4b821cd4f2880d1aca0a0e0c13fcf133dc566897645d9f1f7e056bd443ef27c9a6c7
+  checksum: 234e833e0d187106dd949a8973662168ba27e2a036ae4af979921375328ee77673ba5def616426ab9554f9224af8e3c73822193af5cbbdf98aadc0e39775724b
   languageName: node
   linkType: hard
 
@@ -11232,16 +11211,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-normalize-url@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "postcss-normalize-url@npm:5.0.2"
+"postcss-normalize-url@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-normalize-url@npm:5.0.3"
   dependencies:
     is-absolute-url: ^3.0.3
     normalize-url: ^6.0.1
     postcss-value-parser: ^4.1.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 161a0a02d33188f61e6e46f10c0f2dcb1f0360adf1c39748340b691b9a686d2885a2aa29341e0733f8250060466e0c1b234ae49232d7827fd8689ee25222bb8c
+  checksum: 34dfc8d1d71f0cf073d3f3edfc94a5381d659275103240c15bb3d4f424e70ceec431dc663c7403e1b813d98f45fb5174f7f0c3fe9fb6b00cdbd62f3ac2f0032c
   languageName: node
   linkType: hard
 
@@ -11339,16 +11318,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-unique-selectors@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-unique-selectors@npm:5.0.1"
+"postcss-unique-selectors@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "postcss-unique-selectors@npm:5.0.2"
   dependencies:
     alphanum-sort: ^1.0.2
     postcss-selector-parser: ^6.0.5
-    uniqs: ^2.0.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 4346c4715b3f5facfd4b52fc8553085241c98b533b8965b1d3c1e370f277092d02c72bde519d70a82102467464e6cde9581e0d0592d07108c67e7ad20e67a23a
+  checksum: ad0f7a8a4f1ed958544c1ede62a1c4b0978e01627a6ef0642f7b044d0f9fdb331318a91f8312f418a773b0f2df06c50896cfaf7e5dd3d0142bd1e5ba75dc9eb7
   languageName: node
   linkType: hard
 
@@ -13766,13 +13744,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uniqs@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "uniqs@npm:2.0.0"
-  checksum: 5ace63e0521fd1ae2c161b3fa167cf6846fc45a71c00496729e0146402c3ae467c6f025a68fbd6766300a9bfbac9f240f2f0198164283bef48012b39db83f81f
-  languageName: node
-  linkType: hard
-
 "unique-filename@npm:^1.1.1":
   version: 1.1.1
   resolution: "unique-filename@npm:1.1.1"
@@ -13916,13 +13887,6 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
-  languageName: node
-  linkType: hard
-
-"vendors@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "vendors@npm:1.0.4"
-  checksum: 4b16e0bc18dbdd7ac8dd745c776c08f6c73e9a7f620ffd9faf94a3d86a35feaf4c6cb1bbdb304d2381548a30d0abe69b83eeb1b7b1bf5bb33935e64b28812681
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This contains **breaking changes**:

- [x] Change `StudioPlugin` to `LegendStudioPlugin`. This change applies for other extension-related classes as well, e.g. `LegendStudioPluginManager`, `*_LegendStudioPreset`, `*_LegendStudioPlugin`, etc.
- [x] Change `QueryPlugin` to `LegendQueryPlugin`. This change applies for other extension-related classes as well, e.g. `LegendQueryPluginManager`, `*_LegendQueryPreset`, `*_LegendQueryPlugin`, etc.

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)

This change is just about renaming classes and reorganizing the codebase

