### PR TITLE
cancel PR running jobs from previous CI builds to save build resource

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - '**'
 
+# Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly
+# NOTE: we don't want this behavior on default branch
+# See https://stackoverflow.com/a/68422069
+concurrency:
+  group: ${{ github.ref == 'refs/heads/master' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) || format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
+  cancel-in-progress: true
+
 jobs:
   # This job is to make sure Webpack builds the application fine. This is helpful
   # to know as we don't want to find out this failure as late as when we prepare the

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - '**'
 
+# Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly
+concurrency:
+  group: ci-pr-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   check-changeset:
     name: Validate Changesets

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -16,13 +16,13 @@ concurrency:
   group: ${{ github.ref == 'refs/heads/master' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) || format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
   cancel-in-progress: true
 
-# NOTE: we cannot run this action in PR because secrets are not accessible from forks
-# See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
 jobs:
   code-quality-check:
     name: SonarCloud Code Quality Check
     runs-on: ubuntu-latest
-    if: github.repository == 'finos/legend-studio' # prevent running this action in forks
+    # NOTE: we cannot run this action in PR because secrets are not accessible from forks
+    # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
+    if: github.ref == 'refs/heads/master' && github.repository == 'finos/legend-studio'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - '**'
 
+# Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly
+# NOTE: we don't want this behavior on default branch
+# See https://stackoverflow.com/a/68422069
+concurrency:
+  group: ${{ github.ref == 'refs/heads/master' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) || format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
+  cancel-in-progress: true
+
 # NOTE: we cannot run this action in PR because secrets are not accessible from forks
 # See https://community.sonarsource.com/t/github-action-ci-build-fail-with-set-the-sonar-token-env-variable/38997
 jobs:

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -56,17 +56,17 @@ jobs:
       - name: Build image
         run: yarn workspace ${{ matrix.package }} build-dry:docker ${{ github.sha }}
       - name: Scan image for security issues
-        uses: Azure/container-scan@v0
-        env:
-          # This internally uses `trivy` CLI, so we can pass `trivy` CLI flags to customize
-          # See https://aquasecurity.github.io/trivy/v0.20.1/getting-started/cli/config/
-          #
-          # Skip `won't fix` CVEs
-          # See https://github.com/Azure/container-scan/issues/61
-          TRIVY_IGNORE_UNFIXED: true
-          # Manually increase timeout as the default 2-minute is not enough
-          # See https://github.com/Azure/container-scan/issues/109
-          TRIVY_TIMEOUT: 10m
+        uses: aquasecurity/trivy-action@0.2.1
         with:
-          image-name: ${{ matrix.image }}:${{ github.sha }}
-          severity-threshold: CRITICAL
+          # TODO: we should probably also setup misconfiguration scanning
+          # See https://github.com/aquasecurity/trivy-action#using-trivy-to-scan-infrastucture-as-code
+          scan-type: image
+          image-ref: ${{ matrix.image }}:${{ github.sha }}
+          format: table
+          exit-code: 1
+          # Ignore unpatched/unfixed vulnerabilities/CVEs
+          ignore-unfixed: true
+          severity: CRITICAL
+          # Manually increase timeout as the default 2-minute is not enough
+          # See https://github.com/aquasecurity/trivy/issues/802
+          timeout: 10m

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -13,6 +13,13 @@ on:
     branches:
       - '**'
 
+# Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly
+# NOTE: we don't want this behavior on default branch
+# See https://stackoverflow.com/a/68422069
+concurrency:
+  group: ${{ github.ref == 'refs/heads/master' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) || format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
+  cancel-in-progress: true
+
 jobs:
   check-docker-image:
     name: Run Docker Image Checks

--- a/.github/workflows/manual__publish-docker.yml
+++ b/.github/workflows/manual__publish-docker.yml
@@ -1,4 +1,4 @@
-name: (Manual) Docker Publish
+name: (Manual) Publish Docker
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual__publish-npm-snapshot.yml
+++ b/.github/workflows/manual__publish-npm-snapshot.yml
@@ -1,4 +1,4 @@
-name: (Manual) NPM Snapshot Publish
+name: (Manual) Publish NPM Snapshot
 
 on: workflow_dispatch
 

--- a/.github/workflows/publish-docker-snapshot.yml
+++ b/.github/workflows/publish-docker-snapshot.yml
@@ -1,4 +1,4 @@
-name: Docker Snapshot Publish
+name: Publish Docker Snapshot
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       # Release branches are meant for recovery releases, i.e. patch version bumps (e.g. 1.6.1, 1.7.1)
       - 'release/**'
 
-# This job is meant for both standard and path release process
+# This job is shared by both standard and recovery release processes
 # See https://github.com/finos/legend-studio/blob/master/docs/workflow/release-process.md
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - '**'
 
+# Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly
+# NOTE: we don't want this behavior on default branch
+# See https://stackoverflow.com/a/68422069
+concurrency:
+  group: ${{ github.ref == 'refs/heads/master' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) || format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
+  cancel-in-progress: true
+
 jobs:
   integration-and-unit-test:
     name: Run Unit & Integration Tests


### PR DESCRIPTION
## Summary

- [x] Re-disable SonarCloud scan in PR CI
- [x] Use [trivy-action](https://github.com/aquasecurity/trivy-action) instead of [Azure/container-scan](https://github.com/Azure/container-scan) for checking vulnerabilities in Docker images - see blocker issue https://github.com/Azure/container-scan/issues/122
- [x] Uninstall `scanitizer` app
- [x] Cancel running jobs from previous pipelines of the same workflow on PR to save resource when commits are pushed quickly.
Note that we don't want this behavior on default branch

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

