### PR TITLE
Fix milestoned dates getting dropped for queries with derived properties of return type `class`

### DIFF
--- a/.changeset/wicked-worms-sniff.md
+++ b/.changeset/wicked-worms-sniff.md
@@ -1,0 +1,3 @@
+---
+"@finos/legend-query": patch
+---

--- a/packages/legend-query/src/stores/QueryBuilderLambdaBuilder.ts
+++ b/packages/legend-query/src/stores/QueryBuilderLambdaBuilder.ts
@@ -115,6 +115,16 @@ const isDefaultDatePropagationSupported = (
 ): boolean => {
   const property = currentPropertyExpression.func;
   const graph = queryBuilderState.graphManagerState.graph;
+  // Default date propagation is not supported for current expression when the previous property expression is a derived property.
+  if (
+    prevPropertyExpression &&
+    prevPropertyExpression.func instanceof DerivedProperty &&
+    prevPropertyExpression.func._OWNER.derivedProperties.includes(
+      prevPropertyExpression.func,
+    )
+  ) {
+    return false;
+  }
   // Default date propagation is not supported for current expression when the milestonedParameterValues of
   // the previous property expression doesn't match with the global milestonedParameterValues
   if (

--- a/packages/legend-query/src/stores/QueryBuilderPropertyEditorState.ts
+++ b/packages/legend-query/src/stores/QueryBuilderPropertyEditorState.ts
@@ -147,6 +147,14 @@ export const generateMilestonedPropertyParameterValue = (
   derivedPropertyExpressionState: QueryBuilderDerivedPropertyExpressionState,
   idx: number,
 ): ValueSpecification | undefined => {
+  // Milestoning transformations should not be done on actual derived properties.
+  if (
+    derivedPropertyExpressionState.derivedProperty._OWNER.derivedProperties.includes(
+      derivedPropertyExpressionState.derivedProperty,
+    )
+  ) {
+    return undefined;
+  }
   const querySetupState =
     derivedPropertyExpressionState.queryBuilderState.querySetupState;
   const temporalSource = getDerivedPropertyMilestoningSteoreotype(


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Closes #1276 
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

https://user-images.githubusercontent.com/87973126/178240417-3e02fb2e-2324-43bb-873e-8786f4860171.mp4



***Model Data used in Video***
```
###Relational
Database my::db
(
  Table PersonTable
  (
    NAME CHAR(200),
    FIRMID INTEGER,
    ID INTEGER
  )
  Table FirmTable
  (
    FIRMNAME CHAR(200),
    ID INTEGER
  )
  Table HobbyTable
  (
    NAME CHAR(200),
    ID INTEGER
  )

  Join Firm_Person(PersonTable.FIRMID = FirmTable.ID)
  Join Person_Hobby(PersonTable.ID = HobbyTable.ID)
)


###Pure
Class <<meta::pure::profiles::temporal.businesstemporal>> my::Firm
{
  legalName: String[1];
  id: Integer[1];
  employee: my::employee[1];
  derivedProp(date: StrictDate[1]) {$this.employee}: my::employee[1];
}

Class <<meta::pure::profiles::temporal.businesstemporal>> my::employee
{
  name: String[1];
  id: Integer[1];
  hobby: my::hobby[1];
}

Class <<meta::pure::profiles::temporal.businesstemporal>> my::hobby
{
  name: String[1];
  id: Integer[1];
}


###Mapping
Mapping my::map
(
  *my::Firm: Relational
  {
    ~mainTable [my::db]FirmTable
    legalName: [my::db]FirmTable.FIRMNAME,
    id: [my::db]FirmTable.ID,
    employee[my_employee]: [my::db]@Firm_Person
  }
  *my::employee: Relational
  {
    ~mainTable [my::db]PersonTable
    name: [my::db]PersonTable.NAME,
    id: [my::db]PersonTable.ID,
    hobby[my_hobby]: [my::db]@Person_Hobby
  }
  *my::hobby: Relational
  {
    ~mainTable [my::db]HobbyTable
    name: [my::db]HobbyTable.NAME,
    id: [my::db]HobbyTable.ID
  }
)


###Runtime
Runtime my::runtime
{
  mappings:
  [
    my::map
  ];
}
```
<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
