### PR TITLE
Warn users that they lose their query changes when exiting query builder

### DIFF
--- a/.changeset/neat-olives-fetch.md
+++ b/.changeset/neat-olives-fetch.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-query': patch
+---

--- a/.changeset/nervous-trainers-act.md
+++ b/.changeset/nervous-trainers-act.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-studio-extension-query-builder': patch
+---
+
+Warn users that they lose their query changes when exiting query builder ([#1274](https://github.com/finos/legend-studio/issues/1274)).

--- a/.changeset/wicked-carrots-cover.md
+++ b/.changeset/wicked-carrots-cover.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-graph': patch
+---

--- a/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graphManager/AbstractPureGraphManager.ts
@@ -211,6 +211,9 @@ export abstract class AbstractPureGraphManager {
   abstract pureCodeToLambda(
     lambda: string,
     lambdaId?: string,
+    options?: {
+      pruneSourceInformation?: boolean;
+    },
   ): Promise<RawLambda>;
   abstract lambdaToPureCode(
     lambda: RawLambda,

--- a/packages/legend-graph/src/models/protocols/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/V1_PureGraphManager.ts
@@ -1463,8 +1463,15 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
   async pureCodeToLambda(
     lambda: string,
     lambdaId?: string,
+    options?: {
+      pruneSourceInformation?: boolean;
+    },
   ): Promise<RawLambda> {
-    const result = await this.engine.transformCodeToLambda(lambda, lambdaId);
+    const result = await this.engine.transformCodeToLambda(
+      lambda,
+      lambdaId,
+      options,
+    );
     return new RawLambda(result.parameters, result.body);
   }
 

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_Engine.ts
@@ -299,7 +299,9 @@ export class V1_Engine {
         lambdaId ?? '',
         undefined,
         undefined,
-        !options?.pruneSourceInformation ?? true,
+        options?.pruneSourceInformation !== undefined
+          ? !options?.pruneSourceInformation
+          : true,
       )) as unknown as V1_RawLambda;
     } catch (error) {
       assertErrorThrown(error);

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_Engine.ts
@@ -289,6 +289,9 @@ export class V1_Engine {
   async transformCodeToLambda(
     code: string,
     lambdaId?: string,
+    options?: {
+      pruneSourceInformation?: boolean;
+    },
   ): Promise<V1_RawLambda> {
     try {
       return (await this.engineServerClient.grammarToJSON_lambda(
@@ -296,7 +299,7 @@ export class V1_Engine {
         lambdaId ?? '',
         undefined,
         undefined,
-        true,
+        !options?.pruneSourceInformation ?? true,
       )) as unknown as V1_RawLambda;
     } catch (error) {
       assertErrorThrown(error);

--- a/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-graph/src/models/protocols/pure/v1/engine/V1_Engine.ts
@@ -300,7 +300,7 @@ export class V1_Engine {
         undefined,
         undefined,
         options?.pruneSourceInformation !== undefined
-          ? !options?.pruneSourceInformation
+          ? !options.pruneSourceInformation
           : true,
       )) as unknown as V1_RawLambda;
     } catch (error) {

--- a/packages/legend-query/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderState.ts
@@ -22,6 +22,7 @@ import {
   guaranteeNonNullable,
   guaranteeType,
   filterByType,
+  hashObject,
 } from '@finos/legend-shared';
 import {
   type QueryBuilderFilterOperator,
@@ -149,6 +150,24 @@ export class StandardQueryBuilderMode extends QueryBuilderMode {
   }
 }
 
+class QueryBuilderChangeDetectionState {
+  querybuildState: QueryBuilderState;
+  queryHashCode = hashObject(new RawLambda(undefined, undefined));
+  isEnabled = false;
+
+  constructor(queryBuilderState: QueryBuilderState) {
+    this.querybuildState = queryBuilderState;
+  }
+
+  setQueryHashCode(val: string): void {
+    this.queryHashCode = val;
+  }
+
+  setIsEnabled(val: boolean): void {
+    this.isEnabled = val;
+  }
+}
+
 export class QueryBuilderState {
   applicationStore: ApplicationStore<LegendApplicationConfig>;
   graphManagerState: GraphManagerState;
@@ -207,6 +226,7 @@ export class QueryBuilderState {
   showFunctionPanel = false;
   showParameterPanel = false;
   showPostFilterPanel = false;
+  changeDetectionState: QueryBuilderChangeDetectionState;
 
   constructor(
     applicationStore: ApplicationStore<LegendApplicationConfig>,
@@ -231,6 +251,7 @@ export class QueryBuilderState {
       showFunctionPanel: observable,
       showParameterPanel: observable,
       showPostFilterPanel: observable,
+      changeDetectionState: observable,
       setMode: action,
       resetQueryBuilder: action,
       resetQuerySetup: action,
@@ -266,6 +287,7 @@ export class QueryBuilderState {
     this.observableContext = new ObserverContext(
       this.graphManagerState.pluginManager.getPureGraphManagerPlugins(),
     );
+    this.changeDetectionState = new QueryBuilderChangeDetectionState(this);
   }
 
   setMode(val: QueryBuilderMode): void {

--- a/packages/legend-query/src/stores/QueryTextEditorState.ts
+++ b/packages/legend-query/src/stores/QueryTextEditorState.ts
@@ -105,6 +105,7 @@ export class QueryTextEditorState extends LambdaEditorState {
           (yield this.queryBuilderState.graphManagerState.graphManager.pureCodeToLambda(
             this.fullLambdaString,
             this.lambdaId,
+            { pruneSourceInformation: true },
           )) as RawLambda;
         this.setParserError(undefined);
         this.rawLambdaState.setLambda(lambda);

--- a/packages/legend-studio-extension-query-builder/src/components/MappingExecutionQueryBuilder.tsx
+++ b/packages/legend-studio-extension-query-builder/src/components/MappingExecutionQueryBuilder.tsx
@@ -23,7 +23,7 @@ import { observer } from 'mobx-react-lite';
 import { QueryBuilder_EditorExtensionState } from '../stores/QueryBuilder_EditorExtensionState.js';
 import { useApplicationStore } from '@finos/legend-application';
 import { QueryBuilderMode } from '@finos/legend-query';
-import { assertErrorThrown } from '@finos/legend-shared';
+import { assertErrorThrown, hashObject } from '@finos/legend-shared';
 import { PencilIcon } from '@finos/legend-art';
 import { isStubbed_RawLambda } from '@finos/legend-graph';
 
@@ -64,6 +64,12 @@ export const MappingExecutionQueryBuilder = observer(
         queryBuilderExtension.queryBuilderState.initialize(
           executionState.queryState.query,
         );
+        queryBuilderExtension.queryBuilderState.changeDetectionState.setQueryHashCode(
+          hashObject(executionState.queryState.query),
+        );
+        queryBuilderExtension.queryBuilderState.changeDetectionState.setIsEnabled(
+          true,
+        );
         await flowResult(
           queryBuilderExtension.setEmbeddedQueryBuilderMode({
             actionConfigs: [
@@ -80,6 +86,9 @@ export const MappingExecutionQueryBuilder = observer(
                         );
                         applicationStore.notifySuccess(
                           `Mapping execution query is updated`,
+                        );
+                        queryBuilderExtension.queryBuilderState.changeDetectionState.setQueryHashCode(
+                          hashObject(rawLambda),
                         );
                         queryBuilderExtension.setEmbeddedQueryBuilderMode(
                           undefined,

--- a/packages/legend-studio-extension-query-builder/src/components/MappingTestQueryBuilder.tsx
+++ b/packages/legend-studio-extension-query-builder/src/components/MappingTestQueryBuilder.tsx
@@ -20,7 +20,7 @@ import { observer } from 'mobx-react-lite';
 import { QueryBuilder_EditorExtensionState } from '../stores/QueryBuilder_EditorExtensionState.js';
 import { useApplicationStore } from '@finos/legend-application';
 import { MappingExecutionQueryBuilderMode } from './MappingExecutionQueryBuilder.js';
-import { assertErrorThrown } from '@finos/legend-shared';
+import { assertErrorThrown, hashObject } from '@finos/legend-shared';
 import { PencilIcon } from '@finos/legend-art';
 import { isStubbed_RawLambda } from '@finos/legend-graph';
 
@@ -51,6 +51,12 @@ export const MappingTestQueryBuilder = observer(
         queryBuilderExtension.queryBuilderState.initialize(
           testState.queryState.query,
         );
+        queryBuilderExtension.queryBuilderState.changeDetectionState.setQueryHashCode(
+          hashObject(testState.queryState.query),
+        );
+        queryBuilderExtension.queryBuilderState.changeDetectionState.setIsEnabled(
+          true,
+        );
         await flowResult(
           queryBuilderExtension.setEmbeddedQueryBuilderMode({
             actionConfigs: [
@@ -67,6 +73,9 @@ export const MappingTestQueryBuilder = observer(
                         );
                         applicationStore.notifySuccess(
                           `Mapping test query is updated`,
+                        );
+                        queryBuilderExtension.queryBuilderState.changeDetectionState.setQueryHashCode(
+                          hashObject(rawLambda),
                         );
                         queryBuilderExtension.setEmbeddedQueryBuilderMode(
                           undefined,

--- a/packages/legend-studio-extension-query-builder/src/components/ServiceQueryBuilder.tsx
+++ b/packages/legend-studio-extension-query-builder/src/components/ServiceQueryBuilder.tsx
@@ -23,7 +23,7 @@ import { observer } from 'mobx-react-lite';
 import { QueryBuilder_EditorExtensionState } from '../stores/QueryBuilder_EditorExtensionState.js';
 import { useApplicationStore } from '@finos/legend-application';
 import { StandardQueryBuilderMode } from '@finos/legend-query';
-import { assertErrorThrown } from '@finos/legend-shared';
+import { assertErrorThrown, hashObject } from '@finos/legend-shared';
 import { PencilIcon } from '@finos/legend-art';
 import {
   isStubbed_RawLambda,
@@ -66,6 +66,12 @@ export const ServiceQueryBuilder = observer(
             queryBuilderExtension.queryBuilderState.initialize(
               executionState.execution.func,
             );
+            queryBuilderExtension.queryBuilderState.changeDetectionState.setQueryHashCode(
+              hashObject(executionState.execution.func),
+            );
+            queryBuilderExtension.queryBuilderState.changeDetectionState.setIsEnabled(
+              true,
+            );
             await flowResult(
               queryBuilderExtension.setEmbeddedQueryBuilderMode({
                 actionConfigs: [
@@ -82,6 +88,9 @@ export const ServiceQueryBuilder = observer(
                             );
                             applicationStore.notifySuccess(
                               `Service execution query is updated`,
+                            );
+                            queryBuilderExtension.queryBuilderState.changeDetectionState.setQueryHashCode(
+                              hashObject(rawLambda),
                             );
                             queryBuilderExtension.setEmbeddedQueryBuilderMode(
                               undefined,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Fixes https://github.com/finos/legend-studio/issues/1274
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

- [x] Do not alert when exiting query builder opened by right-clicking a class
- [x] only alert users when there are changes in query builder opened from a mapping-test or service

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->


https://user-images.githubusercontent.com/73408381/178505536-b26e446a-5189-4929-8caa-d9c9e4c731df.mov



<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
