### PR TITLE
Fix `Binding` and `ServiceStore` elements appearing multiple times in explorer tree

### DIFF
--- a/.changeset/late-ears-whisper.md
+++ b/.changeset/late-ears-whisper.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-extension-external-store-service": patch
+---
+
+Fix `ServiceStore` element appearing multiple times in explorer tree.

--- a/.changeset/purple-starfishes-exercise.md
+++ b/.changeset/purple-starfishes-exercise.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-graph": patch
+---
+
+Fix `Binding` element appearing multiple times in explorer tree.

--- a/packages/legend-extension-external-store-service/src/models/protocols/pure/ESService_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-external-store-service/src/models/protocols/pure/ESService_PureProtocolProcessorPlugin.ts
@@ -67,7 +67,6 @@ import {
   V1_ElementBuilder,
   V1_initPackageableElement,
   V1_transformElementReference,
-  _package_addElement,
 } from '@finos/legend-graph';
 import { V1_RootServiceStoreClassMapping } from './v1/model/packageableElements/store/serviceStore/mapping/V1_ESService_RootServiceStoreClassMapping';
 import { RootServiceInstanceSetImplementation } from '../../metamodels/pure/model/packageableElements/store/serviceStore/mapping/ESService_RootServiceInstanceSetImplementation';
@@ -119,10 +118,6 @@ export class ESService_PureProtocolProcessorPlugin
           const path = context.currentSubGraph.buildPath(
             elementProtocol.package,
             elementProtocol.name,
-          );
-          _package_addElement(
-            context.currentSubGraph.getOrCreatePackage(elementProtocol.package),
-            element,
           );
           context.currentSubGraph.setOwnStore(path, element);
           return element;

--- a/packages/legend-graph/src/models/protocols/pure/DSLExternalFormat_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-graph/src/models/protocols/pure/DSLExternalFormat_PureProtocolProcessorPlugin.ts
@@ -86,7 +86,6 @@ import {
   V1_schemaSetModelSchema,
   V1_SCHEMA_SET_ELEMENT_PROTOCOL_TYPE,
 } from './v1/transformation/pureProtocol/serializationHelpers/V1_DSLExternalFormat_ProtocolHelper';
-import { _package_addElement } from '../../GraphModifierHelper';
 
 const BINDING_ELEMENT_CLASSIFIER_PATH =
   'meta::external::shared::format::binding::Binding';
@@ -118,10 +117,6 @@ export class DSLExternalFormat_PureProtocolProcessorPlugin
           const path = context.currentSubGraph.buildPath(
             elementProtocol.package,
             elementProtocol.name,
-          );
-          _package_addElement(
-            context.currentSubGraph.getOrCreatePackage(elementProtocol.package),
-            element,
           );
           context.currentSubGraph.setOwnStore(path, element);
           return element;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

We are adding `Binding` and `ServiceStore` to the package again in the ProtocolProcessorPlugins which ends up showing the same element multiple times in the explorer tree. We noticed this behavior after this change #973 as we removed `addUniqueEntry` for adding a child into the package
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

***Before the change:***
![pic2](https://user-images.githubusercontent.com/87973126/161228679-1308bb96-23a3-4612-b45c-529e5c1e85c2.PNG)

***After the change:***
![pic1](https://user-images.githubusercontent.com/87973126/161228739-40ee001f-97da-4dbb-959b-39d34186c6c7.PNG)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
