### PR TITLE
Partial revert of #1241

### DIFF
--- a/.changeset/cool-zoos-repair.md
+++ b/.changeset/cool-zoos-repair.md
@@ -1,5 +1,0 @@
----
-'@finos/legend-studio': minor
----
-
-Allow the project dependency configuration to contain `HEAD` as a alid version option and added restrictions on review-creation to ensure no project dependency is set to the `HEAD` option in the project.

--- a/.changeset/four-lobsters-search.md
+++ b/.changeset/four-lobsters-search.md
@@ -1,3 +1,0 @@
----
-'@finos/legend-server-depot': patch
----

--- a/.changeset/hungry-dots-brush.md
+++ b/.changeset/hungry-dots-brush.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-mapping-generation': patch
+'@finos/legend-server-sdlc': patch
+'@finos/legend-studio': patch
+---

--- a/.changeset/testing-water-fix.md
+++ b/.changeset/testing-water-fix.md
@@ -1,4 +1,0 @@
----
-'@finos/legend-server-sdlc': major
----
-**BREAKING CHANGE:** Change `versionId` in `ProjectDependency` to be of string format.

--- a/packages/legend-extension-mapping-generation/src/components/MappingGenerationEditor.tsx
+++ b/packages/legend-extension-mapping-generation/src/components/MappingGenerationEditor.tsx
@@ -42,7 +42,7 @@ import {
 import type { MappingGenerationEditorState } from '../stores/MappingGenerationEditorState.js';
 import { flowResult, runInAction } from 'mobx';
 import {
-  Mapping,
+  type Mapping,
   createValidationError,
   isStubbed_PackageableElement,
   stub_Mapping,

--- a/packages/legend-server-sdlc/src/models/configuration/ProjectDependency.ts
+++ b/packages/legend-server-sdlc/src/models/configuration/ProjectDependency.ts
@@ -20,7 +20,9 @@ import {
   hashArray,
   uuid,
   SerializationFactory,
+  usingModelSchema,
 } from '@finos/legend-shared';
+import { VersionId } from '../version/VersionId.js';
 import { observable, action, computed, makeObservable } from 'mobx';
 
 const PROJECT_DEPENDENCY_HASH_STRUCTURE = 'PROJECT_DEPENDENCY';
@@ -28,9 +30,9 @@ const PROJECT_DEPENDENCY_HASH_STRUCTURE = 'PROJECT_DEPENDENCY';
 export class ProjectDependency implements Hashable {
   readonly _UUID = uuid();
   projectId: string;
-  versionId: string;
+  versionId: VersionId;
 
-  constructor(projectId: string, versionId?: string) {
+  constructor(projectId: string, versionId?: VersionId) {
     makeObservable(this, {
       projectId: observable,
       versionId: observable,
@@ -40,13 +42,13 @@ export class ProjectDependency implements Hashable {
     });
 
     this.projectId = projectId;
-    this.versionId = versionId ?? '0.0.0';
+    this.versionId = versionId ?? new VersionId();
   }
 
   static readonly serialization = new SerializationFactory(
     createModelSchema(ProjectDependency, {
       projectId: primitive(),
-      versionId: primitive(),
+      versionId: usingModelSchema(VersionId.serialization.schema),
     }),
   );
 
@@ -55,7 +57,7 @@ export class ProjectDependency implements Hashable {
   }
 
   setVersionId(id: string): void {
-    this.versionId = id;
+    this.versionId.setId(id);
   }
 
   get isLegacyDependency(): boolean {
@@ -80,7 +82,9 @@ export class ProjectDependency implements Hashable {
     return hashArray([
       PROJECT_DEPENDENCY_HASH_STRUCTURE,
       this.projectId,
-      this.versionId,
+      this.versionId.majorVersion.toString(),
+      this.versionId.minorVersion.toString(),
+      this.versionId.patchVersion.toString(),
     ]);
   }
 }

--- a/packages/legend-studio/src/components/editor/edit-panel/__tests__/ProjectConfigurationEditor.test.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/__tests__/ProjectConfigurationEditor.test.tsx
@@ -41,11 +41,19 @@ const TEST_DATA__ProjectConfiguration = {
   projectDependencies: [
     {
       projectId: 'PROD-1',
-      versionId: '2.0.0',
+      versionId: {
+        majorVersion: 2,
+        minorVersion: 0,
+        patchVersion: 0,
+      },
     },
     {
       projectId: 'org.finos.legend:prod-2',
-      versionId: '3.0.0',
+      versionId: {
+        majorVersion: 3,
+        minorVersion: 0,
+        patchVersion: 0,
+      },
     },
   ],
   metamodelDependencies: [],

--- a/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
+++ b/packages/legend-studio/src/components/editor/edit-panel/project-configuration-editor/ProjectConfigurationEditor.tsx
@@ -50,8 +50,6 @@ import {
 } from '@finos/legend-application';
 import { LEGEND_STUDIO_APP_EVENT } from '../../../../stores/LegendStudioAppEvent.js';
 import {
-  SNAPSHOT_VERSION_ALIAS,
-  MASTER_SNAPSHOT_ALIAS,
   type ProjectData,
   compareSemVerVersions,
   generateGAVCoordinates,
@@ -234,16 +232,12 @@ const ProjectDependencyEditor = observer(
     // version
     const version = projectDependency.versionId;
     const versions = selectedProject?.versions ?? [];
-    let versionOptions = versions
+    const versionOptions = versions
       .slice()
       .sort((v1, v2) => compareSemVerVersions(v2, v1))
       .map((v) => ({ value: v, label: v }));
-    versionOptions = [
-      { label: SNAPSHOT_VERSION_ALIAS, value: MASTER_SNAPSHOT_ALIAS },
-      ...versionOptions,
-    ];
     const selectedVersionOption: VersionOption | null =
-      versionOptions.find((v) => v.value === version) ?? null;
+      versionOptions.find((v) => v.value === version.id) ?? null;
     const versionDisabled =
       Boolean(!versions.length || !projectDependency.projectId.length) ||
       !configState.associatedProjectsAndVersionsFetched ||
@@ -269,17 +263,13 @@ const ProjectDependencyEditor = observer(
     };
     const openProject = (): void => {
       if (!projectDependency.isLegacyDependency) {
-        const projectDependencyVersionId =
-          projectDependency.versionId === MASTER_SNAPSHOT_ALIAS
-            ? SNAPSHOT_VERSION_ALIAS
-            : projectDependency.versionId;
         applicationStore.navigator.openNewWindow(
           `${
             applicationStore.config.baseUrl
           }view/archive/${generateGAVCoordinates(
             guaranteeNonNullable(projectDependency.groupId),
             guaranteeNonNullable(projectDependency.artifactId),
-            projectDependencyVersionId,
+            projectDependency.versionId.id,
           )}`,
         );
       }

--- a/packages/legend-studio/src/stores/EditorGraphState.ts
+++ b/packages/legend-studio/src/stores/EditorGraphState.ts
@@ -1111,7 +1111,7 @@ export class EditorGraphState {
               return new ProjectDependencyCoordinates(
                 projectData.groupId,
                 projectData.artifactId,
-                dep.versionId,
+                dep.versionId.id,
               );
             });
         } else {
@@ -1119,7 +1119,7 @@ export class EditorGraphState {
             new ProjectDependencyCoordinates(
               guaranteeNonNullable(dep.groupId),
               guaranteeNonNullable(dep.artifactId),
-              dep.versionId,
+              dep.versionId.id,
             ),
           );
         }

--- a/packages/legend-studio/src/stores/__tests__/ProjectDependencyManager.test.ts
+++ b/packages/legend-studio/src/stores/__tests__/ProjectDependencyManager.test.ts
@@ -122,11 +122,19 @@ const PROJECT_CONFIG = {
   projectDependencies: [
     {
       projectId: 'PROD_1',
-      versionId: '1.0.0',
+      versionId: {
+        majorVersion: 1,
+        minorVersion: 0,
+        patchVersion: 0,
+      },
     },
     {
       projectId: 'groupId:artifactId',
-      versionId: '1.0.0',
+      versionId: {
+        majorVersion: 1,
+        minorVersion: 0,
+        patchVersion: 0,
+      },
     },
   ],
   metamodelDependencies: [],

--- a/packages/legend-studio/src/stores/editor-state/ProjectConfigurationEditorState.ts
+++ b/packages/legend-studio/src/stores/editor-state/ProjectConfigurationEditorState.ts
@@ -125,7 +125,7 @@ export class ProjectConfigurationEditorState extends EditorState {
   get containsSnapshotDependencies(): boolean {
     return Boolean(
       this.originalProjectConfiguration?.projectDependencies.some(
-        (dependency) => dependency.versionId === MASTER_SNAPSHOT_ALIAS,
+        (dependency) => dependency.versionId.id === MASTER_SNAPSHOT_ALIAS,
       ),
     );
   }


### PR DESCRIPTION
Partial revert of "allow specifying `HEAD` as project dependency version for workspace (#1241)" - we want to release a version without this change first to prioritize releasing https://github.com/finos/legend-studio/pull/1248