### PR TITLE
Fix rendering generated file with no content in file generation editor

### DIFF
--- a/.changeset/sixty-countries-bow.md
+++ b/.changeset/sixty-countries-bow.md
@@ -2,4 +2,4 @@
 '@finos/legend-studio': patch
 ---
 
-Fix rendering generated code with no content in File Generation Editor.
+Fix rendering generated file with no content in file generation editor.

--- a/.changeset/sixty-countries-bow.md
+++ b/.changeset/sixty-countries-bow.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio': patch
+---
+
+Fix rendering generated code with no content in File Generation Editor.

--- a/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
+++ b/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
@@ -26,7 +26,9 @@ export const getTextContent = (
 ): string => {
   switch (format?.toLowerCase()) {
     case EDITOR_LANGUAGE.JSON:
-      return JSON.stringify(JSON.parse(content), undefined, TAB_SIZE);
+      return content.length
+        ? JSON.stringify(JSON.parse(content), undefined, TAB_SIZE)
+        : content;
     default:
       return content;
   }

--- a/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
+++ b/packages/legend-studio/src/stores/editor-state/FileGenerationViewerState.ts
@@ -19,6 +19,7 @@ import { EditorState } from './EditorState';
 import { observable, makeObservable, computed } from 'mobx';
 import type { GenerationFile } from '../shared/FileGenerationTreeUtil';
 import { EDITOR_LANGUAGE, TAB_SIZE } from '@finos/legend-application';
+import { returnUndefOnError } from '@finos/legend-shared';
 
 export const getTextContent = (
   content: string,
@@ -26,9 +27,11 @@ export const getTextContent = (
 ): string => {
   switch (format?.toLowerCase()) {
     case EDITOR_LANGUAGE.JSON:
-      return content.length
-        ? JSON.stringify(JSON.parse(content), undefined, TAB_SIZE)
-        : content;
+      return (
+        returnUndefOnError(() =>
+          JSON.stringify(JSON.parse(content), undefined, TAB_SIZE),
+        ) ?? content
+      );
     default:
       return content;
   }


### PR DESCRIPTION
## Summary

This bug is found when we handle `Morphir` file generation


https://user-images.githubusercontent.com/13574879/142946554-54295242-9a02-4acb-a60c-a6752ef4d38c.mov


## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)
