### PR TITLE
temporarily disable service store grammar roundtrip test

### DIFF
--- a/.changeset/dirty-llamas-push.md
+++ b/.changeset/dirty-llamas-push.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-manual-tests': patch
+---

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
@@ -108,9 +108,6 @@ const EXCLUSIONS: { [key: string]: ROUNTRIP_TEST_PHASES[] | typeof SKIP } = {
   ],
   'merge-operation-mapping.pure': [ROUNTRIP_TEST_PHASES.PROTOCOL_ROUNDTRIP],
 
-  // TODO: remove this when https://github.com/finos/legend-engine/pull/519 is merged.
-  'ESService-path-offset.pure': SKIP,
-
   // TODO: remove these when the issue of source ID in relational property mapping is resolved.
   // Engine is removing these sources when the owner is the parent class mapping and studio is not
   'basic-class-mapping-extends.pure': [ROUNTRIP_TEST_PHASES.PROTOCOL_ROUNDTRIP],
@@ -127,6 +124,10 @@ const EXCLUSIONS: { [key: string]: ROUNTRIP_TEST_PHASES[] | typeof SKIP } = {
   // Used to test graph building performance. Test passes but will SKIP as to not increase build time
   // Current time to complete test is 6576 ms
   'profiling-model-cdm.pure': SKIP,
+
+  // TODO: remove this when https://github.com/finos/legend-studio/pull/984 is reverted.
+  'ESService-basic.pure': SKIP,
+  'ESService-path-offset.pure': SKIP,
 };
 
 type GrammarRoundtripOptions = {


### PR DESCRIPTION
## Summary

In the same vein as https://github.com/finos/legend-studio/pull/984 will turn back on when we re-apply the changes for Service Store

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

