### PR TITLE
minor fixes

### DIFF
--- a/.changeset/shy-glasses-press.md
+++ b/.changeset/shy-glasses-press.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-manual-tests': patch
+---

--- a/.changeset/swift-pots-call.md
+++ b/.changeset/swift-pots-call.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+'@finos/legend-manual-tests': patch
+'@finos/legend-studio': patch
+---

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "glob-parent": "^6.0.1"
   },
   "devDependencies": {
-    "@actions/core": "1.8.1",
-    "@actions/github": "5.0.2",
+    "@actions/core": "1.8.2",
+    "@actions/github": "5.0.3",
     "@babel/core": "7.17.10",
     "@changesets/cli": "2.22.0",
     "@finos/babel-preset-legend-studio": "workspace:*",
@@ -107,7 +107,6 @@
     "semver": "7.3.7",
     "sort-package-json": "1.57.0",
     "stylelint": "14.8.2",
-    "tunnel": "0.0.6",
     "typescript": "4.6.4",
     "yargs": "17.5.0"
   },

--- a/packages/legend-graph/src/__tests__/roundtripTestData/TEST_DATA__RelationalRoundtrip.ts
+++ b/packages/legend-graph/src/__tests__/roundtripTestData/TEST_DATA__RelationalRoundtrip.ts
@@ -4055,6 +4055,7 @@ export const TEST_DATA__RelationalDatabaseConnectionRoundtrip = [
         authenticationStrategy: {
           _type: 'gcpApplicationDefaultCredentials',
         },
+        databaseType: 'BigQuery',
         datasourceSpecification: {
           _type: 'bigQuery',
           defaultDataset: 'legend_testing_dataset',

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
@@ -86,6 +86,9 @@ const EXCLUSIONS: { [key: string]: ROUNTRIP_TEST_PHASES[] | typeof SKIP } = {
     ROUNTRIP_TEST_PHASES.PROTOCOL_ROUNDTRIP,
   ],
 
+  // TODO: Unskip this test when we merge https://github.com/finos/legend-studio/pull/1108
+  'DSLPersistence-basic.pure': SKIP,
+
   // TODO: Unskip once https://github.com/finos/legend-engine/pull/658 is resolved
   'relational-dataElement.pure': SKIP,
 };

--- a/packages/legend-studio/src/components/editor/ActivityBar.tsx
+++ b/packages/legend-studio/src/components/editor/ActivityBar.tsx
@@ -34,7 +34,6 @@ import {
   CodeBranchIcon,
   EmptyClockIcon,
   WrenchIcon,
-  FlaskIcon,
 } from '@finos/legend-art';
 import { useEditorStore } from './EditorStoreProvider';
 import { forwardRef } from 'react';
@@ -246,11 +245,11 @@ export const ActivityBar = observer(() => {
       title: 'Workflow Manager',
       icon: <WrenchIcon />,
     },
-    !editorStore.isInConflictResolutionMode && {
-      mode: ACTIVITY_MODE.GLOBAL_TEST_RUNNER,
-      title: 'Global Test Runner',
-      icon: <FlaskIcon />,
-    },
+    // !editorStore.isInConflictResolutionMode && {
+    //   mode: ACTIVITY_MODE.GLOBAL_TEST_RUNNER,
+    //   title: 'Global Test Runner',
+    //   icon: <FlaskIcon />,
+    // },
   ].filter((activity): activity is ActivityDisplay => Boolean(activity));
 
   return (

--- a/packages/legend-studio/src/components/editor/side-bar/testable/__tests__/GlobalTestRunner.test.tsx
+++ b/packages/legend-studio/src/components/editor/side-bar/testable/__tests__/GlobalTestRunner.test.tsx
@@ -36,7 +36,8 @@ beforeEach(async () => {
     entities: TEST_DATA__RelationalServiceTestable,
   });
 });
-test(
+
+test.skip(
   integrationTest('Test navigation on gloabl test runner explorer'),
   async () => {
     const globalTestRunnerButton =

--- a/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -58,7 +58,10 @@ import {
 } from './FlatDataInstanceSetImplementationState';
 import type { TreeNodeData, TreeData } from '@finos/legend-art';
 import { UnsupportedInstanceSetImplementationState } from './UnsupportedInstanceSetImplementationState';
-import { RootRelationalInstanceSetImplementationState } from './relational/RelationalInstanceSetImplementationState';
+import {
+  RelationalInstanceSetImplementationState,
+  RootRelationalInstanceSetImplementationState,
+} from './relational/RelationalInstanceSetImplementationState';
 import {
   type CompilationError,
   type PackageableElement,
@@ -1236,14 +1239,9 @@ export class MappingEditorState extends ElementEditorState {
               `Can't reveal compilation error: mapping ID is missing`,
             ),
           );
-          // NOTE: Unfortunately this is quite convoluted at the moment that is because we maintain a separate state
-          // that wraps around property mapping, this is deliberate as we don't want to mix UI state in metamodel classes
-          // in the future if this gets bigger, we might need to move this out to `MappingElementState`
-          if (
-            newMappingElement instanceof PureInstanceSetImplementation ||
-            newMappingElement instanceof FlatDataInstanceSetImplementation ||
-            newMappingElement instanceof EmbeddedFlatDataPropertyMapping
-          ) {
+          // TODO: take care of operation mapping using systematic coordinates
+          // See https://github.com/finos/legend-studio/issues/1168
+          if (newMappingElement instanceof InstanceSetImplementation) {
             const propertyMapping = findPropertyMapping(
               newMappingElement,
               guaranteeNonNullable(
@@ -1260,10 +1258,14 @@ export class MappingEditorState extends ElementEditorState {
                 this.openMappingElement(newMappingElement, false);
               }
               if (
+                // TODO: take care of operation mapping using systematic coordinates
+                // See https://github.com/finos/legend-studio/issues/1168
                 this.currentTabState instanceof
                   PureInstanceSetImplementationState ||
                 this.currentTabState instanceof
-                  FlatDataInstanceSetImplementationState
+                  FlatDataInstanceSetImplementationState ||
+                this.currentTabState instanceof
+                  RelationalInstanceSetImplementationState
               ) {
                 const propertyMappingState: LambdaEditorState | undefined = (
                   this.currentTabState.propertyMappingStates as unknown[]

--- a/scripts/github-bot/package.json
+++ b/scripts/github-bot/package.json
@@ -14,8 +14,8 @@
     "lint:js": "echo \"Skipped - already done as part of linting ./scripts\""
   },
   "dependencies": {
-    "@actions/core": "1.8.1",
-    "@actions/github": "5.0.2",
+    "@actions/core": "1.8.2",
+    "@actions/github": "5.0.3",
     "chalk": "5.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,31 +5,33 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@actions/core@npm:1.8.1":
-  version: 1.8.1
-  resolution: "@actions/core@npm:1.8.1"
+"@actions/core@npm:1.8.2":
+  version: 1.8.2
+  resolution: "@actions/core@npm:1.8.2"
   dependencies:
-    "@actions/http-client": ^2.0.0
-  checksum: 9a3758528e32a951d457cf29494125360251a3631bc63af9465895ab5749a55b85db043226c39c260b8d931c16a237156051e40a7351d484ab2f7249f82fa3bf
+    "@actions/http-client": ^2.0.1
+  checksum: 1cd1a47f751501900a579e641565bbe13a09d626507a4fa46b51e6a959a74a89134490ae7311570ed8ec1735ada83bcfde81a456ea4d2e24e323c16e94e39fd1
   languageName: node
   linkType: hard
 
-"@actions/github@npm:5.0.2":
-  version: 5.0.2
-  resolution: "@actions/github@npm:5.0.2"
+"@actions/github@npm:5.0.3":
+  version: 5.0.3
+  resolution: "@actions/github@npm:5.0.3"
   dependencies:
-    "@actions/http-client": ^2.0.0
+    "@actions/http-client": ^2.0.1
     "@octokit/core": ^3.6.0
     "@octokit/plugin-paginate-rest": ^2.17.0
     "@octokit/plugin-rest-endpoint-methods": ^5.13.0
-  checksum: fb6c4cda9e55d10533ad091b0d001c13083057c127fcc7d6c287c0ae35d7a5f78eecd829c57a1224880d109a943d4a788c019215bde8ff4d811b36c5a71b72f9
+  checksum: 1d8e8c5c351dd069a96b1ec39c8f609a2bbcb135d69bb8d9bb5c00752bdff81ec6d67ca90eb77dedc657cd630af484538f881c16eb5b008fd3ee5f430d0c38d2
   languageName: node
   linkType: hard
 
-"@actions/http-client@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@actions/http-client@npm:2.0.0"
-  checksum: ac0818271563f3608601a4781014a2df98be4324adac43572509846066e64329637c2f4982624de99ff1df4a92911d393f5978ae3a779e26639e031dba593e6f
+"@actions/http-client@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@actions/http-client@npm:2.0.1"
+  dependencies:
+    tunnel: ^0.0.6
+  checksum: 799ec3df91e28a9da91ce6592e94f8b8923ccf6cc21a2f72c7429be5af5273f1625335411adc2a1bb222d56c852d5767214dfa6fa32a6da7e81dba8290e08f17
   languageName: node
   linkType: hard
 
@@ -2357,8 +2359,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/legend-internal-github-bot@workspace:scripts/github-bot"
   dependencies:
-    "@actions/core": 1.8.1
-    "@actions/github": 5.0.2
+    "@actions/core": 1.8.2
+    "@actions/github": 5.0.3
     chalk: 5.0.1
   languageName: unknown
   linkType: soft
@@ -10130,8 +10132,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "legend-studio@workspace:."
   dependencies:
-    "@actions/core": 1.8.1
-    "@actions/github": 5.0.2
+    "@actions/core": 1.8.2
+    "@actions/github": 5.0.3
     "@babel/core": 7.17.10
     "@changesets/cli": 2.22.0
     "@finos/babel-preset-legend-studio": "workspace:*"
@@ -10157,7 +10159,6 @@ __metadata:
     semver: 7.3.7
     sort-package-json: 1.57.0
     stylelint: 14.8.2
-    tunnel: 0.0.6
     typescript: 4.6.4
     yargs: 17.5.0
   languageName: unknown
@@ -15297,7 +15298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tunnel@npm:0.0.6":
+"tunnel@npm:^0.0.6":
   version: 0.0.6
   resolution: "tunnel@npm:0.0.6"
   checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa


### PR DESCRIPTION
## Summary

- [x] Properly reveal compilation error for relational property mapping (like what we did for M2M and FlatData)
- [x] temporarily disable grammar roundtrip test for persistence DSL
- [x] fix broken test introduced by #1010 
- [x] revert the workaround introduced in #1162
- [x] Temporarily disable broken `DSL Persistence` grammar roundtrip test
- [x] Temporarily hide `global test runner` from activity bar 

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)
