### PR TITLE
Fix recursive viewing of parent class in explorer tree of query builder

### DIFF
--- a/.changeset/thirty-kids-begin.md
+++ b/.changeset/thirty-kids-begin.md
@@ -1,0 +1,5 @@
+---
+"@finos/legend-application-query": patch
+---
+
+Fix recursive viewing of parent class in explorer tree for associations ([#1172](https://github.com/finos/legend-studio/issues/1172)).

--- a/packages/legend-application-query/src/components/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderExplorerPanel.tsx
@@ -777,7 +777,9 @@ const QueryBuilderExplorerTree = observer(
                 explorerState.mappingModelCoverageAnalysisResult,
               ),
             );
-            treeData.nodes.set(propertyTreeNodeData.id, propertyTreeNodeData);
+            if (propertyTreeNodeData) {
+              treeData.nodes.set(propertyTreeNodeData.id, propertyTreeNodeData);
+            }
           });
           node.type._subclasses.forEach((subclass) => {
             const subTypeTreeNodeData = getQueryBuilderSubTypeNodeData(

--- a/packages/legend-application-query/src/components/QueryBuilderPropertySearchPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderPropertySearchPanel.tsx
@@ -169,6 +169,7 @@ const QueryBuilderTreeNodeViewer = observer(
               ),
             );
             if (
+              propertyTreeNodeData &&
               !(propertyTreeNodeData.type instanceof Class) &&
               propertyTreeNodeData.mappingData.mapped
             ) {

--- a/packages/legend-application-query/src/stores/QueryBuilderPropertySearchPanelState.ts
+++ b/packages/legend-application-query/src/stores/QueryBuilderPropertySearchPanelState.ts
@@ -262,7 +262,7 @@ export class QueryBuilderPropertySearchPanelState {
                 ),
               );
               if (
-                propertyTreeNodeData.mappingData.mapped &&
+                propertyTreeNodeData?.mappingData.mapped &&
                 !propertyTreeNodeData.isPartOfDerivedPropertyBranch
               ) {
                 nextLevelPropertyNodes.push(propertyTreeNodeData);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Closes #1172 
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

***Model Data for Association***
```
###Relational
Database my::db
(
  Table PersonTable
  (
    NAME CHAR(200),
    FIRMID INTEGER
  )
  Table FirmTable
  (
    FIRMNAME CHAR(200),
    ID INTEGER
  )

  Join Firm_Person(PersonTable.FIRMID = FirmTable.ID)
)


###Pure
Class my::Firm
{
  legalName: String[1];
  id: Integer[1];
}

Class my::Person
{
  name: String[1];
  firmID: Integer[1];
}

Association my::Employment
{
  firm: my::Firm[*];
  employees: my::Person[*];
}


###Mapping
Mapping my::map
(
  my::Person[per1]: Relational
  {
    ~mainTable [my::db]PersonTable
    name: [my::db]PersonTable.NAME
  }
  my::Firm[fir1]: Relational
  {
    ~mainTable [my::db]FirmTable
    legalName: [my::db]FirmTable.FIRMNAME
  }

  my::Employment: Relational
  {
    AssociationMapping
    (
      firm[per1,fir1]: [my::db]@Firm_Person,
      employees[fir1,per1]: [my::db]@Firm_Person
    )
  }
)
```
![pic](https://user-images.githubusercontent.com/87973126/182566227-d92d5798-49dd-4836-9a01-acdd3745ad42.PNG)


<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
