### PR TITLE
Fix studio not showing notifications

### DIFF
--- a/.changeset/thin-pumpkins-jog.md
+++ b/.changeset/thin-pumpkins-jog.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-application": patch
+---
+
+Fix a regression where applications are not showing notification by bringing back `<NotificationManager />` to `<LegendApplicationComponentFrameworkProvider/>`.

--- a/packages/legend-application/src/components/ApplicationStoreProviderTestUtils.tsx
+++ b/packages/legend-application/src/components/ApplicationStoreProviderTestUtils.tsx
@@ -20,7 +20,6 @@ import { WebApplicationNavigator } from '../stores/WebApplicationNavigator';
 import type { LegendApplicationConfig } from '../stores/LegendApplicationConfig';
 import { ApplicationStoreProvider } from './ApplicationStoreProvider';
 import type { LegendApplicationPluginManager } from '../application/LegendApplicationPluginManager';
-import { NotificationManager } from './NotificationManager';
 
 export const TEST__ApplicationStoreProvider: React.FC<{
   children: React.ReactNode;
@@ -28,7 +27,6 @@ export const TEST__ApplicationStoreProvider: React.FC<{
   pluginManager: LegendApplicationPluginManager;
 }> = ({ children, config, pluginManager }) => (
   <ApplicationStoreProvider config={config} pluginManager={pluginManager}>
-    <NotificationManager />
     {children}
   </ApplicationStoreProvider>
 );

--- a/packages/legend-application/src/components/LegendApplicationComponentFrameworkProvider.tsx
+++ b/packages/legend-application/src/components/LegendApplicationComponentFrameworkProvider.tsx
@@ -17,6 +17,7 @@
 import { LegendStyleProvider } from '@finos/legend-art';
 import { ActionAlert } from './ActionAlert';
 import { BlockingAlert } from './BlockingAlert';
+import { NotificationManager } from './NotificationManager';
 
 export const LegendApplicationComponentFrameworkProvider: React.FC<{
   children: React.ReactNode;
@@ -27,6 +28,7 @@ export const LegendApplicationComponentFrameworkProvider: React.FC<{
     <LegendStyleProvider>
       <BlockingAlert />
       <ActionAlert />
+      <NotificationManager />
       {children}
     </LegendStyleProvider>
   );


### PR DESCRIPTION

## Summary

Fix a regression caused by https://github.com/finos/legend-studio/pull/1034. Bring back `<NotificationManager />` to `<LegendApplicationComponentFrameworkProvider />`

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

![pic](https://user-images.githubusercontent.com/87973126/163327110-632a875a-f652-496f-af4b-28ba759682c0.PNG)


<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
