### PR TITLE
fix regression where documentation link no longer works

### DIFF
--- a/.changeset/great-carpets-reply.md
+++ b/.changeset/great-carpets-reply.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-query': patch
+---

--- a/.changeset/serious-walls-attack.md
+++ b/.changeset/serious-walls-attack.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application': patch
+---
+
+Fix a regression introduced in `5.0.0` where the link to the documentation page does not work.

--- a/packages/legend-application/src/stores/ApplicationStore.ts
+++ b/packages/legend-application/src/stores/ApplicationStore.ts
@@ -146,6 +146,7 @@ export class ApplicationStore<T extends LegendApplicationConfig> {
     ].forEach((entry) =>
       this.docRegistry.registerEntry(entry.key, entry.content),
     );
+    this.docRegistry.url = this.config.documentationUrl;
 
     // Register plugins
     this.log.registerPlugins(pluginManager.getLoggerPlugins());

--- a/packages/legend-query/style/_query-builder.scss
+++ b/packages/legend-query/style/_query-builder.scss
@@ -763,13 +763,16 @@
     }
 
     &__reset-btn {
-      @include flexVCenter;
+      @include flexCenter;
 
       height: 2rem;
       width: 2rem;
-      font-size: 2rem;
-      color: var(--color-light-grey-300);
-      font-weight: 700;
+      margin-right: 0.5rem;
+
+      svg {
+        font-size: 1.8rem;
+        color: var(--color-light-grey-200);
+      }
     }
   }
 


### PR DESCRIPTION

## Summary

- [x] fix regression where documentation link no longer works

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

