### PR TITLE
minor fixes for serialization and React component typings

### DIFF
--- a/.changeset/calm-moons-hang.md
+++ b/.changeset/calm-moons-hang.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-shared': patch
+---
+
+Add `NullphobicSerializationFactory` which only differs to `SerializationFactory` in its deserialization helper method: it will prune all `null` values found in the JSON before deserializing. This is to accommodate for use case where some server (e.g. Java using Jackson) returns `null` for fields whose values are not set (technically, the server should return `undefined`, but this is unfortunately, not always the case).

--- a/.changeset/silly-tips-yell.md
+++ b/.changeset/silly-tips-yell.md
@@ -1,0 +1,34 @@
+---
+'@finos/babel-preset-legend-studio': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/legend-application': patch
+'@finos/legend-art': patch
+'@finos/legend-dev-utils': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-extension-dsl-diagram': patch
+'@finos/legend-extension-dsl-serializer': patch
+'@finos/legend-extension-dsl-text': patch
+'@finos/legend-extension-external-format-json-schema': patch
+'@finos/legend-extension-external-language-morphir': patch
+'@finos/legend-extension-external-store-service': patch
+'@finos/legend-graph': patch
+'@finos/legend-graph-extension-collection': patch
+'@finos/legend-manual-tests': patch
+'@finos/legend-model-storage': patch
+'@finos/legend-query': patch
+'@finos/legend-query-app': patch
+'@finos/legend-query-deployment': patch
+'@finos/legend-server-depot': patch
+'@finos/legend-server-sdlc': patch
+'@finos/legend-shared': patch
+'@finos/legend-studio': patch
+'@finos/legend-studio-app': patch
+'@finos/legend-studio-deployment': patch
+'@finos/legend-studio-extension-management-toolkit': patch
+'@finos/legend-studio-extension-query-builder': patch
+'@finos/legend-taxonomy': patch
+'@finos/legend-taxonomy-app': patch
+'@finos/legend-taxonomy-deployment': patch
+'@finos/legend-tracer-extension-zipkin': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/fixtures/legend-mock-server/package.json
+++ b/fixtures/legend-mock-server/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "nodemon": "2.0.15",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "chalk": "5.0.0",
     "cross-env": "7.0.3",
     "envinfo": "7.8.1",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "fs-extra": "10.0.0",
     "husky": "7.0.4",
     "inquirer": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:ci": "yarn build && yarn test:coverage",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
+    "test:manual": "yarn workspace @finos/legend-manual-tests test:manual",
     "test:watch": "jest --watch"
   },
   "lint-staged": {

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "rimraf": "3.0.2",
     "typescript": "4.5.2"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -34,7 +34,7 @@
     "@babel/eslint-parser": "7.16.3",
     "@typescript-eslint/eslint-plugin": "5.5.0",
     "@typescript-eslint/parser": "5.5.0",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-prettier": "4.0.0",

--- a/packages/eslint-plugin/src/configs/recommended.js
+++ b/packages/eslint-plugin/src/configs/recommended.js
@@ -89,7 +89,7 @@ const ES_RULES = {
   'no-void': ERROR,
   'no-whitespace-before-property': ERROR,
   'object-curly-spacing': [WARN, 'always'],
-  'prefer-arrow-callback': ERROR,
+  'prefer-arrow-callback': [ERROR, { allowNamedFunctions: true }],
   'prefer-const': WARN,
   'prefer-named-capture-group': WARN,
   'prefer-template': WARN,

--- a/packages/legend-application/package.json
+++ b/packages/legend-application/package.json
@@ -63,7 +63,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "@testing-library/dom": "8.11.1",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-application/src/components/ApplicationStoreProviderTestUtils.tsx
+++ b/packages/legend-application/src/components/ApplicationStoreProviderTestUtils.tsx
@@ -21,15 +21,11 @@ import type { LegendApplicationConfig } from '../stores/ApplicationConfig';
 import { ApplicationStoreProvider } from './ApplicationStoreProvider';
 import type { LegendApplicationPluginManager } from '../application/LegendApplicationPluginManager';
 
-export const TEST__ApplicationStoreProvider = ({
-  children,
-  config,
-  pluginManager,
-}: {
+export const TEST__ApplicationStoreProvider: React.FC<{
   children: React.ReactNode;
   config: LegendApplicationConfig;
   pluginManager: LegendApplicationPluginManager;
-}): React.ReactElement => (
+}> = ({ children, config, pluginManager }) => (
   <ApplicationStoreProvider config={config} pluginManager={pluginManager}>
     {children}
   </ApplicationStoreProvider>

--- a/packages/legend-application/src/components/WebApplicationNavigatorProvider.tsx
+++ b/packages/legend-application/src/components/WebApplicationNavigatorProvider.tsx
@@ -25,11 +25,9 @@ const WebApplicationNavigatorContext = createContext<
   WebApplicationNavigator | undefined
 >(undefined);
 
-export const WebApplicationNavigatorProvider = ({
-  children,
-}: {
+export const WebApplicationNavigatorProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => {
+}> = ({ children }) => {
   const history = useHistory() as History;
   const navigator = useLocalObservable(
     () => new WebApplicationNavigator(history),

--- a/packages/legend-application/src/stores/WebApplicationNavigator.ts
+++ b/packages/legend-application/src/stores/WebApplicationNavigator.ts
@@ -35,8 +35,8 @@ import { guaranteeNonNullable } from '@finos/legend-shared';
  * As such, instead, we should design a more generic concept `Location` to pass around.
  * We would need to flesh out the details, but this is the rough idea.
  *
- * Another thought is that we should also genericize Router so it handles more than just
- * URLs. If we make `router` and `navigator` work together, we can potentially genericize
+ * Another thought is that we should also generalize Router so it handles more than just
+ * URLs. If we make `router` and `navigator` work together, we can potentially generalize
  * application navigation
  *
  * However, this depends on how and when we move to another platform, like `electron` for example

--- a/packages/legend-art/package.json
+++ b/packages/legend-art/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-art/src/components/BaseMuiComponents.tsx
+++ b/packages/legend-art/src/components/BaseMuiComponents.tsx
@@ -27,7 +27,7 @@ const useBaseMenuStyles = makeStyles({
   },
 });
 
-export const BaseMenu: React.FC<MenuProps> = (props: MenuProps) => {
+export const BaseMenu: React.FC<MenuProps> = (props) => {
   const classes = useBaseMenuStyles();
   const { children, ...otherProps } = props;
 
@@ -59,7 +59,7 @@ const useBasePopoverStyles = makeStyles({
   },
 });
 
-export const BasePopover: React.FC<PopoverProps> = (props: PopoverProps) => {
+export const BasePopover: React.FC<PopoverProps> = (props) => {
   const classes = useBasePopoverStyles();
   const { children, ...otherProps } = props;
 

--- a/packages/legend-art/src/components/CustomSelectorInput.tsx
+++ b/packages/legend-art/src/components/CustomSelectorInput.tsx
@@ -152,7 +152,7 @@ export type SelectComponent = CreatableSelect<SelectOption> | Select;
 export const CustomSelectorInput = forwardRef<
   SelectComponent,
   CustomSelectorInputProps
->((props, ref) => {
+>(function CustomSelectorInput(props, ref) {
   const {
     option,
     allowCreating,
@@ -201,8 +201,6 @@ export const CustomSelectorInput = forwardRef<
     />
   );
 });
-
-CustomSelectorInput.displayName = 'CustomSelectorInput';
 
 export const compareLabelFn = (
   a: { label: string },

--- a/packages/legend-art/src/components/menu/MenuContent.tsx
+++ b/packages/legend-art/src/components/menu/MenuContent.tsx
@@ -20,7 +20,7 @@ import clsx from 'clsx';
 export const MenuContent = forwardRef<
   HTMLDivElement,
   { className?: string; children: React.ReactNode }
->((props, ref) => {
+>(function MenuContent(props, ref) {
   const { className, children, ...otherProps } = props;
   return (
     <div ref={ref} className={clsx('menu', className)} {...otherProps}>
@@ -28,8 +28,6 @@ export const MenuContent = forwardRef<
     </div>
   );
 });
-
-MenuContent.displayName = 'MenuContent';
 
 export const MenuContentItem: React.FC<{
   className?: string;

--- a/packages/legend-dev-utils/package.json
+++ b/packages/legend-dev-utils/package.json
@@ -89,7 +89,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "rimraf": "3.0.2"
   },
   "publishConfig": {

--- a/packages/legend-extension-dsl-data-space/package.json
+++ b/packages/legend-extension-dsl-data-space/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-extension-dsl-diagram/package.json
+++ b/packages/legend-extension-dsl-diagram/package.json
@@ -59,7 +59,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "@testing-library/react": "12.1.2",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "jest-canvas-mock": "2.3.1",
     "npm-run-all": "4.1.5",

--- a/packages/legend-extension-dsl-serializer/package.json
+++ b/packages/legend-extension-dsl-serializer/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-extension-dsl-text/package.json
+++ b/packages/legend-extension-dsl-text/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-extension-external-format-json-schema/package.json
+++ b/packages/legend-extension-external-format-json-schema/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-extension-external-language-morphir/package.json
+++ b/packages/legend-extension-external-language-morphir/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-extension-external-store-service/package.json
+++ b/packages/legend-extension-external-store-service/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-extension-external-store-service/src/models/protocols/pure/v1/transformation/pureGraph/V1_ESService_TransformerHelper.ts
+++ b/packages/legend-extension-external-store-service/src/models/protocols/pure/v1/transformation/pureGraph/V1_ESService_TransformerHelper.ts
@@ -179,9 +179,9 @@ export const V1_transformServiceStoreService = (
   const service = new V1_ServiceStoreService();
   service.id = metamodel.id;
   service.path = metamodel.path;
-  if (metamodel.requestBody !== undefined) {
-    service.requestBody = V1_transformTypeReference(metamodel.requestBody);
-  }
+  service.requestBody = metamodel.requestBody
+    ? V1_transformTypeReference(metamodel.requestBody)
+    : undefined;
   service.method = metamodel.method;
   service.parameters = metamodel.parameters.map((parameter) =>
     V1_transformServiceParameter(parameter),
@@ -199,11 +199,9 @@ export const V1_transformServiceToServiceGroupPtr = (
   const serviceGroup = new V1_ServiceGroupPtr();
   serviceGroup.serviceGroup = metamodel.id;
   serviceGroup.serviceStore = metamodel.owner.path;
-  if (metamodel.parent !== undefined) {
-    serviceGroup.parent = V1_transformServiceToServiceGroupPtr(
-      metamodel.parent,
-    );
-  }
+  serviceGroup.parent = metamodel.parent
+    ? V1_transformServiceToServiceGroupPtr(metamodel.parent)
+    : undefined;
   return serviceGroup;
 };
 
@@ -213,9 +211,9 @@ export const V1_transformServiceToServicePtr = (
   const service = new V1_ServiceStoreServicePtr();
   service.service = metamodel.id;
   service.serviceStore = metamodel.owner.path;
-  if (metamodel.parent !== undefined) {
-    service.parent = V1_transformServiceToServiceGroupPtr(metamodel.parent);
-  }
+  service.parent = metamodel.parent
+    ? V1_transformServiceToServiceGroupPtr(metamodel.parent)
+    : undefined;
   return service;
 };
 

--- a/packages/legend-extension-external-store-service/src/models/protocols/pure/v1/transformation/pureProtocol/V1_ESService_ProtocolHelper.ts
+++ b/packages/legend-extension-external-store-service/src/models/protocols/pure/v1/transformation/pureProtocol/V1_ESService_ProtocolHelper.ts
@@ -16,6 +16,7 @@
 
 import type { PlainObject } from '@finos/legend-shared';
 import {
+  optionalCustom,
   UnsupportedOperationError,
   usingConstantValueSchema,
   usingModelSchema,
@@ -239,8 +240,9 @@ const V1_serviceModelSchema = (
     method: primitive(),
     parameters: list(usingModelSchema(V1_serviceParameterModelSchema)),
     path: primitive(),
-    requestBody: optional(
-      custom(V1_serializeTypeReference, V1_deserializeTypeReference),
+    requestBody: optionalCustom(
+      V1_serializeTypeReference,
+      V1_deserializeTypeReference,
     ),
     response: usingModelSchema(V1_complexTypeReferenceModelSchema),
     security: list(

--- a/packages/legend-extension-external-store-service/src/models/protocols/pure/v1/transformation/pureProtocol/V1_ESService_ProtocolHelper.ts
+++ b/packages/legend-extension-external-store-service/src/models/protocols/pure/v1/transformation/pureProtocol/V1_ESService_ProtocolHelper.ts
@@ -240,20 +240,7 @@ const V1_serviceModelSchema = (
     parameters: list(usingModelSchema(V1_serviceParameterModelSchema)),
     path: primitive(),
     requestBody: optional(
-      custom(
-        (val) => {
-          if (val !== undefined) {
-            return V1_serializeTypeReference(val);
-          }
-          return undefined;
-        },
-        (val) => {
-          if (val !== undefined) {
-            return V1_deserializeTypeReference(val);
-          }
-          return undefined;
-        },
-      ),
+      custom(V1_serializeTypeReference, V1_deserializeTypeReference),
     ),
     response: usingModelSchema(V1_complexTypeReferenceModelSchema),
     security: list(

--- a/packages/legend-graph-extension-collection/package.json
+++ b/packages/legend-graph-extension-collection/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "rimraf": "3.0.2",
     "typescript": "4.5.2"

--- a/packages/legend-graph/package.json
+++ b/packages/legend-graph/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-graph/src/GraphManagerStateProvider.tsx
+++ b/packages/legend-graph/src/GraphManagerStateProvider.tsx
@@ -25,15 +25,11 @@ const GraphManagerStateContext = createContext<GraphManagerState | undefined>(
   undefined,
 );
 
-export const GraphManagerStateProvider = ({
-  children,
-  pluginManager,
-  log,
-}: {
+export const GraphManagerStateProvider: React.FC<{
   children: React.ReactNode;
   pluginManager: GraphPluginManager;
   log: Log;
-}): React.ReactElement => {
+}> = ({ children, pluginManager, log }) => {
   const graphManagerState = useLocalObservable(
     () => new GraphManagerState(pluginManager, log),
   );

--- a/packages/legend-graph/src/GraphManagerTestUtils.tsx
+++ b/packages/legend-graph/src/GraphManagerTestUtils.tsx
@@ -83,11 +83,9 @@ export const TEST__provideMockedGraphManagerState = (customization?: {
   return value;
 };
 
-export const TEST__GraphManagerStateProvider = ({
-  children,
-}: {
+export const TEST__GraphManagerStateProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => (
+}> = ({ children }) => (
   <GraphManagerStateProvider
     pluginManager={new TEST__GraphPluginManager()}
     log={new Log()}

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -219,10 +219,7 @@ export { V1_rawLambdaModelSchema } from './models/protocols/pure/v1/transformati
 export { V1_transformPropertyReference } from './models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer';
 export { V1_EngineServerClient } from './models/protocols/pure/v1/engine/V1_EngineServerClient';
 export { V1_Engine } from './models/protocols/pure/v1/engine/V1_Engine';
-export {
-  V1_pureModelContextDataPropSchema,
-  V1_deserializePureModelContextData as V1_jsonToPureModelContextData,
-} from './models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization';
+export { V1_deserializePureModelContextData as V1_jsonToPureModelContextData } from './models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization';
 export {
   V1_propertyPointerModelSchema,
   V1_stereotypePtrSchema,

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/execution/V1_ExecuteInput.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/execution/V1_ExecuteInput.ts
@@ -17,16 +17,16 @@
 import {
   createModelSchema,
   custom,
+  object,
   optional,
   primitive,
   SKIP,
 } from 'serializr';
 import { SerializationFactory, usingModelSchema } from '@finos/legend-shared';
-import type { V1_PureModelContextData } from '../../model/context/V1_PureModelContextData';
+import { V1_PureModelContextData } from '../../model/context/V1_PureModelContextData';
 import type { V1_Runtime } from '../../model/packageableElements/runtime/V1_Runtime';
 import type { V1_RawExecutionContext } from '../../model/rawValueSpecification/V1_RawExecutionContext';
 import type { V1_RawLambda } from '../../model/rawValueSpecification/V1_RawLambda';
-import { V1_pureModelContextDataPropSchema } from '../../transformation/pureProtocol/V1_PureProtocolSerialization';
 import { V1_serializeRuntime } from '../../transformation/pureProtocol/serializationHelpers/V1_RuntimeSerializationHelper';
 import {
   V1_rawBaseExecutionContextModelSchema,
@@ -46,7 +46,7 @@ export class V1_ExecuteInput {
       clientVersion: optional(primitive()),
       function: usingModelSchema(V1_rawLambdaModelSchema),
       mapping: primitive(),
-      model: V1_pureModelContextDataPropSchema,
+      model: object(V1_PureModelContextData),
       runtime: custom(
         (val) => V1_serializeRuntime(val),
         () => SKIP,

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/grammar/V1_JsonToGrammarInput.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/grammar/V1_JsonToGrammarInput.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { createModelSchema, optional, primitive } from 'serializr';
+import { createModelSchema, object, optional, primitive } from 'serializr';
 import { SerializationFactory, usingModelSchema } from '@finos/legend-shared';
 import { V1_ParserError } from '../../engine/grammar/V1_ParserError';
 import { V1_LambdaInput } from './V1_LambdaInput';
-import type { V1_PureModelContextData } from '../../model/context/V1_PureModelContextData';
-import { V1_pureModelContextDataPropSchema } from '../../transformation/pureProtocol/V1_PureProtocolSerialization';
+import { V1_PureModelContextData } from '../../model/context/V1_PureModelContextData';
 
 export enum V1_RenderStyle {
   STANDARD = 'STANDARD',
@@ -35,7 +34,7 @@ export class V1_JsonToGrammarInput {
 
   static readonly serialization = new SerializationFactory(
     createModelSchema(V1_JsonToGrammarInput, {
-      modelDataContext: V1_pureModelContextDataPropSchema,
+      modelDataContext: optional(object(V1_PureModelContextData)),
       isolatedLambdas: usingModelSchema(V1_LambdaInput.serialization.schema),
       renderStyle: optional(primitive()),
       codeError: usingModelSchema(V1_ParserError.serialization.schema),

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/query/V1_Query.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/query/V1_Query.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { SerializationFactory, usingModelSchema } from '@finos/legend-shared';
+import {
+  NullphobicSerializationFactory,
+  usingModelSchema,
+} from '@finos/legend-shared';
 import { createModelSchema, list, optional, primitive } from 'serializr';
 import type { V1_StereotypePtr } from '../../model/packageableElements/domain/V1_StereotypePtr';
 import type { V1_TaggedValue } from '../../model/packageableElements/domain/V1_TaggedValue';
@@ -36,7 +39,7 @@ export class V1_Query {
   taggedValues?: V1_TaggedValue[] | undefined;
   stereotypes?: V1_StereotypePtr[] | undefined;
 
-  static readonly serialization = new SerializationFactory(
+  static readonly serialization = new NullphobicSerializationFactory(
     createModelSchema(V1_Query, {
       artifactId: primitive(),
       content: primitive(),
@@ -61,7 +64,7 @@ export class V1_LightQuery {
   artifactId!: string;
   versionId!: string;
 
-  static readonly serialization = new SerializationFactory(
+  static readonly serialization = new NullphobicSerializationFactory(
     createModelSchema(V1_Query, {
       artifactId: primitive(),
       id: primitive(),

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/query/V1_QuerySearchSpecification.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/query/V1_QuerySearchSpecification.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { SerializationFactory, usingModelSchema } from '@finos/legend-shared';
+import {
+  NullphobicSerializationFactory,
+  SerializationFactory,
+  usingModelSchema,
+} from '@finos/legend-shared';
 import { createModelSchema, list, optional, primitive } from 'serializr';
 import type { V1_StereotypePtr } from '../../model/packageableElements/domain/V1_StereotypePtr';
 import type { V1_TaggedValue } from '../../model/packageableElements/domain/V1_TaggedValue';
@@ -43,7 +47,7 @@ export class V1_QuerySearchSpecification {
   limit?: number | undefined;
   showCurrentUserQueriesOnly?: boolean | undefined;
 
-  static readonly serialization = new SerializationFactory(
+  static readonly serialization = new NullphobicSerializationFactory(
     createModelSchema(V1_QuerySearchSpecification, {
       limit: optional(primitive()),
       projectCoordinates: optional(

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/V1_PureProtocolSerialization.ts
@@ -23,6 +23,7 @@ import {
   SKIP,
   serialize,
   deserialize,
+  object,
 } from 'serializr';
 import type { PlainObject } from '@finos/legend-shared';
 import {
@@ -111,12 +112,6 @@ const alloySDLCSerializationModelSchema = createModelSchema(V1_AlloySDLC, {
   ),
 });
 
-export const V1_pureModelContextDataPropSchema = custom(
-  (value) =>
-    value === undefined ? SKIP : serialize(V1_PureModelContextData, value),
-  (value) => deserialize(V1_PureModelContextData, value),
-);
-
 const V1_pureModelContextTextSchema = createModelSchema(
   V1_PureModelContextText,
   {
@@ -124,14 +119,6 @@ const V1_pureModelContextTextSchema = createModelSchema(
     serializer: usingModelSchema(V1_Protocol.serialization.schema),
     code: optional(primitive()),
   },
-);
-
-export const V1_pureModelContextTextPropSchema = custom(
-  (value) =>
-    value === undefined
-      ? SKIP
-      : serialize(V1_pureModelContextTextSchema, value),
-  (value) => deserialize(V1_pureModelContextTextSchema, value),
 );
 
 const V1_pureModelContextPointerModelSchema = createModelSchema(
@@ -148,7 +135,7 @@ const V1_pureModelContextCompositeModelSchema = createModelSchema(
   {
     _type: usingConstantValueSchema(V1_PureModelContextType.COMPOSITE),
     serializer: usingModelSchema(V1_Protocol.serialization.schema),
-    data: V1_pureModelContextDataPropSchema,
+    data: object(V1_PureModelContextData),
     pointer: usingModelSchema(V1_pureModelContextPointerModelSchema),
   },
 );

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DatabaseSerializationHelper.ts
@@ -21,13 +21,13 @@ import {
   list,
   deserialize,
   serialize,
-  SKIP,
   object,
   alias,
   optional,
 } from 'serializr';
 import type { PlainObject } from '@finos/legend-shared';
 import {
+  optionalCustom,
   usingConstantValueSchema,
   deserializeArray,
   UnsupportedOperationError,
@@ -343,11 +343,9 @@ const V1_elementWithJoinsModelSchema = createModelSchema(V1_ElementWithJoins, {
     V1_RelationalOperationElementType.ELEMENT_WITH_JOINS,
   ),
   joins: list(usingModelSchema(V1_joinPointerModelSchema)),
-  relationalElement: custom(
-    (val) =>
-      val === undefined ? SKIP : V1_serializeRelationalOperationElement(val),
-    (val) =>
-      val === undefined ? SKIP : V1_deserializeRelationalOperationElement(val),
+  relationalElement: optionalCustom(
+    V1_serializeRelationalOperationElement,
+    V1_deserializeRelationalOperationElement,
   ),
 });
 

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.ts
@@ -251,10 +251,7 @@ export const V1_constraintSchema = createModelSchema(V1_Constraint, {
   enforcementLevel: optional(primitive()),
   externalId: optional(primitive()),
   functionDefinition: usingModelSchema(V1_rawLambdaModelSchema),
-  messageFunction: custom(
-    (value) => (value ? serialize(V1_rawLambdaModelSchema, value) : SKIP),
-    (value) => deserialize(V1_rawLambdaModelSchema, value),
-  ),
+  messageFunction: optional(usingModelSchema(V1_rawLambdaModelSchema)),
   name: primitive(),
 });
 

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MappingSerializationHelper.ts
@@ -577,7 +577,7 @@ function V1_serializeClassMapping(
   } else if (value instanceof V1_AggregationAwareClassMapping) {
     return serialize(aggregationAwareClassMappingModelSchema, value);
   }
-  if (plugins !== undefined) {
+  if (plugins) {
     const extraClassMappingSerializers = plugins.flatMap(
       (plugin) =>
         (
@@ -615,7 +615,7 @@ function V1_deserializeClassMapping(
     case V1_ClassMappingType.AGGREGATION_AWARE:
       return deserialize(aggregationAwareClassMappingModelSchema, json);
     default: {
-      if (plugins !== undefined) {
+      if (plugins) {
         const extraClassMappingDeserializers = plugins.flatMap(
           (plugin) =>
             (
@@ -1007,18 +1007,8 @@ export const V1_mappingModelSchema = (
     ),
     classMappings: list(
       custom(
-        (val) => {
-          if (plugins !== undefined) {
-            return V1_serializeClassMapping(val, plugins);
-          }
-          return V1_serializeClassMapping(val);
-        },
-        (val) => {
-          if (plugins !== undefined) {
-            return V1_deserializeClassMapping(val, plugins);
-          }
-          return V1_deserializeClassMapping(val);
-        },
+        (val) => V1_serializeClassMapping(val, plugins),
+        (val) => V1_deserializeClassMapping(val, plugins),
       ),
     ),
     enumerationMappings: list(

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MilestoningSerializationHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/V1_MilestoningSerializationHelper.ts
@@ -16,16 +16,15 @@
 
 import type { PlainObject } from '@finos/legend-shared';
 import {
+  optionalCustom,
   usingConstantValueSchema,
   UnsupportedOperationError,
 } from '@finos/legend-shared';
 import {
   createModelSchema,
-  custom,
   deserialize,
   primitive,
   serialize,
-  SKIP,
 } from 'serializr';
 import { V1_BusinessMilestoning } from '../../../model/packageableElements/store/relational/model/milestoning/V1_BusinessMilestoning';
 import { V1_BusinessSnapshotMilestoning } from '../../../model/packageableElements/store/relational/model/milestoning/V1_BusinessSnapshotMilestoning';
@@ -49,9 +48,9 @@ const businessMilestoningModelSchema = createModelSchema(
   {
     _type: usingConstantValueSchema(V1_MilestoningType.BUSINESS_MILESTONING),
     from: primitive(),
-    infinityDate: custom(
-      (val) => (val ? V1_serializeRawValueSpecification(val) : SKIP),
-      (val) => (val ? V1_deserializeRawValueSpecification(val) : SKIP),
+    infinityDate: optionalCustom(
+      V1_serializeRawValueSpecification,
+      V1_deserializeRawValueSpecification,
     ),
     thru: primitive(),
     thruIsInclusive: primitive(),
@@ -64,9 +63,9 @@ const businessSnapshotMilestoningModelSchema = createModelSchema(
     _type: usingConstantValueSchema(
       V1_MilestoningType.BUSINESS_SNAPSHOT_MILESTONING,
     ),
-    infinityDate: custom(
-      (val) => (val ? V1_serializeRawValueSpecification(val) : SKIP),
-      (val) => (val ? V1_deserializeRawValueSpecification(val) : SKIP),
+    infinityDate: optionalCustom(
+      V1_serializeRawValueSpecification,
+      V1_deserializeRawValueSpecification,
     ),
     snapshotDate: primitive(),
   },
@@ -77,9 +76,9 @@ const processingMilestoningModelSchema = createModelSchema(
   {
     _type: usingConstantValueSchema(V1_MilestoningType.PROCESSING_MILESTONING),
     in: primitive(),
-    infinityDate: custom(
-      (val) => (val ? V1_serializeRawValueSpecification(val) : SKIP),
-      (val) => (val ? V1_deserializeRawValueSpecification(val) : SKIP),
+    infinityDate: optionalCustom(
+      V1_serializeRawValueSpecification,
+      V1_deserializeRawValueSpecification,
     ),
     out: primitive(),
     outIsInclusive: primitive(),

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/executionPlan/V1_ExecutionPlanSerializationHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureProtocol/serializationHelpers/executionPlan/V1_ExecutionPlanSerializationHelper.ts
@@ -22,10 +22,10 @@ import {
   primitive,
   list,
   optional,
-  SKIP,
 } from 'serializr';
 import type { PlainObject } from '@finos/legend-shared';
 import {
+  optionalCustom,
   deserializeArray,
   serializeArray,
   deseralizeMap,
@@ -64,9 +64,9 @@ const dataTypeResultTypeModelSchema = createModelSchema(V1_DataTypeResultType, {
 
 const TDSColumnModelSchema = createModelSchema(V1_TDSColumn, {
   doc: optional(primitive()),
-  enumMapping: custom(
-    (val) => (val ? serializeMap(val) : SKIP),
-    (val) => (val ? deseralizeMap(val) : undefined),
+  enumMapping: optionalCustom(
+    (val: Map<string, unknown>) => serializeMap(val),
+    deseralizeMap,
   ),
   name: primitive(),
   relationalType: optional(primitive()),

--- a/packages/legend-manual-tests/package.json
+++ b/packages/legend-manual-tests/package.json
@@ -34,7 +34,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "axios": "0.24.0",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-model-storage/package.json
+++ b/packages/legend-model-storage/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "lodash": "4.17.21",
     "rimraf": "3.0.2",

--- a/packages/legend-query-app/package.json
+++ b/packages/legend-query-app/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "sass": "1.44.0",

--- a/packages/legend-query-deployment/package.json
+++ b/packages/legend-query-deployment/package.json
@@ -41,7 +41,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "copy-webpack-plugin": "10.0.0",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "typescript": "4.5.2",

--- a/packages/legend-query/package.json
+++ b/packages/legend-query/package.json
@@ -72,7 +72,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "@testing-library/dom": "8.11.1",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-query/src/components/LegendQueryStoreProvider.tsx
+++ b/packages/legend-query/src/components/LegendQueryStoreProvider.tsx
@@ -28,13 +28,10 @@ const LegendQueryStoreContext = createContext<LegendQueryStore | undefined>(
   undefined,
 );
 
-export const LegendQueryStoreProvider = ({
-  children,
-  pluginManager,
-}: {
+export const LegendQueryStoreProvider: React.FC<{
   children: React.ReactNode;
   pluginManager: LegendQueryPluginManager;
-}): React.ReactElement => {
+}> = ({ children, pluginManager }) => {
   const applicationStore = useApplicationStore<LegendQueryConfig>();
   const depotServerClient = useDepotServerClient();
   const graphManagerState = useGraphManagerState();

--- a/packages/legend-query/src/components/QueryComponentTestUtils.tsx
+++ b/packages/legend-query/src/components/QueryComponentTestUtils.tsx
@@ -54,11 +54,9 @@ import { QUERY_BUILDER_TEST_ID } from './QueryBuilder_TestID';
 import type { LegendQueryConfig } from '../application/LegendQueryConfig';
 import type { Entity } from '@finos/legend-model-storage';
 
-export const TEST__LegendQueryStoreProvider = ({
-  children,
-}: {
+export const TEST__LegendQueryStoreProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => (
+}> = ({ children }) => (
   <LegendQueryStoreProvider pluginManager={LegendQueryPluginManager.create()}>
     {children}
   </LegendQueryStoreProvider>

--- a/packages/legend-query/src/components/QuerySetupStoreProvider.tsx
+++ b/packages/legend-query/src/components/QuerySetupStoreProvider.tsx
@@ -24,11 +24,9 @@ const QuerySetupStoreContext = createContext<QuerySetupStore | undefined>(
   undefined,
 );
 
-export const QuerySetupStoreProvider = ({
-  children,
-}: {
+export const QuerySetupStoreProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => {
+}> = ({ children }) => {
   const queryStore = useLegendQueryStore();
   const store = useLocalObservable(() => new QuerySetupStore(queryStore));
   return (

--- a/packages/legend-server-depot/package.json
+++ b/packages/legend-server-depot/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-server-depot/src/DepotServerClientProvider.tsx
+++ b/packages/legend-server-depot/src/DepotServerClientProvider.tsx
@@ -24,13 +24,10 @@ const DepotServerClientContext = createContext<DepotServerClient | undefined>(
   undefined,
 );
 
-export const DepotServerClientProvider = ({
-  children,
-  config,
-}: {
+export const DepotServerClientProvider: React.FC<{
   children: React.ReactNode;
   config: DepotServerClientConfig;
-}): React.ReactElement => {
+}> = ({ children, config }) => {
   const depotServerClient = useLocalObservable(
     () => new DepotServerClient(config),
   );

--- a/packages/legend-server-depot/src/DepotServerClientTestUtils.tsx
+++ b/packages/legend-server-depot/src/DepotServerClientTestUtils.tsx
@@ -32,11 +32,9 @@ export const TEST__provideMockedDepotServerClient = (customization?: {
   return value;
 };
 
-export const TEST__DepotServerClientProvider = ({
-  children,
-}: {
+export const TEST__DepotServerClientProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => (
+}> = ({ children }) => (
   <DepotServerClientProvider config={{ serverUrl: '' }}>
     {children}
   </DepotServerClientProvider>

--- a/packages/legend-server-sdlc/package.json
+++ b/packages/legend-server-sdlc/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-server-sdlc/src/SDLCServerClientProvider.tsx
+++ b/packages/legend-server-sdlc/src/SDLCServerClientProvider.tsx
@@ -24,13 +24,10 @@ const SDLCServerClientContext = createContext<SDLCServerClient | undefined>(
   undefined,
 );
 
-export const SDLCServerClientProvider = ({
-  children,
-  config,
-}: {
+export const SDLCServerClientProvider: React.FC<{
   children: React.ReactNode;
   config: SDLCServerClientConfig;
-}): React.ReactElement => {
+}> = ({ children, config }) => {
   const sdlcServerClient = useLocalObservable(
     () => new SDLCServerClient(config),
   );

--- a/packages/legend-server-sdlc/src/SDLCServerClientTestUtils.tsx
+++ b/packages/legend-server-sdlc/src/SDLCServerClientTestUtils.tsx
@@ -33,11 +33,9 @@ export const TEST__provideMockedSDLCServerClient = (customization?: {
   return value;
 };
 
-export const TEST__SDLCServerClientProvider = ({
-  children,
-}: {
+export const TEST__SDLCServerClientProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => (
+}> = ({ children }) => (
   <SDLCServerClientProvider config={{ serverUrl: '', env: '' }}>
     {children}
   </SDLCServerClientProvider>

--- a/packages/legend-server-sdlc/src/models/review/Review.ts
+++ b/packages/legend-server-sdlc/src/models/review/Review.ts
@@ -15,13 +15,7 @@
  */
 
 import { User } from '../User';
-import {
-  SKIP,
-  custom,
-  createModelSchema,
-  primitive,
-  optional,
-} from 'serializr';
+import { SKIP, custom, createModelSchema, primitive } from 'serializr';
 import { SerializationFactory, usingModelSchema } from '@finos/legend-shared';
 import type { WorkspaceType } from '../workspace/Workspace';
 
@@ -49,31 +43,22 @@ export class Review {
   static readonly serialization = new SerializationFactory(
     createModelSchema(Review, {
       author: usingModelSchema(User.serialization.schema),
-      closedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      closedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
-      committedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      committedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
       createdAt: custom(
         () => SKIP,
         (value: string) => new Date(value),
       ),
       id: primitive(),
-      lastUpdatedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      lastUpdatedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
       projectId: primitive(),
       state: primitive(),

--- a/packages/legend-server-sdlc/src/models/workflow/Workflow.ts
+++ b/packages/legend-server-sdlc/src/models/workflow/Workflow.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  custom,
-  SKIP,
-  createModelSchema,
-  primitive,
-  optional,
-} from 'serializr';
+import { custom, SKIP, createModelSchema, primitive } from 'serializr';
 import { SerializationFactory } from '@finos/legend-shared';
 
 export enum WorkflowStatus {
@@ -49,21 +43,15 @@ export class Workflow {
         () => SKIP,
         (value: string) => new Date(value),
       ),
-      finishedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      finishedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
       projectId: primitive(),
       revisionId: primitive(),
-      startedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      startedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
       status: primitive(),
       webURL: primitive(),

--- a/packages/legend-server-sdlc/src/models/workflow/WorkflowJob.ts
+++ b/packages/legend-server-sdlc/src/models/workflow/WorkflowJob.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  custom,
-  SKIP,
-  createModelSchema,
-  primitive,
-  optional,
-} from 'serializr';
+import { custom, SKIP, createModelSchema, primitive } from 'serializr';
 import { SerializationFactory } from '@finos/legend-shared';
 
 export enum WorkflowJobStatus {
@@ -55,21 +49,15 @@ export class WorkflowJob {
         () => SKIP,
         (value: string) => new Date(value),
       ),
-      finishedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      finishedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
       projectId: primitive(),
       revisionId: primitive(),
-      startedAt: optional(
-        custom(
-          () => SKIP,
-          (value: string | null | undefined) =>
-            value ? new Date(value) : undefined,
-        ),
+      startedAt: custom(
+        () => SKIP,
+        (value: string | null | undefined) => (value ? new Date(value) : SKIP),
       ),
       status: primitive(),
       webURL: primitive(),

--- a/packages/legend-server-sdlc/src/models/workspace/Workspace.ts
+++ b/packages/legend-server-sdlc/src/models/workspace/Workspace.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import { createModelSchema, primitive } from 'serializr';
-import {
-  usingNullableOptionalPrimitiveSchema,
-  SerializationFactory,
-} from '@finos/legend-shared';
+import { createModelSchema, optional, primitive } from 'serializr';
+import { NullphobicSerializationFactory } from '@finos/legend-shared';
 
 export enum WorkspaceAccessType {
   WORKSPACE = 'WORKSPACE',
@@ -37,10 +34,10 @@ export class Workspace {
 
   accessType = WorkspaceAccessType.WORKSPACE;
 
-  static readonly serialization = new SerializationFactory(
+  static readonly serialization = new NullphobicSerializationFactory(
     createModelSchema(Workspace, {
       projectId: primitive(),
-      userId: usingNullableOptionalPrimitiveSchema(),
+      userId: optional(primitive()),
       workspaceId: primitive(),
     }),
   );

--- a/packages/legend-shared/package.json
+++ b/packages/legend-shared/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "lodash": "4.17.21",
     "rimraf": "3.0.2",

--- a/packages/legend-shared/src/CommonUtils.ts
+++ b/packages/legend-shared/src/CommonUtils.ts
@@ -138,6 +138,22 @@ export const pruneObject = (
     unknown
   >;
 
+/**
+ * Recursively remove fields with null values in object
+ *
+ * This is particularly useful in serialization, especially when handling response
+ * coming from servers where `null` are returned for missing fields. We would like to
+ * treat them as `undefined` instead, so we want to strip all the `null` values from the
+ * plain JSON object.
+ */
+export const pruneNullValues = (
+  obj: Record<PropertyKey, unknown>,
+): Record<PropertyKey, unknown> =>
+  pickBy(obj, (val: unknown): boolean => val !== null) as Record<
+    PropertyKey,
+    unknown
+  >;
+
 // Stringify object shallowly
 // See https://stackoverflow.com/questions/16466220/limit-json-stringification-depth
 export const shallowStringify = (object: unknown): string =>

--- a/packages/legend-shared/src/application/SerializationUtils.ts
+++ b/packages/legend-shared/src/application/SerializationUtils.ts
@@ -15,8 +15,9 @@
  */
 
 import type { PlainObject } from '../CommonUtils';
+import { pruneNullValues } from '../CommonUtils';
 import type { ClazzOrModelSchema, ModelSchema, PropSchema } from 'serializr';
-import { optional, custom, SKIP, deserialize, serialize } from 'serializr';
+import { custom, SKIP, deserialize, serialize } from 'serializr';
 
 // NOTE: we need these methods because `map()` of `serializr` tries to smartly determines if it should produce object or ES6 Map
 // but we always want ES6 Map, so we would use this function
@@ -60,6 +61,32 @@ export class SerializationFactory<T> extends BasicSerializationFactory<T> {
   fromJson = (val: PlainObject<T>): T => deserialize(this.schema, val);
 }
 
+/**
+ * Similar to {@link SerializationFactory} but used for entities coming from server which returns
+ * values which have not been set to `null` instead of `undefined`. This will cause `serializr` to
+ * throw.
+ *
+ * e.g.
+ * // in Server (Java + Jackson):
+ * Person person; // this will be serialized to `null` by Jackson (depending on the setting of the server)
+ *
+ * // in our code (TS + serializr):
+ * person: optional(object(Person))
+ *
+ * --> error thrown
+ */
+export class NullphobicSerializationFactory<T> {
+  readonly schema: ModelSchema<T>;
+
+  constructor(schema: ModelSchema<T>) {
+    this.schema = schema;
+  }
+
+  toJson = (val: T): PlainObject<T> => serialize(this.schema, val);
+  fromJson = (val: PlainObject<T>): T =>
+    deserialize(this.schema, pruneNullValues(val));
+}
+
 export const usingModelSchema = <T>(schema: ModelSchema<T>): PropSchema =>
   custom(
     (value) => (value === undefined ? SKIP : serialize(schema, value)),
@@ -98,16 +125,4 @@ export const usingConstantValueSchema = (
   custom(
     () => value,
     () => value,
-  );
-
-/**
- * Sometimes, servers might return primitive fields which have not been set as `null` instead of `undefined`
- * This shema will force-convert the value to `undefined` if it's `null`.
- */
-export const usingNullableOptionalPrimitiveSchema = (): PropSchema =>
-  optional(
-    custom(
-      (value) => value ?? SKIP,
-      (value) => value ?? undefined,
-    ),
   );

--- a/packages/legend-shared/src/application/SerializationUtils.ts
+++ b/packages/legend-shared/src/application/SerializationUtils.ts
@@ -76,7 +76,10 @@ export class SerializationFactory<T> extends BasicSerializationFactory<T> {
  * --> error thrown
  */
 export class NullphobicSerializationFactory<T> {
-  readonly schema: ModelSchema<T>;
+  /**
+   * Since we customize the behavior of the deserializer, we must not expose the schema
+   */
+  private readonly schema: ModelSchema<T>;
 
   constructor(schema: ModelSchema<T>) {
     this.schema = schema;

--- a/packages/legend-shared/src/application/SerializationUtils.ts
+++ b/packages/legend-shared/src/application/SerializationUtils.ts
@@ -129,3 +129,23 @@ export const usingConstantValueSchema = (
     () => value,
     () => value,
   );
+
+/**
+ * This is the idiomatic usage pattern for `optional(custom(...))`.
+ *
+ * `optional` only affects serialization so we must make sure to check
+ * if the value is `undefined` or not, if yes, serialize, else, return `undefined`
+ * which will be processed by `optional(...)` as `SKIP`.
+ *
+ * `optional` does not affect deserialization, however, as `undefined` values
+ * are automatically skipped
+ * See https://github.com/mobxjs/serializr/issues/73#issuecomment-535641545
+ */
+export const optionalCustom = <T>(
+  serializer: (val: T) => PlainObject<T>,
+  deserializer: (val: PlainObject<T>) => T,
+): PropSchema =>
+  custom(
+    (val) => (val ? serializer(val) : SKIP),
+    (val) => (val ? deserializer(val) : SKIP),
+  );

--- a/packages/legend-studio-app/package.json
+++ b/packages/legend-studio-app/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "sass": "1.44.0",

--- a/packages/legend-studio-deployment/package.json
+++ b/packages/legend-studio-deployment/package.json
@@ -41,7 +41,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "copy-webpack-plugin": "10.0.0",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "typescript": "4.5.2",

--- a/packages/legend-studio-extension-management-toolkit/package.json
+++ b/packages/legend-studio-extension-management-toolkit/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio-extension-query-builder/package.json
+++ b/packages/legend-studio-extension-query-builder/package.json
@@ -62,7 +62,7 @@
     "@testing-library/dom": "8.11.1",
     "@testing-library/react": "12.1.2",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio/CHANGELOG.md
+++ b/packages/legend-studio/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 - [#642](https://github.com/finos/legend-studio/pull/642) [`729e248`](https://github.com/finos/legend-studio/commit/729e248634a3710d94257ead28c7a0c9307798cb) ([@akphi](https://github.com/akphi)) - **BREAKING CHANGE:** The handling of multiple SDLC instances has been reworked, to target a specific server option in the config, the URL must now include an additional prefix `sdlc-` to the server key, for example, `/studio/myServer/...` now becomes `/studio/sdlc-myServer/...`. On the config side, when `sdlc` field is configured with a list of option, we expect exactly one option to declare `default: true` and this would be used to the default option - _the old behavior is that the default option is the one with key of value `-`_.
 
-* [#659](https://github.com/finos/legend-studio/pull/659) [`caf3d4aa`](https://github.com/finos/legend-studio/commit/caf3d4aa3a98ca109cabb525eeb7d8615def7343) ([@akphi](https://github.com/akphi)) - **BREAKING CHANGE:** Genericize `Studio` plugin methods to generate `Edit Query` buttons to generate any query editor action: i.e. `MappingExecutionQueryEditorRendererConfiguration -> MappingExecutionQueryEditorActionConfiguration`, etc.
+* [#659](https://github.com/finos/legend-studio/pull/659) [`caf3d4aa`](https://github.com/finos/legend-studio/commit/caf3d4aa3a98ca109cabb525eeb7d8615def7343) ([@akphi](https://github.com/akphi)) - **BREAKING CHANGE:** Generalize `Studio` plugin methods to generate `Edit Query` buttons to generate any query editor action: i.e. `MappingExecutionQueryEditorRendererConfiguration -> MappingExecutionQueryEditorActionConfiguration`, etc.
 
 - [#642](https://github.com/finos/legend-studio/pull/642) [`729e2486`](https://github.com/finos/legend-studio/commit/729e248634a3710d94257ead28c7a0c9307798cb) ([@akphi](https://github.com/akphi)) - **BREAKING CHANGE:** Update the shape of `ApplicationPageRenderEntry` to take a unique `key` and multiple `urlPatterns`. Also, we nolonger automatically decorate the pattern to pick up the SDLC instance anymore, so plugin authors who need this will need to manually modify their URL patterns with the function `generateRoutePatternWithSDLCServerKey()` that we now expose.
 
@@ -224,7 +224,7 @@
 
 ### Patch Changes
 
-- [#390](https://github.com/finos/legend-studio/pull/390) [`bbba2e3`](https://github.com/finos/legend-studio/commit/bbba2e34487c32a4bd41033d485fc8dbf22d32fb) ([@akphi](https://github.com/akphi)) - Genericize `LambdaEditor` so it nolonger depends on `EditorStore` and can be used between different Legend applications.
+- [#390](https://github.com/finos/legend-studio/pull/390) [`bbba2e3`](https://github.com/finos/legend-studio/commit/bbba2e34487c32a4bd41033d485fc8dbf22d32fb) ([@akphi](https://github.com/akphi)) - Generalize `LambdaEditor` so it nolonger depends on `EditorStore` and can be used between different Legend applications.
 
 ## 0.2.6
 

--- a/packages/legend-studio/package.json
+++ b/packages/legend-studio/package.json
@@ -72,7 +72,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "@testing-library/dom": "8.11.1",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-studio/src/components/EditorComponentTestUtils.tsx
+++ b/packages/legend-studio/src/components/EditorComponentTestUtils.tsx
@@ -142,11 +142,9 @@ export const TEST_DATA__DefaultSDLCInfo = {
   ],
 };
 
-export const TEST__LegendStudioStoreProvider = ({
-  children,
-}: {
+export const TEST__LegendStudioStoreProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => (
+}> = ({ children }) => (
   <LegendStudioStoreProvider pluginManager={LegendStudioPluginManager.create()}>
     {children}
   </LegendStudioStoreProvider>

--- a/packages/legend-studio/src/components/LegendStudioStoreProvider.tsx
+++ b/packages/legend-studio/src/components/LegendStudioStoreProvider.tsx
@@ -28,13 +28,10 @@ const LegendStudioStoreContext = createContext<LegendStudioStore | undefined>(
   undefined,
 );
 
-export const LegendStudioStoreProvider = ({
-  pluginManager,
-  children,
-}: {
+export const LegendStudioStoreProvider: React.FC<{
   pluginManager: LegendStudioPluginManager;
   children: React.ReactNode;
-}): React.ReactElement => {
+}> = ({ pluginManager, children }) => {
   const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcServerClient = useSDLCServerClient();
   const depotServerClient = useDepotServerClient();

--- a/packages/legend-studio/src/components/editor/EditorStoreProvider.tsx
+++ b/packages/legend-studio/src/components/editor/EditorStoreProvider.tsx
@@ -27,11 +27,9 @@ import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const EditorStoreContext = createContext<EditorStore | undefined>(undefined);
 
-export const EditorStoreProvider = ({
-  children,
-}: {
+export const EditorStoreProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => {
+}> = ({ children }) => {
   const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcServerClient = useSDLCServerClient();
   const depotServerClient = useDepotServerClient();

--- a/packages/legend-studio/src/components/editor/aux-panel/Console.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/Console.tsx
@@ -17,6 +17,7 @@
 import { observer } from 'mobx-react-lite';
 
 // TODO: add `xterm` so we have a stream/log
+// See https://github.com/finos/legend-studio/issues/273
 export const Console = observer(() => (
   <div className="console-panel">
     <div className="console-panel__content"></div>

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
@@ -306,16 +306,16 @@ export const MappingElementExplorer = observer(
   },
 );
 
-type MappingElementTreeNodeContainerProps = TreeNodeContainerProps<
-  MappingExplorerTreeNodeData,
-  {
-    isReadOnly: boolean;
-    onNodeExpand: (node: MappingExplorerTreeNodeData) => void;
-  }
->;
-
 const MappingElementTreeNodeContainer = observer(
-  (props: MappingElementTreeNodeContainerProps) => {
+  (
+    props: TreeNodeContainerProps<
+      MappingExplorerTreeNodeData,
+      {
+        isReadOnly: boolean;
+        onNodeExpand: (node: MappingExplorerTreeNodeData) => void;
+      }
+    >,
+  ) => {
     const { node, level, stepPaddingInRem, onNodeSelect, innerProps } = props;
     const { isReadOnly, onNodeExpand } = innerProps;
     const mappingElement = node.mappingElement;

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/execution-plan-viewer/ExecutionNodesViewer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/execution-plan-viewer/ExecutionNodesViewer.tsx
@@ -15,7 +15,7 @@
  */
 
 import { observer } from 'mobx-react-lite';
-import { SqlPlanViewer } from './SqlPlanViewer';
+import { SQLPlanViewer } from './SQLExecutionPlanViewer';
 import type { ExecutionPlanState } from '../../../../../stores/ExecutionPlanState';
 import { EXECUTION_PLAN_VIEW_MODE } from '../../../../../stores/ExecutionPlanState';
 import {
@@ -95,20 +95,12 @@ const generateDataTypeLabel = (type: unknown | undefined): string => {
     return `UNDEFINED`;
   }
 };
-interface resultTypeProps {
-  resultType: ResultType;
-}
-interface TDSresultTypeProps {
-  colName: string;
-  colType: DataType | undefined;
-  colSourceDatatype: unknown;
-}
 
-const TDSResultTypeViewer: React.FC<TDSresultTypeProps> = (props: {
+const TDSResultTypeViewer: React.FC<{
   colName: string;
   colType: DataType | undefined;
   colSourceDatatype: unknown;
-}) => {
+}> = (props) => {
   const { colName, colType, colSourceDatatype } = props;
 
   return (
@@ -154,10 +146,8 @@ const TDSResultTypeViewer: React.FC<TDSresultTypeProps> = (props: {
   );
 };
 
-//Only TDS result type is supported
-const ResultTypeViewer: React.FC<resultTypeProps> = (props: {
-  resultType: ResultType;
-}) => {
+// Only TDS result type is supported
+const ResultTypeViewer: React.FC<{ resultType: ResultType }> = (props) => {
   const { resultType } = props;
   return (
     <div className="panel">
@@ -185,8 +175,9 @@ const ResultTypeViewer: React.FC<resultTypeProps> = (props: {
     </div>
   );
 };
-//Json viewer
-const JSONViewer: React.FC<{ query: string }> = (props: { query: string }) => {
+
+// JSON viewer
+const JSONViewer: React.FC<{ query: string }> = (props) => {
   const { query } = props;
   return (
     <div className="panel__content">
@@ -199,13 +190,9 @@ const JSONViewer: React.FC<{ query: string }> = (props: { query: string }) => {
     </div>
   );
 };
-interface executionPlanStateProps {
-  displayData: string;
-  executionPlanState: ExecutionPlanState;
-}
 
-//Currently only support SQLExecution Node and RelationalTDSInstatiation Node
-export const ExecutionNodesViewer: React.FC<executionPlanStateProps> = observer(
+// Currently, only support SQLExecution Node and RelationalTDSInstatiation Node
+export const ExecutionNodesViewer = observer(
   (props: { displayData: string; executionPlanState: ExecutionPlanState }) => {
     const { displayData, executionPlanState } = props;
     let currentElement;
@@ -274,9 +261,9 @@ export const ExecutionNodesViewer: React.FC<executionPlanStateProps> = observer(
 
         {currentElement instanceof SQLExecutionNode &&
           executionPlanState.viewMode === EXECUTION_PLAN_VIEW_MODE.FORM && (
-            <SqlPlanViewer
+            <SQLPlanViewer
               query={currentElement.sqlQuery}
-              resultCoulumns={currentElement.resultColumns}
+              resultColumns={currentElement.resultColumns}
               connection={currentElement.connection}
               executionPlanState={executionPlanState}
             />

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/execution-plan-viewer/ExecutionPlanTree.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/execution-plan-viewer/ExecutionPlanTree.tsx
@@ -233,10 +233,7 @@ const ExecutionNodeElementTreeNodeContainer: React.FC<
 export const ExecutionPlanTree: React.FC<{
   executionPlanState: ExecutionPlanState;
   executionPlan: ExecutionPlan;
-}> = (props: {
-  executionPlanState: ExecutionPlanState;
-  executionPlan: ExecutionPlan;
-}) => {
+}> = (props) => {
   const { executionPlanState, executionPlan } = props;
   // NOTE: We only need to compute this once so we use lazy initial state syntax
   // See https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
@@ -298,6 +295,7 @@ export const ExecutionPlanTree: React.FC<{
 
     return childrenNodes;
   };
+
   return (
     <TreeView
       components={{

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/execution-plan-viewer/ExecutionPlanViewer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/execution-plan-viewer/ExecutionPlanViewer.tsx
@@ -242,10 +242,7 @@ const ExecutionNodeElementTreeNodeContainer: React.FC<
 export const ExecutionPlanTree: React.FC<{
   executionPlanState: ExecutionPlanState;
   executionPlan: ExecutionPlan;
-}> = (props: {
-  executionPlanState: ExecutionPlanState;
-  executionPlan: ExecutionPlan;
-}) => {
+}> = (props) => {
   const { executionPlanState, executionPlan } = props;
   // NOTE: We only need to compute this once so we use lazy initial state syntax
   // See https://reactjs.org/docs/hooks-reference.html#lazy-initial-state

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -349,13 +349,13 @@ const ProjectConfig = observer(() => {
   );
 });
 
-type PackageTreeNodeContainerProps = TreeNodeContainerProps<
-  PackageTreeNodeData,
-  { disableContextMenu: boolean; isContextImmutable?: boolean }
->;
-
 const PackageTreeNodeContainer = observer(
-  (props: PackageTreeNodeContainerProps) => {
+  (
+    props: TreeNodeContainerProps<
+      PackageTreeNodeData,
+      { disableContextMenu: boolean; isContextImmutable?: boolean }
+    >,
+  ) => {
     const { node, level, stepPaddingInRem, onNodeSelect, innerProps } = props;
     const editorStore = useEditorStore();
     const [isSelectedFromContextMenu, setIsSelectedFromContextMenu] =

--- a/packages/legend-studio/src/components/setup/ProjectSelector.tsx
+++ b/packages/legend-studio/src/components/setup/ProjectSelector.tsx
@@ -143,5 +143,3 @@ export const ProjectSelector = observer(
   },
   { forwardRef: true },
 );
-
-ProjectSelector.displayName = 'ProjectSelector';

--- a/packages/legend-studio/src/components/setup/SetupStoreProvider.tsx
+++ b/packages/legend-studio/src/components/setup/SetupStoreProvider.tsx
@@ -24,11 +24,9 @@ import type { LegendStudioConfig } from '../../application/LegendStudioConfig';
 
 const SetupStoreContext = createContext<SetupStore | undefined>(undefined);
 
-export const SetupStoreProvider = ({
-  children,
-}: {
+export const SetupStoreProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => {
+}> = ({ children }) => {
   const applicationStore = useApplicationStore<LegendStudioConfig>();
   const sdlcServerClient = useSDLCServerClient();
   const store = useLocalObservable(

--- a/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
+++ b/packages/legend-studio/src/components/setup/WorkspaceSelector.tsx
@@ -130,5 +130,3 @@ export const WorkspaceSelector = observer(
   },
   { forwardRef: true },
 );
-
-WorkspaceSelector.displayName = 'WorkspaceSelector';

--- a/packages/legend-studio/src/components/viewer/ViewerStoreProvider.tsx
+++ b/packages/legend-studio/src/components/viewer/ViewerStoreProvider.tsx
@@ -24,11 +24,9 @@ import { ViewerEditorMode } from '../../stores/viewer/ViewerEditorMode';
 
 const ViewerStoreContext = createContext<ViewerStore | undefined>(undefined);
 
-export const ViewerStoreProvider = ({
-  children,
-}: {
+export const ViewerStoreProvider: React.FC<{
   children: React.ReactNode;
-}): React.ReactElement => {
+}> = ({ children }) => {
   const editorStore = useEditorStore();
   editorStore.setMode(EDITOR_MODE.VIEWER);
   const store = useLocalObservable(() => new ViewerStore(editorStore));

--- a/packages/legend-taxonomy-app/package.json
+++ b/packages/legend-taxonomy-app/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "sass": "1.44.0",

--- a/packages/legend-taxonomy-deployment/package.json
+++ b/packages/legend-taxonomy-deployment/package.json
@@ -41,7 +41,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "copy-webpack-plugin": "10.0.0",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "typescript": "4.5.2",

--- a/packages/legend-taxonomy/package.json
+++ b/packages/legend-taxonomy/package.json
@@ -64,7 +64,7 @@
     "@finos/legend-dev-utils": "workspace:*",
     "@testing-library/dom": "8.11.1",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",

--- a/packages/legend-taxonomy/src/components/LegendTaxonomyStoreProvider.tsx
+++ b/packages/legend-taxonomy/src/components/LegendTaxonomyStoreProvider.tsx
@@ -29,13 +29,10 @@ const LegendTaxonomyStoreContext = createContext<
   LegendTaxonomyStore | undefined
 >(undefined);
 
-export const LegendTaxonomyStoreProvider = ({
-  children,
-  pluginManager,
-}: {
+export const LegendTaxonomyStoreProvider: React.FC<{
   children: React.ReactNode;
   pluginManager: LegendTaxonomyPluginManager;
-}): React.ReactElement => {
+}> = ({ children, pluginManager }) => {
   const applicationStore = useApplicationStore<LegendTaxonomyConfig>();
   const taxonomyServerClient = new TaxonomyServerClient(
     applicationStore.config.currentTaxonomyServerOption.url,

--- a/packages/legend-tracer-extension-zipkin/package.json
+++ b/packages/legend-tracer-extension-zipkin/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "jest": "27.4.3",
     "rimraf": "3.0.2",
     "typescript": "4.5.2"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.3",
-    "eslint": "8.3.0",
+    "eslint": "8.4.0",
     "rimraf": "3.0.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,20 +1884,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@eslint/eslintrc@npm:1.0.4"
+"@eslint/eslintrc@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@eslint/eslintrc@npm:1.0.5"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.3.2
-    espree: ^9.0.0
+    espree: ^9.2.0
     globals: ^13.9.0
     ignore: ^4.0.6
     import-fresh: ^3.2.1
     js-yaml: ^4.1.0
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
-  checksum: 570f87e216944830b3761889f14cdf1e9bc7dcc2211e941585cfc2768575954e26852605eb441e21c9581472f89ea0e9cfdb8309523e9fe0a57fe9342bda4fe0
+  checksum: b35b50d7b65bd8acd92a05b6fb15ac62c0cefa40dfef0324ca5bf8632bf3679bab6e173c53b3ad1e1d837701cecdbd9c144b35f46588cdf4e046a9caa272488d
   languageName: node
   linkType: hard
 
@@ -1924,7 +1924,7 @@ __metadata:
     "@babel/preset-typescript": 7.16.0
     "@babel/runtime": 7.16.3
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     react-refresh: 0.11.0
     rimraf: 3.0.2
     typescript: 4.5.2
@@ -1942,7 +1942,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.5.0
     "@typescript-eslint/parser": 5.5.0
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     eslint-config-prettier: 8.3.0
     eslint-plugin-import: 2.25.3
     eslint-plugin-prettier: 4.0.0
@@ -1973,7 +1973,7 @@ __metadata:
     "@types/react-dom": 17.0.11
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     history: 5.1.0
     jest: 27.4.3
     mobx: 6.3.8
@@ -2010,7 +2010,7 @@ __metadata:
     "@types/react-window": 1.8.5
     clsx: 1.1.1
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2057,7 +2057,7 @@ __metadata:
     cross-env: 7.0.3
     css-loader: 6.5.1
     cssnano: 5.0.12
-    eslint: 8.3.0
+    eslint: 8.4.0
     html-webpack-plugin: 5.5.0
     isbinaryfile: 4.0.8
     jest: 27.4.3
@@ -2097,7 +2097,7 @@ __metadata:
     "@types/react": 17.0.37
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2132,7 +2132,7 @@ __metadata:
     "@testing-library/react": 12.1.2
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     jest-canvas-mock: 2.3.1
     mobx: 6.3.8
@@ -2165,7 +2165,7 @@ __metadata:
     "@finos/legend-studio": "workspace:*"
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2196,7 +2196,7 @@ __metadata:
     "@finos/legend-studio": "workspace:*"
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2220,7 +2220,7 @@ __metadata:
     "@finos/legend-graph": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     npm-run-all: 4.1.5
     rimraf: 3.0.2
@@ -2242,7 +2242,7 @@ __metadata:
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     npm-run-all: 4.1.5
     rimraf: 3.0.2
@@ -2264,7 +2264,7 @@ __metadata:
     "@finos/legend-studio": "workspace:*"
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2286,7 +2286,7 @@ __metadata:
   dependencies:
     "@finos/legend-dev-utils": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     fastify: 3.24.1
     fastify-cors: 6.0.2
     nodemon: 2.0.15
@@ -2309,7 +2309,7 @@ __metadata:
     "@finos/legend-extension-external-store-service": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     rimraf: 3.0.2
     typescript: 4.5.2
@@ -2324,7 +2324,7 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2361,7 +2361,7 @@ __metadata:
     "@finos/legend-shared": "workspace:*"
     axios: 0.24.0
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     npm-run-all: 4.1.5
     rimraf: 3.0.2
@@ -2376,7 +2376,7 @@ __metadata:
     "@finos/legend-dev-utils": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     lodash: 4.17.21
     rimraf: 3.0.2
@@ -2397,7 +2397,7 @@ __metadata:
     "@finos/legend-shared": "workspace:*"
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     npm-run-all: 4.1.5
     react: 17.0.2
     rimraf: 3.0.2
@@ -2414,7 +2414,7 @@ __metadata:
     "@finos/legend-query-app": "workspace:*"
     copy-webpack-plugin: 10.0.0
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     npm-run-all: 4.1.5
     rimraf: 3.0.2
     typescript: 4.5.2
@@ -2448,7 +2448,7 @@ __metadata:
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
     date-fns: 2.27.0
-    eslint: 8.3.0
+    eslint: 8.4.0
     history: 5.1.0
     jest: 27.4.3
     mobx: 6.3.8
@@ -2480,7 +2480,7 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2500,7 +2500,7 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2524,7 +2524,7 @@ __metadata:
     "@types/seedrandom": 3.0.1
     "@types/uuid": 8.3.3
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     hash.js: 1.1.7
     http-status-codes: 2.1.4
     jest: 27.4.3
@@ -2563,7 +2563,7 @@ __metadata:
     "@finos/legend-studio-extension-query-builder": "workspace:*"
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     npm-run-all: 4.1.5
     react: 17.0.2
     rimraf: 3.0.2
@@ -2580,7 +2580,7 @@ __metadata:
     "@finos/legend-studio-app": "workspace:*"
     copy-webpack-plugin: 10.0.0
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     npm-run-all: 4.1.5
     rimraf: 3.0.2
     typescript: 4.5.2
@@ -2604,7 +2604,7 @@ __metadata:
     "@types/react": 17.0.37
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2639,7 +2639,7 @@ __metadata:
     "@testing-library/react": 12.1.2
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     mobx: 6.3.8
     mobx-react-lite: 3.2.2
@@ -2675,7 +2675,7 @@ __metadata:
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
     date-fns: 2.27.0
-    eslint: 8.3.0
+    eslint: 8.4.0
     history: 5.1.0
     jest: 27.4.3
     mobx: 6.3.8
@@ -2714,7 +2714,7 @@ __metadata:
     "@finos/legend-taxonomy": "workspace:*"
     "@types/react": 17.0.37
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     npm-run-all: 4.1.5
     react: 17.0.2
     rimraf: 3.0.2
@@ -2731,7 +2731,7 @@ __metadata:
     "@finos/legend-taxonomy-app": "workspace:*"
     copy-webpack-plugin: 10.0.0
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     npm-run-all: 4.1.5
     rimraf: 3.0.2
     typescript: 4.5.2
@@ -2761,7 +2761,7 @@ __metadata:
     "@types/react-dom": 17.0.11
     "@types/react-router-dom": 5.3.2
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     history: 5.1.0
     jest: 27.4.3
     mobx: 6.3.8
@@ -2790,7 +2790,7 @@ __metadata:
     "@finos/legend-shared": "workspace:*"
     "@types/zipkin-javascript-opentracing": 1.6.0
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     jest: 27.4.3
     opentracing: 0.14.5
     rimraf: 3.0.2
@@ -2806,7 +2806,7 @@ __metadata:
   resolution: "@finos/stylelint-config-legend-studio@workspace:packages/stylelint-config"
   dependencies:
     cross-env: 7.0.3
-    eslint: 8.3.0
+    eslint: 8.4.0
     postcss: 8.4.4
     postcss-scss: 4.0.2
     rimraf: 3.0.2
@@ -2826,18 +2826,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@humanwhocodes/config-array@npm:0.6.0"
+"@humanwhocodes/config-array@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "@humanwhocodes/config-array@npm:0.9.2"
   dependencies:
-    "@humanwhocodes/object-schema": ^1.2.0
+    "@humanwhocodes/object-schema": ^1.2.1
     debug: ^4.1.1
     minimatch: ^3.0.4
-  checksum: 1025b07514b7bfd10a05e8b6cb5e6520878e9c8836b3dd0569fc07df29a09e428c2df1e0760b1d461da8ed6f81ca83ecb02e24198f80b0a177a2acbf532e267c
+  checksum: 28a9e2974c50a86765cb6cc96e03d29187ea33fdaba62c4f35db89002e3cfbd340e64c9f6cf869e33e2e5cdcc06e78763458f4178d38a6f30aea1308787ca706
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^1.2.0":
+"@humanwhocodes/object-schema@npm:^1.2.1":
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
@@ -4397,7 +4397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.6.0":
+"acorn@npm:^8.0.4, acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.6.0":
   version: 8.6.0
   resolution: "acorn@npm:8.6.0"
   bin:
@@ -7011,12 +7011,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:8.3.0":
-  version: 8.3.0
-  resolution: "eslint@npm:8.3.0"
+"eslint@npm:8.4.0":
+  version: 8.4.0
+  resolution: "eslint@npm:8.4.0"
   dependencies:
-    "@eslint/eslintrc": ^1.0.4
-    "@humanwhocodes/config-array": ^0.6.0
+    "@eslint/eslintrc": ^1.0.5
+    "@humanwhocodes/config-array": ^0.9.2
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
@@ -7027,7 +7027,7 @@ __metadata:
     eslint-scope: ^7.1.0
     eslint-utils: ^3.0.0
     eslint-visitor-keys: ^3.1.0
-    espree: ^9.1.0
+    espree: ^9.2.0
     esquery: ^1.4.0
     esutils: ^2.0.2
     fast-deep-equal: ^3.1.3
@@ -7055,29 +7055,18 @@ __metadata:
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: c0338471fc787384077b132fb1496f264a4d7ed032b9072b2f6b8b1c833edc89b0a4890080576781ce6101a2700341af413ecbf1b66f0780aa02601c40fb2008
+  checksum: 12eb9e7af353d4b8afbf5417f923a93e1da8aa065d97026d98c3e7f69442639eae5c013a5251fe20273dbbe9ad6f36445a985b3e9929e911dda79fb40e308eb0
   languageName: node
   linkType: hard
 
-"espree@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "espree@npm:9.0.0"
-  dependencies:
-    acorn: ^8.5.0
-    acorn-jsx: ^5.3.1
-    eslint-visitor-keys: ^3.0.0
-  checksum: f313c642e35587ce62a419f57ceea47937a719b084c7b31f649d2ca15ed92bc2dde58e2ac4fc381a74364b0db0b97d9cdb2a5d1ca0ccd7483bde9b4b04fe23e8
-  languageName: node
-  linkType: hard
-
-"espree@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "espree@npm:9.1.0"
+"espree@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "espree@npm:9.2.0"
   dependencies:
     acorn: ^8.6.0
     acorn-jsx: ^5.3.1
     eslint-visitor-keys: ^3.1.0
-  checksum: ba9b0f759c49c19a098e0bb97f3b9b05441a60dec3f868bc412ae300e00ba20cb0bd2c6a1bdd6c4f0056e6382650bf45b4982d81e67ad0210c1c16b336f73c39
+  checksum: ae533a058036e3efeeac43a0ee39c74ab347e2a73bbe2946fba33cc0d84aca657e675bc317ed9afd95338f79d5d5a862afec2f717d2539ae13fa9f1638371761
   languageName: node
   linkType: hard
 
@@ -10159,7 +10148,7 @@ __metadata:
     chalk: 5.0.0
     cross-env: 7.0.3
     envinfo: 7.8.1
-    eslint: 8.3.0
+    eslint: 8.4.0
     fs-extra: 10.0.0
     husky: 7.0.4
     inquirer: 8.2.0


### PR DESCRIPTION
## Summary

- [x] Trying to cleanup non-idiomatic usage of `React.FC`
- [x] Use the knowledge we got from https://mobx.js.org/react-integration.html to eliminate `.displayName` and instead use `function` form with `observer()` 
- [x] Add `NullphobicSerializationFactory` that will handle cases where we want the deserializer to prune `null` values returned by the servers
- [x] Standardize the way we handle `optional(custom(...))` for serialization 

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)
