### PR TITLE
Add parameter instance values when executing unsupported queries

### DIFF
--- a/.changeset/red-beers-fail.md
+++ b/.changeset/red-beers-fail.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-query": patch
+---
+
+Add parameter instance values when executing unsupported queries.

--- a/packages/legend-query/src/stores/QueryBuilderLambdaBuilder.ts
+++ b/packages/legend-query/src/stores/QueryBuilderLambdaBuilder.ts
@@ -70,6 +70,45 @@ export const buildGetAllFunction = (
   return _func;
 };
 
+export const buildParametersLetLambdaFunc = (
+  queryBuilderState: QueryBuilderState,
+): LambdaFunction => {
+  const multiplicityOne =
+    queryBuilderState.graphManagerState.graph.getTypicalMultiplicity(
+      TYPICAL_MULTIPLICITY_TYPE.ONE,
+    );
+  const typeString = queryBuilderState.graphManagerState.graph.getPrimitiveType(
+    PRIMITIVE_TYPE.STRING,
+  );
+  const typeAny = queryBuilderState.graphManagerState.graph.getType(
+    CORE_PURE_PATH.ANY,
+  );
+  const letlambdaFunction = new LambdaFunction(
+    new FunctionType(typeAny, multiplicityOne),
+  );
+  letlambdaFunction.expressionSequence =
+    queryBuilderState.queryParametersState.parameters
+      .map((_var) => {
+        if (_var.values) {
+          const letFunc = new SimpleFunctionExpression(
+            extractElementNameFromPath(SUPPORTED_FUNCTIONS.LET),
+            multiplicityOne,
+          );
+          const letVar = new PrimitiveInstanceValue(
+            GenericTypeExplicitReference.create(new GenericType(typeString)),
+            multiplicityOne,
+          );
+          letVar.values = [_var.variableName];
+          letFunc.parametersValues.push(letVar);
+          letFunc.parametersValues.push(_var.values);
+          return letFunc;
+        }
+        return undefined;
+      })
+      .filter(isNonNullable);
+  return letlambdaFunction;
+};
+
 export const buildLambdaFunction = (
   queryBuilderState: QueryBuilderState,
   options?: {
@@ -378,27 +417,9 @@ export const buildLambdaFunction = (
     // add let statements for each parameter
     if (options?.isBuildingExecutionQuery) {
       lambdaFunction.functionType.parameters = [];
-      const letsFuncs = queryBuilderState.queryParametersState.parameters
-        .map((_var) => {
-          if (_var.values) {
-            const letFunc = new SimpleFunctionExpression(
-              extractElementNameFromPath(SUPPORTED_FUNCTIONS.LET),
-              multiplicityOne,
-            );
-            const letVar = new PrimitiveInstanceValue(
-              GenericTypeExplicitReference.create(new GenericType(typeString)),
-              multiplicityOne,
-            );
-            letVar.values = [_var.variableName];
-            letFunc.parametersValues.push(letVar);
-            letFunc.parametersValues.push(_var.values);
-            return letFunc;
-          }
-          return undefined;
-        })
-        .filter(isNonNullable);
+      const letsFuncs = buildParametersLetLambdaFunc(queryBuilderState);
       lambdaFunction.expressionSequence = [
-        ...letsFuncs,
+        ...letsFuncs.expressionSequence,
         ...lambdaFunction.expressionSequence,
       ];
     } else {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Fixes https://github.com/finos/legend-studio/issues/832

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
