### PR TITLE
fix service registration on semi interactive with a pure multi execution

### DIFF
--- a/.changeset/thirty-moles-switch.md
+++ b/.changeset/thirty-moles-switch.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-graph": patch
+---
+
+Fix semi interactive service registration with a pure multi execution.

--- a/.changeset/thirty-moles-switch.md
+++ b/.changeset/thirty-moles-switch.md
@@ -2,4 +2,4 @@
 "@finos/legend-graph": patch
 ---
 
-Fix semi interactive service registration with a pure multi execution.
+Support Pure `multi-execution` when registering service in `semi-interactive` mode ([#1059](https://github.com/finos/legend-studio/issues/1059))

--- a/packages/legend-graph/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -1901,6 +1901,8 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
         data.origin = new V1_PureModelContextPointer(protocol);
         data.elements = [this.elementToProtocol<V1_Service>(service)];
         // SDLC info
+        // TODO: We may need to add `runtime` pointers if the runtime defned in the service is a packageable runtime
+        // and not embedded.
         const execution = service.execution;
         if (execution instanceof PureSingleExecution) {
           sdlcInfo.packageableElementPointers = [
@@ -1909,6 +1911,15 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
               execution.mapping.value.path,
             ),
           ];
+        } else if (execution instanceof PureMultiExecution) {
+          sdlcInfo.packageableElementPointers =
+            execution.executionParameters.map(
+              (e) =>
+                new V1_PackageableElementPointer(
+                  V1_PackageableElementPointerType.MAPPING,
+                  e.mapping.value.path,
+                ),
+            );
         } else {
           throw new UnsupportedOperationError(
             `Can't register service with the specified execution`,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/finos/legend-studio/issues/1059

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
