### PR TITLE
fix double building graph in create query

### DIFF
--- a/.changeset/tender-hotels-taste.md
+++ b/.changeset/tender-hotels-taste.md
@@ -1,0 +1,3 @@
+---
+"@finos/legend-query": patch
+---

--- a/packages/legend-query/src/components/LegendQueryEditor.tsx
+++ b/packages/legend-query/src/components/LegendQueryEditor.tsx
@@ -292,7 +292,9 @@ export const CreateQueryLoader = observer(() => {
       : undefined;
 
   useEffect(() => {
-    queryStore.setupCreateQueryInfoState(params);
+    if (queryStore.editorInitState.isInInitialState) {
+      queryStore.setupCreateQueryInfoState(params);
+    }
   }, [queryStore, params]);
 
   // TODO: this will make the route change as the users select another mapping and runtime


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
- Fix opening query builder via `createQuery` option with a class param as it loads the graph twice causing inconsistency in behavior and calling `mapping/modelCoverage` with empty graph. 



<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
