### PR TITLE
simplify metamodels

### DIFF
--- a/.changeset/cold-readers-hide.md
+++ b/.changeset/cold-readers-hide.md
@@ -1,0 +1,10 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-extension-dsl-diagram': patch
+'@finos/legend-extension-mapping-generation': patch
+'@finos/legend-graph': patch
+'@finos/legend-query': patch
+'@finos/legend-server-sdlc': patch
+'@finos/legend-shared': patch
+'@finos/legend-studio': patch
+---

--- a/.changeset/fifty-students-turn.md
+++ b/.changeset/fifty-students-turn.md
@@ -1,0 +1,13 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-extension-dsl-diagram': patch
+'@finos/legend-extension-dsl-text': patch
+'@finos/legend-extension-mapping-generation': patch
+'@finos/legend-graph': patch
+'@finos/legend-query': patch
+'@finos/legend-server-sdlc': patch
+'@finos/legend-shared': patch
+'@finos/legend-studio': patch
+'@finos/legend-taxonomy': patch
+---

--- a/.changeset/new-poems-end.md
+++ b/.changeset/new-poems-end.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': major
+---
+
+**BREAKING CHANGE:** Renamed extra fields added to the metamodels for navigation or other graph management purposes, such as `owner`, `parent`, `uuid`, etc. to `_OWNER`, `_PARENT`, `_UUID`, etc.; these fields are also made `readonly`.

--- a/.changeset/rude-socks-check.md
+++ b/.changeset/rude-socks-check.md
@@ -1,0 +1,12 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-extension-dsl-diagram': patch
+'@finos/legend-extension-mapping-generation': patch
+'@finos/legend-graph': patch
+'@finos/legend-query': patch
+'@finos/legend-server-sdlc': patch
+'@finos/legend-shared': patch
+'@finos/legend-studio': patch
+'@finos/legend-taxonomy': patch
+---

--- a/.changeset/selfish-walls-exercise.md
+++ b/.changeset/selfish-walls-exercise.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': major
+---
+
+**BREAKING CHANGE:** Move some `enum`s out of metamodels, such as `SET_IMPLEMENTATION_TYPE`, `BASIC_SET_IMPLEMENTATION_TYPE`, `PACKAGEABLE_ELEMENT_POINTER_TYPE`, `CLASS_PROPERTY_TYPE`, etc.

--- a/.changeset/spotty-lies-wonder.md
+++ b/.changeset/spotty-lies-wonder.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Update `LocalMappingPropertyInfo` metamodel to have `localMappingPropertyType: PackageableElementReference<Type>`

--- a/.changeset/sweet-teachers-destroy.md
+++ b/.changeset/sweet-teachers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': major
+---
+
+**BREAKING CHANGE:** Removed `buildState` from `BasicModel` and `DependencyManager` and moved them to `GraphManagerState` since these states don't belong inherently to the graph but the graph manager. As such, methods like `AbstractPureGraphManager.buildSystem()`, `AbstractPureGraphManager.buildGraph()` etc. now require the build state to as a parameter.

--- a/packages/legend-application/src/stores/LambdaEditorState.ts
+++ b/packages/legend-application/src/stores/LambdaEditorState.ts
@@ -27,7 +27,7 @@ import {
  * editing _something_ but allows user to edit via text.
  */
 export abstract class LambdaEditorState {
-  uuid = uuid();
+  readonly uuid = uuid();
   lambdaPrefix: string;
   lambdaString: string; // value shown in lambda editor which can be edited
   parserError?: ParserError | undefined;

--- a/packages/legend-application/src/stores/LambdaEditorState.ts
+++ b/packages/legend-application/src/stores/LambdaEditorState.ts
@@ -71,8 +71,8 @@ export abstract class LambdaEditorState {
   setCompilationError(compilationError: CompilationError | undefined): void {
     // account for the lambda prefix offset in source information
     if (compilationError?.sourceInformation) {
-      compilationError.setSourceInformation(
-        this.processSourceInformation(compilationError.sourceInformation),
+      compilationError.sourceInformation = this.processSourceInformation(
+        compilationError.sourceInformation,
       );
     }
     this.compilationError = compilationError;
@@ -81,8 +81,8 @@ export abstract class LambdaEditorState {
   setParserError(parserError: ParserError | undefined): void {
     // account for the lambda prefix offset in source information
     if (parserError?.sourceInformation) {
-      parserError.setSourceInformation(
-        this.processSourceInformation(parserError.sourceInformation),
+      parserError.sourceInformation = this.processSourceInformation(
+        parserError.sourceInformation,
       );
     }
     this.parserError = parserError;

--- a/packages/legend-extension-dsl-data-space/src/components/query/DataSpaceQuerySetup.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/query/DataSpaceQuerySetup.tsx
@@ -213,14 +213,14 @@ export const DataspaceQuerySetup = observer(
               querySetupState.setUpDataSpaceState.isInProgress && (
                 <BlankPanelContent>
                   {querySetupState.queryStore.buildGraphState.message ??
-                    querySetupState.queryStore.graphManagerState.graph
-                      .systemModel.buildState.message ??
-                    querySetupState.queryStore.graphManagerState.graph
-                      .dependencyManager.buildState.message ??
-                    querySetupState.queryStore.graphManagerState.graph
-                      .generationModel.buildState.message ??
-                    querySetupState.queryStore.graphManagerState.graph
-                      .buildState.message}
+                    querySetupState.queryStore.graphManagerState
+                      .systemBuildState.message ??
+                    querySetupState.queryStore.graphManagerState
+                      .dependenciesBuildState.message ??
+                    querySetupState.queryStore.graphManagerState
+                      .generationsBuildState.message ??
+                    querySetupState.queryStore.graphManagerState.graphBuildState
+                      .message}
                 </BlankPanelContent>
               )}
             {!querySetupState.dataSpaceViewerState &&

--- a/packages/legend-extension-dsl-data-space/src/models/protocols/pure/DSLDataSpace_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-dsl-data-space/src/models/protocols/pure/DSLDataSpace_PureProtocolProcessorPlugin.ts
@@ -60,7 +60,7 @@ import {
   V1_taggedValueSchema,
   PackageableElementExplicitReference,
   V1_PackageableElementPointer,
-  V1_PackageableElementPointerType,
+  PackageableElementPointerType,
   V1_buildTaggedValue,
   V1_transformStereotype,
   V1_transformTaggedValue,
@@ -263,11 +263,11 @@ export class DSLDataSpace_PureProtocolProcessorPlugin extends PureProtocolProces
               contextProtocol.name = execContext.name;
               contextProtocol.description = execContext.description;
               contextProtocol.mapping = new V1_PackageableElementPointer(
-                V1_PackageableElementPointerType.MAPPING,
+                PackageableElementPointerType.MAPPING,
                 execContext.mapping,
               );
               contextProtocol.defaultRuntime = new V1_PackageableElementPointer(
-                V1_PackageableElementPointerType.RUNTIME,
+                PackageableElementPointerType.RUNTIME,
                 execContext.defaultRuntime,
               );
               return contextProtocol;

--- a/packages/legend-extension-dsl-diagram/src/models/__tests__/DSLDiagram_BuildFailure.test.ts
+++ b/packages/legend-extension-dsl-diagram/src/models/__tests__/DSLDiagram_BuildFailure.test.ts
@@ -84,6 +84,7 @@ test(unitTest('Missing class in diagram class view'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingClassInDiagram as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(`Can't find type 'ui::test1::NotFound'`);
 });

--- a/packages/legend-extension-dsl-diagram/src/models/metamodels/pure/packageableElements/diagram/DSLDiagram_ClassView.ts
+++ b/packages/legend-extension-dsl-diagram/src/models/metamodels/pure/packageableElements/diagram/DSLDiagram_ClassView.ts
@@ -23,7 +23,8 @@ import { DIAGRAM_HASH_STRUCTURE } from '../../../../DSLDiagram_ModelUtils';
 import type { Class, PackageableElementReference } from '@finos/legend-graph';
 
 export class ClassView extends PositionedRectangle implements Hashable {
-  owner: Diagram;
+  readonly _OWNER: Diagram;
+
   class: PackageableElementReference<Class>;
   id: string;
   hideProperties?: boolean | undefined;
@@ -36,7 +37,7 @@ export class ClassView extends PositionedRectangle implements Hashable {
     _class: PackageableElementReference<Class>,
   ) {
     super(new Point(0, 0), new Rectangle(0, 0));
-    this.owner = owner;
+    this._OWNER = owner;
     this.id = id;
     this.class = _class;
   }

--- a/packages/legend-extension-dsl-diagram/src/models/metamodels/pure/packageableElements/diagram/DSLDiagram_ClassViewReference.ts
+++ b/packages/legend-extension-dsl-diagram/src/models/metamodels/pure/packageableElements/diagram/DSLDiagram_ClassViewReference.ts
@@ -42,7 +42,7 @@ export class ClassViewExplicitReference extends ClassViewReference {
 
   private constructor(value: ClassView) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner,
+      value._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-extension-dsl-diagram/src/models/metamodels/pure/packageableElements/diagram/DSLDiagram_RelationshipView.ts
+++ b/packages/legend-extension-dsl-diagram/src/models/metamodels/pure/packageableElements/diagram/DSLDiagram_RelationshipView.ts
@@ -23,7 +23,8 @@ import { ClassViewExplicitReference } from './DSLDiagram_ClassViewReference';
 import { DIAGRAM_HASH_STRUCTURE } from '../../../../DSLDiagram_ModelUtils';
 
 export class RelationshipView implements Hashable {
-  owner: Diagram;
+  readonly _OWNER: Diagram;
+
   from: RelationshipEdgeView;
   to: RelationshipEdgeView;
   /**
@@ -39,7 +40,7 @@ export class RelationshipView implements Hashable {
   path: Point[] = [];
 
   constructor(owner: Diagram, from: ClassView, to: ClassView) {
-    this.owner = owner;
+    this._OWNER = owner;
     this.from = new RelationshipEdgeView(
       ClassViewExplicitReference.create(from),
     );

--- a/packages/legend-extension-dsl-diagram/src/stores/studio/DiagramEditorState.ts
+++ b/packages/legend-extension-dsl-diagram/src/stores/studio/DiagramEditorState.ts
@@ -71,7 +71,7 @@ const DIAGRAM_EDITOR_HOTKEY_MAP = Object.freeze({
 });
 
 export abstract class DiagramEditorSidePanelState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   diagramEditorState: DiagramEditorState;
 
@@ -277,7 +277,7 @@ export class DiagramEditorState extends ElementEditorState {
         } else if (this.renderer.mouseOverClassProperty) {
           return this.isReadOnly ||
             this.editorStore.graphManagerState.isElementReadOnly(
-              this.renderer.mouseOverClassProperty.owner,
+              this.renderer.mouseOverClassProperty._OWNER,
             )
             ? 'diagram-editor__cursor--not-allowed'
             : 'diagram-editor__cursor--text';
@@ -285,7 +285,7 @@ export class DiagramEditorState extends ElementEditorState {
           return this.isReadOnly ||
             this.editorStore.graphManagerState.isElementReadOnly(
               this.renderer.mouseOverPropertyHolderViewLabel.property.value
-                .owner,
+                ._OWNER,
             )
             ? 'diagram-editor__cursor--not-allowed'
             : 'diagram-editor__cursor--text';
@@ -400,7 +400,7 @@ export class DiagramEditorState extends ElementEditorState {
     ): void => {
       if (
         !this.isReadOnly &&
-        !this.editorStore.graphManagerState.isElementReadOnly(property.owner)
+        !this.editorStore.graphManagerState.isElementReadOnly(property._OWNER)
       ) {
         this.setInlinePropertyEditorState(
           new DiagramEditorInlinePropertyEditorState(

--- a/packages/legend-extension-dsl-text/src/components/studio/DSLText_LegendStudioPlugin.tsx
+++ b/packages/legend-extension-dsl-text/src/components/studio/DSLText_LegendStudioPlugin.tsx
@@ -55,6 +55,7 @@ import {
   MARKDOWN_TEXT_SNIPPET,
   PLAIN_TEXT_SNIPPET,
 } from './DSLText_CodeSnippets';
+import { create_TextElement } from '../../helper/DSLText_Helper';
 
 const TEXT_ELEMENT_TYPE = 'TEXT';
 const TEXT_ELEMENT_PROJECT_EXPLORER_DND_TYPE = 'PROJECT_EXPLORER_TEXT';
@@ -122,7 +123,7 @@ export class DSLText_LegendStudioPlugin
         state: NewElementState,
       ): PackageableElement | undefined => {
         if (type === TEXT_ELEMENT_TYPE) {
-          return new Text(name);
+          return create_TextElement(name);
         }
         return undefined;
       },

--- a/packages/legend-extension-dsl-text/src/components/studio/TextElementEditor.tsx
+++ b/packages/legend-extension-dsl-text/src/components/studio/TextElementEditor.tsx
@@ -16,10 +16,7 @@
 
 import { useRef, useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
-import {
-  prettyCONSTName,
-  UnsupportedOperationError,
-} from '@finos/legend-shared';
+import { prettyCONSTName } from '@finos/legend-shared';
 import { StudioTextInputEditor, useEditorStore } from '@finos/legend-studio';
 import { TextEditorState } from '../../stores/studio/TextEditorState';
 import {
@@ -30,22 +27,19 @@ import {
   MenuContentItem,
 } from '@finos/legend-art';
 import { EDITOR_LANGUAGE } from '@finos/legend-application';
-import { TEXT_TYPE } from '../../models/metamodels/pure/model/packageableElements/text/DSLText_Text';
 import {
   text_setContent,
   text_setType,
 } from '../../stores/studio/DSLText_GraphModifierHelper';
+import { TEXT_TYPE } from '../../helper/DSLText_Helper';
 
-const getTextElementEditorLanguage = (type: TEXT_TYPE): EDITOR_LANGUAGE => {
+const getTextElementEditorLanguage = (type: string): EDITOR_LANGUAGE => {
   switch (type) {
     case TEXT_TYPE.MARKDOWN:
       return EDITOR_LANGUAGE.MARKDOWN;
     case TEXT_TYPE.PLAIN_TEXT:
-      return EDITOR_LANGUAGE.TEXT;
     default:
-      throw new UnsupportedOperationError(
-        `Can't derive text editor format for text content of type '${type}'`,
-      );
+      return EDITOR_LANGUAGE.TEXT;
   }
 };
 
@@ -83,6 +77,7 @@ export const TextElementEditor = observer(() => {
             className="edit-panel__element-view"
             content={
               <MenuContent>
+                {/* TODO: account for unknown types */}
                 {Object.values(TEXT_TYPE).map((mode) => (
                   <MenuContentItem
                     key={mode}

--- a/packages/legend-extension-dsl-text/src/helper/DSLText_Helper.ts
+++ b/packages/legend-extension-dsl-text/src/helper/DSLText_Helper.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-import { action } from 'mobx';
-import type { Text } from '../../models/metamodels/pure/model/packageableElements/text/DSLText_Text';
+import { Text } from '../models/metamodels/pure/model/packageableElements/text/DSLText_Text';
 
-export const text_setType = action((text: Text, type: string): void => {
-  text.type = type;
-});
+export enum TEXT_TYPE {
+  PLAIN_TEXT = 'plainText',
+  MARKDOWN = 'markdown',
+}
 
-export const text_setContent = action((text: Text, content: string): void => {
-  text.content = content;
-});
+export const create_TextElement = (name: string): Text => {
+  const metamodel = new Text(name);
+  metamodel.type = TEXT_TYPE.PLAIN_TEXT;
+  metamodel.content = '';
+
+  return metamodel;
+};

--- a/packages/legend-extension-dsl-text/src/models/metamodels/pure/model/packageableElements/text/DSLText_Text.ts
+++ b/packages/legend-extension-dsl-text/src/models/metamodels/pure/model/packageableElements/text/DSLText_Text.ts
@@ -21,21 +21,9 @@ import {
   PackageableElement,
 } from '@finos/legend-graph';
 
-// TODO: to be moved out of metamodel
-export enum TEXT_TYPE {
-  PLAIN_TEXT = 'plainText',
-  MARKDOWN = 'markdown',
-}
-
 export class Text extends PackageableElement implements Hashable {
-  type: TEXT_TYPE;
-  content: string;
-
-  constructor(name: string) {
-    super(name);
-    this.type = TEXT_TYPE.PLAIN_TEXT;
-    this.content = '';
-  }
+  type!: string;
+  content!: string;
 
   protected override get _elementHashCode(): string {
     return hashArray([

--- a/packages/legend-extension-dsl-text/src/models/protocols/pure/DSLText_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-dsl-text/src/models/protocols/pure/DSLText_PureProtocolProcessorPlugin.ts
@@ -27,10 +27,7 @@ import {
   V1_TEXT_ELEMENT_PROTOCOL_TYPE,
 } from './v1/transformation/pureProtocol/V1_DSLText_ProtocolHelper';
 import { getOwnText } from '../../../graphManager/DSLText_GraphManagerHelper';
-import {
-  Text,
-  TEXT_TYPE,
-} from '../../metamodels/pure/model/packageableElements/text/DSLText_Text';
+import { Text } from '../../metamodels/pure/model/packageableElements/text/DSLText_Text';
 import {
   type PackageableElement,
   type V1_ElementProtocolClassifierPathGetter,
@@ -84,10 +81,7 @@ export class DSLText_PureProtocolProcessorPlugin extends PureProtocolProcessorPl
             elementProtocol.name,
           );
           const element = getOwnText(path, context.currentSubGraph);
-          element.type =
-            Object.values(TEXT_TYPE).find(
-              (type) => type === elementProtocol.type,
-            ) ?? TEXT_TYPE.PLAIN_TEXT;
+          element.type = elementProtocol.type;
           element.content = guaranteeNonNullable(
             elementProtocol.content,
             `Text element 'content' field is missing`,

--- a/packages/legend-extension-mapping-generation/src/components/MappingGenerationEditor.tsx
+++ b/packages/legend-extension-mapping-generation/src/components/MappingGenerationEditor.tsx
@@ -172,7 +172,7 @@ const ArrayEditor = observer(
             {arrayValues.map((value, idx) => (
               // NOTE: since the value must be unique, we will use it as the key
               <div
-                key={value.value.uuid}
+                key={value.value._UUID}
                 className={
                   showEditInput === idx
                     ? 'mapping-generation-editor__configuration__item'

--- a/packages/legend-graph/src/GraphManagerTestUtils.tsx
+++ b/packages/legend-graph/src/GraphManagerTestUtils.tsx
@@ -175,6 +175,7 @@ export const TEST__buildGraphWithEntities = async (
   await graphManagerState.graphManager.buildGraph(
     graphManagerState.graph,
     entities,
+    graphManagerState.graphBuildState,
     options,
   );
 };
@@ -236,6 +237,7 @@ export const TEST__checkBuildingResolvedElements = async (
   await graphManagerState.graphManager.buildGraph(
     graphManagerState.graph,
     entities,
+    graphManagerState.graphBuildState,
   );
   const transformedEntities = graphManagerState.graph.allOwnElements.map(
     (element) => graphManagerState.graphManager.elementToEntity(element),

--- a/packages/legend-graph/src/MetaModelConst.ts
+++ b/packages/legend-graph/src/MetaModelConst.ts
@@ -361,3 +361,11 @@ export const MILESTONING_END_DATE_PARAMETER_NAME = 'end';
 export const DEFAULT_PROCESSING_DATE_MILESTONING_PARAMETER_NAME =
   'processingDate';
 export const DEFAULT_BUSINESS_DATE_MILESTONING_PARAMETER_NAME = 'businessDate';
+
+export enum PackageableElementPointerType {
+  STORE = 'STORE',
+  MAPPING = 'MAPPING',
+  RUNTIME = 'RUNTIME',
+  FILE_GENERATION = 'FILE_GENERATION',
+  SERVICE = 'SERVICE',
+}

--- a/packages/legend-graph/src/__tests__/Inference.test.ts
+++ b/packages/legend-graph/src/__tests__/Inference.test.ts
@@ -54,6 +54,7 @@ test(
       graphManagerState.graphManager.buildGraph(
         graphManagerState.graph,
         TEST_DATA__ImportResolutionMultipleMatchesFound as Entity[],
+        graphManagerState.graphBuildState,
       ),
     ).rejects.toThrow(
       `Can't resolve element with path 'A' - multiple matches found [test::A, test2::A]`,

--- a/packages/legend-graph/src/__tests__/buildGraph/Dependency.test.ts
+++ b/packages/legend-graph/src/__tests__/buildGraph/Dependency.test.ts
@@ -104,16 +104,16 @@ test(
       graphManagerState.systemModel,
       dependencyManager,
       dependencyEntitiesMap,
+      graphManagerState.dependenciesBuildState,
     );
-    expect(
-      graphManagerState.graph.dependencyManager.buildState.hasSucceeded,
-    ).toBe(true);
+    expect(graphManagerState.dependenciesBuildState.hasSucceeded).toBe(true);
 
     await graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       entities,
+      graphManagerState.graphBuildState,
     );
-    expect(graphManagerState.graph.buildState.hasSucceeded).toBe(true);
+    expect(graphManagerState.graphBuildState.hasSucceeded).toBe(true);
     Array.from(dependencyEntitiesMap.keys()).forEach((k) =>
       expect(dependencyManager.getModel(k)).toBeDefined(),
     );
@@ -147,15 +147,15 @@ test(
       graphManagerState.systemModel,
       dependencyManager,
       dependencyEntitiesMap,
+      graphManagerState.dependenciesBuildState,
     );
-    expect(
-      graphManagerState.graph.dependencyManager.buildState.hasSucceeded,
-    ).toBe(true);
+    expect(graphManagerState.dependenciesBuildState.hasSucceeded).toBe(true);
 
     await expect(() =>
       graphManagerState.graphManager.buildGraph(
         graphManagerState.graph,
         firstDependencyEntities,
+        graphManagerState.graphBuildState,
       ),
     ).rejects.toThrowError(`Element 'model::ClassB' already exists`);
   },

--- a/packages/legend-graph/src/__tests__/buildGraph/Generation.test.ts
+++ b/packages/legend-graph/src/__tests__/buildGraph/Generation.test.ts
@@ -57,13 +57,14 @@ const testGeneratedElements = async (
   const graphManagerState = TEST__getTestGraphManagerState();
   await TEST__buildGraphWithEntities(graphManagerState, entities);
 
-  expect(graphManagerState.graph.buildState.hasSucceeded).toBe(true);
+  expect(graphManagerState.graphBuildState.hasSucceeded).toBe(true);
   // build generation graph
   const generatedEntitiesMap = new Map<string, Entity[]>();
   generatedEntitiesMap.set(PARENT_ELEMENT_PATH, generatedEntities);
   await graphManagerState.graphManager.buildGenerations(
     graphManagerState.graph,
     generatedEntitiesMap,
+    graphManagerState.generationsBuildState,
   );
 
   expect(graphManagerState.graph.generationModel.allOwnElements.length).toBe(

--- a/packages/legend-graph/src/__tests__/buildGraph/GraphBuildFailure.test.ts
+++ b/packages/legend-graph/src/__tests__/buildGraph/GraphBuildFailure.test.ts
@@ -49,6 +49,7 @@ test(unitTest('Missing super type'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingSuperType as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Can't find supertype 'ui::test1::Organism' of class 'ui::test1::Animal'`,
@@ -60,6 +61,7 @@ test(unitTest('Missing profile'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingProfile as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(`Can't find profile 'ui::test1::ProfileTest'`);
 });
@@ -69,6 +71,7 @@ test(unitTest('Duplicated element'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__DuplicatedElement as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(`Element 'ui::test1::Animal' already exists`);
 });
@@ -78,6 +81,7 @@ test(unitTest('Missing class property'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingProperty as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(`Can't find type 'ui::test1::NotFound'`);
 });
@@ -87,6 +91,7 @@ test(unitTest('Missing stereotype'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingStereoType as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Can't find stereotype 'missingStereotype' in profile 'ui::meta::pure::profiles::TestProfile'`,
@@ -98,6 +103,7 @@ test(unitTest('Missing tagged value'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingTagValue as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Can't find tag 'missingTag' in profile 'ui::meta::pure::profiles::TestProfile'`,
@@ -109,6 +115,7 @@ test(unitTest('Missing class in Pure Instance class mapping'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingTargetClassinMapping as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(`Can't find type 'ui::test1::Target_Something'`);
 });
@@ -136,6 +143,7 @@ test.skip(unitTest('Missing class mapping with ID'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__MissingClassMappingWithTargetId as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Can't find class mapping with ID 'notFound' in mapping 'ui::myMap'`,
@@ -154,6 +162,7 @@ test.skip(unitTest('Duplicate enumeration values'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__DuplicateEnumerationValues as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Found duplicated value 'enum_value' in enumeration 'test::enum'`,
@@ -172,6 +181,7 @@ test.skip(unitTest('Duplicate profile tags'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__DuplicateProfileTags as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Found duplicated tag 'tag1' in profile 'test::profile1'`,
@@ -190,6 +200,7 @@ test.skip(unitTest('Duplicate profile stereotypes'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__DuplicateProfileStereotypes as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Found duplicated stereotype 'stereotype1' in profile 'test::profile2'`,
@@ -208,6 +219,7 @@ test.skip(unitTest('Duplicate class properties'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__DuplicateClassProperties as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Found duplicated property 'abc' in class 'test::class'`,
@@ -226,6 +238,7 @@ test.skip(unitTest('Duplicate association properties'), async () => {
     graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       TEST_DATA__DuplicateAssociationProperties as Entity[],
+      graphManagerState.graphBuildState,
     ),
   ).rejects.toThrowError(
     `Found duplicated property 'abc' in association 'test::association'`,

--- a/packages/legend-graph/src/__tests__/buildGraph/GraphBuildSuccess.test.ts
+++ b/packages/legend-graph/src/__tests__/buildGraph/GraphBuildSuccess.test.ts
@@ -38,7 +38,7 @@ beforeAll(async () => {
 
 test(unitTest('Graph has been initialized properly'), () => {
   const graph = graphManagerState.graph;
-  expect(graph.buildState.hasSucceeded).toBeTruthy();
+  expect(graphManagerState.graphBuildState.hasSucceeded).toBeTruthy();
   expect(
     Array.from(graphManagerState.coreModel.multiplicitiesIndex.values()).length,
   ).toBeGreaterThan(0);

--- a/packages/legend-graph/src/__tests__/buildGraph/GraphBuildSuccess.test.ts
+++ b/packages/legend-graph/src/__tests__/buildGraph/GraphBuildSuccess.test.ts
@@ -55,8 +55,8 @@ test(unitTest('Enumeration is loaded properly'), () => {
   const profile = graph.getProfile('ui::test1::ProfileTest');
   const taggedValue = guaranteeNonNullable(pureEnum.taggedValues[0]);
   expect(taggedValue.value).toEqual('Enumeration Tag');
-  expect(profile).toEqual(taggedValue.tag.value.owner);
-  expect(profile).toEqual(pureEnum.stereotypes[0]?.value.owner);
+  expect(profile).toEqual(taggedValue.tag.value._OWNER);
+  expect(profile).toEqual(pureEnum.stereotypes[0]?.value._OWNER);
 });
 
 test(unitTest('Class is loaded properly'), () => {
@@ -65,7 +65,7 @@ test(unitTest('Class is loaded properly'), () => {
   const stereotype = guaranteeNonNullable(testClass.stereotypes[0]).value;
   expect(
     graph
-      .getProfile(stereotype.owner.path)
+      .getProfile(stereotype._OWNER.path)
       .stereotypes.find((s) => s.value === stereotype.value),
   ).toBeDefined();
   const personClass = graph.getClass('ui::test2::Person');

--- a/packages/legend-graph/src/graph/BasicModel.ts
+++ b/packages/legend-graph/src/graph/BasicModel.ts
@@ -16,7 +16,6 @@
 
 import {
   type Clazz,
-  ActionState,
   UnsupportedOperationError,
   getClass,
   IllegalStateError,
@@ -101,9 +100,6 @@ const FORBIDDEN_EXTENSION_ELEMENT_CLASS = new Set([
 export abstract class BasicModel {
   root: Package;
   readonly extensions: PureGraphExtension<PackageableElement>[] = [];
-
-  // TODO: to be moved, this is graph-manager logic and should be moved elsewhere
-  buildState = ActionState.create();
 
   private elementSectionMap = new Map<string, Section>();
 

--- a/packages/legend-graph/src/graph/DependencyManager.ts
+++ b/packages/legend-graph/src/graph/DependencyManager.ts
@@ -15,11 +15,7 @@
  */
 
 import { ROOT_PACKAGE_NAME } from '../MetaModelConst';
-import {
-  type Clazz,
-  ActionState,
-  guaranteeNonNullable,
-} from '@finos/legend-shared';
+import { type Clazz, guaranteeNonNullable } from '@finos/legend-shared';
 import type { PackageableElement } from '../models/metamodels/pure/packageableElements/PackageableElement';
 import type { Enumeration } from '../models/metamodels/pure/packageableElements/domain/Enumeration';
 import type { Type } from '../models/metamodels/pure/packageableElements/domain/Type';
@@ -71,16 +67,10 @@ export class DependencyManager {
   root = new Package(ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT);
   projectDependencyModelsIndex = new Map<string, BasicModel>();
 
-  // TODO: to be moved, this is graph-manager logic and should be moved elsewhere
-  buildState = ActionState.create();
-
   private readonly extensionElementClasses: Clazz<PackageableElement>[];
 
   constructor(extensionElementClasses: Clazz<PackageableElement>[]) {
     this.extensionElementClasses = extensionElementClasses;
-    this.buildState.setMessageFormatter(
-      (message: string) => `[dependency] ${message}`,
-    );
   }
 
   /**

--- a/packages/legend-graph/src/graph/PureModel.ts
+++ b/packages/legend-graph/src/graph/PureModel.ts
@@ -142,10 +142,6 @@ export class SystemModel extends BasicModel {
 
   constructor(extensionElementClasses: Clazz<PackageableElement>[]) {
     super(ROOT_PACKAGE_NAME.SYSTEM, extensionElementClasses);
-
-    this.buildState.setMessageFormatter(
-      (message: string) => `[system] ${message}`,
-    );
   }
 
   /**
@@ -167,10 +163,6 @@ export class SystemModel extends BasicModel {
 export class GenerationModel extends BasicModel {
   constructor(extensionElementClasses: Clazz<PackageableElement>[]) {
     super(ROOT_PACKAGE_NAME.MODEL_GENERATION, extensionElementClasses);
-
-    this.buildState.setMessageFormatter(
-      (message: string) => `[generation] ${message}`,
-    );
   }
 }
 

--- a/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
@@ -49,6 +49,7 @@ import type {
 } from '../models/metamodels/pure/executionPlan/ExecutionPlan';
 import type { ExecutionNode } from '../models/metamodels/pure/executionPlan/nodes/ExecutionNode';
 import type {
+  ActionState,
   Log,
   ServerClientConfig,
   TracerService,
@@ -127,6 +128,7 @@ export abstract class AbstractPureGraphManager {
   abstract buildSystem(
     coreModel: CoreModel,
     systemModel: SystemModel,
+    buildState: ActionState,
     options?: GraphBuilderOptions,
   ): Promise<GraphBuilderReport>;
 
@@ -136,6 +138,7 @@ export abstract class AbstractPureGraphManager {
   abstract buildGraph(
     graph: PureModel,
     entities: Entity[],
+    buildState: ActionState,
     options?: GraphBuilderOptions,
   ): Promise<GraphBuilderReport>;
 
@@ -152,12 +155,14 @@ export abstract class AbstractPureGraphManager {
     systemModel: SystemModel,
     dependencyManager: DependencyManager,
     dependencyEntitiesMap: Map<string, Entity[]>,
+    buildState: ActionState,
     options?: GraphBuilderOptions,
   ): Promise<GraphBuilderReport>;
 
   abstract buildGenerations(
     graph: PureModel,
     generationEntities: Map<string, Entity[]>,
+    buildState: ActionState,
     options?: GraphBuilderOptions,
   ): Promise<GraphBuilderReport>;
 
@@ -367,6 +372,7 @@ export abstract class AbstractPureGraphManager {
   abstract deleteQuery(queryId: string): Promise<void>;
 
   // ------------------------------------------- Legend Query -------------------------------------
+
   abstract buildGraphForCreateQuerySetup(
     graph: PureModel,
     entities: Entity[],

--- a/packages/legend-graph/src/graphManager/action/EngineError.ts
+++ b/packages/legend-graph/src/graphManager/action/EngineError.ts
@@ -15,26 +15,10 @@
  */
 
 import { ApplicationError } from '@finos/legend-shared';
-import { observable, action, makeObservable } from 'mobx';
 import type { SourceInformation } from '../action/SourceInformation';
 
 export class EngineError extends ApplicationError {
   sourceInformation?: SourceInformation | undefined;
-
-  constructor(message: string | undefined) {
-    super(message);
-
-    // TODO: check if we need this to be observable or not?
-    makeObservable(this, {
-      message: observable,
-      sourceInformation: observable,
-      setSourceInformation: action,
-    });
-  }
-
-  setSourceInformation(sourceInformation: SourceInformation | undefined): void {
-    this.sourceInformation = sourceInformation;
-  }
 }
 
 export class ParserError extends EngineError {}

--- a/packages/legend-graph/src/graphManager/action/TEMPORARY__AbstractEngineConfig.ts
+++ b/packages/legend-graph/src/graphManager/action/TEMPORARY__AbstractEngineConfig.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { action, makeObservable, observable } from 'mobx';
-
 const DEFAULT_TAB_SIZE = 2;
 
 /**
@@ -52,20 +50,5 @@ export class TEMPORARY__AbstractEngineConfig {
 
   setUseBase64ForAdhocConnectionDataUrls(val: boolean): void {
     this.useBase64ForAdhocConnectionDataUrls = val;
-  }
-
-  constructor() {
-    makeObservable(this, {
-      env: observable,
-      currentUserId: observable,
-      baseUrl: observable,
-      useClientRequestPayloadCompression: observable,
-      useBase64ForAdhocConnectionDataUrls: observable,
-      setEnv: action,
-      setCurrentUserId: action,
-      setBaseUrl: action,
-      setUseClientRequestPayloadCompression: action,
-      setUseBase64ForAdhocConnectionDataUrls: action,
-    });
   }
 }

--- a/packages/legend-graph/src/graphManager/action/changeDetection/DSLMapping_ObserverHelper.ts
+++ b/packages/legend-graph/src/graphManager/action/changeDetection/DSLMapping_ObserverHelper.ts
@@ -139,7 +139,7 @@ export const observe_LocalMappingPropertyInfo = skipObserved(
       hashCode: computed,
     });
 
-    // TODO localMappingPropertyType!: Type;
+    observe_PackageableElementReference(metamodel.localMappingPropertyType);
     observe_Multiplicity(metamodel.localMappingPropertyMultiplicity);
 
     return metamodel;

--- a/packages/legend-graph/src/graphManager/action/changeDetection/EngineObserverHelper.ts
+++ b/packages/legend-graph/src/graphManager/action/changeDetection/EngineObserverHelper.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { action, makeObservable, observable } from 'mobx';
+import type { TEMPORARY__AbstractEngineConfig } from '../TEMPORARY__AbstractEngineConfig';
+import { skipObserved } from './CoreObserverHelper';
+
+export const observe_TEMPORARY__AbstractEngineConfig = skipObserved(
+  (
+    metamodel: TEMPORARY__AbstractEngineConfig,
+  ): TEMPORARY__AbstractEngineConfig =>
+    makeObservable(metamodel, {
+      env: observable,
+      currentUserId: observable,
+      baseUrl: observable,
+      useClientRequestPayloadCompression: observable,
+      useBase64ForAdhocConnectionDataUrls: observable,
+      setEnv: action,
+      setCurrentUserId: action,
+      setBaseUrl: action,
+      setUseClientRequestPayloadCompression: action,
+      setUseBase64ForAdhocConnectionDataUrls: action,
+    }),
+);

--- a/packages/legend-graph/src/graphManager/action/execution/ExecutionResult.ts
+++ b/packages/legend-graph/src/graphManager/action/execution/ExecutionResult.ts
@@ -85,7 +85,7 @@ export class TabularDataSet {
 }
 
 export class TdsExecutionResult extends ExecutionResult {
-  uuid = uuid();
+  readonly _UUID = uuid();
   override builder = new TdsBuilder();
   result = new TabularDataSet();
 }

--- a/packages/legend-graph/src/graphManager/action/generation/DatabaseBuilderInput.ts
+++ b/packages/legend-graph/src/graphManager/action/generation/DatabaseBuilderInput.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import { uuid } from '@finos/legend-shared';
 import type { RelationalDatabaseConnection } from '../../../models/metamodels/pure/packageableElements/store/relational/connection/RelationalDatabaseConnection';
 
 export class DatabasePattern {
-  readonly uuid = uuid();
   schemaPattern = '';
   tablePattern = '';
   escapeSchemaPattern?: boolean | undefined;

--- a/packages/legend-graph/src/graphManager/action/generation/DatabaseBuilderInput.ts
+++ b/packages/legend-graph/src/graphManager/action/generation/DatabaseBuilderInput.ts
@@ -14,36 +14,19 @@
  * limitations under the License.
  */
 
-import { makeObservable, observable, action } from 'mobx';
 import { uuid } from '@finos/legend-shared';
 import type { RelationalDatabaseConnection } from '../../../models/metamodels/pure/packageableElements/store/relational/connection/RelationalDatabaseConnection';
 
 export class DatabasePattern {
-  uuid = uuid();
+  readonly uuid = uuid();
   schemaPattern = '';
   tablePattern = '';
   escapeSchemaPattern?: boolean | undefined;
   escapeTablePattern?: boolean | undefined;
 
   constructor(schemaPattern: string, tablePattern: string) {
-    makeObservable(this, {
-      schemaPattern: observable,
-      tablePattern: observable,
-      escapeSchemaPattern: observable,
-      escapeTablePattern: observable,
-      setTablePattern: action,
-      setSchemaPattern: action,
-    });
     this.schemaPattern = schemaPattern;
     this.tablePattern = tablePattern;
-  }
-
-  setSchemaPattern(val: string): void {
-    this.schemaPattern = val;
-  }
-
-  setTablePattern(val: string): void {
-    this.tablePattern = val;
   }
 }
 
@@ -53,16 +36,6 @@ export class DatabaseBuilderConfig {
   enrichPrimaryKeys = false;
   enrichColumns = false;
   patterns: DatabasePattern[] = [];
-
-  constructor() {
-    makeObservable(this, {
-      maxTables: observable,
-      enrichTables: observable,
-      enrichPrimaryKeys: observable,
-      enrichColumns: observable,
-      patterns: observable,
-    });
-  }
 }
 
 export class TargetDatabase {
@@ -70,10 +43,6 @@ export class TargetDatabase {
   package: string;
 
   constructor(_package: string, name: string) {
-    makeObservable(this, {
-      name: observable,
-      package: observable,
-    });
     this.package = _package;
     this.name = name;
   }
@@ -85,11 +54,6 @@ export class DatabaseBuilderInput {
   connection: RelationalDatabaseConnection;
 
   constructor(connection: RelationalDatabaseConnection) {
-    makeObservable(this, {
-      targetDatabase: observable,
-      config: observable,
-      connection: observable,
-    });
     this.connection = connection;
     this.targetDatabase = new TargetDatabase('', '');
     this.config = new DatabaseBuilderConfig();

--- a/packages/legend-graph/src/helpers/MappingHelper.ts
+++ b/packages/legend-graph/src/helpers/MappingHelper.ts
@@ -128,7 +128,7 @@ export const getAllSuperSetImplementations = (
   ) {
     const superSetImpl = [
       getClassMappingById(
-        currentSetImpl.parent,
+        currentSetImpl._PARENT,
         currentSetImpl.superSetImplementationId,
       ),
     ];

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -309,6 +309,8 @@ export * from './graphManager/action/changeDetection/DSLExternalFormat_ObserverH
 export * from './graphManager/action/changeDetection/DSLService_ObserverHelper';
 export * from './graphManager/action/changeDetection/DSLGenerationSpecification_ObserverHelper';
 
+export * from './graphManager/action/changeDetection/EngineObserverHelper';
+
 // --------------------------------------------- TO BE MODULARIZED --------------------------------------------------
 
 export * from './DSLMapping_Exports';

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -32,11 +32,7 @@ export {
   GenericTypeExplicitReference,
 } from './models/metamodels/pure/packageableElements/domain/GenericTypeReference';
 export { GenericType } from './models/metamodels/pure/packageableElements/domain/GenericType';
-export {
-  Class,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
-} from './models/metamodels/pure/packageableElements/domain/Class';
+export { Class } from './models/metamodels/pure/packageableElements/domain/Class';
 export { type AnnotatedElement } from './models/metamodels/pure/packageableElements/domain/AnnotatedElement';
 export { Package } from './models/metamodels/pure/packageableElements/domain/Package';
 export { Constraint } from './models/metamodels/pure/packageableElements/domain/Constraint';

--- a/packages/legend-graph/src/models/metamodels/pure/Reference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/Reference.ts
@@ -73,3 +73,12 @@ export abstract class ReferenceWithOwner extends RequiredReference {
     this.ownerReference = ownerReference;
   }
 }
+
+export abstract class OptionalReferenceWithOwner extends OptionalReference {
+  readonly ownerReference: OptionalReference;
+
+  protected constructor(ownerReference: OptionalReference) {
+    super();
+    this.ownerReference = ownerReference;
+  }
+}

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElement.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElement.ts
@@ -69,10 +69,10 @@ export interface PackageableElementVisitor<T> {
 }
 
 export abstract class PackageableElement implements Hashable, Stubable {
-  readonly uuid = uuid();
-
+  readonly _UUID = uuid();
   protected _isDeleted = false;
   protected _isDisposed = false;
+
   name: string;
   package?: Package | undefined;
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElement.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElement.ts
@@ -141,38 +141,6 @@ export abstract class PackageableElement implements Hashable, Stubable {
   ): T;
 }
 
-// TODO: to be moved out of metamodel
-export enum PACKAGEABLE_ELEMENT_TYPE {
-  PRIMITIVE = 'PRIMITIVE',
-  PACKAGE = 'PACKAGE',
-  PROFILE = 'PROFILE',
-  ENUMERATION = 'ENUMERATION',
-  CLASS = 'CLASS',
-  ASSOCIATION = 'ASSOCIATION',
-  FUNCTION = 'FUNCTION',
-  MEASURE = 'MEASURE',
-  UNIT = 'UNIT',
-  FLAT_DATA_STORE = 'FLAT_DATA_STORE',
-  DATABASE = 'DATABASE',
-  SERVICE_STORE = 'SERVICE_STORE',
-  MAPPING = 'MAPPING',
-  SERVICE = 'SERVICE',
-  CONNECTION = 'CONNECTION',
-  RUNTIME = 'RUNTIME',
-  FILE_GENERATION = 'FILE_GENERATION',
-  GENERATION_SPECIFICATION = 'GENERATION_SPECIFICATION',
-  SECTION_INDEX = 'SECTION_INDEX',
-  DATA = 'Data',
-}
-
-// TODO: to be moved out of metamodel
-export enum PACKAGEABLE_ELEMENT_POINTER_TYPE {
-  STORE = 'STORE',
-  MAPPING = 'MAPPING',
-  FILE_GENERATION = 'FILE_GENERATION',
-  SERVICE = 'SERVICE',
-}
-
 export const getElementPointerHashCode = (
   pointerType: string,
   path: string,

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElement.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElement.ts
@@ -111,14 +111,12 @@ export abstract class PackageableElement implements Hashable, Stubable {
      * Trigger recomputation on `hashCode` so if the element is observed, hash code computation will now
      * remove itself from all observables it previously observed
      *
-     * NOTE: we used to do this since we decorate `hashCode` with `computed({ keepAlive: true })` which
-     * poses a memory-leak threat
-     *
-     * See https://mobx.js.org/computeds.html#keepalive
-     *
+     * NOTE: for example, we used to do this since we decorate `hashCode` with
+     * `computed({ keepAlive: true })` which poses a memory-leak threat.
      * However, since we're calling `keepAlive` actively now and dispose it right away to return `hashCode` to
      * a normal computed value, we might not need this step anymore. But we're being extremely defensive here
      * to avoid memory leak.
+     * See https://mobx.js.org/computeds.html#keepalive
      */
     try {
       this.hashCode;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElementReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/PackageableElementReference.ts
@@ -134,7 +134,7 @@ export class PackageableElementImplicitReference<
     // when the parent section does not exist or has been deleted
     if (
       this.parentSection === undefined ||
-      this.parentSection.parent.isDeleted
+      this.parentSection._OWNER.isDeleted
     ) {
       return currentElementPath;
     }
@@ -240,7 +240,7 @@ export class OptionalPackageableElementImplicitReference<
     // when the parent section does not exist or has been deleted
     if (
       this.parentSection === undefined ||
-      this.parentSection.parent.isDeleted
+      this.parentSection._OWNER.isDeleted
     ) {
       return currentElementPath;
     }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/connection/Connection.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/connection/Connection.ts
@@ -38,9 +38,11 @@ export interface ConnectionVisitor<T> {
 }
 
 export abstract class Connection implements Hashable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
-  // in Pure right now, this is of type Any[1], but technically it should be a store
+  /**
+   * NOTE: in Pure right now, this is of type Any[1], but technically it should be a store
+   */
   store: PackageableElementReference<Store>;
 
   constructor(store: PackageableElementReference<Store>) {

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/AbstractProperty.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/AbstractProperty.ts
@@ -26,7 +26,7 @@ export type PropertyOwner = Class | Association;
 
 export interface AbstractProperty extends Hashable, Stubable {
   name: string;
-  owner: PropertyOwner;
+  _OWNER: PropertyOwner;
   genericType: GenericTypeReference;
   multiplicity: Multiplicity;
 }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Association.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Association.ts
@@ -16,6 +16,7 @@
 
 import {
   type Hashable,
+  type Writable,
   guaranteeNonNullable,
   guaranteeType,
   assertTrue,
@@ -35,19 +36,6 @@ import type { TaggedValue } from './TaggedValue';
 import type { StereotypeReference } from './StereotypeReference';
 import { DerivedProperty } from './DerivedProperty';
 import type { AbstractProperty } from './AbstractProperty';
-
-// NOTE: we might want to revisit this decision to initialize to association properties to stubs
-const initAssociationProperties = (
-  association: Association,
-): [Property, Property] => {
-  const properties: [Property, Property] = [
-    Property.createStub(Class.createStub(), Class.createStub()),
-    Property.createStub(Class.createStub(), Class.createStub()),
-  ];
-  properties[0].owner = association;
-  properties[1].owner = association;
-  return properties;
-};
 
 /**
  * Assocation needs exactly 2 properties (for 2 classes, not enumeration, not primitive), e.g.
@@ -69,16 +57,29 @@ export class Association
   extends PackageableElement
   implements AnnotatedElement, Hashable, Stubable
 {
-  properties: [Property, Property] = initAssociationProperties(this);
-  stereotypes: StereotypeReference[] = [];
-  taggedValues: TaggedValue[] = [];
-  derivedProperties: DerivedProperty[] = [];
-
   /**
    * To store the abstract properties generated while processing the milestoning properties. The properties
    * generated are `allVersions`, `allVersionsInRange` and derived property with date parameter.
    */
   _generatedMilestonedProperties: AbstractProperty[] = [];
+
+  properties!: [Property, Property];
+  stereotypes: StereotypeReference[] = [];
+  taggedValues: TaggedValue[] = [];
+  derivedProperties: DerivedProperty[] = [];
+
+  constructor(name: string) {
+    super(name);
+
+    // NOTE: we might want to revisit this decision to initialize to association properties to stubs
+    const properties: [Property, Property] = [
+      Property.createStub(Class.createStub(), Class.createStub()),
+      Property.createStub(Class.createStub(), Class.createStub()),
+    ];
+    (properties[0] as Writable<Property>)._OWNER = this;
+    (properties[1] as Writable<Property>)._OWNER = this;
+    this.properties = properties;
+  }
 
   getFirstProperty = (): Property => guaranteeNonNullable(this.properties[0]);
   getSecondProperty = (): Property => guaranteeNonNullable(this.properties[1]);

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Class.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Class.ts
@@ -20,7 +20,6 @@ import {
   uniqBy,
   IllegalStateError,
   guaranteeNonNullable,
-  UnsupportedOperationError,
 } from '@finos/legend-shared';
 import {
   CORE_HASH_STRUCTURE,
@@ -33,9 +32,6 @@ import type { DerivedProperty } from './DerivedProperty';
 import type { AbstractProperty } from './AbstractProperty';
 import { type Stubable, isStubArray } from '../../../../../helpers/Stubable';
 import type { PackageableElementVisitor } from '../PackageableElement';
-import { PrimitiveType } from './PrimitiveType';
-import { Enumeration } from './Enumeration';
-import { Measure, Unit } from './Measure';
 import type { StereotypeReference } from './StereotypeReference';
 import type { TaggedValue } from './TaggedValue';
 import type { GenericTypeReference } from './GenericTypeReference';
@@ -235,28 +231,3 @@ export class Class extends Type implements Hashable, Stubable {
     return visitor.visit_Class(this);
   }
 }
-
-// TODO: to be moved out of metamodel
-export enum CLASS_PROPERTY_TYPE {
-  CLASS = 'CLASS',
-  ENUMERATION = 'ENUMERATION',
-  MEASURE = 'MEASURE',
-  UNIT = 'UNIT',
-  PRIMITIVE = 'PRIMITIVE',
-}
-
-// TODO: to be moved out of metamodel
-export const getClassPropertyType = (type: Type): CLASS_PROPERTY_TYPE => {
-  if (type instanceof PrimitiveType) {
-    return CLASS_PROPERTY_TYPE.PRIMITIVE;
-  } else if (type instanceof Enumeration) {
-    return CLASS_PROPERTY_TYPE.ENUMERATION;
-  } else if (type instanceof Class) {
-    return CLASS_PROPERTY_TYPE.CLASS;
-  } else if (type instanceof Unit) {
-    return CLASS_PROPERTY_TYPE.UNIT;
-  } else if (type instanceof Measure) {
-    return CLASS_PROPERTY_TYPE.MEASURE;
-  }
-  throw new UnsupportedOperationError(`Can't classify class property`, type);
-};

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Constraint.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Constraint.ts
@@ -21,8 +21,8 @@ import type { Class } from './Class';
 import type { Stubable } from '../../../../../helpers/Stubable';
 
 export class Constraint implements Hashable, Stubable {
-  readonly uuid = uuid();
-  owner: Class;
+  readonly _UUID = uuid();
+  readonly _OWNER: Class;
 
   name: string;
   /**
@@ -42,7 +42,7 @@ export class Constraint implements Hashable, Stubable {
 
   constructor(name: string, owner: Class, functionDefinition: RawLambda) {
     this.name = name;
-    this.owner = owner;
+    this._OWNER = owner;
     this.functionDefinition = functionDefinition;
   }
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/DerivedProperty.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/DerivedProperty.ts
@@ -34,8 +34,8 @@ import {
 export class DerivedProperty
   implements AbstractProperty, AnnotatedElement, Hashable, Stubable
 {
-  readonly uuid = uuid();
-  owner: PropertyOwner; // readonly
+  readonly _UUID = uuid();
+  readonly _OWNER: PropertyOwner;
 
   name: string;
   genericType: GenericTypeReference;
@@ -64,7 +64,7 @@ export class DerivedProperty
     this.name = name;
     this.multiplicity = multiplicity;
     this.genericType = genericType;
-    this.owner = owner;
+    this._OWNER = owner;
   }
   static createStub = (type: Type, _class: Class): DerivedProperty =>
     new DerivedProperty(

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Enum.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Enum.ts
@@ -23,8 +23,8 @@ import type { Stubable } from '../../../../../helpers/Stubable';
 import type { StereotypeReference } from './StereotypeReference';
 
 export class Enum implements AnnotatedElement, Hashable, Stubable {
-  readonly uuid = uuid();
-  owner: Enumeration;
+  readonly _UUID = uuid();
+  readonly _OWNER: Enumeration;
 
   name: string;
   stereotypes: StereotypeReference[] = [];
@@ -32,7 +32,7 @@ export class Enum implements AnnotatedElement, Hashable, Stubable {
 
   constructor(name: string, owner: Enumeration) {
     this.name = name;
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   static createStub = (parentEnumeration: Enumeration): Enum =>

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/EnumValueReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/EnumValueReference.ts
@@ -50,7 +50,7 @@ export class EnumValueExplicitReference extends EnumValueReference {
 
   private constructor(value: Enum) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner,
+      value._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/GenericType.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/GenericType.ts
@@ -19,7 +19,8 @@ import type { Type } from './Type';
 import type { Stubable } from '../../../../../helpers/Stubable';
 
 export class GenericType implements Stubable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
+
   rawType: Type;
 
   constructor(rawType: Type) {

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Property.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Property.ts
@@ -33,8 +33,8 @@ import type { StereotypeReference } from './StereotypeReference';
 export class Property
   implements AbstractProperty, AnnotatedElement, Hashable, Stubable
 {
-  readonly uuid = uuid();
-  owner: PropertyOwner; // readonly
+  readonly _UUID = uuid();
+  readonly _OWNER: PropertyOwner;
 
   name: string;
   multiplicity: Multiplicity;
@@ -51,7 +51,7 @@ export class Property
     this.name = name;
     this.multiplicity = multiplicity;
     this.genericType = genericType;
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   static createStub = (type: Type, _class: Class): Property =>

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/PropertyReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/PropertyReference.ts
@@ -65,9 +65,9 @@ export class PropertyExplicitReference extends PropertyReference {
 
   private constructor(value: AbstractProperty) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner instanceof Association
-        ? value.owner.getPropertyAssociatedClass(value)
-        : value.owner,
+      value._OWNER instanceof Association
+        ? value._OWNER.getPropertyAssociatedClass(value)
+        : value._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Stereotype.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Stereotype.ts
@@ -19,13 +19,13 @@ import type { Profile } from './Profile';
 import type { Stubable } from '../../../../../helpers/Stubable';
 
 export class Stereotype implements Stubable {
-  readonly uuid = uuid();
-  owner: Profile;
+  readonly _UUID = uuid();
+  readonly _OWNER: Profile;
 
   value: string;
 
   constructor(owner: Profile, value: string) {
-    this.owner = owner;
+    this._OWNER = owner;
     this.value = value;
   }
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/StereotypeReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/StereotypeReference.ts
@@ -62,7 +62,7 @@ export class StereotypeExplicitReference extends StereotypeReference {
 
   private constructor(value: Stereotype) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner,
+      value._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Tag.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/Tag.ts
@@ -19,13 +19,13 @@ import type { Profile } from './Profile';
 import type { Stubable } from '../../../../../helpers/Stubable';
 
 export class Tag implements Stubable {
-  readonly uuid = uuid();
-  owner: Profile;
+  readonly _UUID = uuid();
+  readonly _OWNER: Profile;
 
   value: string;
 
   constructor(owner: Profile, value: string) {
-    this.owner = owner;
+    this._OWNER = owner;
     this.value = value;
   }
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/TagReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/TagReference.ts
@@ -62,7 +62,7 @@ export class TagExplicitReference extends TagReference {
 
   private constructor(value: Tag) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner,
+      value._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/TaggedValue.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/domain/TaggedValue.ts
@@ -21,7 +21,7 @@ import type { Stubable } from '../../../../../helpers/Stubable';
 import { type TagReference, TagExplicitReference } from './TagReference';
 
 export class TaggedValue implements Hashable, Stubable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   tag: TagReference;
   value: string;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/externalFormat/schemaSet/DSLExternalFormat_Schema.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/externalFormat/schemaSet/DSLExternalFormat_Schema.ts
@@ -18,7 +18,7 @@ import { uuid, hashArray, type Hashable } from '@finos/legend-shared';
 import { DSL_EXTERNAL_FORMAT_HASH_STRUCTURE } from '../../../../../DSLExternalFormat_ModelUtils';
 
 export class Schema implements Hashable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   id?: string | undefined;
   location?: string | undefined;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/generationSpecification/GenerationSpecification.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/generationSpecification/GenerationSpecification.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { CORE_HASH_STRUCTURE } from '../../../../../MetaModelConst';
+import {
+  CORE_HASH_STRUCTURE,
+  PackageableElementPointerType,
+} from '../../../../../MetaModelConst';
 import { type Hashable, hashArray } from '@finos/legend-shared';
 import {
   type PackageableElementVisitor,
   PackageableElement,
-  PACKAGEABLE_ELEMENT_POINTER_TYPE,
   getElementPointerHashCode,
 } from '../PackageableElement';
 import type { PackageableElementReference } from '../PackageableElementReference';
@@ -69,7 +71,7 @@ export class GenerationSpecification
       hashArray(
         this.fileGenerations.map((fileGeneration) =>
           getElementPointerHashCode(
-            PACKAGEABLE_ELEMENT_POINTER_TYPE.FILE_GENERATION,
+            PackageableElementPointerType.FILE_GENERATION,
             fileGeneration.hashValue,
           ),
         ),

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/AssociationImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/AssociationImplementation.ts
@@ -30,7 +30,8 @@ import type { InferableMappingElementIdValue } from './InferableMappingElementId
 export abstract class AssociationImplementation
   implements PropertyMappingsImplementation, Hashable
 {
-  readonly parent: Mapping;
+  readonly _PARENT: Mapping;
+
   association: PackageableElementReference<Association>;
   id: InferableMappingElementIdValue;
   stores: PackageableElementReference<Store>[] = [];
@@ -42,7 +43,7 @@ export abstract class AssociationImplementation
     association: PackageableElementExplicitReference<Association>,
   ) {
     this.id = id;
-    this.parent = parent;
+    this._PARENT = parent;
     this.association = association;
   }
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/EnumValueMapping.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/EnumValueMapping.ts
@@ -21,7 +21,7 @@ import type { Stubable } from '../../../../../helpers/Stubable';
 import type { EnumValueReference } from '../domain/EnumValueReference';
 
 export class SourceValue implements Stubable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   value: Enum | string | number | undefined;
 
@@ -58,7 +58,7 @@ export class EnumValueMapping implements Hashable, Stubable {
             return isNumber(value)
               ? value.toString()
               : value instanceof Enum
-              ? `${value.owner.path}.${value.name}`
+              ? `${value._OWNER.path}.${value.name}`
               : value ?? '';
           }),
       ),

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/EnumerationMapping.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/EnumerationMapping.ts
@@ -33,7 +33,8 @@ import {
 } from './InferableMappingElementId';
 
 export class EnumerationMapping implements Hashable, Stubable {
-  readonly parent: Mapping;
+  readonly _PARENT: Mapping;
+
   enumeration: PackageableElementReference<Enumeration>;
   id: InferableMappingElementIdValue;
   sourceType: OptionalPackageableElementReference<Type>;
@@ -47,7 +48,7 @@ export class EnumerationMapping implements Hashable, Stubable {
   ) {
     this.id = id;
     this.enumeration = enumeration;
-    this.parent = parent;
+    this._PARENT = parent;
     this.sourceType = sourceType;
   }
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/LocalMappingPropertyInfo.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/LocalMappingPropertyInfo.ts
@@ -18,17 +18,17 @@ import { hashArray, type Hashable } from '@finos/legend-shared';
 import type { Multiplicity } from '../domain/Multiplicity';
 import type { Type } from '../domain/Type';
 import { CORE_HASH_STRUCTURE } from '../../../../../MetaModelConst';
+import type { PackageableElementReference } from '../PackageableElementReference';
 
 export class LocalMappingPropertyInfo implements Hashable {
   localMappingProperty!: boolean;
-  // TODO: refactor this to use `PackageableElementReference`
-  localMappingPropertyType!: Type;
+  localMappingPropertyType!: PackageableElementReference<Type>;
   localMappingPropertyMultiplicity!: Multiplicity;
 
   get hashCode(): string {
     return hashArray([
       CORE_HASH_STRUCTURE.LOCAL_MAPPING_PROPERTY,
-      this.localMappingPropertyType.path,
+      this.localMappingPropertyType.hashValue,
       this.localMappingPropertyMultiplicity,
     ]);
   }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/MappingInclude.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/MappingInclude.ts
@@ -21,12 +21,13 @@ import type { Mapping } from './Mapping';
 import type { SubstituteStore } from './SubstituteStore';
 
 export class MappingInclude {
-  owner: Mapping;
+  readonly _OWNER: Mapping;
+
   included: PackageableElementReference<Mapping>;
   storeSubstitutions: SubstituteStore[] = [];
 
   constructor(owner: Mapping, included: PackageableElementReference<Mapping>) {
-    this.owner = owner;
+    this._OWNER = owner;
     this.included = included;
   }
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/MappingTest.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/MappingTest.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../../../helpers/ValidationHelper';
 
 export class MappingTest implements Hashable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   name: string;
   /**

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/OperationSetImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/OperationSetImplementation.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  type Hashable,
-  hashArray,
-  guaranteeNonNullable,
-} from '@finos/legend-shared';
+import { type Hashable, hashArray } from '@finos/legend-shared';
 import { CORE_HASH_STRUCTURE } from '../../../../../MetaModelConst';
 import type { PackageableElementReference } from '../PackageableElementReference';
 import {
@@ -38,13 +34,6 @@ export enum OperationType {
   INHERITANCE = 'INHERITANCE',
   MERGE = 'MERGE',
 }
-
-// TODO: to be moved out of metamodel
-export const getClassMappingOperationType = (value: string): OperationType =>
-  guaranteeNonNullable(
-    Object.values(OperationType).find((type) => type === value),
-    `Encountered unsupproted class mapping operation type '${value}'`,
-  );
 
 export class OperationSetImplementation
   extends SetImplementation

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/PropertyMapping.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/PropertyMapping.ts
@@ -68,13 +68,21 @@ export abstract class PropertyMapping implements Hashable, Stubable {
   readonly _isEmbedded: boolean = false;
 
   property: PropertyReference;
-  // NOTE: in case the holder of this property mapping is an embedded property mapping, that embedded property mapping is considered the source
-  // otherwise, it is always the top/root `InstanceSetImplementation` that is considered the source implementation
-  // TODO: change this to use `SetImplemenetationReference`
+  /**
+   * NOTE: in case the holder of this property mapping is an embedded property mapping,
+   * that embedded property mapping is considered the source otherwise, it is always
+   * the top/root `InstanceSetImplementation` that is considered the source implementation
+   *
+   * TODO: change this to use `SetImplemenetationReference`
+   */
   sourceSetImplementation: SetImplementation;
-  // NOTE: in Pure, we actually only store `targetId` and `sourceId` instead of the reference
-  // but for convenience and graph completeness validation purpose we will resolve to the actual set implementations here
-  // TODO: change this to use `OptionalSetImplemenetationReference`
+  /**
+   * NOTE: in Pure, we actually only store `targetId` and `sourceId` instead of the
+   * reference but for convenience and graph completeness validation purpose we will
+   * resolve to the actual set implementations here
+   *
+   * TODO: change this to use `OptionalSetImplemenetationReference`
+   */
   targetSetImplementation?: SetImplementation | undefined;
   localMappingProperty?: LocalMappingPropertyInfo | undefined;
   // store?: Store | undefined;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/PropertyMapping.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/PropertyMapping.ts
@@ -61,9 +61,13 @@ export interface PropertyMappingVisitor<T> {
 }
 
 export abstract class PropertyMapping implements Hashable, Stubable {
-  readonly isEmbedded: boolean = false;
+  /**
+   * the immediate parent instance set implementation that holds the property mappings
+   */
+  readonly _OWNER: PropertyMappingsImplementation;
+  readonly _isEmbedded: boolean = false;
+
   property: PropertyReference;
-  owner: PropertyMappingsImplementation; // the immediate parent instance set implementation that holds the property mappings
   // NOTE: in case the holder of this property mapping is an embedded property mapping, that embedded property mapping is considered the source
   // otherwise, it is always the top/root `InstanceSetImplementation` that is considered the source implementation
   // TODO: change this to use `SetImplemenetationReference`
@@ -81,7 +85,7 @@ export abstract class PropertyMapping implements Hashable, Stubable {
     source: SetImplementation,
     target?: SetImplementation,
   ) {
-    this.owner = owner;
+    this._OWNER = owner;
     this.sourceSetImplementation = source;
     this.targetSetImplementation = target;
     this.property = property;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/PropertyOwnerImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/PropertyOwnerImplementation.ts
@@ -21,5 +21,5 @@ export interface PropertyOwnerImplementation {
   id: InferableMappingElementIdValue;
   // TODO: consider changing this to object ref instead of ID
   // superSetImplementationId?: string | undefined;
-  parent: Mapping;
+  _PARENT: Mapping;
 }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementation.ts
@@ -69,8 +69,9 @@ export interface SetImplementationVisitor<T> {
 export abstract class SetImplementation
   implements PropertyOwnerImplementation, Hashable, Stubable
 {
-  readonly parent: Mapping;
-  readonly isEmbedded: boolean = false;
+  readonly _PARENT: Mapping;
+  readonly _isEmbedded: boolean = false;
+
   id: InferableMappingElementIdValue;
   class: PackageableElementReference<Class>;
   root: InferableMappingElementRoot;
@@ -82,7 +83,7 @@ export abstract class SetImplementation
     root: InferableMappingElementRoot,
   ) {
     this.id = id;
-    this.parent = parent;
+    this._PARENT = parent;
     this.class = _class;
     this.root = root;
   }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementation.ts
@@ -105,21 +105,3 @@ export abstract class SetImplementation
     visitor: SetImplementationVisitor<T>,
   ): T;
 }
-
-// TODO: to be moved out of metamodel
-export enum BASIC_SET_IMPLEMENTATION_TYPE {
-  OPERATION = 'operation',
-  INSTANCE = 'instance',
-}
-
-// TODO: to be moved out of metamodel
-export enum SET_IMPLEMENTATION_TYPE {
-  OPERATION = 'operation',
-  MERGE_OPERATION = 'mergeOperation',
-  PUREINSTANCE = 'pureInstance',
-  FLAT_DATA = 'flatData',
-  EMBEDDED_FLAT_DATA = 'embeddedFlatData',
-  RELATIONAL = 'relational',
-  EMBEDDED_RELATIONAL = 'embeddedRelational',
-  AGGREGATION_AWARE = 'aggregationAware',
-}

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementationContainer.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementationContainer.ts
@@ -19,7 +19,7 @@ import type { SetImplementationReference } from './SetImplementationReference';
 import type { Stubable } from '../../../../../helpers/Stubable';
 
 export class SetImplementationContainer implements Stubable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   setImplementation: SetImplementationReference;
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementationReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementationReference.ts
@@ -15,13 +15,19 @@
  */
 
 import {
-  PackageableElementExplicitReference,
-  type PackageableElementReference,
   type PackageableElementImplicitReference,
+  type OptionalPackageableElementImplicitReference,
+  type PackageableElementReference,
+  type OptionalPackageableElementReference,
+  PackageableElementExplicitReference,
+  OptionalPackageableElementExplicitReference,
 } from '../PackageableElementReference';
 import type { Mapping } from './Mapping';
 import type { SetImplementation } from './SetImplementation';
-import { ReferenceWithOwner } from '../../Reference';
+import {
+  OptionalReferenceWithOwner,
+  ReferenceWithOwner,
+} from '../../Reference';
 
 export abstract class SetImplementationReference extends ReferenceWithOwner {
   override readonly ownerReference: PackageableElementReference<Mapping>;
@@ -69,5 +75,59 @@ export class SetImplementationImplicitReference extends SetImplementationReferen
     value: SetImplementation,
   ): SetImplementationImplicitReference {
     return new SetImplementationImplicitReference(ownerReference, value);
+  }
+}
+
+export abstract class OptionalSetImplementationReference extends OptionalReferenceWithOwner {
+  override readonly ownerReference: OptionalPackageableElementReference<Mapping>;
+  value?: SetImplementation | undefined;
+
+  protected constructor(
+    ownerReference: OptionalPackageableElementReference<Mapping>,
+    value: SetImplementation | undefined,
+  ) {
+    super(ownerReference);
+    this.ownerReference = ownerReference;
+    this.value = value;
+  }
+}
+
+export class OptionalSetImplementationExplicitReference extends OptionalSetImplementationReference {
+  override readonly ownerReference: OptionalPackageableElementReference<Mapping>;
+
+  private constructor(value: SetImplementation | undefined) {
+    const ownerReference = OptionalPackageableElementExplicitReference.create(
+      value?._PARENT,
+    );
+    super(ownerReference, value);
+    this.ownerReference = ownerReference;
+  }
+
+  static create(
+    value: SetImplementation,
+  ): OptionalSetImplementationExplicitReference {
+    return new OptionalSetImplementationExplicitReference(value);
+  }
+}
+
+export class OptionalSetImplementationImplicitReference extends OptionalSetImplementationReference {
+  override readonly ownerReference: OptionalPackageableElementReference<Mapping>;
+
+  private constructor(
+    ownerReference: OptionalPackageableElementImplicitReference<Mapping>,
+    value: SetImplementation | undefined,
+  ) {
+    super(ownerReference, value);
+    this.ownerReference = ownerReference;
+  }
+
+  static create(
+    ownerReference: PackageableElementImplicitReference<Mapping>,
+    value: SetImplementation,
+  ): OptionalSetImplementationImplicitReference {
+    return new OptionalSetImplementationImplicitReference(
+      ownerReference,
+      value,
+    );
   }
 }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementationReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SetImplementationReference.ts
@@ -42,7 +42,7 @@ export class SetImplementationExplicitReference extends SetImplementationReferen
 
   private constructor(value: SetImplementation) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.parent,
+      value._PARENT,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SubstituteStore.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/mapping/SubstituteStore.ts
@@ -19,7 +19,8 @@ import type { PackageableElementReference } from '../PackageableElementReference
 import type { MappingInclude } from './MappingInclude';
 
 export class SubstituteStore {
-  owner: MappingInclude;
+  readonly _OWNER: MappingInclude;
+
   original: PackageableElementReference<Store>;
   substitute: PackageableElementReference<Store>;
 
@@ -28,7 +29,7 @@ export class SubstituteStore {
     original: PackageableElementReference<Store>,
     substitue: PackageableElementReference<Store>,
   ) {
-    this.owner = owner;
+    this._OWNER = owner;
     this.original = original;
     this.substitute = substitue;
   }

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/runtime/Runtime.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/runtime/Runtime.ts
@@ -33,7 +33,7 @@ import {
 import type { PackageableElementReference } from '../PackageableElementReference';
 
 export class IdentifiedConnection implements Hashable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   id: string;
   connection: Connection;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/runtime/Runtime.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/runtime/Runtime.ts
@@ -21,15 +21,15 @@ import {
   assertTrue,
   uuid,
 } from '@finos/legend-shared';
-import { CORE_HASH_STRUCTURE } from '../../../../../MetaModelConst';
+import {
+  CORE_HASH_STRUCTURE,
+  PackageableElementPointerType,
+} from '../../../../../MetaModelConst';
 import type { Connection } from '../connection/Connection';
 import type { PackageableRuntime } from './PackageableRuntime';
 import type { Mapping } from '../mapping/Mapping';
 import type { Store } from '../store/Store';
-import {
-  getElementPointerHashCode,
-  PACKAGEABLE_ELEMENT_POINTER_TYPE,
-} from '../PackageableElement';
+import { getElementPointerHashCode } from '../PackageableElement';
 import type { PackageableElementReference } from '../PackageableElementReference';
 
 export class IdentifiedConnection implements Hashable {
@@ -68,7 +68,7 @@ export class StoreConnections implements Hashable {
     return hashArray([
       CORE_HASH_STRUCTURE.STORE_CONNECTIONS,
       getElementPointerHashCode(
-        PACKAGEABLE_ELEMENT_POINTER_TYPE.STORE,
+        PackageableElementPointerType.STORE,
         this.store.hashValue,
       ),
       hashArray(this.storeConnections),
@@ -112,7 +112,7 @@ export class EngineRuntime extends Runtime implements Hashable {
       hashArray(
         this.mappings.map((mapping) =>
           getElementPointerHashCode(
-            PACKAGEABLE_ELEMENT_POINTER_TYPE.MAPPING,
+            PackageableElementPointerType.MAPPING,
             mapping.hashValue,
           ),
         ),

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/section/Section.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/section/Section.ts
@@ -22,13 +22,14 @@ import type { SectionIndex } from './SectionIndex';
 import type { PackageableElementExplicitReference } from '../PackageableElementReference';
 
 export abstract class Section implements Hashable {
-  readonly parent: SectionIndex;
+  readonly _OWNER: SectionIndex;
+
   parserName: string;
   elements: PackageableElementExplicitReference<PackageableElement>[] = [];
 
-  constructor(parserName: string, parent: SectionIndex) {
+  constructor(parserName: string, owner: SectionIndex) {
     this.parserName = parserName;
-    this.parent = parent;
+    this._OWNER = owner;
   }
 
   get hashCode(): string {

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/service/DEPRECATED__ServiceTest.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/service/DEPRECATED__ServiceTest.ts
@@ -24,10 +24,10 @@ import type { Service } from './Service';
  * @deprecated
  */
 export abstract class DEPRECATED__ServiceTest implements Hashable {
-  owner: Service;
+  readonly _OWNER: Service;
 
   constructor(owner: Service) {
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   abstract get hashCode(): string;
@@ -38,7 +38,7 @@ export abstract class DEPRECATED__ServiceTest implements Hashable {
  * @deprecated
  */
 export class DEPRECATED__TestContainer implements Hashable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   parametersValues: unknown[] = []; // Any[*]; // ValueSpecification?
   /**

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/service/ServiceExecution.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/service/ServiceExecution.ts
@@ -31,7 +31,8 @@ export abstract class ServiceExecution implements Hashable {
 }
 
 export class PureExecution extends ServiceExecution implements Hashable {
-  owner: Service;
+  readonly _OWNER: Service;
+
   /**
    * Studio does not process value specification, they are left in raw JSON form
    *
@@ -42,7 +43,7 @@ export class PureExecution extends ServiceExecution implements Hashable {
   constructor(func: RawLambda, owner: Service) {
     super();
     this.func = func;
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   get queryValidationResult(): ValidationIssue | undefined {
@@ -95,7 +96,7 @@ export class PureSingleExecution extends PureExecution implements Hashable {
 }
 
 export class KeyedExecutionParameter implements Hashable {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
 
   key: string;
   mapping: PackageableElementReference<Mapping>;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/mapping/EmbeddedFlatDataPropertyMapping.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/mapping/EmbeddedFlatDataPropertyMapping.ts
@@ -50,13 +50,14 @@ export class EmbeddedFlatDataPropertyMapping
   extends AbstractFlatDataPropertyMapping
   implements InstanceSetImplementation, Hashable
 {
+  readonly _PARENT: Mapping;
+  override readonly _isEmbedded = true;
+
   root = InferableMappingElementRootExplicitValue.create(false);
-  override readonly isEmbedded = true;
   class: PackageableElementReference<Class>;
   id: InferableMappingElementIdValue;
   propertyMappings: PropertyMapping[] = [];
   rootInstanceSetImplementation: InstanceSetImplementation; // in Pure we call this `setMappingOwner`
-  readonly parent: Mapping;
   mappingClass?: MappingClass | undefined;
 
   constructor(
@@ -72,7 +73,7 @@ export class EmbeddedFlatDataPropertyMapping
     this.class = _class;
     this.id = id;
     this.rootInstanceSetImplementation = rootInstanceSetImplementation;
-    this.parent = rootInstanceSetImplementation.parent;
+    this._PARENT = rootInstanceSetImplementation._PARENT;
   }
 
   // As of now, there is no stub cases of Embedded Flat Property Mapping since they are created with an existing property mapping

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/mapping/FlatDataInputData.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/mapping/FlatDataInputData.ts
@@ -15,14 +15,14 @@
  */
 
 import { hashArray, type Hashable } from '@finos/legend-shared';
-import { CORE_HASH_STRUCTURE } from '../../../../../../../MetaModelConst';
+import {
+  CORE_HASH_STRUCTURE,
+  PackageableElementPointerType,
+} from '../../../../../../../MetaModelConst';
 import { InputData } from '../../../mapping/InputData';
 import type { FlatData } from '../model/FlatData';
 import type { PackageableElementReference } from '../../../PackageableElementReference';
-import {
-  PACKAGEABLE_ELEMENT_POINTER_TYPE,
-  getElementPointerHashCode,
-} from '../../../PackageableElement';
+import { getElementPointerHashCode } from '../../../PackageableElement';
 import {
   type ValidationIssue,
   createValidationError,
@@ -54,7 +54,7 @@ export class FlatDataInputData extends InputData implements Hashable {
     return hashArray([
       CORE_HASH_STRUCTURE.FLAT_DATA_INPUT_DATA,
       getElementPointerHashCode(
-        PACKAGEABLE_ELEMENT_POINTER_TYPE.STORE,
+        PackageableElementPointerType.STORE,
         this.sourceFlatData.hashValue,
       ),
       this.data,

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation.ts
@@ -85,7 +85,7 @@ export class FlatDataInstanceSetImplementation
       CORE_HASH_STRUCTURE.FLAT_DATA_INSTANCE_SET_IMPLEMENTATION,
       super.hashCode,
       this.sourceRootRecordType.ownerReference.hashValue,
-      this.sourceRootRecordType.value.owner.name,
+      this.sourceRootRecordType.value._OWNER.name,
       this.filter ?? '',
       hashArray(
         this.propertyMappings.filter(

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/FlatDataDataType.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/FlatDataDataType.ts
@@ -20,10 +20,10 @@ import type { FlatDataSection } from './FlatDataSection';
 import type { PrimitiveType } from '../../../domain/PrimitiveType';
 
 export abstract class FlatDataDataType {
-  readonly correspondingPrimitiveType?: PrimitiveType | undefined;
+  readonly _correspondingPrimitiveType?: PrimitiveType | undefined;
 
   constructor(correspondingPrimitiveType?: PrimitiveType) {
-    this.correspondingPrimitiveType = correspondingPrimitiveType;
+    this._correspondingPrimitiveType = correspondingPrimitiveType;
   }
 
   abstract get hashCode(): string;
@@ -156,11 +156,11 @@ export class RootFlatDataRecordType
   extends FlatDataRecordType
   implements Hashable
 {
-  owner: FlatDataSection;
+  readonly _OWNER: FlatDataSection;
 
   constructor(owner: FlatDataSection) {
     super();
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   override get hashCode(): string {

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/FlatDataSection.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/FlatDataSection.ts
@@ -25,7 +25,8 @@ import type { FlatDataProperty } from './FlatDataProperty';
 import type { RootFlatDataRecordType } from './FlatDataDataType';
 
 export class FlatDataSection implements Hashable {
-  owner: FlatData;
+  readonly _OWNER: FlatData;
+
   driverId: string;
   name: string;
   sectionProperties: FlatDataProperty[] = [];
@@ -34,13 +35,13 @@ export class FlatDataSection implements Hashable {
   constructor(driverId: string, name: string, owner: FlatData) {
     this.name = name;
     this.driverId = driverId;
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   getRecordType = (): RootFlatDataRecordType =>
     guaranteeNonNullable(
       this.recordType,
-      `No record type defined in section '${this.name}' of flat-data store '${this.owner.path}'`,
+      `No record type defined in section '${this.name}' of flat-data store '${this._OWNER.path}'`,
     );
 
   get hashCode(): string {

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/FlatDataSectionReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/FlatDataSectionReference.ts
@@ -54,7 +54,7 @@ export class FlatDataSectionExplicitReference extends FlatDataSectionReference {
 
   private constructor(value: FlatDataSection) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner,
+      value._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/RootFlatDataRecordTypeReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/flatData/model/RootFlatDataRecordTypeReference.ts
@@ -42,7 +42,7 @@ export class RootFlatDataRecordTypeExplicitReference extends RootFlatDataRecordT
 
   private constructor(value: RootFlatDataRecordType) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.owner.owner,
+      value._OWNER._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/mapping/EmbeddedRelationalInstanceSetImplementation.ts
@@ -49,14 +49,15 @@ export class EmbeddedRelationalInstanceSetImplementation
     RelationalInstanceSetImplementation,
     Hashable
 {
+  readonly _PARENT: Mapping;
+  override readonly _isEmbedded = true;
+
   root = InferableMappingElementRootExplicitValue.create(false);
-  override readonly isEmbedded = true;
   id: InferableMappingElementIdValue;
   propertyMappings: PropertyMapping[] = [];
   class: PackageableElementReference<Class>;
   rootInstanceSetImplementation: RootRelationalInstanceSetImplementation; // in Pure we call this `setMappingOwner`
   primaryKey: RelationalOperationElement[] = [];
-  readonly parent: Mapping;
   mappingClass?: MappingClass | undefined;
 
   constructor(
@@ -72,7 +73,7 @@ export class EmbeddedRelationalInstanceSetImplementation
     this.class = _class;
     this.id = id;
     this.rootInstanceSetImplementation = rootInstanceSetImplementation;
-    this.parent = rootInstanceSetImplementation.parent;
+    this._PARENT = rootInstanceSetImplementation._PARENT;
   }
 
   getEmbeddedSetImplmentations(): InstanceSetImplementation[] {

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/ColumnReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/ColumnReference.ts
@@ -43,7 +43,7 @@ export class ColumnExplicitReference extends ColumnReference {
 
   private constructor(value: Column) {
     const ownerReference = PackageableElementExplicitReference.create(
-      getSchemaFromRelation(value.owner).owner,
+      getSchemaFromRelation(value.owner)._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/Schema.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/Schema.ts
@@ -26,31 +26,32 @@ import type { View } from './View';
 import type { Relation } from './RelationalOperationElement';
 
 export class Schema implements Hashable {
-  owner: Database;
+  readonly _OWNER: Database;
+
   name: string;
   tables: Table[] = [];
   views: View[] = [];
 
   constructor(name: string, owner: Database) {
     this.name = name;
-    this.owner = owner;
+    this._OWNER = owner;
   }
 
   getTable = (name: string): Table =>
     guaranteeNonNullable(
       this.tables.find((table) => table.name === name),
-      `Can't find table '${name}' in schema '${this.name}' of database '${this.owner.path}'`,
+      `Can't find table '${name}' in schema '${this.name}' of database '${this._OWNER.path}'`,
     );
   getView = (name: string): View =>
     guaranteeNonNullable(
       this.views.find((view) => view.name === name),
-      `Can't find view '${name}' in schema '${this.name}' of database '${this.owner.path}'`,
+      `Can't find view '${name}' in schema '${this.name}' of database '${this._OWNER.path}'`,
     );
   getRelation = (name: string): Relation => {
     const relations: (Table | View)[] = this.tables;
     return guaranteeNonNullable(
       relations.concat(this.views).find((relation) => relation.name === name),
-      `Can't find relation '${name}' in schema '${this.name}' of database '${this.owner.path}'`,
+      `Can't find relation '${name}' in schema '${this.name}' of database '${this._OWNER.path}'`,
     );
   };
 

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/TableReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/TableReference.ts
@@ -74,7 +74,7 @@ export class TableExplicitReference extends TableReference {
 
   private constructor(value: Table) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.schema.owner,
+      value.schema._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/ViewReference.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/packageableElements/store/relational/model/ViewReference.ts
@@ -65,7 +65,7 @@ export class ViewExplicitReference extends ViewReference {
 
   private constructor(value: View) {
     const ownerReference = PackageableElementExplicitReference.create(
-      value.schema.owner,
+      value.schema._OWNER,
     );
     super(ownerReference, value);
     this.ownerReference = ownerReference;

--- a/packages/legend-graph/src/models/metamodels/pure/rawValueSpecification/RawVariableExpression.ts
+++ b/packages/legend-graph/src/models/metamodels/pure/rawValueSpecification/RawVariableExpression.ts
@@ -32,7 +32,8 @@ export class RawVariableExpression
   extends RawValueSpecification
   implements Hashable, Stubable
 {
-  readonly uuid = uuid();
+  readonly _UUID = uuid();
+
   name: string;
   type: PackageableElementReference<Type>;
   multiplicity: Multiplicity;

--- a/packages/legend-graph/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -19,6 +19,7 @@ import {
   CORE_PURE_PATH,
   ELEMENT_PATH_DELIMITER,
   SOURCE_INFORMATION_KEY,
+  PackageableElementPointerType,
 } from '../../../../MetaModelConst';
 import {
   type Clazz,
@@ -103,7 +104,6 @@ import { V1_PureModelContextData } from './model/context/V1_PureModelContextData
 import {
   type V1_PackageableElement,
   type V1_PackageableElementVisitor,
-  V1_PackageableElementPointerType,
   V1_PackageableElementPointer,
 } from './model/packageableElements/V1_PackageableElement';
 import { V1_ProtocolToMetaModelGraphFirstPassBuilder } from './transformation/pureGraph/to/V1_ProtocolToMetaModelGraphFirstPassBuilder';
@@ -2045,7 +2045,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
         if (execution instanceof PureSingleExecution) {
           sdlcInfo.packageableElementPointers = [
             new V1_PackageableElementPointer(
-              V1_PackageableElementPointerType.MAPPING,
+              PackageableElementPointerType.MAPPING,
               execution.mapping.value.path,
             ),
           ];
@@ -2054,7 +2054,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
             execution.executionParameters.map(
               (e) =>
                 new V1_PackageableElementPointer(
-                  V1_PackageableElementPointerType.MAPPING,
+                  PackageableElementPointerType.MAPPING,
                   e.mapping.value.path,
                 ),
             );
@@ -2073,7 +2073,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
         const pointer = new V1_PureModelContextPointer(protocol, sdlcInfo);
         sdlcInfo.packageableElementPointers = [
           new V1_PackageableElementPointer(
-            V1_PackageableElementPointerType.SERVICE,
+            PackageableElementPointerType.SERVICE,
             service.path,
           ),
         ];

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_EngineServerClient.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { action, makeObservable, observable } from 'mobx';
 import {
   ContentType,
   AbstractServerClient,
@@ -99,14 +98,6 @@ export class V1_EngineServerClient extends AbstractServerClient {
     },
   ) {
     super(config);
-
-    makeObservable(this, {
-      baseUrl: observable,
-      enableCompression: observable,
-      setBaseUrl: action,
-      setCompression: action,
-    });
-
     this.queryBaseUrl = config.queryBaseUrl;
   }
 

--- a/packages/legend-graph/src/models/protocols/pure/v1/model/packageableElements/V1_PackageableElement.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/model/packageableElements/V1_PackageableElement.ts
@@ -74,15 +74,6 @@ export abstract class V1_PackageableElement implements Hashable {
   ): T;
 }
 
-// TODO: to be moved out of metamodel
-export enum V1_PackageableElementPointerType {
-  STORE = 'STORE',
-  MAPPING = 'MAPPING',
-  RUNTIME = 'RUNTIME',
-  FILE_GENERATION = 'FILE_GENERATION',
-  SERVICE = 'SERVICE',
-}
-
 export class V1_PackageableElementPointer implements Hashable {
   type!: string;
   path!: string;

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_CoreTransformerHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_CoreTransformerHelper.ts
@@ -24,7 +24,6 @@ import { V1_Multiplicity } from '../../../model/packageableElements/domain/V1_Mu
 import {
   V1_PackageableElementPointer,
   type V1_PackageableElement,
-  type V1_PackageableElementPointerType,
 } from '../../../model/packageableElements/V1_PackageableElement';
 
 export const V1_transformOptionalElementReference = <
@@ -40,7 +39,7 @@ export const V1_transformElementReference = <T extends PackageableElement>(
 export const V1_transformElementReferencePointer = <
   T extends PackageableElement,
 >(
-  pointerType: V1_PackageableElementPointerType,
+  pointerType: string,
   ref: PackageableElementReference<T>,
 ): V1_PackageableElementPointer =>
   new V1_PackageableElementPointer(

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
@@ -192,7 +192,7 @@ export const V1_transformTableAliasToTablePointer = (
 
 export const V1_transformTableToTablePointer = (table: Table): V1_TablePtr => {
   const tablePtr = new V1_TablePtr();
-  tablePtr.database = table.schema.owner.path;
+  tablePtr.database = table.schema._OWNER.path;
   // NOTE: Sometimes, we interpret this, so to maintain roundtrip stability, we need to handle this differrently
   // See https://github.com/finos/legend-studio/issues/295
   tablePtr.mainTableDb = tablePtr.database;

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_GenerationSpecificationTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_GenerationSpecificationTransformer.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { PackageableElementPointerType } from '../../../../../../../MetaModelConst';
 import type { ConfigurationProperty } from '../../../../../../metamodels/pure/packageableElements/fileGeneration/ConfigurationProperty';
 import type { FileGenerationSpecification } from '../../../../../../metamodels/pure/packageableElements/fileGeneration/FileGenerationSpecification';
 import type {
@@ -27,7 +28,6 @@ import {
   V1_GenerationSpecification,
   V1_GenerationTreeNode,
 } from '../../../model/packageableElements/generationSpecification/V1_GenerationSpecification';
-import { V1_PackageableElementPointerType } from '../../../model/packageableElements/V1_PackageableElement';
 import {
   V1_transformElementReferencePointer,
   V1_initPackageableElement,
@@ -52,10 +52,10 @@ export const V1_transformGenerationSpecification = (
 ): V1_GenerationSpecification => {
   const spec = new V1_GenerationSpecification();
   V1_initPackageableElement(spec, element);
-  spec.fileGenerations = element.fileGenerations.map((f) =>
+  spec.fileGenerations = element.fileGenerations.map((fileGeneration) =>
     V1_transformElementReferencePointer(
-      V1_PackageableElementPointerType.FILE_GENERATION,
-      f,
+      PackageableElementPointerType.FILE_GENERATION,
+      fileGeneration,
     ),
   );
   spec.generationNodes = element.generationNodes.map(

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -201,7 +201,7 @@ const transformEnumValueMapping = (
       } else if (value.value instanceof Enum) {
         const _enum = new V1_EnumValueMappingEnumSourceValue();
         _enum.value = value.value.name;
-        _enum.enumeration = value.value.owner.path;
+        _enum.enumeration = value.value._OWNER.path;
         return _enum;
       }
       throw new UnsupportedOperationError(
@@ -911,7 +911,7 @@ const transformFlatDataInstanceSetImpl = (
   if (root !== undefined) {
     classMapping.root = root;
   }
-  classMapping.sectionName = element.sourceRootRecordType.value.owner.name;
+  classMapping.sectionName = element.sourceRootRecordType.value._OWNER.name;
   return classMapping;
 };
 

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -177,7 +177,8 @@ const transformLocalPropertyInfo = (
   value: LocalMappingPropertyInfo,
 ): V1_LocalMappingPropertyInfo => {
   const localPropertyInfo = new V1_LocalMappingPropertyInfo();
-  localPropertyInfo.type = value.localMappingPropertyType.path;
+  localPropertyInfo.type =
+    value.localMappingPropertyType.valueForSerialization ?? '';
   localPropertyInfo.multiplicity = V1_transformMultiplicity(
     value.localMappingPropertyMultiplicity,
   );

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_MappingTransformer.ts
@@ -86,7 +86,6 @@ import {
   V1_EnumValueMappingStringSourceValue,
 } from '../../../model/packageableElements/mapping/V1_EnumValueMapping';
 import type { V1_PropertyMapping } from '../../../model/packageableElements/mapping/V1_PropertyMapping';
-import { V1_PackageableElementPointerType } from '../../../model/packageableElements/V1_PackageableElement';
 import type { V1_ClassMapping } from '../../../model/packageableElements/mapping/V1_ClassMapping';
 import type { V1_InputData } from '../../../model/packageableElements/mapping/V1_InputData';
 import type { V1_AssociationMapping } from '../../../model/packageableElements/mapping/V1_AssociationMapping';
@@ -140,7 +139,10 @@ import { V1_JoinPointer } from '../../../model/packageableElements/store/relatio
 import type { V1_RawRelationalOperationElement } from '../../../model/packageableElements/store/relational/model/V1_RawRelationalOperationElement';
 import { RelationalInputData } from '../../../../../../metamodels/pure/packageableElements/store/relational/mapping/RelationalInputData';
 import { V1_RelationalInputData } from '../../../model/packageableElements/store/relational/mapping/V1_RelationalInputData';
-import { SOURCE_INFORMATION_KEY } from '../../../../../../../MetaModelConst';
+import {
+  SOURCE_INFORMATION_KEY,
+  PackageableElementPointerType,
+} from '../../../../../../../MetaModelConst';
 import type { V1_GraphTransformerContext } from './V1_GraphTransformerContext';
 import type { DSLMapping_PureProtocolProcessorPlugin_Extension } from '../../../../DSLMapping_PureProtocolProcessorPlugin_Extension';
 import type { InstanceSetImplementation } from '../../../../../../metamodels/pure/packageableElements/mapping/InstanceSetImplementation';
@@ -257,7 +259,7 @@ const transformFlatDataInputData = (
   const inputData = new V1_FlatDataInputData();
   inputData.data = element.data;
   inputData.sourceFlatData = V1_transformElementReferencePointer(
-    V1_PackageableElementPointerType.STORE,
+    PackageableElementPointerType.STORE,
     element.sourceFlatData,
   );
   return inputData;

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RuntimeTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_RuntimeTransformer.ts
@@ -22,7 +22,6 @@ import {
   type StoreConnections,
   type Runtime,
 } from '../../../../../../metamodels/pure/packageableElements/runtime/Runtime';
-import { V1_PackageableElementPointerType } from '../../../model/packageableElements/V1_PackageableElement';
 import {
   V1_initPackageableElement,
   V1_transformElementReference,
@@ -38,6 +37,7 @@ import {
 } from '../../../model/packageableElements/runtime/V1_Runtime';
 import { V1_transformConnection } from './V1_ConnectionTransformer';
 import type { V1_GraphTransformerContext } from './V1_GraphTransformerContext';
+import { PackageableElementPointerType } from '../../../../../../../MetaModelConst';
 
 const transformStoreConnections = (
   element: StoreConnections,
@@ -45,7 +45,7 @@ const transformStoreConnections = (
 ): V1_StoreConnections => {
   const connections = new V1_StoreConnections();
   connections.store = V1_transformElementReferencePointer(
-    V1_PackageableElementPointerType.STORE,
+    PackageableElementPointerType.STORE,
     element.store,
   );
   connections.storeConnections = element.storeConnections.map((value) => {
@@ -67,7 +67,7 @@ const transformEngineRuntime = (
   );
   runtime.mappings = element.mappings.map((e) =>
     V1_transformElementReferencePointer(
-      V1_PackageableElementPointerType.MAPPING,
+      PackageableElementPointerType.MAPPING,
       e,
     ),
   );

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ValueSpecificationTransformer.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/from/V1_ValueSpecificationTransformer.ts
@@ -259,7 +259,7 @@ class V1_ValueSpecificationTransformer
     const _enumValue = new V1_EnumValue();
     const _enum = guaranteeNonNullable(valueSpecification.values[0]).value;
     _enumValue.value = _enum.name;
-    _enumValue.fullPath = _enum.owner.path;
+    _enumValue.fullPath = _enum._OWNER.path;
     return _enumValue;
   }
 

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassBuilder.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingFirstPassBuilder.ts
@@ -18,12 +18,13 @@ import {
   UnsupportedOperationError,
   assertNonEmptyString,
   assertNonNullable,
+  guaranteeNonNullable,
 } from '@finos/legend-shared';
 import type { Mapping } from '../../../../../../metamodels/pure/packageableElements/mapping/Mapping';
 import type { SetImplementation } from '../../../../../../metamodels/pure/packageableElements/mapping/SetImplementation';
 import {
   OperationSetImplementation,
-  getClassMappingOperationType,
+  OperationType,
 } from '../../../../../../metamodels/pure/packageableElements/mapping/OperationSetImplementation';
 import { PureInstanceSetImplementation } from '../../../../../../metamodels/pure/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation';
 import { FlatDataInstanceSetImplementation } from '../../../../../../metamodels/pure/packageableElements/store/flatData/mapping/FlatDataInstanceSetImplementation';
@@ -50,6 +51,12 @@ import { toOptionalPackageableElementReference } from '../../../../../../metamod
 import type { DSLMapping_PureProtocolProcessorPlugin_Extension } from '../../../../DSLMapping_PureProtocolProcessorPlugin_Extension';
 import type { V1_MergeOperationClassMapping } from '../../../model/packageableElements/mapping/V1_MergeOperationClassMapping';
 import { MergeOperationSetImplementation } from '../../../../../../metamodels/pure/packageableElements/mapping/MergeOperationSetImplementation';
+
+const getClassMappingOperationType = (value: string): OperationType =>
+  guaranteeNonNullable(
+    Object.values(OperationType).find((type) => type === value),
+    `Encountered unsupproted class mapping operation type '${value}'`,
+  );
 
 export class V1_ProtocolToMetaModelClassMappingFirstPassBuilder
   implements V1_ClassMappingVisitor<SetImplementation>

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassBuilder.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelClassMappingSecondPassBuilder.ts
@@ -265,7 +265,7 @@ export class V1_ProtocolToMetaModelClassMappingSecondPassBuilder
       );
       const dbs = new Set(
         Array.from(tableAliasMap.values()).map(
-          (e) => e.relation.value.schema.owner,
+          (e) => e.relation.value.schema._OWNER,
         ),
       );
       assertTrue(

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingBuilder.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingBuilder.ts
@@ -205,7 +205,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
       localMapping.localMappingPropertyMultiplicity = _multiplicity;
       localMapping.localMappingPropertyType = this.context.resolveType(
         localMappingProperty.type,
-      ).value;
+      );
     } else {
       assertNonEmptyString(
         protocol.property.class,
@@ -478,7 +478,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
       localMapping.localMappingPropertyMultiplicity = _multiplicity;
       localMapping.localMappingPropertyType = this.context.resolveType(
         localMappingProperty.type,
-      ).value;
+      );
       propertyOwner = property._OWNER;
     } else {
       if (this.immediateParent instanceof AssociationImplementation) {

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingBuilder.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/V1_ProtocolToMetaModelPropertyMappingBuilder.ts
@@ -113,7 +113,7 @@ const resolveRelationalPropertyMappingSource = (
   if (immediateParent instanceof AssociationImplementation) {
     if (value.source) {
       return TEMPORARY__getClassMappingByIdOrReturnUnresolved(
-        immediateParent.parent,
+        immediateParent._PARENT,
         value.source,
       );
     }
@@ -122,7 +122,7 @@ const resolveRelationalPropertyMappingSource = (
     );
     const _class =
       immediateParent.association.value.getPropertyAssociatedClass(property);
-    const setImpls = getClassMappingsByClass(immediateParent.parent, _class);
+    const setImpls = getClassMappingsByClass(immediateParent._PARENT, _class);
     return setImpls.find((r) => r.root.value) ?? setImpls[0];
   }
   return topParent;
@@ -181,7 +181,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
     if (protocol.localMappingProperty) {
       const localMappingProperty = protocol.localMappingProperty;
       const mappingClass = new MappingClass(
-        `${this.topParent?.parent.path}_${this.topParent?.id}${protocol.property.property}`,
+        `${this.topParent?._PARENT.path}_${this.topParent?.id}${protocol.property.property}`,
       );
       const _multiplicity = this.context.graph.getMultiplicity(
         localMappingProperty.multiplicity.lowerBound,
@@ -220,24 +220,24 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
       if (protocol.target) {
         targetSetImplementation =
           TEMPORARY__getClassMappingByIdOrReturnUnresolved(
-            topParent.parent,
+            topParent._PARENT,
             protocol.target,
           );
       } else {
         // NOTE: if no there is one non-root class mapping, auto-nominate that as the target set implementation
         const setImplementation = getClassMappingsByClass(
-          topParent.parent,
+          topParent._PARENT,
           guaranteeType(propertyType, Class),
         )[0];
         targetSetImplementation = guaranteeNonNullable(
           setImplementation,
-          `Can't find any class mapping for class '${propertyType.path}' in mapping '${topParent.parent.path}'`,
+          `Can't find any class mapping for class '${propertyType.path}' in mapping '${topParent._PARENT.path}'`,
         );
       }
     }
     const sourceSetImplementation = protocol.source
       ? TEMPORARY__getClassMappingByIdOrReturnUnresolved(
-          topParent.parent,
+          topParent._PARENT,
           protocol.source,
         )
       : undefined;
@@ -261,7 +261,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
         // TODO: Since we don't support includedMappings, this will throw errors, but right now we can just make it undefined.
         this.context.log.debug(
           LogEvent.create(GRAPH_MANAGER_EVENT.GRAPH_BUILDER_FAILURE),
-          `Can't find enumeration mapping with ID '${protocol.enumMappingId}' in mapping '${topParent.parent.path}' (perhaps because we haven't supported included mappings)`,
+          `Can't find enumeration mapping with ID '${protocol.enumMappingId}' in mapping '${topParent._PARENT.path}' (perhaps because we haven't supported included mappings)`,
         );
       }
       purePropertyMapping.transformer = enumerationMapping;
@@ -315,7 +315,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
     if (propertyType instanceof Class && protocol.target) {
       targetSetImplementation = this.topParent
         ? TEMPORARY__getClassMappingByIdOrReturnUnresolved(
-            this.topParent.parent,
+            this.topParent._PARENT,
             protocol.target,
           )
         : undefined;
@@ -345,7 +345,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
         // TODO: Since we don't support includedMappings, this will throw errors, but right now we can just make it undefined.
         this.context.log.debug(
           LogEvent.create(GRAPH_MANAGER_EVENT.GRAPH_BUILDER_FAILURE),
-          `Can't find enumeration mapping with ID '${protocol.enumMappingId}' in mapping '${this.topParent?.parent.path} (perhaps because we haven't supported included mappings)`,
+          `Can't find enumeration mapping with ID '${protocol.enumMappingId}' in mapping '${this.topParent?._PARENT.path} (perhaps because we haven't supported included mappings)`,
         );
       }
       flatDataPropertyMapping.transformer = enumerationMapping;
@@ -454,7 +454,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
     if (protocol.localMappingProperty) {
       const localMappingProperty = protocol.localMappingProperty;
       const mappingClass = new MappingClass(
-        `${this.topParent?.parent.path}_${this.topParent?.id}${protocol.property.property}`,
+        `${this.topParent?._PARENT.path}_${this.topParent?.id}${protocol.property.property}`,
       );
       const _multiplicity = this.context.graph.getMultiplicity(
         localMappingProperty.multiplicity.lowerBound,
@@ -479,7 +479,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
       localMapping.localMappingPropertyType = this.context.resolveType(
         localMappingProperty.type,
       ).value;
-      propertyOwner = property.owner;
+      propertyOwner = property._OWNER;
     } else {
       if (this.immediateParent instanceof AssociationImplementation) {
         propertyOwner = this.immediateParent.association.value;
@@ -504,12 +504,12 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
     const propertyType = property.genericType.value.rawType;
     let targetSetImplementation: SetImplementation | undefined;
     if (propertyType instanceof Class) {
-      let parentMapping = this.topParent?.parent;
+      let parentMapping = this.topParent?._PARENT;
       if (
         !parentMapping &&
         this.immediateParent instanceof AssociationImplementation
       ) {
-        parentMapping = this.immediateParent.parent;
+        parentMapping = this.immediateParent._PARENT;
       }
       if (protocol.target) {
         targetSetImplementation = parentMapping
@@ -596,7 +596,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
         // TODO: Since we don't support includedMappings, this will throw errors, but right now we can just make it undefined.
         this.context.log.debug(
           LogEvent.create(GRAPH_MANAGER_EVENT.GRAPH_BUILDER_FAILURE),
-          `Can't find enumeration mapping with ID '${protocol.enumMappingId}' in mapping '${this.topParent?.parent.path}' (perhaps because we haven't supported included mappings)`,
+          `Can't find enumeration mapping with ID '${protocol.enumMappingId}' in mapping '${this.topParent?._PARENT.path}' (perhaps because we haven't supported included mappings)`,
         );
       }
       relationalPropertyMapping.transformer = enumerationMapping;
@@ -665,7 +665,7 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
     );
     inline.inlineSetImplementation =
       TEMPORARY__getClassMappingByIdOrReturnUnresolved(
-        topParent.parent,
+        topParent._PARENT,
         protocol.setImplementationId,
       );
     return inline;
@@ -717,8 +717,8 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
             this.context,
             embedded,
             this.topParent,
-            this.topParent?.parent
-              ? getAllEnumerationMappings(this.topParent.parent)
+            this.topParent?._PARENT
+              ? getAllEnumerationMappings(this.topParent._PARENT)
               : [],
             this.tableAliasMap,
           ),
@@ -777,8 +777,8 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
             this.context,
             otherwiseEmbedded,
             this.topParent,
-            this.topParent?.parent
-              ? getAllEnumerationMappings(this.topParent.parent)
+            this.topParent?._PARENT
+              ? getAllEnumerationMappings(this.topParent._PARENT)
               : [],
             this.tableAliasMap,
           ),
@@ -790,8 +790,8 @@ export class V1_ProtocolToMetaModelPropertyMappingBuilder
           this.context,
           otherwiseEmbedded,
           this.topParent,
-          this.topParent?.parent
-            ? getAllEnumerationMappings(this.topParent.parent)
+          this.topParent?._PARENT
+            ? getAllEnumerationMappings(this.topParent._PARENT)
             : [],
           this.tableAliasMap,
         ),

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/__tests__/V1_ValueSpecificationBuilder.test.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/__tests__/V1_ValueSpecificationBuilder.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Entity } from '@finos/legend-model-storage';
-import { unitTest, Log } from '@finos/legend-shared';
+import { unitTest, Log, ActionState } from '@finos/legend-shared';
 import {
   CoreModel,
   PureModel,
@@ -66,7 +66,7 @@ describe(unitTest('Lambda processing roundtrip test'), () => {
       new TEST__GraphPluginManager(),
       new Log(),
     );
-    await graphManager.buildGraph(graph, entities);
+    await graphManager.buildGraph(graph, entities, ActionState.create());
     const fn = (): void => {
       graphManager.buildValueSpecification(lambdaJson, graph);
     };

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_DatabaseBuilderHelper.ts
@@ -534,7 +534,7 @@ const buildViewSecondPass = (
     const filterPtr = srcView.filter.filter;
     const db = filterPtr.db
       ? context.resolveDatabase(filterPtr.db).value
-      : view.schema.owner;
+      : view.schema._OWNER;
     view.filter = processFilterMapping(srcView.filter, db, context);
   }
   if (groupByColumns.length) {

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MappingBuilderHelper.ts
@@ -313,7 +313,7 @@ export const V1_resolveClassMappingRoot = (mapping: Mapping): void => {
       // ensure you are only altering current mapping
       if (
         classMapping.root.value === false &&
-        classMapping.parent === mapping
+        classMapping._PARENT === mapping
       ) {
         classMapping.root = InferableMappingElementRootImplicitValue.create(
           true,

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MilestoneBuilderHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_MilestoneBuilderHelper.ts
@@ -74,7 +74,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           dateProperty.parameters = [
             buildMilestoningParameter(
@@ -87,7 +87,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           const milestonedAllVersionsInRange = new DerivedProperty(
             `${property.name}${MILESTONING_VERSION_PROPERTY_SUFFIX.ALL_VERSIONS_IN_RANGE}`,
@@ -95,7 +95,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           milestonedAllVersionsInRange.parameters = [
             buildMilestoningParameter(MILESTONING_START_DATE_PARAMETER_NAME),
@@ -117,7 +117,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           dateProperty.parameters = [
             buildMilestoningParameter(
@@ -130,7 +130,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           const milestonedAllVersionsInRange = new DerivedProperty(
             `${property.name}${MILESTONING_VERSION_PROPERTY_SUFFIX.ALL_VERSIONS_IN_RANGE}`,
@@ -138,7 +138,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           milestonedAllVersionsInRange.parameters = [
             buildMilestoningParameter(MILESTONING_START_DATE_PARAMETER_NAME),
@@ -160,7 +160,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           dateProperty.parameters = [
             buildMilestoningParameter(
@@ -176,7 +176,7 @@ export const V1_buildMilestoningProperties = (
             GenericTypeExplicitReference.create(
               new GenericType(property.genericType.value.rawType),
             ),
-            property.owner,
+            property._OWNER,
           );
           propertyOwner._generatedMilestonedProperties.push(dateProperty);
           propertyOwner._generatedMilestonedProperties.push(

--- a/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
@@ -50,10 +50,7 @@ import {
   V1_IdentifiedConnection,
 } from '../../../../model/packageableElements/runtime/V1_Runtime';
 import { V1_buildEngineRuntime } from './V1_RuntimeBuilderHelper';
-import {
-  V1_PackageableElementPointer,
-  V1_PackageableElementPointerType,
-} from '../../../../model/packageableElements/V1_PackageableElement';
+import { V1_PackageableElementPointer } from '../../../../model/packageableElements/V1_PackageableElement';
 import { V1_buildRawLambdaWithResolvedPaths } from './V1_ValueSpecificationPathResolver';
 import { GraphBuilderError } from '../../../../../../../../graphManager/GraphManagerUtils';
 import {
@@ -82,6 +79,7 @@ import {
   V1_DEPRECATED__MultiExecutionTest,
 } from '../../../../model/packageableElements/service/V1_DEPRECATED__ServiceTest';
 import type { TestSuite } from '../../../../../../../metamodels/pure/test/Test';
+import { PackageableElementPointerType } from '../../../../../../../../MetaModelConst';
 
 const buildConnectionTestData = (
   element: V1_ConnectionTestData,
@@ -273,7 +271,7 @@ const buildServiceExecutionRuntime = (
   context: V1_GraphBuilderContext,
 ): Runtime => {
   const mappingPointer = new V1_PackageableElementPointer(
-    V1_PackageableElementPointerType.MAPPING,
+    PackageableElementPointerType.MAPPING,
     mapping,
   );
   if (runtime instanceof V1_RuntimePointer) {
@@ -309,7 +307,7 @@ const buildServiceExecutionRuntime = (
       if (!storeConnections) {
         const newStoreConnections = new V1_StoreConnections();
         newStoreConnections.store = new V1_PackageableElementPointer(
-          V1_PackageableElementPointerType.STORE,
+          PackageableElementPointerType.STORE,
           connection.store,
         );
         storeConnections = newStoreConnections;

--- a/packages/legend-query/src/components/QueryBuilderFunctionsExplorerPanel.tsx
+++ b/packages/legend-query/src/components/QueryBuilderFunctionsExplorerPanel.tsx
@@ -113,7 +113,7 @@ const QueryBuilderFunctionInfoTooltip: React.FC<{
             </div>
             <div className="query-builder__tooltip__item__value">
               {element.taggedValues
-                .filter((t) => t.tag.value.owner.name === 'doc')
+                .filter((t) => t.tag.value._OWNER.name === 'doc')
                 .map((t) => t.value)
                 .join('; ')}
             </div>

--- a/packages/legend-query/src/components/QueryBuilderResultPanel.tsx
+++ b/packages/legend-query/src/components/QueryBuilderResultPanel.tsx
@@ -72,7 +72,7 @@ const QueryBuilderResultValues = observer(
           // if we execute once then immediate add another column and execute again
           // the old columns rendering will be kept the same and the new column
           // will be pushed to last regardless of its type (aggregation or simple projection)
-          key={executionResult.uuid}
+          key={executionResult._UUID}
           className="ag-theme-balham-dark query-builder__result__tds-grid"
         >
           <AgGridReact rowData={rowData}>

--- a/packages/legend-query/src/components/QueryBuilderValueSpecificationEditor.tsx
+++ b/packages/legend-query/src/components/QueryBuilderValueSpecificationEditor.tsx
@@ -278,7 +278,7 @@ const EnumValueInstanceValueEditor = observer(
     const { valueSpecification, className, resetValue } = props;
     const enumValueRef = guaranteeNonNullable(valueSpecification.values[0]);
     const enumValue = enumValueRef.value;
-    const options = enumValue.owner.values.map((value) => ({
+    const options = enumValue._OWNER.values.map((value) => ({
       label: value.name,
       value: value,
     }));

--- a/packages/legend-query/src/components/QueryComponentTestUtils.tsx
+++ b/packages/legend-query/src/components/QueryComponentTestUtils.tsx
@@ -117,6 +117,7 @@ export const TEST__setUpQueryEditor = async (
   await mockedQueryStore.graphManagerState.graphManager.buildGraph(
     mockedQueryStore.graphManagerState.graph,
     entities,
+    mockedQueryStore.graphManagerState.graphBuildState,
   );
 
   const query = new Query();

--- a/packages/legend-query/src/components/QueryEditor.tsx
+++ b/packages/legend-query/src/components/QueryEditor.tsx
@@ -221,7 +221,7 @@ const QueryEditorHeader = observer(() => {
 const QueryEditorInner = observer(() => {
   const queryStore = useLegendQueryStore();
   const isLoadingEditor =
-    !queryStore.graphManagerState.graph.buildState.hasCompleted ||
+    !queryStore.graphManagerState.graphBuildState.hasCompleted ||
     !queryStore.editorInitState.hasCompleted;
   return (
     <div className="query-editor">
@@ -235,13 +235,10 @@ const QueryEditorInner = observer(() => {
         {isLoadingEditor && (
           <BlankPanelContent>
             {queryStore.buildGraphState.message ??
-              queryStore.graphManagerState.graph.systemModel.buildState
-                .message ??
-              queryStore.graphManagerState.graph.dependencyManager.buildState
-                .message ??
-              queryStore.graphManagerState.graph.generationModel.buildState
-                .message ??
-              queryStore.graphManagerState.graph.buildState.message}
+              queryStore.graphManagerState.systemBuildState.message ??
+              queryStore.graphManagerState.dependenciesBuildState.message ??
+              queryStore.graphManagerState.generationsBuildState.message ??
+              queryStore.graphManagerState.graphBuildState.message}
           </BlankPanelContent>
         )}
       </div>

--- a/packages/legend-query/src/components/QuerySetup.tsx
+++ b/packages/legend-query/src/components/QuerySetup.tsx
@@ -325,7 +325,7 @@ const ServiceQuerySetup = observer(
     const canProceed =
       querySetupState.currentProject &&
       querySetupState.currentVersionId &&
-      queryStore.graphManagerState.graph.buildState.hasSucceeded &&
+      queryStore.graphManagerState.graphBuildState.hasSucceeded &&
       querySetupState.currentService;
 
     // project
@@ -355,7 +355,10 @@ const ServiceQuerySetup = observer(
       LATEST_VERSION_ALIAS,
       SNAPSHOT_VERSION_ALIAS,
       ...(querySetupState.currentProject?.versions ?? []),
-    ].map(buildVersionOption);
+    ]
+      .slice()
+      .sort((v1, v2) => compareSemVerVersions(v2, v1))
+      .map(buildVersionOption);
     const selectedVersionOption = querySetupState.currentVersionId
       ? buildVersionOption(querySetupState.currentVersionId)
       : null;
@@ -479,30 +482,29 @@ const ServiceQuerySetup = observer(
           <div className="query-setup__service-query__graph">
             {(!querySetupState.currentProject ||
               !querySetupState.currentVersionId ||
-              !queryStore.graphManagerState.graph.buildState.hasSucceeded) && (
+              !queryStore.graphManagerState.graphBuildState.hasSucceeded) && (
               <div className="query-setup__service-query__graph__loader">
                 <PanelLoadingIndicator
                   isLoading={
                     Boolean(querySetupState.currentProject) &&
                     Boolean(querySetupState.currentVersionId) &&
-                    !queryStore.graphManagerState.graph.buildState.hasSucceeded
+                    !queryStore.graphManagerState.graphBuildState.hasSucceeded
                   }
                 />
                 {queryStore.buildGraphState.isInProgress && (
                   <BlankPanelContent>
                     {queryStore.buildGraphState.message ??
-                      queryStore.graphManagerState.graph.systemModel.buildState
+                      queryStore.graphManagerState.systemBuildState.message ??
+                      queryStore.graphManagerState.dependenciesBuildState
                         .message ??
-                      queryStore.graphManagerState.graph.dependencyManager
-                        .buildState.message ??
-                      queryStore.graphManagerState.graph.generationModel
-                        .buildState.message ??
-                      queryStore.graphManagerState.graph.buildState.message}
+                      queryStore.graphManagerState.generationsBuildState
+                        .message ??
+                      queryStore.graphManagerState.graphBuildState.message}
                   </BlankPanelContent>
                 )}
                 {!queryStore.buildGraphState.isInProgress && (
                   <BlankPanelContent>
-                    {queryStore.graphManagerState.graph.buildState.hasFailed
+                    {queryStore.graphManagerState.graphBuildState.hasFailed
                       ? `Can't build graph`
                       : 'Project and version must be specified'}
                   </BlankPanelContent>
@@ -511,7 +513,7 @@ const ServiceQuerySetup = observer(
             )}
             {querySetupState.currentProject &&
               querySetupState.currentVersionId &&
-              queryStore.graphManagerState.graph.buildState.hasSucceeded && (
+              queryStore.graphManagerState.graphBuildState.hasSucceeded && (
                 <>
                   <div className="query-setup__wizard__group">
                     <div className="query-setup__wizard__group__title">
@@ -583,7 +585,7 @@ const CreateQuerySetup = observer(
     const canProceed =
       querySetupState.currentProject &&
       querySetupState.currentVersionId &&
-      queryStore.graphManagerState.graph.buildState.hasSucceeded &&
+      queryStore.graphManagerState.graphBuildState.hasSucceeded &&
       querySetupState.currentMapping &&
       querySetupState.currentRuntime;
 
@@ -763,30 +765,29 @@ const CreateQuerySetup = observer(
           <div className="query-setup__create-query__graph">
             {(!querySetupState.currentProject ||
               !querySetupState.currentVersionId ||
-              !queryStore.graphManagerState.graph.buildState.hasSucceeded) && (
+              !queryStore.graphManagerState.graphBuildState.hasSucceeded) && (
               <div className="query-setup__create-query__graph__loader">
                 <PanelLoadingIndicator
                   isLoading={
                     Boolean(querySetupState.currentProject) &&
                     Boolean(querySetupState.currentVersionId) &&
-                    !queryStore.graphManagerState.graph.buildState.hasSucceeded
+                    !queryStore.graphManagerState.graphBuildState.hasSucceeded
                   }
                 />
                 {queryStore.buildGraphState.isInProgress && (
                   <BlankPanelContent>
                     {queryStore.buildGraphState.message ??
-                      queryStore.graphManagerState.graph.systemModel.buildState
+                      queryStore.graphManagerState.systemBuildState.message ??
+                      queryStore.graphManagerState.dependenciesBuildState
                         .message ??
-                      queryStore.graphManagerState.graph.dependencyManager
-                        .buildState.message ??
-                      queryStore.graphManagerState.graph.generationModel
-                        .buildState.message ??
-                      queryStore.graphManagerState.graph.buildState.message}
+                      queryStore.graphManagerState.generationsBuildState
+                        .message ??
+                      queryStore.graphManagerState.graphBuildState.message}
                   </BlankPanelContent>
                 )}
                 {!queryStore.buildGraphState.isInProgress && (
                   <BlankPanelContent>
-                    {queryStore.graphManagerState.graph.buildState.hasFailed
+                    {queryStore.graphManagerState.graphBuildState.hasFailed
                       ? `Can't build graph`
                       : 'Project and version must be specified'}
                   </BlankPanelContent>
@@ -795,7 +796,7 @@ const CreateQuerySetup = observer(
             )}
             {querySetupState.currentProject &&
               querySetupState.currentVersionId &&
-              queryStore.graphManagerState.graph.buildState.hasSucceeded && (
+              queryStore.graphManagerState.graphBuildState.hasSucceeded && (
                 <>
                   <div className="query-setup__wizard__group">
                     <div className="query-setup__wizard__group__title">

--- a/packages/legend-query/src/stores/LegendQueryStore.ts
+++ b/packages/legend-query/src/stores/LegendQueryStore.ts
@@ -759,7 +759,9 @@ export class LegendQueryStore {
       const dependencyManager =
         this.graphManagerState.createEmptyDependencyManager();
       this.graphManagerState.graph.dependencyManager = dependencyManager;
-      dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+      this.graphManagerState.dependenciesBuildState.setMessage(
+        `Fetching dependencies...`,
+      );
       const dependencyEntitiesMap = (yield flowResult(
         this.getProjectDependencyEntities(project, versionId, options),
       )) as Map<string, Entity[]>;
@@ -771,6 +773,7 @@ export class LegendQueryStore {
           this.graphManagerState.systemModel,
           dependencyManager,
           dependencyEntitiesMap,
+          this.graphManagerState.dependenciesBuildState,
         )) as GraphBuilderReport;
       dependency_buildReport.timings[
         GRAPH_MANAGER_EVENT.GRAPH_DEPENDENCIES_FETCHED
@@ -781,6 +784,7 @@ export class LegendQueryStore {
         (yield this.graphManagerState.graphManager.buildGraph(
           this.graphManagerState.graph,
           entities,
+          this.graphManagerState.graphBuildState,
         )) as GraphBuilderReport;
       graph_buildReport.timings[GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED] =
         stopWatch.getRecord(GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED);
@@ -854,7 +858,9 @@ export class LegendQueryStore {
       stopWatch.record();
       const dependencyManager =
         this.graphManagerState.createEmptyDependencyManager();
-      dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+      this.graphManagerState.dependenciesBuildState.setMessage(
+        `Fetching dependencies...`,
+      );
       const dependencyEntitiesMap = (yield flowResult(
         this.getProjectDependencyEntities(project, versionId, options),
       )) as Map<string, Entity[]>;
@@ -869,7 +875,6 @@ export class LegendQueryStore {
           dependencyEntitiesMap,
         ),
       );
-      this.graphManagerState.graph.buildState.pass();
       this.buildGraphState.pass();
     } catch (error) {
       assertErrorThrown(error);
@@ -919,7 +924,9 @@ export class LegendQueryStore {
       stopWatch.record();
       const dependencyManager =
         this.graphManagerState.createEmptyDependencyManager();
-      dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+      this.graphManagerState.dependenciesBuildState.setMessage(
+        `Fetching dependencies...`,
+      );
       const dependencyEntitiesMap = (yield flowResult(
         this.getProjectDependencyEntities(project, versionId, options),
       )) as Map<string, Entity[]>;
@@ -934,7 +941,6 @@ export class LegendQueryStore {
           dependencyEntitiesMap,
         ),
       );
-      this.graphManagerState.graph.buildState.pass();
       this.buildGraphState.pass();
     } catch (error) {
       assertErrorThrown(error);

--- a/packages/legend-query/src/stores/LegendQueryStore.ts
+++ b/packages/legend-query/src/stores/LegendQueryStore.ts
@@ -875,6 +875,7 @@ export class LegendQueryStore {
           dependencyEntitiesMap,
         ),
       );
+
       this.buildGraphState.pass();
     } catch (error) {
       assertErrorThrown(error);
@@ -941,6 +942,7 @@ export class LegendQueryStore {
           dependencyEntitiesMap,
         ),
       );
+
       this.buildGraphState.pass();
     } catch (error) {
       assertErrorThrown(error);

--- a/packages/legend-query/src/stores/QueryBuilderAggregationState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderAggregationState.ts
@@ -37,7 +37,7 @@ import {
 } from './QueryBuilderProjectionState';
 
 export abstract class QueryBuilderAggregateOperator {
-  uuid = uuid();
+  readonly uuid = uuid();
 
   abstract getLabel(
     projectionColumnState: QueryBuilderProjectionColumnState,
@@ -86,7 +86,7 @@ export abstract class QueryBuilderAggregateOperator {
 }
 
 export class QueryBuilderAggregateColumnState {
-  uuid = uuid();
+  readonly uuid = uuid();
   aggregationState: QueryBuilderAggregationState;
   projectionColumnState: QueryBuilderProjectionColumnState;
   lambdaParameterName: string = DEFAULT_LAMBDA_VARIABLE_NAME;

--- a/packages/legend-query/src/stores/QueryBuilderExplorerState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderExplorerState.ts
@@ -235,7 +235,7 @@ export const buildPropertyExpressionFromExplorerTreeNodeData = (
 const resolveTargetSetImplementationForPropertyMapping = (
   propertyMapping: PropertyMapping,
 ): SetImplementation | undefined => {
-  if (propertyMapping.isEmbedded) {
+  if (propertyMapping._isEmbedded) {
     return propertyMapping as unknown as SetImplementation;
   } else if (propertyMapping.targetSetImplementation) {
     return propertyMapping.targetSetImplementation;

--- a/packages/legend-query/src/stores/QueryBuilderFilterState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderFilterState.ts
@@ -57,7 +57,7 @@ import {
 } from './QueryBuilderOperatorsHelper';
 
 export abstract class QueryBuilderFilterOperator {
-  uuid = uuid();
+  readonly uuid = uuid();
 
   abstract getLabel(filterConditionState: FilterConditionState): string;
 

--- a/packages/legend-query/src/stores/QueryBuilderLambdaProcessor.ts
+++ b/packages/legend-query/src/stores/QueryBuilderLambdaProcessor.ts
@@ -147,11 +147,11 @@ const validatePropertyExpressionChain = (
 ): void => {
   if (
     propertyExpression.func.genericType.value.rawType instanceof Class &&
-    propertyExpression.func.owner._generatedMilestonedProperties.length !== 0
+    propertyExpression.func._OWNER._generatedMilestonedProperties.length !== 0
   ) {
     const name = propertyExpression.func.name;
     const func =
-      propertyExpression.func.owner._generatedMilestonedProperties.find(
+      propertyExpression.func._OWNER._generatedMilestonedProperties.find(
         (e) => e.name === name,
       );
     if (func) {

--- a/packages/legend-query/src/stores/QueryBuilderOperatorsHelper.ts
+++ b/packages/legend-query/src/stores/QueryBuilderOperatorsHelper.ts
@@ -78,7 +78,7 @@ export const getNonCollectionValueSpecificationType = (
   if (valueSpecification instanceof PrimitiveInstanceValue) {
     return valueSpecification.genericType.value.rawType;
   } else if (valueSpecification instanceof EnumValueInstanceValue) {
-    return guaranteeNonNullable(valueSpecification.values[0]).value.owner;
+    return guaranteeNonNullable(valueSpecification.values[0]).value._OWNER;
   } else if (valueSpecification instanceof VariableExpression) {
     return valueSpecification.genericType?.value.rawType;
   } else if (valueSpecification instanceof SimpleFunctionExpression) {
@@ -125,7 +125,7 @@ export const getCollectionValueSpecificationType = (
     (values as EnumValueInstanceValue[]).forEach((val) => {
       addUniqueEntry(
         valueEnumerationTypes,
-        guaranteeNonNullable(val.values[0]).value.owner,
+        guaranteeNonNullable(val.values[0]).value._OWNER,
       );
     });
     if (valueEnumerationTypes.length > 1) {

--- a/packages/legend-query/src/stores/QueryBuilderPostFilterOperator.ts
+++ b/packages/legend-query/src/stores/QueryBuilderPostFilterOperator.ts
@@ -27,7 +27,7 @@ import type {
 } from './QueryBuilderPostFilterState';
 
 export abstract class QueryBuilderPostFilterOperator {
-  uuid = uuid();
+  readonly uuid = uuid();
 
   abstract getLabel(): string;
 

--- a/packages/legend-query/src/stores/QueryBuilderProjectionState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderProjectionState.ts
@@ -100,7 +100,7 @@ export interface QueryBuilderProjectionColumnDragSource {
 }
 
 export abstract class QueryBuilderProjectionColumnState {
-  uuid = uuid();
+  readonly uuid = uuid();
   projectionState: QueryBuilderProjectionState;
   isBeingDragged = false;
   columnName: string;

--- a/packages/legend-query/src/stores/QueryBuilderPropertyEditorState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderPropertyEditorState.ts
@@ -63,7 +63,7 @@ export const getDerivedPropertyMilestoningSteoreotype = (
   property: DerivedProperty,
   graph: PureModel,
 ): MILESTONING_STEREOTYPE | undefined => {
-  const owner = property.owner;
+  const owner = property._OWNER;
   if (owner instanceof Class) {
     return getMilestoneTemporalStereotype(owner, graph);
   } else if (owner instanceof Association) {
@@ -156,7 +156,7 @@ export const generateMilestonedPropertyParameterValue = (
   const temporalTarget =
     derivedPropertyExpressionState.propertyExpression.func.genericType.value
       .rawType instanceof Class &&
-    derivedPropertyExpressionState.propertyExpression.func.owner
+    derivedPropertyExpressionState.propertyExpression.func._OWNER
       ._generatedMilestonedProperties.length !== 0
       ? getMilestoneTemporalStereotype(
           derivedPropertyExpressionState.propertyExpression.func.genericType
@@ -603,11 +603,12 @@ export class QueryBuilderPropertyExpressionState {
       // check if the property is milestoned
       if (
         currentExpression.func.genericType.value.rawType instanceof Class &&
-        currentExpression.func.owner._generatedMilestonedProperties.length !== 0
+        currentExpression.func._OWNER._generatedMilestonedProperties.length !==
+          0
       ) {
         const name = currentExpression.func.name;
         const func =
-          currentExpression.func.owner._generatedMilestonedProperties.find(
+          currentExpression.func._OWNER._generatedMilestonedProperties.find(
             (e) => e.name === name,
           );
         if (func) {

--- a/packages/legend-query/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderState.ts
@@ -48,7 +48,6 @@ import {
   type LambdaFunction,
   type Mapping,
   type PackageableRuntime,
-  type Service,
   type ValueSpecification,
   GenericTypeExplicitReference,
   GenericType,
@@ -586,24 +585,5 @@ export class QueryBuilderState {
     return this.graphManagerState.graph.ownRuntimes.concat(
       this.graphManagerState.graph.dependencyManager.runtimes,
     );
-  }
-
-  getMappingOptions(): PackageableElementOption<Mapping>[] {
-    return this.mappings.map(
-      (e) => buildElementOption(e) as PackageableElementOption<Mapping>,
-    );
-  }
-
-  getRuntimeOptions(): PackageableElementOption<PackageableRuntime>[] {
-    return this.runtimes.map(
-      (e) =>
-        buildElementOption(e) as PackageableElementOption<PackageableRuntime>,
-    );
-  }
-
-  getServiceOptions(): PackageableElementOption<Service>[] {
-    return this.graphManagerState.graph.ownServices
-      .concat(this.graphManagerState.graph.dependencyManager.services)
-      .map((e) => buildElementOption(e) as PackageableElementOption<Service>);
   }
 }

--- a/packages/legend-query/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderState.ts
@@ -576,15 +576,21 @@ export class QueryBuilderState {
       );
   }
 
-  getMappingOptions(): PackageableElementOption<Mapping>[] {
-    return this.mappings.map(
-      (e) => buildElementOption(e) as PackageableElementOption<Mapping>,
-    );
-  }
-
   get mappings(): Mapping[] {
     return this.graphManagerState.graph.ownMappings.concat(
       this.graphManagerState.graph.dependencyManager.mappings,
+    );
+  }
+
+  get runtimes(): PackageableRuntime[] {
+    return this.graphManagerState.graph.ownRuntimes.concat(
+      this.graphManagerState.graph.dependencyManager.runtimes,
+    );
+  }
+
+  getMappingOptions(): PackageableElementOption<Mapping>[] {
+    return this.mappings.map(
+      (e) => buildElementOption(e) as PackageableElementOption<Mapping>,
     );
   }
 
@@ -592,12 +598,6 @@ export class QueryBuilderState {
     return this.runtimes.map(
       (e) =>
         buildElementOption(e) as PackageableElementOption<PackageableRuntime>,
-    );
-  }
-
-  get runtimes(): PackageableRuntime[] {
-    return this.graphManagerState.graph.ownRuntimes.concat(
-      this.graphManagerState.graph.dependencyManager.runtimes,
     );
   }
 

--- a/packages/legend-query/src/stores/QueryFunctionsExplorerState.ts
+++ b/packages/legend-query/src/stores/QueryFunctionsExplorerState.ts
@@ -229,7 +229,7 @@ const getAllPackagesFromElement = (element: PackageableElement): Package[] => {
 };
 
 export class QueryFunctionExplorerState {
-  uuid = uuid();
+  readonly uuid = uuid();
   queryFunctionsState: QueryFunctionsExplorerState;
   concreteFunctionDefinition: ConcreteFunctionDefinition;
 

--- a/packages/legend-query/src/stores/QuerySetupStore.ts
+++ b/packages/legend-query/src/stores/QuerySetupStore.ts
@@ -35,12 +35,13 @@ import {
   type PackageableRuntime,
   type Service,
   QuerySearchSpecification,
-  PureSingleExecution,
-  PureMultiExecution,
 } from '@finos/legend-graph';
 import type { LegendQueryStore } from './LegendQueryStore';
 import { ProjectData } from '@finos/legend-server-depot';
-import type { PackageableElementOption } from '@finos/legend-application';
+import {
+  buildElementOption,
+  type PackageableElementOption,
+} from '@finos/legend-application';
 
 export abstract class QuerySetupState {
   setupStore: QuerySetupStore;
@@ -131,6 +132,7 @@ export class CreateQuerySetupState extends QuerySetupState {
   currentVersionId?: string | undefined;
   currentMapping?: Mapping | undefined;
   currentRuntime?: PackageableRuntime | undefined;
+  mappingOptions: PackageableElementOption<Mapping>[] = [];
 
   constructor(setupStore: QuerySetupStore) {
     super(setupStore);
@@ -141,11 +143,13 @@ export class CreateQuerySetupState extends QuerySetupState {
       currentVersionId: observable,
       currentMapping: observable,
       currentRuntime: observable,
+      mappingOptions: observable,
       runtimeOptions: computed,
       setCurrentProject: action,
       setCurrentVersionId: action,
       setCurrentMapping: action,
       setCurrentRuntime: action,
+      setMappingOptions: action,
       loadProjects: flow,
     });
   }
@@ -166,13 +170,20 @@ export class CreateQuerySetupState extends QuerySetupState {
     this.currentRuntime = val;
   }
 
+  setMappingOptions(val: PackageableElementOption<Mapping>[]): void {
+    this.mappingOptions = val;
+  }
+
   get runtimeOptions(): PackageableElementOption<PackageableRuntime>[] {
     const currentMapping = this.currentMapping;
     if (!currentMapping) {
       return [];
     }
-    return this.queryStore.queryBuilderState
-      .getRuntimeOptions()
+    return this.queryStore.queryBuilderState.runtimes
+      .map(
+        (e) =>
+          buildElementOption(e) as PackageableElementOption<PackageableRuntime>,
+      )
       .filter((runtime) =>
         runtime.value.runtimeValue.mappings
           .map((mappingReference) => [
@@ -211,11 +222,13 @@ export class ServiceQuerySetupState extends QuerySetupState {
   currentVersionId?: string | undefined;
   currentService?: Service | undefined;
   currentServiceExecutionKey?: string | undefined;
+  serviceExecutionOptions: ServiceExecutionOption[] = [];
 
   constructor(setupStore: QuerySetupStore) {
     super(setupStore);
 
     makeObservable(this, {
+      serviceExecutionOptions: observable,
       projects: observable,
       currentProject: observable,
       currentVersionId: observable,
@@ -224,6 +237,7 @@ export class ServiceQuerySetupState extends QuerySetupState {
       setCurrentProject: action,
       setCurrentVersionId: action,
       setCurrentServiceExecution: action,
+      setServiceExecutionOptions: action,
       loadProjects: flow,
     });
   }
@@ -244,30 +258,8 @@ export class ServiceQuerySetupState extends QuerySetupState {
     this.currentServiceExecutionKey = key;
   }
 
-  get serviceExecutionOptions(): ServiceExecutionOption[] {
-    return this.queryStore.queryBuilderState
-      .getServiceOptions()
-      .flatMap((option) => {
-        const service = option.value;
-        const serviceExecution = service.execution;
-        if (serviceExecution instanceof PureSingleExecution) {
-          return {
-            label: service.name,
-            value: {
-              service,
-            },
-          };
-        } else if (serviceExecution instanceof PureMultiExecution) {
-          return serviceExecution.executionParameters.map((parameter) => ({
-            label: `${service.name} [${parameter.key}]`,
-            value: {
-              service,
-              key: parameter.key,
-            },
-          }));
-        }
-        return [];
-      });
+  setServiceExecutionOptions(val: ServiceExecutionOption[]): void {
+    this.serviceExecutionOptions = val;
   }
 
   *loadProjects(): GeneratorFn<void> {

--- a/packages/legend-query/src/stores/__tests__/QueryBuilder_ExplorerState.test.ts
+++ b/packages/legend-query/src/stores/__tests__/QueryBuilder_ExplorerState.test.ts
@@ -218,6 +218,7 @@ describe(integrationTest('Build property mapping data'), () => {
     await graphManagerState.graphManager.buildGraph(
       graphManagerState.graph,
       entities,
+      graphManagerState.graphBuildState,
     );
     const _mapping = graphManagerState.graph.getMapping(mapping);
     const _class = graphManagerState.graph.getClass(rootClass);

--- a/packages/legend-server-sdlc/src/models/configuration/ProjectDependency.ts
+++ b/packages/legend-server-sdlc/src/models/configuration/ProjectDependency.ts
@@ -28,7 +28,7 @@ import { observable, action, computed, makeObservable } from 'mobx';
 const PROJECT_DEPENDENCY_HASH_STRUCTURE = 'PROJECT_DEPENDENCY';
 
 export class ProjectDependency implements Hashable {
-  uuid = uuid();
+  readonly _UUID = uuid();
   projectId: string;
   versionId: VersionId;
 

--- a/packages/legend-shared/src/CommonUtils.ts
+++ b/packages/legend-shared/src/CommonUtils.ts
@@ -205,8 +205,15 @@ export const getNullableFirstElement = <T>(array: T[]): T | undefined =>
  * NOTE: This is useful in network client interface where we enforce that the input and output for the network call must be plain object,
  * so as to force proper handling (i.e. deserialize/serialize) but also signal from documentation perspective about the type/shape of the plain object
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type PlainObject<T> = Record<PropertyKey, unknown>;
+export type PlainObject<T> = Record<PropertyKey, unknown>; // eslint-disable-line @typescript-eslint/no-unused-vars
+
+/**
+ * This type allows modification of `readonly` attributes for class/interface
+ * This is useful to set properties like `owner`, `parent` where we can't do so in the constructors
+ *
+ * See https://stackoverflow.com/questions/46634876/how-can-i-change-a-readonly-property-in-typescript
+ */
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };
 
 /**
  * NOTE: This object mutates the input object (obj1)

--- a/packages/legend-studio/src/components/EditorComponentTestUtils.tsx
+++ b/packages/legend-studio/src/components/EditorComponentTestUtils.tsx
@@ -384,19 +384,18 @@ export const TEST__setUpEditor = async (
   // assert immutable models have been model
   await waitFor(() =>
     expect(
-      mockedEditorStore.graphManagerState.systemModel.buildState.hasSucceeded,
+      mockedEditorStore.graphManagerState.systemBuildState.hasSucceeded,
     ).toBe(true),
   );
   await waitFor(() =>
     expect(
-      mockedEditorStore.graphManagerState.graph.dependencyManager.buildState
-        .hasSucceeded,
+      mockedEditorStore.graphManagerState.dependenciesBuildState.hasSucceeded,
     ).toBe(true),
   );
   // assert main model has been build
   await waitFor(() =>
     expect(
-      mockedEditorStore.graphManagerState.graph.buildState.hasSucceeded,
+      mockedEditorStore.graphManagerState.graphBuildState.hasSucceeded,
     ).toBe(true),
   );
   // assert explorer trees have been built and rendered

--- a/packages/legend-studio/src/components/editor/ActivityBar.tsx
+++ b/packages/legend-studio/src/components/editor/ActivityBar.tsx
@@ -78,7 +78,7 @@ export const ActivityBar = observer(() => {
       .length;
   const localChangesDisplayLabel = localChanges > 99 ? '99+' : localChanges;
   const localChangesIndicatorStatusIcon =
-    editorStore.graphManagerState.graph.buildState.hasFailed ||
+    editorStore.graphManagerState.graphBuildState.hasFailed ||
     editorStore.changeDetectionState.initState.hasFailed ? (
       <div />
     ) : !editorStore.changeDetectionState.initState.hasSucceeded ||

--- a/packages/legend-studio/src/components/editor/Editor.tsx
+++ b/packages/legend-studio/src/components/editor/Editor.tsx
@@ -217,7 +217,7 @@ export const EditorInner = observer(() => {
     return true;
   };
   const editable =
-    editorStore.graphManagerState.graph.buildState.hasCompleted &&
+    editorStore.graphManagerState.graphBuildState.hasCompleted &&
     editorStore.isInitialized;
   const isResolvingConflicts =
     editorStore.isInConflictResolutionMode &&

--- a/packages/legend-studio/src/components/editor/StatusBar.tsx
+++ b/packages/legend-studio/src/components/editor/StatusBar.tsx
@@ -77,7 +77,7 @@ export const StatusBar = observer((props: { actionsDisabled: boolean }) => {
   // TODO: we probably should refactor this, these messages are not that helpful and
   // meant for different purposes
   const pushStatusText =
-    editorStore.graphManagerState.graph.buildState.hasFailed ||
+    editorStore.graphManagerState.graphBuildState.hasFailed ||
     editorStore.changeDetectionState.initState.hasFailed
       ? 'change detection halted'
       : !editorStore.changeDetectionState.initState.hasSucceeded
@@ -102,7 +102,7 @@ export const StatusBar = observer((props: { actionsDisabled: boolean }) => {
   // TODO: we probably should refactor this, these messages are not that helpful and
   // meant for different purposes
   const conflictResolutionStatusText =
-    editorStore.graphManagerState.graph.buildState.hasFailed ||
+    editorStore.graphManagerState.graphBuildState.hasFailed ||
     editorStore.changeDetectionState.initState.hasFailed
       ? 'change detection halted'
       : !editorStore.changeDetectionState.initState.hasSucceeded

--- a/packages/legend-studio/src/components/editor/aux-panel/DevTool.tsx
+++ b/packages/legend-studio/src/components/editor/aux-panel/DevTool.tsx
@@ -18,12 +18,14 @@ import { observer } from 'mobx-react-lite';
 import { clsx, CheckSquareIcon, SquareIcon } from '@finos/legend-art';
 import { isValidUrl } from '@finos/legend-shared';
 import { useEditorStore } from '../EditorStoreProvider';
+import { observe_TEMPORARY__AbstractEngineConfig } from '@finos/legend-graph';
 
 export const DevTool = observer(() => {
   const editorStore = useEditorStore();
   // Engine
-  const engineConfig =
-    editorStore.graphManagerState.graphManager.TEMPORARY__getEngineConfig();
+  const engineConfig = observe_TEMPORARY__AbstractEngineConfig(
+    editorStore.graphManagerState.graphManager.TEMPORARY__getEngineConfig(),
+  );
   const changeEngineClientBaseUrl: React.ChangeEventHandler<
     HTMLInputElement
   > = (event) =>

--- a/packages/legend-studio/src/components/editor/edit-panel/FunctionEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/FunctionEditor.tsx
@@ -582,7 +582,7 @@ export const FunctionMainEditor = observer(
           >
             {functionElement.parameters.map((param) => (
               <ParameterBasicEditor
-                key={param.uuid}
+                key={param._UUID}
                 parameter={param}
                 deleteParameter={deleteParameter(param)}
                 isReadOnly={isReadOnly}
@@ -795,7 +795,7 @@ export const FunctionEditor = observer(() => {
               >
                 {functionElement.taggedValues.map((taggedValue) => (
                   <TaggedValueEditor
-                    key={taggedValue.uuid}
+                    key={taggedValue._UUID}
                     taggedValue={taggedValue}
                     deleteValue={_deleteTaggedValue(taggedValue)}
                     isReadOnly={isReadOnly}
@@ -813,7 +813,7 @@ export const FunctionEditor = observer(() => {
               >
                 {functionElement.stereotypes.map((stereotype) => (
                   <StereotypeSelector
-                    key={stereotype.value.uuid}
+                    key={stereotype.value._UUID}
                     stereotype={stereotype}
                     deleteStereotype={_deleteStereotype(stereotype)}
                     isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/RuntimeEditor.tsx
@@ -742,7 +742,7 @@ const IdentifiedConnectionsPerStoreEditor = observer(
                         {currentRuntimeEditorTabState.identifiedConnections.map(
                           (rtConnection) => (
                             <IdentifiedConnectionsPerStoreExplorerItem
-                              key={rtConnection.uuid}
+                              key={rtConnection._UUID}
                               identifiedConnection={rtConnection}
                               currentRuntimeEditorTabState={
                                 currentRuntimeEditorTabState
@@ -949,7 +949,7 @@ const RuntimeGeneralEditor = observer(
               <div className="panel__content__form__section__list">
                 {runtimeValue.mappings.map((mappingRef) => (
                   <RuntimeMappingEditor
-                    key={mappingRef.value.uuid}
+                    key={mappingRef.value._UUID}
                     runtimeEditorState={runtimeEditorState}
                     mappingRef={mappingRef}
                     isReadOnly={isReadOnly || isRuntimeEmbedded}

--- a/packages/legend-studio/src/components/editor/edit-panel/data-editor/DataElementEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/data-editor/DataElementEditor.tsx
@@ -365,7 +365,7 @@ export const DataElementEditor = observer(() => {
                 >
                   {dataElement.stereotypes.map((stereotype) => (
                     <StereotypeSelector
-                      key={stereotype.value.uuid}
+                      key={stereotype.value._UUID}
                       stereotype={stereotype}
                       deleteStereotype={_deleteStereotype(stereotype)}
                       isReadOnly={isReadOnly}
@@ -413,7 +413,7 @@ export const DataElementEditor = observer(() => {
                 >
                   {dataElement.taggedValues.map((taggedValue) => (
                     <TaggedValueEditor
-                      key={taggedValue.uuid}
+                      key={taggedValue._UUID}
                       taggedValue={taggedValue}
                       deleteValue={deleteTaggedValue(taggedValue)}
                       isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/external-format-editor/BindingElementEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/external-format-editor/BindingElementEditor.tsx
@@ -153,7 +153,7 @@ const BindingScopeEditor = observer(
               <div className="binding-scope-editor__panel__content__form__section__list">
                 {elements.map((elementRef) => (
                   <BindingScopeEntryEditor
-                    key={elementRef.value.uuid}
+                    key={elementRef.value._UUID}
                     elementRef={elementRef}
                     removeElement={removeElement}
                     isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/external-format-editor/SchemaSetElementEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/external-format-editor/SchemaSetElementEditor.tsx
@@ -302,7 +302,7 @@ const SchemaSetGeneralEditor = observer(
                 <MenuContent className="schema-set-panel__dropdown">
                   {schemaSet.schemas.map((schema: Schema, index: number) => (
                     <MenuContentItem
-                      key={schema.uuid}
+                      key={schema._UUID}
                       className={
                         currentSchema === schema
                           ? 'schema-set-panel__option schema-set-panel__option__active'
@@ -361,7 +361,7 @@ const SchemaSetGeneralEditor = observer(
                 )}
                 {currentSchema !== undefined && (
                   <SchemaBasicEditor
-                    key={currentSchema.uuid}
+                    key={currentSchema._UUID}
                     language={language}
                     schema={currentSchema}
                     isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
@@ -123,7 +123,7 @@ export const ClassMappingEditor = observer(
       case SET_IMPLEMENTATION_TYPE.FLAT_DATA: {
         sourceType = CLASS_MAPPING_SOURCE_TYPE.FLAT_DATA;
         sourceName = (setImplementation as FlatDataInstanceSetImplementation)
-          .sourceRootRecordType.value.owner.name;
+          .sourceRootRecordType.value._OWNER.name;
         break;
       }
       case SET_IMPLEMENTATION_TYPE.EMBEDDED_FLAT_DATA: {
@@ -132,7 +132,7 @@ export const ClassMappingEditor = observer(
           setImplementation as EmbeddedFlatDataPropertyMapping;
         sourceName = (
           flatDataInstanceSetImpl.rootInstanceSetImplementation as FlatDataInstanceSetImplementation
-        ).sourceRootRecordType.value.owner.name;
+        ).sourceRootRecordType.value._OWNER.name;
         break;
       }
       case SET_IMPLEMENTATION_TYPE.RELATIONAL: {

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/ClassMappingEditor.tsx
@@ -34,7 +34,6 @@ import {
   type EmbeddedFlatDataPropertyMapping,
   type RootRelationalInstanceSetImplementation,
   fromElementPathToMappingElementId,
-  SET_IMPLEMENTATION_TYPE,
   OperationSetImplementation,
   OperationType,
 } from '@finos/legend-graph';
@@ -44,6 +43,7 @@ import {
   operationMapping_setParameters,
   setImpl_setRoot,
 } from '../../../../stores/graphModifier/DSLMapping_GraphModifierHelper';
+import { SET_IMPLEMENTATION_TYPE } from '../../../../stores/shared/ModelUtil';
 
 export const OperatorSelector = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
@@ -289,7 +289,7 @@ const EnumValueMappingEditor = observer(
           <div>
             {matchingEnumValueMapping.sourceValues.map((sourceValue, idx) => (
               <SourceValueInput
-                key={sourceValue.uuid}
+                key={sourceValue._UUID}
                 isReadOnly={isReadOnly}
                 sourceValue={sourceValue}
                 expectedType={sourceType.value}

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
@@ -65,7 +65,7 @@ const SimplePropertyMappingEditor = observer(
       propertyMapping.property.value.genericType.value.rawType;
     const canDrop =
       dragItem &&
-      dragItem.data.field.flatDataDataType.correspondingPrimitiveType ===
+      dragItem.data.field.flatDataDataType._correspondingPrimitiveType ===
         expectedType;
     const onExpectedTypeLabelSelect = (): void =>
       propertyMappingState.instanceSetImplementationState.setSelectedType(
@@ -165,8 +165,8 @@ const EnumerationPropertyMappingEditor = observer(
     };
     // Drag and Drop
     const canDrop =
-      dragItem?.data.field.flatDataDataType.correspondingPrimitiveType &&
-      dragItem.data.field.flatDataDataType.correspondingPrimitiveType ===
+      dragItem?.data.field.flatDataDataType._correspondingPrimitiveType &&
+      dragItem.data.field.flatDataDataType._correspondingPrimitiveType ===
         expectedType;
 
     return (

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataPropertyMappingEditor.tsx
@@ -38,8 +38,6 @@ import { type ConnectDropTarget, useDrop } from 'react-dnd';
 import { useEditorStore } from '../../EditorStoreProvider';
 import { guaranteeType } from '@finos/legend-shared';
 import {
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   Enumeration,
   EnumerationMapping,
   FlatDataPropertyMapping,
@@ -47,6 +45,10 @@ import {
 } from '@finos/legend-graph';
 import { StudioLambdaEditor } from '../../../shared/StudioLambdaEditor';
 import { flatDataPropertyMapping_setTransformer } from '../../../../stores/graphModifier/StoreFlatData_GraphModifierHelper';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+} from '../../../../stores/shared/ModelUtil';
 
 const SimplePropertyMappingEditor = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataRecordTypeTree.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/FlatDataRecordTypeTree.tsx
@@ -85,7 +85,7 @@ const RecordFieldTreeNodeContainer: React.FC<
   );
   const nodeTypeIcon = <PURE_PrimitiveTypeIcon />;
   const selectNode = (): void => onNodeSelect?.(node);
-  const primitiveType = node.field.flatDataDataType.correspondingPrimitiveType;
+  const primitiveType = node.field.flatDataDataType._correspondingPrimitiveType;
 
   return (
     <div

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationEditor.tsx
@@ -210,7 +210,7 @@ export const InstanceSetImplementationSourceExplorer = observer(
     );
     const handleDrop = useCallback(
       (item: MappingElementSourceDropTarget): void => {
-        if (!setImplementation.isEmbedded && !isReadOnly) {
+        if (!setImplementation._isEmbedded && !isReadOnly) {
           const embeddedSetImpls =
             setImplementation.getEmbeddedSetImplmentations();
           const droppedPackagableElement = item.data.packageableElement;
@@ -290,7 +290,7 @@ export const InstanceSetImplementationSourceExplorer = observer(
               className="panel__header__action"
               onClick={showSourceSelectorModal}
               disabled={
-                isReadOnly || setImplementation.isEmbedded || isUnsupported
+                isReadOnly || setImplementation._isEmbedded || isUnsupported
               }
               tabIndex={-1}
               title="Select Source..."

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationSourceSelectorModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationSourceSelectorModal.tsx
@@ -52,7 +52,7 @@ export const getMappingElementSourceFilterText = (
   if (val instanceof Class) {
     return val.path;
   } else if (val instanceof RootFlatDataRecordType) {
-    return val.owner.name;
+    return val._OWNER.name;
   } else if (val instanceof TableAlias) {
     return `${val.relation.ownerReference.value.path}.${val.relation.value.schema.name}.${val.relation.value.name}`;
   }
@@ -72,7 +72,7 @@ export const getSourceElementLabel = (
   if (srcElement instanceof Class) {
     sourceLabel = srcElement.name;
   } else if (srcElement instanceof RootFlatDataRecordType) {
-    sourceLabel = srcElement.owner.name;
+    sourceLabel = srcElement._OWNER.name;
   } else if (srcElement instanceof TableAlias) {
     sourceLabel = `${srcElement.relation.ownerReference.value.name}.${
       srcElement.relation.value.schema.name === DEFAULT_DATABASE_SCHEMA_NAME
@@ -92,7 +92,7 @@ export const buildMappingElementSourceOption = (
     return buildElementOption(source) as MappingElementSourceSelectOption;
   } else if (source instanceof RootFlatDataRecordType) {
     return {
-      label: `${source.owner.owner.name}.${source.owner.name}`,
+      label: `${source._OWNER._OWNER.name}.${source._OWNER.name}`,
       value: source,
     };
   } else if (source instanceof TableAlias) {

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
@@ -338,7 +338,7 @@ const MappingElementTreeNodeContainer = observer(
     );
     const mappingElementTarget = getMappingElementTarget(mappingElement);
     const mappingElementTooltipText =
-      mappingElement instanceof PropertyMapping && mappingElement.isEmbedded
+      mappingElement instanceof PropertyMapping && mappingElement._isEmbedded
         ? `Embedded class mapping '${mappingElement.id.value}' for property '${mappingElement.property.value.name}' (${mappingElement.property.value.genericType.value.rawType.name}) of type '${mappingElement.sourceSetImplementation.class.value.name}'`
         : `${toSentenceCase(
             getMappingElementType(mappingElement).toLowerCase(),

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
@@ -473,7 +473,7 @@ export const MappingTestsExplorer = observer(
                 .sort((a, b) => a.test.name.localeCompare(b.test.name))
                 .map((testState) => (
                   <MappingTestExplorer
-                    key={testState.test.uuid}
+                    key={testState.test._UUID}
                     testState={testState}
                     isReadOnly={isReadOnly}
                   />

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
@@ -43,8 +43,8 @@ import {
   Class,
   Enumeration,
   Association,
-  BASIC_SET_IMPLEMENTATION_TYPE,
 } from '@finos/legend-graph';
+import { BASIC_SET_IMPLEMENTATION_TYPE } from '../../../../stores/shared/ModelUtil';
 
 interface ClassMappingSubTypeOption {
   label: string;

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/OperationSetImplementationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/OperationSetImplementationEditor.tsx
@@ -159,7 +159,7 @@ export const OperationSetImplementationEditor = observer(
     const visit =
       (param: SetImplementationContainer): (() => void) =>
       (): void => {
-        const parent = param.setImplementation.value.parent;
+        const parent = param.setImplementation.value._PARENT;
         // TODO: think more about this flow. Right now we open the mapping element in the parent mapping
         if (parent !== mappingEditorState.element) {
           editorStore.openElement(parent);
@@ -219,7 +219,7 @@ export const OperationSetImplementationEditor = observer(
           >
             {setImplementation.parameters.map((param) => (
               <div
-                key={param.uuid}
+                key={param._UUID}
                 className="operation-mapping-editor__parameter"
               >
                 <div className="operation-mapping-editor__parameter__selector">

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
@@ -90,7 +90,7 @@ export const PropertyMappingsEditor = observer(
         instanceSetImplementationState.setImplementation,
       );
     const isEmbedded =
-      instanceSetImplementationState.setImplementation.isEmbedded;
+      instanceSetImplementationState.setImplementation._isEmbedded;
     // Parser Error
     const propertyMappingStates =
       instanceSetImplementationState.propertyMappingStates.filter(
@@ -122,7 +122,7 @@ export const PropertyMappingsEditor = observer(
             if (!rootMappingElement.root.value) {
               setImpl_setRoot(rootMappingElement, true);
             }
-            const parent = rootMappingElement.parent;
+            const parent = rootMappingElement._PARENT;
             if (parent !== mappingEditorState.element) {
               // TODO: think more about this flow. Right now we open the mapping element in the parent mapping
               editorStore.openElement(parent);

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PropertyMappingsEditor.tsx
@@ -45,10 +45,7 @@ import {
   type Type,
   getRootSetImplementation,
   Class,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   SetImplementation,
-  SET_IMPLEMENTATION_TYPE,
   PrimitiveType,
   PureInstanceSetImplementation,
   EmbeddedFlatDataPropertyMapping,
@@ -59,6 +56,11 @@ import {
   setImpl_nominateRoot,
   setImpl_setRoot,
 } from '../../../../stores/graphModifier/DSLMapping_GraphModifierHelper';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+  SET_IMPLEMENTATION_TYPE,
+} from '../../../../stores/shared/ModelUtil';
 
 export const getExpectedReturnType = (
   targetSetImplementation: SetImplementation | undefined,

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PurePropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/PurePropertyMappingEditor.tsx
@@ -38,8 +38,6 @@ import { type ConnectDropTarget, useDrop } from 'react-dnd';
 import { useEditorStore } from '../../EditorStoreProvider';
 import {
   Enumeration,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   EnumerationMapping,
   DerivedProperty,
   getEnumerationMappingsByEnumeration,
@@ -47,6 +45,10 @@ import {
 import { StudioLambdaEditor } from '../../../shared/StudioLambdaEditor';
 import { purePropertyMapping_setTransformer } from '../../../../stores/graphModifier/DSLMapping_GraphModifierHelper';
 import { getExpectedReturnType } from './PropertyMappingsEditor';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+} from '../../../../stores/shared/ModelUtil';
 
 const SimplePropertyMappingEditor = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/relational/RelationalPropertyMappingEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/relational/RelationalPropertyMappingEditor.tsx
@@ -38,8 +38,6 @@ import {
 } from './TableOrViewSourceTree';
 import { useEditorStore } from '../../../EditorStoreProvider';
 import {
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   Enumeration,
   EnumerationMapping,
   RelationalPropertyMapping,
@@ -48,6 +46,10 @@ import {
 import { StudioLambdaEditor } from '../../../../shared/StudioLambdaEditor';
 import { relationalPropertyMapping_setTransformer } from '../../../../../stores/graphModifier/StoreRelational_GraphModifierHelper';
 import { getExpectedReturnType } from '../PropertyMappingsEditor';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+} from '../../../../../stores/shared/ModelUtil';
 
 const SimplePropertyMappingEditor = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/relational/TableOrViewSourceTree.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/mapping-editor/relational/TableOrViewSourceTree.tsx
@@ -108,7 +108,7 @@ const generateColumnTreeNodeId = (
     ? parentNode instanceof JoinNodeData
       ? `${parentNode.id} ${JOIN_PIPE_SYMBOL} ${relation.name}.${column.name}`
       : `${parentNode.id}.${column.name}`
-    : `${generateDatabasePointerText(relation.schema.owner.path)}${
+    : `${generateDatabasePointerText(relation.schema._OWNER.path)}${
         relation.schema.name
       }.${relation.name}.${column.name}`;
 
@@ -183,7 +183,7 @@ const getJoinTreeNodeData = (
       );
     });
   // joins
-  relation.schema.owner.joins
+  relation.schema._OWNER.joins
     .slice()
     .filter(
       (_join) =>
@@ -217,7 +217,7 @@ const getRelationTreeData = (
       nodes.set(columnNode.id, columnNode);
     });
   // joins
-  relation.schema.owner.joins
+  relation.schema._OWNER.joins
     .slice()
     .filter(
       (join) =>
@@ -330,7 +330,7 @@ export const TableOrViewSourceTree: React.FC<{
         treeData.nodes.set(columnNode.id, columnNode);
       });
       // joins
-      node.relation.schema.owner.joins
+      node.relation.schema._OWNER.joins
         .filter(
           (join) =>
             join.aliases.filter(

--- a/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
@@ -503,7 +503,7 @@ export const ProjectConfigurationEditor = observer(() => {
               {currentProjectConfiguration.projectDependencies.map(
                 (projectDependency) => (
                   <ProjectDependencyEditor
-                    key={projectDependency.uuid}
+                    key={projectDependency._UUID}
                     projectDependency={projectDependency}
                     deleteValue={deleteProjectDependency(projectDependency)}
                     isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceTestEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/service-editor/ServiceTestEditor.tsx
@@ -213,7 +213,7 @@ export const TestContainerStateExplorer = observer(
             testState.test.asserts.map((test, idx) => (
               <TestContainerItem
                 testState={testState}
-                key={test.uuid}
+                key={test._UUID}
                 testContainer={test}
                 testIdx={idx}
                 isReadOnly={Boolean(isReadOnly)}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
@@ -61,8 +61,6 @@ import {
   Tag,
   Multiplicity,
   Class,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   PrimitiveType,
   Unit,
   StereotypeExplicitReference,
@@ -76,6 +74,10 @@ import {
   annotatedElement_deleteTaggedValue,
   association_changePropertyType,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+} from '../../../../stores/shared/ModelUtil';
 
 const AssociationPropertyBasicEditor = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
@@ -499,7 +499,7 @@ export const AssociationEditor = observer(
                   >
                     {association.taggedValues.map((taggedValue) => (
                       <TaggedValueEditor
-                        key={taggedValue.uuid}
+                        key={taggedValue._UUID}
                         taggedValue={taggedValue}
                         deleteValue={_deleteTaggedValue(taggedValue)}
                         isReadOnly={isReadOnly}
@@ -517,7 +517,7 @@ export const AssociationEditor = observer(
                   >
                     {association.stereotypes.map((stereotype) => (
                       <StereotypeSelector
-                        key={stereotype.value.uuid}
+                        key={stereotype.value._UUID}
                         stereotype={stereotype}
                         deleteStereotype={_deleteStereotype(stereotype)}
                         isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -57,8 +57,6 @@ import {
   PRIMITIVE_TYPE,
   MULTIPLICITY_INFINITE,
   Class,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   Property,
   DerivedProperty,
   GenericType,
@@ -100,6 +98,10 @@ import {
   property_setMultiplicity,
   setGenericTypeReferenceValue,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+} from '../../../../stores/shared/ModelUtil';
 
 const PropertyBasicEditor = observer(
   (props: {

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -113,8 +113,8 @@ const PropertyBasicEditor = observer(
       props;
     const editorStore = useEditorStore();
     const isInheritedProperty =
-      property.owner instanceof Class && property.owner !== _class;
-    const isPropertyFromAssociation = property.owner instanceof Association;
+      property._OWNER instanceof Class && property._OWNER !== _class;
+    const isPropertyFromAssociation = property._OWNER instanceof Association;
     const isIndirectProperty = isInheritedProperty || isPropertyFromAssociation;
     const isPropertyDuplicated = (val: Property): boolean =>
       _class.properties.filter((p) => p.name === val.name).length >= 2;
@@ -185,7 +185,7 @@ const PropertyBasicEditor = observer(
     };
     // NOTE: for now we do not allow directly modifying inherited and associated properties,
     // we would make the user go to the supertype or the association where the property comes from
-    const visitOwner = (): void => editorStore.openElement(property.owner);
+    const visitOwner = (): void => editorStore.openElement(property._OWNER);
 
     return (
       <div className="property-basic-editor">
@@ -334,7 +334,7 @@ const PropertyBasicEditor = observer(
             tabIndex={-1}
             title={`Visit ${
               isInheritedProperty ? 'super type class' : 'association'
-            } '${property.owner.path}'`}
+            } '${property._OWNER.path}'`}
           >
             <ArrowCircleRightIcon />
           </button>
@@ -383,7 +383,7 @@ const DerivedPropertyBasicEditor = observer(
     );
     const dpState =
       editorState.classState.getDerivedPropertyState(derivedProperty);
-    const isInheritedProperty = derivedProperty.owner !== _class;
+    const isInheritedProperty = derivedProperty._OWNER !== _class;
     // Name
     const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) =>
       property_setName(derivedProperty, event.target.value);
@@ -452,7 +452,7 @@ const DerivedPropertyBasicEditor = observer(
       }
     };
     const visitOwner = (): void =>
-      editorStore.openElement(derivedProperty.owner);
+      editorStore.openElement(derivedProperty._OWNER);
     const remove = applicationStore.guardUnhandledError(async () => {
       await flowResult(dpState.convertLambdaObjectToGrammarString(false));
       deleteDerivedProperty();
@@ -602,7 +602,7 @@ const DerivedPropertyBasicEditor = observer(
               className="uml-element-editor__visit-parent-element-btn"
               onClick={visitOwner}
               tabIndex={-1}
-              title={`Visit super type class ${derivedProperty.owner.path}`}
+              title={`Visit super type class ${derivedProperty._OWNER.path}`}
             >
               <ArrowCircleRightIcon />
             </button>
@@ -650,7 +650,7 @@ const ConstraintEditor = observer(
     const hasParserError = editorState.classState.constraintStates.some(
       (state) => state.parserError,
     );
-    const isInheritedConstraint = constraint.owner !== _class;
+    const isInheritedConstraint = constraint._OWNER !== _class;
     const constraintState =
       editorState.classState.getConstraintState(constraint);
     // Name
@@ -663,7 +663,7 @@ const ConstraintEditor = observer(
       );
       deleteConstraint();
     });
-    const visitOwner = (): void => editorStore.openElement(constraint.owner);
+    const visitOwner = (): void => editorStore.openElement(constraint._OWNER);
 
     return (
       <div
@@ -697,7 +697,7 @@ const ConstraintEditor = observer(
               className="uml-element-editor__visit-parent-element-btn"
               onClick={visitOwner}
               tabIndex={-1}
-              title={`Visit super type class ${constraint.owner.path}`}
+              title={`Visit super type class ${constraint._OWNER.path}`}
             >
               <ArrowCircleRightIcon />
             </button>
@@ -866,7 +866,7 @@ export const ClassFormEditor = observer(
       .sort((p1, p2) => p1.name.localeCompare(p2.name))
       .sort(
         (p1, p2) =>
-          (p1.owner === _class ? 1 : 0) - (p2.owner === _class ? 1 : 0),
+          (p1._OWNER === _class ? 1 : 0) - (p2._OWNER === _class ? 1 : 0),
       );
     const deselectProperty = (): void => setSelectedProperty(undefined);
     // Constraints
@@ -905,7 +905,7 @@ export const ClassFormEditor = observer(
       .sort((p1, p2) => p1.name.localeCompare(p2.name))
       .sort(
         (p1, p2) =>
-          (p1.owner === _class ? 1 : 0) - (p2.owner === _class ? 1 : 0),
+          (p1._OWNER === _class ? 1 : 0) - (p2._OWNER === _class ? 1 : 0),
       );
     const deleteDerivedProperty =
       (dp: DerivedProperty): (() => void) =>
@@ -1238,7 +1238,7 @@ export const ClassFormEditor = observer(
                       .concat(indirectProperties)
                       .map((property) => (
                         <PropertyBasicEditor
-                          key={property.uuid}
+                          key={property._UUID}
                           property={property}
                           _class={_class}
                           deleteProperty={deleteProperty(property)}
@@ -1263,7 +1263,7 @@ export const ClassFormEditor = observer(
                       )
                       .map((dp) => (
                         <DerivedPropertyBasicEditor
-                          key={dp.uuid}
+                          key={dp._UUID}
                           derivedProperty={dp}
                           _class={_class}
                           editorState={editorState}
@@ -1285,7 +1285,7 @@ export const ClassFormEditor = observer(
                       )
                       .map((constraint) => (
                         <ConstraintEditor
-                          key={constraint.uuid}
+                          key={constraint._UUID}
                           constraint={constraint}
                           _class={_class}
                           editorState={editorState}
@@ -1305,7 +1305,7 @@ export const ClassFormEditor = observer(
                   >
                     {_class.generalizations.map((superType) => (
                       <SuperTypeEditor
-                        key={superType.value.uuid}
+                        key={superType.value._UUID}
                         superType={superType}
                         _class={_class}
                         deleteSuperType={deleteSuperType(superType)}
@@ -1324,7 +1324,7 @@ export const ClassFormEditor = observer(
                   >
                     {_class.taggedValues.map((taggedValue) => (
                       <TaggedValueEditor
-                        key={taggedValue.uuid}
+                        key={taggedValue._UUID}
                         taggedValue={taggedValue}
                         deleteValue={_deleteTaggedValue(taggedValue)}
                         isReadOnly={isReadOnly}
@@ -1342,7 +1342,7 @@ export const ClassFormEditor = observer(
                   >
                     {_class.stereotypes.map((stereotype) => (
                       <StereotypeSelector
-                        key={stereotype.value.uuid}
+                        key={stereotype.value._UUID}
                         stereotype={stereotype}
                         deleteStereotype={_deleteStereotype(stereotype)}
                         isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
@@ -79,7 +79,8 @@ const EnumBasicEditor = observer(
       enum_setName(_enum, event.target.value);
     };
     const isEnumValueDuplicated = (val: Enum): boolean =>
-      _enum.owner.values.filter((value) => value.name === val.name).length >= 2;
+      _enum._OWNER.values.filter((value) => value.name === val.name).length >=
+      2;
 
     return (
       <div className="enum-basic-editor">
@@ -279,7 +280,7 @@ const EnumEditor = observer(
               >
                 {_enum.taggedValues.map((taggedValue) => (
                   <TaggedValueEditor
-                    key={taggedValue.uuid}
+                    key={taggedValue._UUID}
                     taggedValue={taggedValue}
                     deleteValue={_deleteTaggedValue(taggedValue)}
                     isReadOnly={isReadOnly}
@@ -297,7 +298,7 @@ const EnumEditor = observer(
               >
                 {_enum.stereotypes.map((stereotype) => (
                   <StereotypeSelector
-                    key={stereotype.value.uuid}
+                    key={stereotype.value._UUID}
                     stereotype={stereotype}
                     deleteStereotype={_deleteStereotype(stereotype)}
                     isReadOnly={isReadOnly}
@@ -522,7 +523,7 @@ export const EnumerationEditor = observer(
                   <div className="panel__content__lists">
                     {enumeration.values.map((enumValue) => (
                       <EnumBasicEditor
-                        key={enumValue.uuid}
+                        key={enumValue._UUID}
                         _enum={enumValue}
                         deleteValue={deleteValue(enumValue)}
                         selectValue={selectValue(enumValue)}
@@ -541,7 +542,7 @@ export const EnumerationEditor = observer(
                   >
                     {enumeration.taggedValues.map((taggedValue) => (
                       <TaggedValueEditor
-                        key={taggedValue.uuid}
+                        key={taggedValue._UUID}
                         taggedValue={taggedValue}
                         deleteValue={_deleteTaggedValue(taggedValue)}
                         isReadOnly={isReadOnly}
@@ -559,7 +560,7 @@ export const EnumerationEditor = observer(
                   >
                     {enumeration.stereotypes.map((stereotype) => (
                       <StereotypeSelector
-                        key={stereotype.value.uuid}
+                        key={stereotype.value._UUID}
                         stereotype={stereotype}
                         deleteStereotype={_deleteStereotype(stereotype)}
                         isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
@@ -45,7 +45,7 @@ const TagBasicEditor = observer(
       tagStereotype_setValue(tag, event.target.value);
     };
     const isTagDuplicated = (val: Tag): boolean =>
-      tag.owner.tags.filter((t) => t.value === val.value).length >= 2;
+      tag._OWNER.tags.filter((t) => t.value === val.value).length >= 2;
 
     return (
       <div className="tag-basic-editor">
@@ -87,7 +87,7 @@ const StereotypeBasicEditor = observer(
       tagStereotype_setValue(stereotype, event.target.value);
     };
     const isStereotypeDuplicated = (val: Stereotype): boolean =>
-      stereotype.owner.stereotypes.filter((s) => s.value === val.value)
+      stereotype._OWNER.stereotypes.filter((s) => s.value === val.value)
         .length >= 2;
 
     return (
@@ -210,7 +210,7 @@ export const ProfileEditor = observer((props: { profile: Profile }) => {
             <div className="panel__content__lists">
               {profile.tags.map((tag) => (
                 <TagBasicEditor
-                  key={tag.uuid}
+                  key={tag._UUID}
                   tag={tag}
                   deleteValue={deleteTag(tag)}
                   isReadOnly={isReadOnly}
@@ -222,7 +222,7 @@ export const ProfileEditor = observer((props: { profile: Profile }) => {
             <div className="panel__content__lists">
               {profile.stereotypes.map((stereotype) => (
                 <StereotypeBasicEditor
-                  key={stereotype.uuid}
+                  key={stereotype._UUID}
                   stereotype={stereotype}
                   deleteStereotype={deleteStereotype(stereotype)}
                   isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
@@ -208,7 +208,7 @@ export const PropertyEditor = observer(
               >
                 {property.taggedValues.map((taggedValue) => (
                   <TaggedValueEditor
-                    key={taggedValue.uuid}
+                    key={taggedValue._UUID}
                     taggedValue={taggedValue}
                     deleteValue={_deleteTaggedValue(taggedValue)}
                     isReadOnly={isReadOnly}
@@ -226,7 +226,7 @@ export const PropertyEditor = observer(
               >
                 {property.stereotypes.map((stereotype) => (
                   <StereotypeSelector
-                    key={stereotype.value.uuid}
+                    key={stereotype.value._UUID}
                     stereotype={stereotype}
                     deleteStereotype={_deleteStereotype(stereotype)}
                     isReadOnly={isReadOnly}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
@@ -57,7 +57,7 @@ export const StereotypeSelector = observer(
     });
     const [selectedProfile, setSelectedProfile] = useState<
       PackageableElementOption<Profile>
-    >({ value: stereotype.value.owner, label: stereotype.value.owner.name });
+    >({ value: stereotype.value._OWNER, label: stereotype.value._OWNER.name });
     const changeProfile = (val: PackageableElementOption<Profile>): void => {
       if (val.value.stereotypes.length) {
         setSelectedProfile(val);
@@ -106,7 +106,7 @@ export const StereotypeSelector = observer(
             className={`stereotype-selector__profile__visit-btn ${
               darkTheme ? 'stereotype-selector-dark-theme' : ''
             }`}
-            disabled={stereotype.value.owner.isStub}
+            disabled={stereotype.value._OWNER.isStub}
             onClick={visitProfile}
             tabIndex={-1}
             title={'Visit profile'}

--- a/packages/legend-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
@@ -64,8 +64,8 @@ export const TaggedValueEditor = observer(
     const [selectedProfile, setSelectedProfile] = useState<
       PackageableElementOption<Profile>
     >({
-      value: taggedValue.tag.value.owner,
-      label: taggedValue.tag.value.owner.name,
+      value: taggedValue.tag.value._OWNER,
+      label: taggedValue.tag.value._OWNER.name,
     });
     const changeProfile = (val: PackageableElementOption<Profile>): void => {
       if (val.value.tags.length) {
@@ -117,7 +117,7 @@ export const TaggedValueEditor = observer(
             className={`tagged-value-editor__profile__visit-btn ${
               darkTheme ? 'tagged-value-editor-dark-theme' : ''
             }`}
-            disabled={taggedValue.tag.value.owner.isStub}
+            disabled={taggedValue.tag.value._OWNER.isStub}
             onClick={visitProfile}
             tabIndex={-1}
             title={'Visit profile'}

--- a/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -38,13 +38,13 @@ import {
   type Store,
   type Class,
   ELEMENT_PATH_DELIMITER,
-  PACKAGEABLE_ELEMENT_TYPE,
 } from '@finos/legend-graph';
 import type { FileGenerationTypeOption } from '../../../stores/editor-state/GraphGenerationState';
 import { flowResult } from 'mobx';
 import { useApplicationStore } from '@finos/legend-application';
 import type { EmbeddedDataTypeOption } from '../../../stores/editor-state/element-editor-state/data/DataEditorState';
 import type { DSLData_LegendStudioPlugin_Extension } from '../../../stores/DSLData_LegendStudioPlugin_Extension';
+import { PACKAGEABLE_ELEMENT_TYPE } from '../../../stores/shared/ModelUtil';
 
 export const getElementTypeLabel = (
   editorStore: EditorStore,

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -69,13 +69,13 @@ import {
   ELEMENT_PATH_DELIMITER,
   ROOT_PACKAGE_NAME,
   Package,
-  PACKAGEABLE_ELEMENT_TYPE,
   isValidFullPath,
   isValidPath,
   getElementRootPackage,
 } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
 import type { LegendStudioConfig } from '../../../application/LegendStudioConfig';
+import { PACKAGEABLE_ELEMENT_TYPE } from '../../../stores/shared/ModelUtil';
 
 const isGeneratedPackageTreeNode = (node: PackageTreeNodeData): boolean =>
   getElementRootPackage(node.packageableElement).path ===

--- a/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/Explorer.tsx
@@ -770,9 +770,9 @@ export const Explorer = observer(() => {
     ((!editorStore.explorerTreeState.buildState.hasCompleted &&
       !editorStore.isInGrammarTextMode) ||
       editorStore.graphState.isUpdatingGraph) &&
-    !editorStore.graphManagerState.graph.buildState.hasFailed;
+    !editorStore.graphManagerState.graphBuildState.hasFailed;
   const showExplorerTrees =
-    editorStore.graphManagerState.graph.buildState.hasSucceeded &&
+    editorStore.graphManagerState.graphBuildState.hasSucceeded &&
     editorStore.explorerTreeState.buildState.hasCompleted &&
     // NOTE: if not in viewer mode, we would only show the explorer tree
     // when graph is properly observed to make sure edit after that can trigger
@@ -877,23 +877,22 @@ export const Explorer = observer(() => {
                 <PanelLoadingIndicator isLoading={isLoading} />
                 {showExplorerTrees && <ExplorerTrees />}
                 {!showExplorerTrees &&
-                  !editorStore.graphManagerState.graph.buildState.hasFailed && (
+                  !editorStore.graphManagerState.graphBuildState.hasFailed && (
                     <div className="explorer__content__progress-msg">
                       {editorStore.initState.message ??
-                        editorStore.graphManagerState.graph.systemModel
-                          .buildState.message ??
-                        editorStore.graphManagerState.graph.dependencyManager
-                          .buildState.message ??
-                        editorStore.graphManagerState.graph.generationModel
-                          .buildState.message ??
-                        editorStore.graphManagerState.graph.buildState
+                        editorStore.graphManagerState.systemBuildState
                           .message ??
+                        editorStore.graphManagerState.dependenciesBuildState
+                          .message ??
+                        editorStore.graphManagerState.generationsBuildState
+                          .message ??
+                        editorStore.graphManagerState.graphBuildState.message ??
                         editorStore.changeDetectionState.graphObserveState
                           .message}
                     </div>
                   )}
                 {!showExplorerTrees &&
-                  editorStore.graphManagerState.graph.buildState.hasFailed && (
+                  editorStore.graphManagerState.graphBuildState.hasFailed && (
                     <BlankPanelContent>
                       <div className="explorer__content__failure-notice">
                         <div className="explorer__content__failure-notice__icon">

--- a/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/__tests__/CreateNewElement.test.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../../EditorComponentTestUtils';
 import { LEGEND_STUDIO_TEST_ID } from '../../../LegendStudioTestID';
 import type { EditorStore } from '../../../../stores/EditorStore';
-import { PACKAGEABLE_ELEMENT_TYPE } from '@finos/legend-graph';
+import { PACKAGEABLE_ELEMENT_TYPE } from '../../../../stores/shared/ModelUtil';
 
 const addRootPackage = (packagePath: string, result: RenderResult): void => {
   fireEvent.click(result.getByTitle('New Element...', { exact: false }));

--- a/packages/legend-studio/src/components/shared/ElementIconUtils.tsx
+++ b/packages/legend-studio/src/components/shared/ElementIconUtils.tsx
@@ -25,7 +25,6 @@ import {
   Measure,
   Unit,
   PrimitiveType,
-  PACKAGEABLE_ELEMENT_TYPE,
 } from '@finos/legend-graph';
 import {
   PURE_ClassIcon,
@@ -47,6 +46,7 @@ import {
   PURE_UnitIcon,
   PURE_PackageIcon,
 } from '@finos/legend-art';
+import { PACKAGEABLE_ELEMENT_TYPE } from '../../stores/shared/ModelUtil';
 
 export const getClassPropertyIcon = (type: Type): React.ReactNode => {
   if (type instanceof PrimitiveType) {

--- a/packages/legend-studio/src/components/shared/TypeTree.tsx
+++ b/packages/legend-studio/src/components/shared/TypeTree.tsx
@@ -41,11 +41,13 @@ import {
   type AbstractProperty,
   Enumeration,
   Class,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
   DEFAULT_SOURCE_PARAMETER_NAME,
   VARIABLE_REFERENCE_TOKEN,
 } from '@finos/legend-graph';
+import {
+  CLASS_PROPERTY_TYPE,
+  getClassPropertyType,
+} from '../../stores/shared/ModelUtil';
 
 const getEnumTypeTreeNodeData = (
   _enum: Enum,

--- a/packages/legend-studio/src/components/viewer/Viewer.tsx
+++ b/packages/legend-studio/src/components/viewer/Viewer.tsx
@@ -243,7 +243,7 @@ export const ViewerInner = observer(() => {
   const applicationStore = useApplicationStore();
   const allowOpeningElement =
     editorStore.sdlcState.currentProject &&
-    editorStore.graphManagerState.graph.buildState.hasSucceeded;
+    editorStore.graphManagerState.graphBuildState.hasSucceeded;
   const resizeSideBar = (handleProps: ResizablePanelHandlerProps): void =>
     editorStore.sideBarDisplayState.setSize(
       (handleProps.domElement as HTMLDivElement).getBoundingClientRect().width,

--- a/packages/legend-studio/src/stores/EditorGraphState.ts
+++ b/packages/legend-studio/src/stores/EditorGraphState.ts
@@ -59,7 +59,6 @@ import {
   EngineError,
   extractSourceInformationCoordinates,
   Package,
-  SET_IMPLEMENTATION_TYPE,
   PureInstanceSetImplementation,
   Profile,
   OperationSetImplementation,
@@ -83,7 +82,6 @@ import {
   SectionIndex,
   RootRelationalInstanceSetImplementation,
   EmbeddedRelationalInstanceSetImplementation,
-  PACKAGEABLE_ELEMENT_TYPE,
   AggregationAwareSetImplementation,
   DependencyGraphBuilderError,
   GraphDataDeserializationError,
@@ -101,6 +99,10 @@ import { CONFIGURATION_EDITOR_TAB } from './editor-state/ProjectConfigurationEdi
 import type { DSLMapping_LegendStudioPlugin_Extension } from './DSLMapping_LegendStudioPlugin_Extension';
 import { graph_dispose } from './graphModifier/GraphModifierHelper';
 import { TestableManagerState } from './sidebar-state/testable/TestableManagerState';
+import {
+  PACKAGEABLE_ELEMENT_TYPE,
+  SET_IMPLEMENTATION_TYPE,
+} from './shared/ModelUtil';
 
 export enum GraphBuilderStatus {
   SUCCEEDED = 'SUCCEEDED',

--- a/packages/legend-studio/src/stores/EditorStore.ts
+++ b/packages/legend-studio/src/stores/EditorStore.ts
@@ -103,7 +103,6 @@ import {
   type Store,
   type GraphManagerState,
   GRAPH_MANAGER_EVENT,
-  PACKAGEABLE_ELEMENT_TYPE,
   PrimitiveType,
   Class,
   Enumeration,
@@ -146,6 +145,7 @@ import {
   graph_renameElement,
 } from './graphModifier/GraphModifierHelper';
 import { TestableManagerState } from './sidebar-state/testable/TestableManagerState';
+import { PACKAGEABLE_ELEMENT_TYPE } from './shared/ModelUtil';
 
 export abstract class EditorExtensionState {
   /**

--- a/packages/legend-studio/src/stores/EditorStore.ts
+++ b/packages/legend-studio/src/stores/EditorStore.ts
@@ -433,7 +433,7 @@ export class EditorStore {
           this.sdlcState.currentWorkspace &&
           this.sdlcState.currentRevision &&
           this.sdlcState.remoteWorkspaceRevision,
-      ) && this.graphManagerState.systemModel.buildState.hasSucceeded
+      ) && this.graphManagerState.systemBuildState.hasSucceeded
     );
   }
   get isInGrammarTextMode(): boolean {

--- a/packages/legend-studio/src/stores/NewElementState.ts
+++ b/packages/legend-studio/src/stores/NewElementState.ts
@@ -48,7 +48,6 @@ import {
   PRIMITIVE_TYPE,
   TYPICAL_MULTIPLICITY_TYPE,
   ELEMENT_PATH_DELIMITER,
-  PACKAGEABLE_ELEMENT_TYPE,
   Package,
   Class,
   Association,
@@ -101,6 +100,7 @@ import {
   dataElement_setEmbeddedData,
   modelStoreData_setInstance,
 } from './graphModifier/DSLData_GraphModifierHelper';
+import { PACKAGEABLE_ELEMENT_TYPE } from './shared/ModelUtil';
 
 export const resolvePackageAndElementName = (
   _package: Package,

--- a/packages/legend-studio/src/stores/ViewerStore.ts
+++ b/packages/legend-studio/src/stores/ViewerStore.ts
@@ -296,7 +296,9 @@ export class ViewerStore {
       this.editorStore.graphManagerState.createEmptyDependencyManager();
     this.editorStore.graphManagerState.graph.dependencyManager =
       dependencyManager;
-    dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+    this.editorStore.graphManagerState.dependenciesBuildState.setMessage(
+      `Fetching dependencies...`,
+    );
     const dependencyEntitiesMap = (yield flowResult(
       this.editorStore.graphState.getConfigurationProjectDependencyEntities(),
     )) as Map<string, Entity[]>;
@@ -308,6 +310,7 @@ export class ViewerStore {
         this.editorStore.graphManagerState.systemModel,
         dependencyManager,
         dependencyEntitiesMap,
+        this.editorStore.graphManagerState.dependenciesBuildState,
       )) as GraphBuilderReport;
     dependency_buildReport.timings[
       GRAPH_MANAGER_EVENT.GRAPH_DEPENDENCIES_FETCHED
@@ -318,6 +321,7 @@ export class ViewerStore {
       (yield this.editorStore.graphManagerState.graphManager.buildGraph(
         this.editorStore.graphManagerState.graph,
         entities,
+        this.editorStore.graphManagerState.graphBuildState,
       )) as GraphBuilderReport;
     graph_buildReport.timings[GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED] =
       stopWatch.getRecord(GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED);
@@ -419,7 +423,9 @@ export class ViewerStore {
       this.editorStore.graphManagerState.createEmptyDependencyManager();
     this.editorStore.graphManagerState.graph.dependencyManager =
       dependencyManager;
-    dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+    this.editorStore.graphManagerState.dependenciesBuildState.setMessage(
+      `Fetching dependencies...`,
+    );
     const dependencyEntitiesMap = new Map<string, Entity[]>();
     (versionId === SNAPSHOT_VERSION_ALIAS
       ? ((yield this.editorStore.depotServerClient.getLatestDependencyEntities(
@@ -450,6 +456,7 @@ export class ViewerStore {
         this.editorStore.graphManagerState.systemModel,
         dependencyManager,
         dependencyEntitiesMap,
+        this.editorStore.graphManagerState.dependenciesBuildState,
       )) as GraphBuilderReport;
     dependency_buildReport.timings[
       GRAPH_MANAGER_EVENT.GRAPH_DEPENDENCIES_FETCHED
@@ -460,6 +467,7 @@ export class ViewerStore {
       (yield this.editorStore.graphManagerState.graphManager.buildGraph(
         this.editorStore.graphManagerState.graph,
         entities,
+        this.editorStore.graphManagerState.graphBuildState,
       )) as GraphBuilderReport;
     graph_buildReport.timings[GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED] =
       stopWatch.getRecord(GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED);
@@ -523,7 +531,7 @@ export class ViewerStore {
 
       // open element if provided an element path
       if (
-        this.editorStore.graphManagerState.graph.buildState.hasSucceeded &&
+        this.editorStore.graphManagerState.graphBuildState.hasSucceeded &&
         this.editorStore.explorerTreeState.buildState.hasCompleted &&
         this.elementPath
       ) {

--- a/packages/legend-studio/src/stores/__tests__/ChangeDetection.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/ChangeDetection.test.ts
@@ -54,6 +54,7 @@ test(unitTest('Change detection works properly'), async () => {
   await editorStore.graphManagerState.graphManager.buildGraph(
     editorStore.graphManagerState.graph,
     entities,
+    editorStore.graphManagerState.graphBuildState,
   );
 
   // set original hash

--- a/packages/legend-studio/src/stores/__tests__/ProjectDependencyManager.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/ProjectDependencyManager.test.ts
@@ -237,19 +237,18 @@ const testDependencyElements = async (
     editorStore.graphManagerState.systemModel,
     dependencyManager,
     dependencyEntitiesMap,
+    editorStore.graphManagerState.dependenciesBuildState,
   );
   expect(
-    editorStore.graphManagerState.graph.dependencyManager.buildState
-      .hasSucceeded,
+    editorStore.graphManagerState.dependenciesBuildState.hasSucceeded,
   ).toBe(true);
 
   await editorStore.graphManagerState.graphManager.buildGraph(
     editorStore.graphManagerState.graph,
     entities,
+    editorStore.graphManagerState.graphBuildState,
   );
-  expect(editorStore.graphManagerState.graph.buildState.hasSucceeded).toBe(
-    true,
-  );
+  expect(editorStore.graphManagerState.graphBuildState.hasSucceeded).toBe(true);
 
   Array.from(dependencyEntitiesMap.keys()).forEach((k) =>
     expect(dependencyManager.getModel(k)).toBeDefined(),

--- a/packages/legend-studio/src/stores/editor-state/EditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/EditorState.ts
@@ -18,7 +18,10 @@ import type { EditorStore } from '../EditorStore';
 import { uuid } from '@finos/legend-shared';
 
 export abstract class EditorState {
-  uuid = uuid(); // NOTE: used to detect when an element editor state changes so we can force a remount of the editor component
+  /**
+   * NOTE: used to detect when an element editor state changes so we can force a remount of the editor component
+   */
+  readonly uuid = uuid();
   editorStore: EditorStore;
 
   constructor(editorStore: EditorStore) {

--- a/packages/legend-studio/src/stores/editor-state/GenerationSpecificationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/GenerationSpecificationEditorState.ts
@@ -46,7 +46,7 @@ export interface GenerationSpecNodeDragSource {
 
 export type GenerationSpecNodeDropTarget = GenerationSpecNodeDragSource;
 export class GenerationTreeNodeState {
-  uuid = uuid();
+  readonly uuid = uuid();
   node: GenerationTreeNode;
   isBeingDragged = false;
 

--- a/packages/legend-studio/src/stores/editor-state/ModelLoaderState.ts
+++ b/packages/legend-studio/src/stores/editor-state/ModelLoaderState.ts
@@ -126,8 +126,8 @@ export class ModelLoaderState extends EditorState {
   *loadCurrentProjectEntities(): GeneratorFn<void> {
     switch (this.currentModelLoadType) {
       case MODEL_UPDATER_INPUT_TYPE.PURE_PROTOCOL: {
-        const graphEntities = this.editorStore.graphManagerState.graph
-          .buildState.hasSucceeded
+        const graphEntities = this.editorStore.graphManagerState.graphBuildState
+          .hasSucceeded
           ? this.editorStore.graphManagerState.graph.allOwnElements.map(
               (element) =>
                 this.editorStore.graphManagerState.graphManager.elementToEntity(
@@ -143,8 +143,8 @@ export class ModelLoaderState extends EditorState {
         break;
       }
       case MODEL_UPDATER_INPUT_TYPE.ENTITIES: {
-        const graphEntities = this.editorStore.graphManagerState.graph
-          .buildState.hasSucceeded
+        const graphEntities = this.editorStore.graphManagerState.graphBuildState
+          .hasSucceeded
           ? this.editorStore.graphManagerState.graph.allOwnElements.map(
               (element) =>
                 this.editorStore.graphManagerState.graphManager.elementToEntity(

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ClassState.ts
@@ -61,7 +61,7 @@ export class DerivedPropertyState extends LambdaEditorState {
 
   get lambdaId(): string {
     return buildSourceInformationSourceId([
-      this.derivedProperty.owner.path,
+      this.derivedProperty._OWNER.path,
       DERIVED_PROPERTY_SOURCE_ID_LABEL,
       this.derivedProperty.name,
       this.uuid, // in case of duplications
@@ -155,7 +155,7 @@ export class ConstraintState extends LambdaEditorState {
 
   get lambdaId(): string {
     return buildSourceInformationSourceId([
-      this.constraint.owner.path,
+      this.constraint._OWNER.path,
       CONSTRAINT_SOURCE_ID_LABEL,
       this.constraint.name,
       this.uuid, // in case of duplications

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/ElementFileGenerationState.ts
@@ -29,7 +29,7 @@ import {
 } from '../../graphModifier/DSLGeneration_GraphModifierHelper';
 
 export class ElementFileGenerationState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   fileGenerationType: string;
   fileGenerationState: FileGenerationState;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/RuntimeEditorState.ts
@@ -85,7 +85,7 @@ export const getClassMappingStore = (
   if (sourceElement instanceof Class) {
     return editorStore.graphManagerState.graph.modelStore;
   } else if (sourceElement instanceof RootFlatDataRecordType) {
-    return sourceElement.owner.owner;
+    return sourceElement._OWNER._OWNER;
   } else if (sourceElement instanceof TableAlias) {
     return sourceElement.relation.ownerReference.value;
   }
@@ -315,7 +315,7 @@ export const getRuntimeExplorerTreeData = (
 };
 
 export abstract class RuntimeEditorTabState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   runtimeEditorState: RuntimeEditorState;
 
@@ -617,7 +617,10 @@ export class IdentifiedConnectionsPerClassEditorTabState extends IdentifiedConne
 export class RuntimeEditorRuntimeTabState extends RuntimeEditorTabState {}
 
 export class RuntimeEditorState {
-  uuid = uuid(); // NOTE: used to force component remount on state change
+  /**
+   * NOTE: used to force component remount on state change
+   */
+  readonly uuid = uuid();
   editorStore: EditorStore;
   runtime: Runtime;
   runtimeValue: EngineRuntime;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/ConnectionEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/ConnectionEditorState.ts
@@ -377,7 +377,10 @@ export class UnsupportedConnectionValueState extends ConnectionValueState {
 }
 
 export class ConnectionEditorState {
-  uuid = uuid(); // NOTE: used to force component remount on state change
+  /**
+   * NOTE: used to force component remount on state change
+   */
+  readonly uuid = uuid();
   editorStore: EditorStore;
   connection: Connection;
   connectionValueState: ConnectionValueState;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
@@ -18,6 +18,7 @@ import type { Entity } from '@finos/legend-model-storage';
 import type { TreeData, TreeNodeData } from '@finos/legend-art';
 import {
   type GeneratorFn,
+  type Writable,
   assertErrorThrown,
   LogEvent,
   addUniqueEntry,
@@ -598,7 +599,7 @@ export class DatabaseBuilderState {
     });
     // update existing schemas
     generatedDb.schemas.forEach((s) => {
-      s.owner = current;
+      (s as Writable<Schema>)._OWNER = current;
       const currentSchemaIndex = current.schemas.findIndex(
         (c) => c.name === s.name,
       );

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
@@ -27,6 +27,7 @@ import {
   guaranteeNonNullable,
   isNonNullable,
   filterByType,
+  ActionState,
 } from '@finos/legend-shared';
 import { observable, action, makeObservable, flow, flowResult } from 'mobx';
 import { LEGEND_STUDIO_APP_EVENT } from '../../../LegendStudioAppEvent';
@@ -497,6 +498,7 @@ export class DatabaseBuilderState {
     (yield this.editorStore.graphManagerState.graphManager.buildGraph(
       dbGraph,
       entities,
+      ActionState.create(),
     )) as Entity[];
     assertTrue(
       dbGraph.ownDatabases.length === 1,
@@ -516,6 +518,7 @@ export class DatabaseBuilderState {
     (yield this.editorStore.graphManagerState.graphManager.buildGraph(
       dbGraph,
       entities,
+      ActionState.create(),
     )) as Entity[];
     assertTrue(
       dbGraph.ownDatabases.length === 1,

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/data/DataEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/data/DataEditorState.ts
@@ -83,7 +83,10 @@ export class UnSupportedDataState extends EmbeddedDataState {
 }
 
 export class EmbeddedDataEditorState {
-  uuid = uuid(); // NOTE: used to force component remount on state change
+  /**
+   * NOTE: used to force component remount on state change
+   */
+  readonly uuid = uuid();
   editorStore: EditorStore;
   embeddedData: EmbeddedData;
   embeddedDataState: EmbeddedDataState;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/FlatDataInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/FlatDataInstanceSetImplementationState.ts
@@ -67,9 +67,9 @@ export class FlatDataPropertyMappingState extends PropertyMappingState {
 
   get lambdaId(): string {
     return buildSourceInformationSourceId([
-      this.propertyMapping.owner.parent.path,
+      this.propertyMapping._OWNER._PARENT.path,
       MAPPING_ELEMENT_SOURCE_ID_LABEL.FLAT_DATA_CLASS_MAPPING,
-      this.propertyMapping.owner.id.value,
+      this.propertyMapping._OWNER.id.value,
       this.propertyMapping.property.value.name,
       this.uuid, // in case of duplications
     ]);

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -74,7 +74,6 @@ import {
   Enumeration,
   Mapping,
   EnumerationMapping,
-  BASIC_SET_IMPLEMENTATION_TYPE,
   SetImplementation,
   PureInstanceSetImplementation,
   MappingTest,
@@ -120,6 +119,7 @@ import {
   setImpl_updateRootOnCreate,
   setImpl_updateRootOnDelete,
 } from '../../../graphModifier/DSLMapping_GraphModifierHelper';
+import { BASIC_SET_IMPLEMENTATION_TYPE } from '../../../shared/ModelUtil';
 
 export interface MappingExplorerTreeNodeData extends TreeNodeData {
   mappingElement: MappingElement;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -850,8 +850,8 @@ export class MappingEditorState extends ElementEditorState {
       return;
     }
     // Open mapping element from included mapping in another mapping editor tab
-    if (mappingElement.parent !== this.element) {
-      this.editorStore.openElement(mappingElement.parent);
+    if (mappingElement._PARENT !== this.element) {
+      this.editorStore.openElement(mappingElement._PARENT);
     }
     const currentMappingEditorState =
       this.editorStore.getCurrentEditorState(MappingEditorState);
@@ -1018,11 +1018,11 @@ export class MappingEditorState extends ElementEditorState {
     } else if (mappingElement instanceof AssociationImplementation) {
       mapping_deleteAssociationMapping(this.mapping, mappingElement);
     } else if (mappingElement instanceof EmbeddedFlatDataPropertyMapping) {
-      deleteEntry(mappingElement.owner.propertyMappings, mappingElement);
+      deleteEntry(mappingElement._OWNER.propertyMappings, mappingElement);
     } else if (
       mappingElement instanceof EmbeddedRelationalInstanceSetImplementation
     ) {
-      deleteEntry(mappingElement.owner.propertyMappings, mappingElement);
+      deleteEntry(mappingElement._OWNER.propertyMappings, mappingElement);
     } else if (mappingElement instanceof SetImplementation) {
       mapping_deleteClassMapping(this.mapping, mappingElement);
     }
@@ -1457,7 +1457,7 @@ export class MappingEditorState extends ElementEditorState {
       );
     } else if (source instanceof RootFlatDataRecordType) {
       inputData = new FlatDataInputData(
-        PackageableElementExplicitReference.create(source.owner.owner),
+        PackageableElementExplicitReference.create(source._OWNER._OWNER),
         createMockDataForMappingElementSource(source, this.editorStore),
       );
     } else if (source instanceof TableAlias) {

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementDecorator.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementDecorator.ts
@@ -156,7 +156,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
     operationMapping_setParameters(
       setImplementation,
       setImplementation.parameters.filter((param) =>
-        getAllClassMappings(setImplementation.parent).find(
+        getAllClassMappings(setImplementation._PARENT).find(
           (setImp) => setImp === param.setImplementation.value,
         ),
       ),
@@ -169,7 +169,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
     operationMapping_setParameters(
       setImplementation,
       setImplementation.parameters.filter((param) =>
-        getAllClassMappings(setImplementation.parent).find(
+        getAllClassMappings(setImplementation._PARENT).find(
           (setImp) => setImp === param.setImplementation.value,
         ),
       ),
@@ -229,7 +229,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
             ];
         // Find existing enumeration mappings for the property enumeration
         const existingEnumerationMappings = getEnumerationMappingsByEnumeration(
-          setImplementation.parent,
+          setImplementation._PARENT,
           (
             enumerationPropertyMapping[0] as PurePropertyMapping
           ).property.value.genericType.value.getRawType(Enumeration),
@@ -257,7 +257,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
           // or should we just simply find all class mappings for the target class
           // as we should not try to `understand` operation class mapping union?
           getLeafSetImplementations(
-            setImplementation.parent,
+            setImplementation._PARENT,
             property.genericType.value.getRawType(Class),
           );
         // if there are no root-resolved set implementations for the class, return empty array
@@ -367,7 +367,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
             ];
         // Find existing enumeration mappings for the property enumeration
         const existingEnumerationMappings = getEnumerationMappingsByEnumeration(
-          setImplementation.parent,
+          setImplementation._PARENT,
           (
             ePropertyMapping[0] as FlatDataPropertyMapping
           ).property.value.genericType.value.getRawType(Enumeration),
@@ -491,7 +491,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
         }
         // Find existing enumeration mappings for the property enumeration
         const existingEnumerationMappings = getEnumerationMappingsByEnumeration(
-          setImplementation.parent,
+          setImplementation._PARENT,
           (
             ePropertyMapping[0] as PropertyMapping
           ).property.value.genericType.value.getRawType(Enumeration),
@@ -521,7 +521,7 @@ export class MappingElementDecorator implements SetImplementationVisitor<void> {
         // or should we just simply find all class mappings for the target class
         // as we should not try to `understand` operation class mapping union?
         const resolvedLeafSetImps = getLeafSetImplementations(
-          setImplementation.parent,
+          setImplementation._PARENT,
           property.genericType.value.getRawType(Class),
         );
         // if there are no root-resolved set implementations for the class, return empty array

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingElementState.ts
@@ -27,7 +27,7 @@ import type {
 import { LambdaEditorState } from '@finos/legend-application';
 
 export class MappingElementState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   mappingElement: MappingElement;
 

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingExecutionState.ts
@@ -182,7 +182,7 @@ export class MappingExecutionQueryState extends LambdaEditorState {
 }
 
 abstract class MappingExecutionInputDataState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   mapping: Mapping;
   inputData?: InputData | undefined;
@@ -317,7 +317,7 @@ export class MappingExecutionFlatDataInputDataState extends MappingExecutionInpu
       mapping,
       new FlatDataInputData(
         PackageableElementExplicitReference.create(
-          guaranteeNonNullable(rootFlatDataRecordType.owner.owner),
+          guaranteeNonNullable(rootFlatDataRecordType._OWNER._OWNER),
         ),
         '',
       ),
@@ -374,7 +374,7 @@ export class MappingExecutionRelationalInputDataState extends MappingExecutionIn
       mapping,
       new RelationalInputData(
         PackageableElementExplicitReference.create(
-          guaranteeNonNullable(tableOrView.schema.owner),
+          guaranteeNonNullable(tableOrView.schema._OWNER),
         ),
         '',
         RelationalInputType.SQL,
@@ -435,7 +435,7 @@ export class MappingExecutionRelationalInputDataState extends MappingExecutionIn
 }
 
 export class MappingExecutionState {
-  uuid = uuid();
+  readonly uuid = uuid();
   name: string;
   editorStore: EditorStore;
   mappingEditorState: MappingEditorState;

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingTestState.ts
@@ -177,7 +177,7 @@ export class MappingTestQueryState extends LambdaEditorState {
 }
 
 abstract class MappingTestInputDataState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   mapping: Mapping;
   inputData: InputData;
@@ -340,7 +340,7 @@ export class MappingTestRelationalInputDataState extends MappingTestInputDataSta
 }
 
 abstract class MappingTestAssertionState {
-  uuid = uuid();
+  readonly uuid = uuid();
   assert: MappingTestAssert;
 
   constructor(assert: MappingTestAssert) {
@@ -389,7 +389,7 @@ export enum MAPPING_TEST_EDITOR_TAB_TYPE {
 }
 
 export class MappingTestState {
-  uuid = uuid();
+  readonly uuid = uuid();
   selectedTab = MAPPING_TEST_EDITOR_TAB_TYPE.SETUP;
   editorStore: EditorStore;
   mappingEditorState: MappingEditorState;
@@ -549,7 +549,7 @@ export class MappingTestState {
         this.mappingEditorState.mapping,
         new FlatDataInputData(
           PackageableElementExplicitReference.create(
-            guaranteeNonNullable(source.owner.owner),
+            guaranteeNonNullable(source._OWNER._OWNER),
           ),
           '',
         ),

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/PureInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/PureInstanceSetImplementationState.ts
@@ -60,9 +60,9 @@ export class PurePropertyMappingState extends PropertyMappingState {
   get lambdaId(): string {
     return buildSourceInformationSourceId(
       [
-        this.propertyMapping.owner.parent.path,
+        this.propertyMapping._OWNER._PARENT.path,
         MAPPING_ELEMENT_SOURCE_ID_LABEL.PURE_INSTANCE_CLASS_MAPPING,
-        this.propertyMapping.owner.id.value,
+        this.propertyMapping._OWNER.id.value,
         this.propertyMapping.property.value.name,
         this.propertyMapping.targetSetImplementation?.id.value,
         this.uuid, // in case of duplications
@@ -147,7 +147,7 @@ export class PureInstanceSetImplementationFilterState extends LambdaEditorState 
 
   get lambdaId(): string {
     return buildSourceInformationSourceId([
-      this.instanceSetImplementation.parent.path,
+      this.instanceSetImplementation._PARENT.path,
       MAPPING_ELEMENT_SOURCE_ID_LABEL.PURE_INSTANCE_CLASS_MAPPING,
       FILTER_SOURCE_ID_LABEL,
       this.uuid,

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/relational/RelationalInstanceSetImplementationState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/relational/RelationalInstanceSetImplementationState.ts
@@ -67,9 +67,9 @@ export class RelationalPropertyMappingState extends PropertyMappingState {
     // NOTE: Added the index here just in case but the order needs to be checked carefully as bugs may result from inaccurate orderings
     return buildSourceInformationSourceId(
       [
-        this.propertyMapping.owner.parent.path,
+        this.propertyMapping._OWNER._PARENT.path,
         MAPPING_ELEMENT_SOURCE_ID_LABEL.RELATIONAL_CLASS_MAPPING,
-        this.propertyMapping.owner.id.value,
+        this.propertyMapping._OWNER.id.value,
         this.propertyMapping.property.value.name,
         this.propertyMapping.targetSetImplementation?.id.value,
         this.uuid, // in case of duplications

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/LegacyServiceTestState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/LegacyServiceTestState.ts
@@ -83,7 +83,7 @@ interface ServiceTestExecutionResult {
 }
 
 export class TestContainerState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   serviceEditorState: ServiceEditorState;
   testState: LegacySingleExecutionTestState;
@@ -623,7 +623,7 @@ export class LegacySingleExecutionTestState {
 }
 
 export class KeyedSingleExecutionState extends LegacySingleExecutionTestState {
-  uuid = uuid();
+  readonly uuid = uuid();
   declare test: DEPRECATED__KeyedSingleExecutionTest;
 
   constructor(

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
@@ -188,7 +188,7 @@ export class ServicePureExecutionQueryState extends LambdaEditorState {
 
   get lambdaId(): string {
     return buildSourceInformationSourceId([
-      this.execution.owner.path,
+      this.execution._OWNER.path,
       'execution',
     ]);
   }

--- a/packages/legend-studio/src/stores/graphModifier/DSLMapping_GraphModifierHelper.ts
+++ b/packages/legend-studio/src/stores/graphModifier/DSLMapping_GraphModifierHelper.ts
@@ -335,7 +335,7 @@ export const operationMapping_deleteParameter = action(
 export const setImpl_updateRootOnCreate = action(
   (setImp: SetImplementation): void => {
     const classMappingsWithSimilarTarget = getOwnClassMappingsByClass(
-      setImp.parent,
+      setImp._PARENT,
       setImp.class.value,
     ).filter((si) => si !== setImp);
     if (classMappingsWithSimilarTarget.length) {
@@ -360,7 +360,7 @@ export const setImpl_updateRootOnCreate = action(
 export const setImpl_updateRootOnDelete = action(
   (setImp: SetImplementation): void => {
     const classMappingsWithSimilarTarget = getOwnClassMappingsByClass(
-      setImp.parent,
+      setImp._PARENT,
       setImp.class.value,
     ).filter((si) => si !== setImp);
     if (classMappingsWithSimilarTarget.length === 1) {
@@ -381,7 +381,7 @@ export const setImpl_updateRootOnDelete = action(
 export const setImpl_nominateRoot = action(
   (setImp: SetImplementation): void => {
     const classMappingsWithSimilarTarget = getOwnClassMappingsByClass(
-      setImp.parent,
+      setImp._PARENT,
       setImp.class.value,
     );
     classMappingsWithSimilarTarget.forEach((si) => {

--- a/packages/legend-studio/src/stores/graphModifier/DomainGraphModifierHelper.ts
+++ b/packages/legend-studio/src/stores/graphModifier/DomainGraphModifierHelper.ts
@@ -161,7 +161,7 @@ export const property_setMultiplicity = action(
 export const stereotypeReference_setValue = action(
   (sV: StereotypeReference, value: Stereotype): void => {
     sV.value = observe_Stereotype(value);
-    packageableElementReference_setValue(sV.ownerReference, value.owner);
+    packageableElementReference_setValue(sV.ownerReference, value._OWNER);
   },
 );
 
@@ -194,7 +194,7 @@ export const annotatedElement_deleteStereotype = action(
 export const taggedValue_setTag = action(
   (taggedValue: TaggedValue, value: Tag): void => {
     taggedValue.tag.value = observe_Tag(value);
-    taggedValue.tag.ownerReference.value = value.owner;
+    taggedValue.tag.ownerReference.value = value._OWNER;
   },
 );
 
@@ -299,7 +299,7 @@ export const enum_deleteValue = action(
 export const enumValueReference_setValue = action(
   (ref: EnumValueReference, value: Enum): void => {
     ref.value = observe_Enum(value);
-    packageableElementReference_setValue(ref.ownerReference, value.owner);
+    packageableElementReference_setValue(ref.ownerReference, value._OWNER);
   },
 );
 

--- a/packages/legend-studio/src/stores/shared/MockDataUtil.ts
+++ b/packages/legend-studio/src/stores/shared/MockDataUtil.ts
@@ -28,10 +28,9 @@ import {
   type Enumeration,
   PRIMITIVE_TYPE,
   Class,
-  CLASS_PROPERTY_TYPE,
-  getClassPropertyType,
 } from '@finos/legend-graph';
 import { DATE_FORMAT, DATE_TIME_FORMAT } from '@finos/legend-application';
+import { CLASS_PROPERTY_TYPE, getClassPropertyType } from './ModelUtil';
 
 export const createMockPrimitiveProperty = (
   primitiveType: PrimitiveType,

--- a/packages/legend-studio/src/stores/shared/ModelUtil.ts
+++ b/packages/legend-studio/src/stores/shared/ModelUtil.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type Type,
+  Class,
+  Enumeration,
+  Measure,
+  PrimitiveType,
+  Unit,
+} from '@finos/legend-graph';
+import { UnsupportedOperationError } from '@finos/legend-shared';
+
+export enum CLASS_PROPERTY_TYPE {
+  CLASS = 'CLASS',
+  ENUMERATION = 'ENUMERATION',
+  MEASURE = 'MEASURE',
+  UNIT = 'UNIT',
+  PRIMITIVE = 'PRIMITIVE',
+}
+
+export const getClassPropertyType = (type: Type): CLASS_PROPERTY_TYPE => {
+  if (type instanceof PrimitiveType) {
+    return CLASS_PROPERTY_TYPE.PRIMITIVE;
+  } else if (type instanceof Enumeration) {
+    return CLASS_PROPERTY_TYPE.ENUMERATION;
+  } else if (type instanceof Class) {
+    return CLASS_PROPERTY_TYPE.CLASS;
+  } else if (type instanceof Unit) {
+    return CLASS_PROPERTY_TYPE.UNIT;
+  } else if (type instanceof Measure) {
+    return CLASS_PROPERTY_TYPE.MEASURE;
+  }
+  throw new UnsupportedOperationError(`Can't classify class property`, type);
+};
+
+export enum PACKAGEABLE_ELEMENT_TYPE {
+  PRIMITIVE = 'PRIMITIVE',
+  PACKAGE = 'PACKAGE',
+  PROFILE = 'PROFILE',
+  ENUMERATION = 'ENUMERATION',
+  CLASS = 'CLASS',
+  ASSOCIATION = 'ASSOCIATION',
+  FUNCTION = 'FUNCTION',
+  MEASURE = 'MEASURE',
+  UNIT = 'UNIT',
+  FLAT_DATA_STORE = 'FLAT_DATA_STORE',
+  DATABASE = 'DATABASE',
+  SERVICE_STORE = 'SERVICE_STORE',
+  MAPPING = 'MAPPING',
+  SERVICE = 'SERVICE',
+  CONNECTION = 'CONNECTION',
+  RUNTIME = 'RUNTIME',
+  FILE_GENERATION = 'FILE_GENERATION',
+  GENERATION_SPECIFICATION = 'GENERATION_SPECIFICATION',
+  SECTION_INDEX = 'SECTION_INDEX',
+  DATA = 'Data',
+}
+
+export enum BASIC_SET_IMPLEMENTATION_TYPE {
+  OPERATION = 'operation',
+  INSTANCE = 'instance',
+}
+
+export enum SET_IMPLEMENTATION_TYPE {
+  OPERATION = 'operation',
+  MERGE_OPERATION = 'mergeOperation',
+  PUREINSTANCE = 'pureInstance',
+  FLAT_DATA = 'flatData',
+  EMBEDDED_FLAT_DATA = 'embeddedFlatData',
+  RELATIONAL = 'relational',
+  EMBEDDED_RELATIONAL = 'embeddedRelational',
+  AGGREGATION_AWARE = 'aggregationAware',
+}

--- a/packages/legend-studio/src/stores/sidebar-state/WorkflowManagerState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/WorkflowManagerState.ts
@@ -186,7 +186,7 @@ export class WorkflowLogState {
 }
 
 export class WorkflowState {
-  uuid = uuid();
+  readonly uuid = uuid();
   editorStore: EditorStore;
   workflowManagerState: WorkflowManagerState;
   treeData: TreeData<WorkflowExplorerTreeNodeData>;

--- a/packages/legend-studio/src/stores/sidebar-state/__tests__/LocalChangeState.test.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/__tests__/LocalChangeState.test.ts
@@ -128,6 +128,7 @@ test(unitTest('Load entity changes'), async () => {
   await editorStore.graphManagerState.graphManager.buildGraph(
     editorStore.graphManagerState.graph,
     entities,
+    editorStore.graphManagerState.graphBuildState,
   );
   const changes = entityChanges.entityChanges.map((e) =>
     EntityChange.serialization.fromJson(e),

--- a/packages/legend-studio/src/stores/sidebar-state/testable/TestableManagerState.ts
+++ b/packages/legend-studio/src/stores/sidebar-state/testable/TestableManagerState.ts
@@ -270,7 +270,7 @@ export const getNodeTestableResult = (
 };
 
 export class TestableState {
-  uuid = uuid();
+  readonly uuid = uuid();
   managerState: TestableManagerState;
   editorStore: EditorStore;
   testableMetadata: TestableMetadata;

--- a/packages/legend-taxonomy/src/components/StandaloneDataSpaceViewer.tsx
+++ b/packages/legend-taxonomy/src/components/StandaloneDataSpaceViewer.tsx
@@ -78,13 +78,11 @@ export const StandaloneDataSpaceViewer = observer(() => {
           taxonomyStore.initStandaloneDataSpaceViewerState.isInProgress && (
             <BlankPanelContent>
               {taxonomyStore.initStandaloneDataSpaceViewerState.message ??
-                taxonomyStore.graphManagerState.graph.systemModel.buildState
+                taxonomyStore.graphManagerState.systemBuildState.message ??
+                taxonomyStore.graphManagerState.dependenciesBuildState
                   .message ??
-                taxonomyStore.graphManagerState.graph.dependencyManager
-                  .buildState.message ??
-                taxonomyStore.graphManagerState.graph.generationModel.buildState
-                  .message ??
-                taxonomyStore.graphManagerState.graph.buildState.message}
+                taxonomyStore.graphManagerState.generationsBuildState.message ??
+                taxonomyStore.graphManagerState.graphBuildState.message}
             </BlankPanelContent>
           )}
         {!taxonomyStore.standaloneDataSpaceViewerState &&

--- a/packages/legend-taxonomy/src/components/TaxonomyNodeViewer.tsx
+++ b/packages/legend-taxonomy/src/components/TaxonomyNodeViewer.tsx
@@ -291,14 +291,13 @@ export const TaxonomyNodeViewer = observer(
                     <BlankPanelContent>
                       {taxonomyNodeViewerState.initDataSpaceViewerState
                         .message ??
-                        taxonomyStore.graphManagerState.graph.systemModel
-                          .buildState.message ??
-                        taxonomyStore.graphManagerState.graph.dependencyManager
-                          .buildState.message ??
-                        taxonomyStore.graphManagerState.graph.generationModel
-                          .buildState.message ??
-                        taxonomyStore.graphManagerState.graph.buildState
-                          .message}
+                        taxonomyStore.graphManagerState.systemBuildState
+                          .message ??
+                        taxonomyStore.graphManagerState.dependenciesBuildState
+                          .message ??
+                        taxonomyStore.graphManagerState.generationsBuildState
+                          .message ??
+                        taxonomyStore.graphManagerState.graphBuildState.message}
                     </BlankPanelContent>
                   </div>
                 )}

--- a/packages/legend-taxonomy/src/stores/LegendTaxonomyStore.ts
+++ b/packages/legend-taxonomy/src/stores/LegendTaxonomyStore.ts
@@ -239,7 +239,9 @@ export class TaxonomyNodeViewerState {
         this.taxonomyStore.graphManagerState.createEmptyDependencyManager();
       this.taxonomyStore.graphManagerState.graph.dependencyManager =
         dependencyManager;
-      dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+      this.taxonomyStore.graphManagerState.dependenciesBuildState.setMessage(
+        `Fetching dependencies...`,
+      );
       const dependencyEntitiesMap = new Map<string, Entity[]>();
       (
         (yield this.taxonomyStore.depotServerClient.getDependencyEntities(
@@ -263,6 +265,7 @@ export class TaxonomyNodeViewerState {
           this.taxonomyStore.graphManagerState.systemModel,
           dependencyManager,
           dependencyEntitiesMap,
+          this.taxonomyStore.graphManagerState.dependenciesBuildState,
         )) as GraphBuilderReport;
       dependency_buildReport.timings[
         GRAPH_MANAGER_EVENT.GRAPH_DEPENDENCIES_FETCHED
@@ -273,6 +276,7 @@ export class TaxonomyNodeViewerState {
         (yield this.taxonomyStore.graphManagerState.graphManager.buildGraph(
           this.taxonomyStore.graphManagerState.graph,
           entities,
+          this.taxonomyStore.graphManagerState.graphBuildState,
         )) as GraphBuilderReport;
       graph_buildReport.timings[GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED] =
         stopWatch.getRecord(GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED);
@@ -806,7 +810,9 @@ export class LegendTaxonomyStore {
       const dependencyManager =
         this.graphManagerState.createEmptyDependencyManager();
       this.graphManagerState.graph.dependencyManager = dependencyManager;
-      dependencyManager.buildState.setMessage(`Fetching dependencies...`);
+      this.graphManagerState.dependenciesBuildState.setMessage(
+        `Fetching dependencies...`,
+      );
       const dependencyEntitiesMap = new Map<string, Entity[]>();
       (
         (yield this.depotServerClient.getDependencyEntities(
@@ -829,6 +835,7 @@ export class LegendTaxonomyStore {
           this.graphManagerState.systemModel,
           dependencyManager,
           dependencyEntitiesMap,
+          this.graphManagerState.dependenciesBuildState,
         )) as GraphBuilderReport;
       dependency_buildReport.timings[
         GRAPH_MANAGER_EVENT.GRAPH_DEPENDENCIES_FETCHED
@@ -839,6 +846,7 @@ export class LegendTaxonomyStore {
         (yield this.graphManagerState.graphManager.buildGraph(
           this.graphManagerState.graph,
           entities,
+          this.graphManagerState.graphBuildState,
         )) as GraphBuilderReport;
       graph_buildReport.timings[GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED] =
         stopWatch.getRecord(GRAPH_MANAGER_EVENT.GRAPH_ENTITIES_FETCHED);


### PR DESCRIPTION
## Summary

- [x] Cleanup unnecessary `mobx` usage in `@finos/legend-graph`, practically from this moment, the core graph does not use `mobx` at all; only `graph manager` does
- [x] For fields of `metamodels` that we added to support better graph navigation (i.e. `owner`, `parent`, etc.) that are not in the actual metamodels, we should prefix them with, `_`, e.g. `_OWNER`, `_UUID`, `_PARENT`. Also make these fields `readonly`
- [x] Move `buildState` out of `BasicModel` and `DependencyManager`, pass it in as parameter, move them into `GraphManagerState`
- [x] Move synthetic `enum` out of model directories `protocols/pure/v1/model, metamodels`: these enums are not native to the metamodel, but was added originally for `Studio` needs
- [x] Refactor to use reference in: `LocalMappingPropertyInfo.localMappingPropertyType`
- [x] Introduced `OptionalSetImplementationReference`

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

