### PR TITLE
make sure to always patch bump dependent packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,9 @@
   "linked": [["@finos/legend-*-app", "@finos/legend-*-deployment"]],
   "access": "public",
   "baseBranch": "master",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "updateInternalDependents": "always"
+  },
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": ["@finos/legend-fixture-*", "@finos/legend-internal-*"]


### PR DESCRIPTION
This is to fix a problem introduce due to some upgrade in `changeset`. Historically, we set it up so all dependent packages will be `patch` bumped. For example:

`a depends on b, b is minor bumped --> a is patch bumped`

Somehow, this behavior is lost, and so by configuring `changeset` with the following, things will work as expected

```json
{
  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
    "updateInternalDependents": "always"
  }
}
```

 See https://github.com/changesets/changesets/pull/542