### PR TITLE
update webpack to ignore Zipkin dependency on NodeJS library

### DIFF
--- a/.changeset/metal-apples-explain.md
+++ b/.changeset/metal-apples-explain.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-dev-utils': patch
+---

--- a/packages/legend-dev-utils/WebpackConfigUtils.js
+++ b/packages/legend-dev-utils/WebpackConfigUtils.js
@@ -296,6 +296,7 @@ export const getWebAppBaseWebpackConfig = (
         // Ignore usage of Node module `os` in `zipkin`
         // See https://github.com/openzipkin/zipkin-js/issues/465
         os: false,
+        url: false,
       },
       alias: {
         ...baseConfig.resolve.alias,


### PR DESCRIPTION
## Summary

`opentracing@0.14.7` causes this to Webpack

```
ERROR in ../../node_modules/zipkin/es/index.js 2:0-22
Module not found: Error: Can't resolve 'url' in '/Users/blacksteed232/Developer/legend/studio/node_modules/zipkin/es'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
	- install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "url": false }
```

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
