### PR TITLE
Add cloud extension for persistence DSL

### DIFF
--- a/.changeset/lemon-wasps-sell.md
+++ b/.changeset/lemon-wasps-sell.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-persistence-cloud': patch
+'@finos/legend-graph-extension-collection': patch
+'@finos/legend-studio-app': patch
+---

--- a/.changeset/ninety-lobsters-add.md
+++ b/.changeset/ninety-lobsters-add.md
@@ -1,5 +1,6 @@
 ---
 '@finos/legend-extension-dsl-persistence-cloud': patch
 '@finos/legend-graph-extension-collection': patch
+'@finos/legend-manual-tests': patch
 '@finos/legend-studio-app': patch
 ---

--- a/packages/legend-extension-dsl-persistence-cloud/.npmignore
+++ b/packages/legend-extension-dsl-persistence-cloud/.npmignore
@@ -1,0 +1,7 @@
+/build
+/style
+**/__mocks__/**
+**/__tests__/**
+/*.*
+!tsconfig.json
+!tsconfig.package.json

--- a/packages/legend-extension-dsl-persistence-cloud/README.md
+++ b/packages/legend-extension-dsl-persistence-cloud/README.md
@@ -1,0 +1,3 @@
+# @finos/legend-extension-dsl-persistence-cloud
+
+Legend extension for Persistence Cloud DSL

--- a/packages/legend-extension-dsl-persistence-cloud/_package.config.js
+++ b/packages/legend-extension-dsl-persistence-cloud/_package.config.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  publish: {
+    typescript: {
+      main: './tsconfig.publish.json',
+      others: ['./tsconfig.package.json'],
+    },
+  },
+};

--- a/packages/legend-extension-dsl-persistence-cloud/jest.config.js
+++ b/packages/legend-extension-dsl-persistence-cloud/jest.config.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getBaseJestDOMProjectConfig } from '../../scripts/test/jest.config.base.js';
+import { loadJSON } from '@finos/legend-dev-utils/DevUtils';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const packageJson = loadJSON(resolve(__dirname, './package.json'));
+
+export default getBaseJestDOMProjectConfig(
+  packageJson.name,
+  'packages/legend-extension-dsl-persistence-cloud',
+);

--- a/packages/legend-extension-dsl-persistence-cloud/package.json
+++ b/packages/legend-extension-dsl-persistence-cloud/package.json
@@ -1,30 +1,28 @@
 {
-  "name": "@finos/legend-studio-app",
-  "version": "6.7.0",
-  "description": "Legend Studio web application",
+  "name": "@finos/legend-extension-dsl-persistence-cloud",
+  "version": "2.0.6",
+  "description": "Legend extension for Persistence Cloud DSL",
   "keywords": [
     "legend",
-    "legend-studio",
-    "studio",
-    "app",
-    "webapp"
+    "legend-extension",
+    "dsl",
+    "dsl-persistence-cloud"
   ],
-  "homepage": "https://github.com/finos/legend-studio/tree/master/packages/legend-studio-app",
+  "homepage": "https://github.com/finos/legend-studio/tree/master/packages/legend-extension-dsl-persistence-cloud",
   "bugs": {
     "url": "https://github.com/finos/legend-studio/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/finos/legend-studio.git",
-    "directory": "packages/legend-studio-app"
+    "directory": "packages/legend-extension-dsl-persistence-cloud"
   },
   "license": "Apache-2.0",
   "sideEffects": false,
   "type": "module",
   "exports": {
     ".": "./lib/index.js",
-    "./lib/index.css": "./lib/index.css",
-    "./scripts/setup.js": "./scripts/setup.js"
+    "./lib/index.css": "./lib/index.css"
   },
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -36,39 +34,48 @@
     "clean:cache": "rimraf \"build\"",
     "clean:lib": "rimraf \"lib\"",
     "dev": "npm-run-all --parallel dev:sass dev:ts",
-    "dev:sass": "sass style:lib --watch --load-path=../../node_modules/@finos/legend-art/scss",
+    "dev:sass": "sass style lib --watch --load-path=../../node_modules/@finos/legend-art/scss",
     "dev:ts": "tsc --watch --preserveWatchOutput",
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location ./build/.eslintcache --report-unused-disable-directives --parser-options=project:\"./tsconfig.json\" \"./src/**/*.{js,ts,tsx}\"",
     "publish:prepare": "node ../../scripts/release/preparePublishContent.js",
-    "publish:snapshot": "node ../../scripts/release/publishDevSnapshot.js"
+    "publish:snapshot": "node ../../scripts/release/publishDevSnapshot.js",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@finos/legend-application": "workspace:*",
-    "@finos/legend-art": "workspace:*",
-    "@finos/legend-extension-dsl-data-space": "workspace:*",
-    "@finos/legend-extension-dsl-diagram": "workspace:*",
     "@finos/legend-extension-dsl-persistence": "workspace:*",
-    "@finos/legend-extension-dsl-persistence-cloud": "workspace:*",
-    "@finos/legend-extension-dsl-text": "workspace:*",
-    "@finos/legend-extension-external-language-morphir": "workspace:*",
-    "@finos/legend-extension-external-store-service": "workspace:*",
-    "@finos/legend-graph-extension-collection": "workspace:*",
+    "@finos/legend-graph": "workspace:*",
+    "@finos/legend-model-storage": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@finos/legend-studio-extension-query-builder": "workspace:*",
-    "@types/react": "18.0.15",
-    "react": "18.2.0"
+    "@types/react": "18.0.14",
+    "mobx": "6.6.1",
+    "react": "18.2.0",
+    "serializr": "2.0.5"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
+    "@jest/globals": "28.1.2",
     "cross-env": "7.0.3",
-    "eslint": "8.20.0",
+    "eslint": "8.19.0",
+    "jest": "28.1.2",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "sass": "1.53.0",
     "typescript": "4.7.4"
   },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
   "publishConfig": {
     "directory": "build/publishContent"
+  },
+  "extensions": {
+    "graphPreset": "@finos/legend-graph-preset-dsl-persistence-cloud",
+    "pureProtocolProcessorPlugin": "@finos/legend-graph-plugin-dsl-persistence-cloud-protocol-processor",
+    "pureGraphManagerPlugin": "@finos/legend-graph-plugin-dsl-persistence-cloud-pure-graph-manager",
+    "pureGraphPlugin": "@finos/legend-graph-plugin-dsl-persistence-cloud-pure-graph",
+    "studioPlugin": "@finos/legend-studio-plugin-dsl-persistence-cloud"
   }
 }

--- a/packages/legend-extension-dsl-persistence-cloud/package.json
+++ b/packages/legend-extension-dsl-persistence-cloud/package.json
@@ -49,7 +49,7 @@
     "@finos/legend-model-storage": "workspace:*",
     "@finos/legend-shared": "workspace:*",
     "@finos/legend-studio": "workspace:*",
-    "@types/react": "18.0.14",
+    "@types/react": "18.0.15",
     "mobx": "6.6.1",
     "react": "18.2.0",
     "serializr": "2.0.5"

--- a/packages/legend-extension-dsl-persistence-cloud/package.json
+++ b/packages/legend-extension-dsl-persistence-cloud/package.json
@@ -56,10 +56,10 @@
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",
-    "@jest/globals": "28.1.2",
+    "@jest/globals": "28.1.3",
     "cross-env": "7.0.3",
-    "eslint": "8.19.0",
-    "jest": "28.1.2",
+    "eslint": "8.20.0",
+    "jest": "28.1.3",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
     "sass": "1.53.0",

--- a/packages/legend-extension-dsl-persistence-cloud/src/DSLPersistenceCloud_Extension.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/DSLPersistenceCloud_Extension.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import packageJson from '../package.json';
+import { DSLPersistenceCloud_PureProtocolProcessorPlugin } from './models/protocols/pure/DSLPersistenceCloud_PureProtocolProcessorPlugin.js';
+import { AbstractPreset } from '@finos/legend-shared';
+
+export class DSLPersistenceCloud_GraphPreset extends AbstractPreset {
+  constructor() {
+    super(packageJson.extensions.graphPreset, packageJson.version, [
+      new DSLPersistenceCloud_PureProtocolProcessorPlugin(),
+    ]);
+  }
+}

--- a/packages/legend-extension-dsl-persistence-cloud/src/index.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './DSLPersistenceCloud_Extension.js';

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/DSLPersistenceCloud_ModelUtils.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/DSLPersistenceCloud_ModelUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum PERSISTENCE_CLOUD_HASH_STRUCTURE {
+  AWS_GLUE_PERSISTENCE_PLATFORM = 'AWS_GLUE_PERSISTENCE_PLATFORM',
+}

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/__tests__/DSLPersistenceCloud_Roundtrip.test.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/__tests__/DSLPersistenceCloud_Roundtrip.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test } from '@jest/globals';
+import { DSLPersistenceCloud_GraphPreset } from '../../DSLPersistenceCloud_Extension.js';
+import { TEST_DATA__roundtrip } from './TEST_DATA__DSLPersistenceCloud_Roundtrip.js';
+import { DSLPersistence_GraphPreset } from '@finos/legend-extension-dsl-persistence';
+import {
+  DSLExternalFormat_GraphPreset,
+  TEST__checkBuildingElementsRoundtrip,
+  TEST__GraphPluginManager,
+} from '@finos/legend-graph';
+import { unitTest } from '@finos/legend-shared';
+import type { Entity } from '@finos/legend-model-storage';
+
+const pluginManager = new TEST__GraphPluginManager();
+pluginManager
+  .usePresets([
+    new DSLPersistence_GraphPreset(),
+    new DSLPersistenceCloud_GraphPreset(),
+    new DSLExternalFormat_GraphPreset(),
+  ])
+  .install();
+
+test(unitTest('DSL Persistence Cloud roundtrip'), async () => {
+  await TEST__checkBuildingElementsRoundtrip(
+    TEST_DATA__roundtrip as Entity[],
+    pluginManager,
+  );
+});

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/__tests__/TEST_DATA__DSLPersistenceCloud_Roundtrip.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/__tests__/TEST_DATA__DSLPersistenceCloud_Roundtrip.ts
@@ -1,0 +1,360 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TEST_DATA__roundtrip = [
+  {
+    path: 'org::dxl::Zoo',
+    classifierPath: 'meta::pure::metamodel::type::Class',
+    content: {
+      _type: 'class',
+      name: 'Zoo',
+      package: 'org::dxl',
+      properties: [
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'name',
+          type: 'String',
+        },
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'zookeeper',
+          type: 'org::dxl::Person',
+        },
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'owner',
+          type: 'org::dxl::Person',
+        },
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'admin',
+          type: 'org::dxl::Person',
+        },
+        {
+          multiplicity: {
+            lowerBound: 0,
+          },
+          name: 'animals',
+          type: 'org::dxl::Animal',
+        },
+      ],
+    },
+  },
+  {
+    path: 'org::dxl::Person',
+    classifierPath: 'meta::pure::metamodel::type::Class',
+    content: {
+      _type: 'class',
+      name: 'Person',
+      package: 'org::dxl',
+      properties: [
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'name',
+          type: 'String',
+        },
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'effectiveDateFrom',
+          type: 'DateTime',
+        },
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'effectiveDateThru',
+          type: 'DateTime',
+        },
+      ],
+    },
+  },
+  {
+    path: 'org::dxl::Animal',
+    classifierPath: 'meta::pure::metamodel::type::Class',
+    content: {
+      _type: 'class',
+      name: 'Animal',
+      package: 'org::dxl',
+      properties: [
+        {
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'name',
+          type: 'String',
+        },
+      ],
+    },
+  },
+  {
+    path: 'org::dxl::ZooBinding',
+    classifierPath: 'meta::external::shared::format::binding::Binding',
+    content: {
+      _type: 'binding',
+      contentType: 'application/json',
+      includedStores: [],
+      modelUnit: {
+        packageableElementExcludes: [],
+        packageableElementIncludes: ['org::dxl::Person'],
+      },
+      name: 'ZooBinding',
+      package: 'org::dxl',
+      schemaSet: undefined,
+    },
+  },
+  {
+    classifierPath: 'meta::relational::metamodel::Database',
+    path: 'org::dxl::ZooDb',
+    content: {
+      _type: 'relational',
+      filters: [],
+      includedStores: [],
+      joins: [],
+      name: 'ZooDb',
+      package: 'org::dxl',
+      schemas: [],
+    },
+  },
+  {
+    path: 'org::dxl::Mapping',
+    classifierPath: 'meta::pure::mapping::Mapping',
+    content: {
+      _type: 'mapping',
+      classMappings: [],
+      enumerationMappings: [],
+      includedMappings: [],
+      name: 'Mapping',
+      package: 'org::dxl',
+      tests: [],
+    },
+  },
+  {
+    path: 'org::dxl::ZooService',
+    classifierPath: 'meta::legend::service::metamodel::Service',
+    content: {
+      _type: 'service',
+      autoActivateUpdates: true,
+      documentation: 'test',
+      execution: {
+        _type: 'pureSingleExecution',
+        func: {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'property',
+              parameters: [
+                {
+                  _type: 'var',
+                  name: 'src',
+                },
+              ],
+              property: 'name',
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              class: 'org::dxl::Zoo',
+              multiplicity: {
+                lowerBound: 1,
+                upperBound: 1,
+              },
+              name: 'src',
+            },
+          ],
+        },
+        mapping: 'org::dxl::Mapping',
+        runtime: {
+          _type: 'engineRuntime',
+          connections: [],
+          mappings: [
+            {
+              path: 'org::dxl::Mapping',
+              type: 'MAPPING',
+            },
+          ],
+        },
+      },
+      name: 'ZooService',
+      owners: [],
+      package: 'org::dxl',
+      pattern: 'test',
+      test: {
+        _type: 'singleExecutionTest',
+        asserts: [],
+        data: 'test',
+      },
+    },
+  },
+  {
+    classifierPath: 'meta::pure::runtime::PackageableConnection',
+    path: 'org::dxl::ZooDbConnection',
+    content: {
+      _type: 'connection',
+      connectionValue: {
+        _type: 'RelationalDatabaseConnection',
+        authenticationStrategy: {
+          _type: 'h2Default',
+        },
+        databaseType: 'H2',
+        datasourceSpecification: {
+          _type: 'h2Local',
+        },
+        element: 'org::dxl::ZooDb',
+        type: 'H2',
+      },
+      name: 'ZooDbConnection',
+      package: 'org::dxl',
+    },
+  },
+  {
+    path: 'org::dxl::ZooPersistence',
+    classifierPath: 'meta::pure::persistence::metamodel::Persistence',
+    content: {
+      _type: 'persistence',
+      documentation: 'A persistence specification for Zoos.',
+      name: 'ZooPersistence',
+      notifier: {
+        notifyees: [
+          {
+            _type: 'emailNotifyee',
+            address: 'abc@xyz.com',
+          },
+          {
+            _type: 'pagerDutyNotifyee',
+            url: 'https://xyz.com',
+          },
+        ],
+      },
+      package: 'org::dxl',
+      persister: {
+        _type: 'batchPersister',
+        ingestMode: {
+          _type: 'bitemporalSnapshot',
+          transactionMilestoning: {
+            _type: 'batchIdAndDateTimeTransactionMilestoning',
+            batchIdInName: 'batchIdIn',
+            batchIdOutName: 'batchIdOut',
+            dateTimeInName: 'IN_Z',
+            dateTimeOutName: 'OUT_Z',
+            derivation: {
+              _type: 'sourceSpecifiesInAndOutDateTime',
+              sourceDateTimeInField: 'systemIn',
+              sourceDateTimeOutField: 'systemOut',
+            },
+          },
+          validityMilestoning: {
+            _type: 'dateTimeValidityMilestoning',
+            dateTimeFromName: 'FROM_Z',
+            dateTimeThruName: 'THRU_Z',
+            derivation: {
+              _type: 'sourceSpecifiesFromAndThruDateTime',
+              sourceDateTimeFromField: 'effectiveFrom',
+              sourceDateTimeThruField: 'effectiveThru',
+            },
+          },
+        },
+        sink: {
+          _type: 'objectStorageSink',
+          binding: 'org::dxl::ZooBinding',
+        },
+        targetShape: {
+          _type: 'multiFlatTarget',
+          modelClass: 'org::dxl::Zoo',
+          parts: [
+            {
+              deduplicationStrategy: {
+                _type: 'noDeduplicationStrategy',
+              },
+              modelProperty: 'zookeeper',
+              partitionFields: [],
+              targetName: 'PersonDataset1',
+            },
+            {
+              deduplicationStrategy: {
+                _type: 'maxVersionDeduplicationStrategy',
+                versionField: 'version',
+              },
+              modelProperty: 'admin',
+              partitionFields: [],
+              targetName: 'PersonDataset2',
+            },
+            {
+              deduplicationStrategy: {
+                _type: 'duplicateCountDeduplicationStrategy',
+                duplicateCountName: 'DUP_COUNT',
+              },
+              modelProperty: 'owner',
+              partitionFields: [],
+              targetName: 'PersonDataset3',
+            },
+          ],
+          transactionScope: 'ALL_TARGETS',
+        },
+      },
+      service: 'org::dxl::ZooService',
+      trigger: {
+        _type: 'manualTrigger',
+      },
+    },
+  },
+  {
+    path: 'org::dxl::ZooPersistenceContext',
+    classifierPath: 'meta::pure::persistence::metamodel::PersistenceContext',
+    content: {
+      _type: 'persistenceContext',
+      name: 'ZooPersistenceContext',
+      package: 'org::dxl',
+      persistence: 'org::dxl::ZooPersistence',
+      platform: {
+        _type: 'awsGlue',
+        dataProcessingUnits: 10,
+      },
+      sinkConnection: {
+        _type: 'RelationalDatabaseConnection',
+        authenticationStrategy: {
+          _type: 'h2Default',
+        },
+        databaseType: 'H2',
+        datasourceSpecification: {
+          _type: 'h2Local',
+        },
+        element: 'org::dxl::ZooDb',
+        type: 'H2',
+      },
+    },
+  },
+];

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/metamodels/pure/model/packageableElements/persistence/cloud/DSLPersistenceCloud_AwsGluePersistencePlatform.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/metamodels/pure/model/packageableElements/persistence/cloud/DSLPersistenceCloud_AwsGluePersistencePlatform.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PERSISTENCE_CLOUD_HASH_STRUCTURE } from '../../../../../../DSLPersistenceCloud_ModelUtils.js';
+import { PersistencePlatform } from '@finos/legend-extension-dsl-persistence';
+import { type Hashable, hashArray } from '@finos/legend-shared';
+
+export class AwsGluePersistencePlatform
+  extends PersistencePlatform
+  implements Hashable
+{
+  dataProcessingUnits!: number;
+
+  override get hashCode(): string {
+    return hashArray([
+      PERSISTENCE_CLOUD_HASH_STRUCTURE.AWS_GLUE_PERSISTENCE_PLATFORM,
+      this.dataProcessingUnits.toString(),
+    ]);
+  }
+}

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/protocols/pure/DSLPersistenceCloud_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/protocols/pure/DSLPersistenceCloud_PureProtocolProcessorPlugin.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import packageJson from '../../../../package.json';
+import { AwsGluePersistencePlatform } from '../../metamodels/pure/model/packageableElements/persistence/cloud/DSLPersistenceCloud_AwsGluePersistencePlatform.js';
+import { V1_AwsGluePersistencePlatform } from './v1/model/packageableElements/persistence/cloud/V1_DSLPersistenceCloud_AwsGluePersistencePlatform.js';
+import {
+  V1_AWS_GLUE_PERSISTENCE_PLATFORM_PROTOCOL_TYPE,
+  V1_awsGluePersistencePlatformModelSchema,
+} from './v1/transformation/pureProtocol/V1_DSLPersistenceCloud_ProtocolHellper.js';
+import type {
+  DSLPersistence_PureProtocolProcessorPlugin_Extension,
+  PersistencePlatform,
+  V1_PersistencePlatform,
+  V1_PersistencePlatformBuilder,
+  V1_PersistencePlatformProtocolDeserializer,
+  V1_PersistencePlatformProtocolSerializer,
+  V1_PersistencePlatformTransformer,
+} from '@finos/legend-extension-dsl-persistence';
+import {
+  PureProtocolProcessorPlugin,
+  type V1_GraphBuilderContext,
+  type V1_GraphTransformerContext,
+} from '@finos/legend-graph';
+import type { PlainObject } from '@finos/legend-shared';
+import { deserialize, serialize } from 'serializr';
+
+export class DSLPersistenceCloud_PureProtocolProcessorPlugin
+  extends PureProtocolProcessorPlugin
+  implements DSLPersistence_PureProtocolProcessorPlugin_Extension
+{
+  constructor() {
+    super(
+      packageJson.extensions.pureProtocolProcessorPlugin,
+      packageJson.version,
+    );
+  }
+
+  V1_getExtraPersistencePlatformBuilders?(): V1_PersistencePlatformBuilder[] {
+    return [
+      (
+        protocol: V1_PersistencePlatform,
+        context: V1_GraphBuilderContext,
+      ): PersistencePlatform | undefined => {
+        if (protocol instanceof V1_AwsGluePersistencePlatform) {
+          const platform = new AwsGluePersistencePlatform();
+          platform.dataProcessingUnits = protocol.dataProcessingUnits;
+          return platform;
+        }
+        return undefined;
+      },
+    ];
+  }
+
+  V1_getExtraPersistencePlatformTransformers?(): V1_PersistencePlatformTransformer[] {
+    return [
+      (
+        metamodel: PersistencePlatform,
+        context: V1_GraphTransformerContext,
+      ): V1_PersistencePlatform | undefined => {
+        if (metamodel instanceof AwsGluePersistencePlatform) {
+          const protocol = new V1_AwsGluePersistencePlatform();
+          protocol.dataProcessingUnits = metamodel.dataProcessingUnits;
+          return protocol;
+        }
+        return undefined;
+      },
+    ];
+  }
+
+  V1_getExtraPersistencePlatformProtocolSerializers?(): V1_PersistencePlatformProtocolSerializer[] {
+    return [
+      (
+        protocol: V1_PersistencePlatform,
+      ): PlainObject<V1_PersistencePlatform> | undefined => {
+        if (protocol instanceof V1_AwsGluePersistencePlatform) {
+          return serialize(V1_awsGluePersistencePlatformModelSchema, protocol);
+        }
+        return undefined;
+      },
+    ];
+  }
+
+  V1_getExtraPersistencePlatformProtocolDeserializers?(): V1_PersistencePlatformProtocolDeserializer[] {
+    return [
+      (
+        json: PlainObject<V1_PersistencePlatform>,
+      ): V1_PersistencePlatform | undefined => {
+        if (json._type === V1_AWS_GLUE_PERSISTENCE_PLATFORM_PROTOCOL_TYPE) {
+          return deserialize(V1_awsGluePersistencePlatformModelSchema, json);
+        }
+        return undefined;
+      },
+    ];
+  }
+}

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/protocols/pure/v1/model/packageableElements/persistence/cloud/V1_DSLPersistenceCloud_AwsGluePersistencePlatform.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/protocols/pure/v1/model/packageableElements/persistence/cloud/V1_DSLPersistenceCloud_AwsGluePersistencePlatform.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PERSISTENCE_CLOUD_HASH_STRUCTURE } from '../../../../../../../DSLPersistenceCloud_ModelUtils.js';
+import { V1_PersistencePlatform } from '@finos/legend-extension-dsl-persistence';
+import { type Hashable, hashArray } from '@finos/legend-shared';
+
+export class V1_AwsGluePersistencePlatform
+  extends V1_PersistencePlatform
+  implements Hashable
+{
+  dataProcessingUnits!: number;
+
+  override get hashCode(): string {
+    return hashArray([
+      PERSISTENCE_CLOUD_HASH_STRUCTURE.AWS_GLUE_PERSISTENCE_PLATFORM,
+      this.dataProcessingUnits.toString(),
+    ]);
+  }
+}

--- a/packages/legend-extension-dsl-persistence-cloud/src/models/protocols/pure/v1/transformation/pureProtocol/V1_DSLPersistenceCloud_ProtocolHellper.ts
+++ b/packages/legend-extension-dsl-persistence-cloud/src/models/protocols/pure/v1/transformation/pureProtocol/V1_DSLPersistenceCloud_ProtocolHellper.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1_AwsGluePersistencePlatform } from '../../model/packageableElements/persistence/cloud/V1_DSLPersistenceCloud_AwsGluePersistencePlatform.js';
+import { usingConstantValueSchema } from '@finos/legend-shared';
+import { createModelSchema, primitive } from 'serializr';
+
+/**********
+ * persistence platfrom
+ **********/
+
+export const V1_AWS_GLUE_PERSISTENCE_PLATFORM_PROTOCOL_TYPE = 'awsGlue';
+
+export const V1_awsGluePersistencePlatformModelSchema = createModelSchema(
+  V1_AwsGluePersistencePlatform,
+  {
+    _type: usingConstantValueSchema(
+      V1_AWS_GLUE_PERSISTENCE_PLATFORM_PROTOCOL_TYPE,
+    ),
+    dataProcessingUnits: primitive(),
+  },
+);

--- a/packages/legend-extension-dsl-persistence-cloud/tsconfig.build.json
+++ b/packages/legend-extension-dsl-persistence-cloud/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "build/prod.tsbuildinfo",
+    "jsx": "react-jsx"
+  },
+  "exclude": ["src/**/__tests__/**/*.*", "src/**/__mocks__/**/*.*"],
+  "references": [
+    { "path": "./tsconfig.package.json" },
+    { "path": "../legend-application/tsconfig.build.json" },
+    { "path": "../legend-extension-dsl-persistence/tsconfig.build.json" },
+    { "path": "../legend-graph/tsconfig.build.json" },
+    { "path": "../legend-model-storage/tsconfig.build.json" },
+    { "path": "../legend-shared/tsconfig.build.json" },
+    { "path": "../legend-studio/tsconfig.build.json" }
+  ]
+}

--- a/packages/legend-extension-dsl-persistence-cloud/tsconfig.json
+++ b/packages/legend-extension-dsl-persistence-cloud/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@finos/legend-dev-utils/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "tsBuildInfoFile": "build/dev.tsbuildinfo",
+    "rootDir": "src",
+    "jsx": "react-jsxdev"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
+  "references": [
+    { "path": "./tsconfig.package.json" },
+    { "path": "../legend-application" },
+    { "path": "../legend-extension-dsl-persistence" },
+    { "path": "../legend-graph" },
+    { "path": "../legend-model-storage" },
+    { "path": "../legend-shared" },
+    { "path": "../legend-studio" }
+  ]
+}

--- a/packages/legend-extension-dsl-persistence-cloud/tsconfig.package.json
+++ b/packages/legend-extension-dsl-persistence-cloud/tsconfig.package.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@finos/legend-dev-utils/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "tsBuildInfoFile": "build/package.tsbuildinfo",
+    "rootDir": "."
+  },
+  "include": ["package.json"]
+}

--- a/packages/legend-extension-dsl-persistence-cloud/tsconfig.publish.json
+++ b/packages/legend-extension-dsl-persistence-cloud/tsconfig.publish.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.build.json",
+  "references": [{ "path": "./tsconfig.package.json" }]
+}

--- a/packages/legend-graph-extension-collection/package.json
+++ b/packages/legend-graph-extension-collection/package.json
@@ -40,6 +40,7 @@
     "@finos/legend-extension-dsl-data-space": "workspace:*",
     "@finos/legend-extension-dsl-diagram": "workspace:*",
     "@finos/legend-extension-dsl-persistence": "workspace:*",
+    "@finos/legend-extension-dsl-persistence-cloud": "workspace:*",
     "@finos/legend-extension-dsl-text": "workspace:*",
     "@finos/legend-extension-external-format-json-schema": "workspace:*",
     "@finos/legend-extension-external-store-service": "workspace:*",

--- a/packages/legend-graph-extension-collection/src/index.ts
+++ b/packages/legend-graph-extension-collection/src/index.ts
@@ -20,6 +20,7 @@ import type { AbstractPreset } from '@finos/legend-shared';
 import { DSLDiagram_GraphPreset } from '@finos/legend-extension-dsl-diagram';
 import { DSLDataSpace_GraphPreset } from '@finos/legend-extension-dsl-data-space';
 import { DSLPersistence_GraphPreset } from '@finos/legend-extension-dsl-persistence';
+import { DSLPersistenceCloud_GraphPreset } from '@finos/legend-extension-dsl-persistence-cloud';
 import { ESService_GraphPreset } from '@finos/legend-extension-external-store-service';
 import { DSLExternalFormat_GraphPreset } from '@finos/legend-graph';
 
@@ -29,6 +30,7 @@ export const getLegendGraphExtensionCollection = (): AbstractPreset[] => [
   new DSLDataSpace_GraphPreset(),
   new DSLExternalFormat_GraphPreset(),
   new DSLPersistence_GraphPreset(),
+  new DSLPersistenceCloud_GraphPreset(),
   new EFJSONSchema_GraphPreset(),
   new ESService_GraphPreset(),
 ];

--- a/packages/legend-graph-extension-collection/tsconfig.build.json
+++ b/packages/legend-graph-extension-collection/tsconfig.build.json
@@ -14,6 +14,7 @@
     },
     { "path": "../legend-extension-dsl-text/tsconfig.build.json" },
     { "path": "../legend-extension-dsl-persistence/tsconfig.build.json" },
+    { "path": "../legend-extension-dsl-persistence-cloud/tsconfig.build.json" },
     { "path": "../legend-extension-dsl-data-space/tsconfig.build.json" },
     {
       "path": "../legend-extension-external-format-json-schema/tsconfig.build.json"

--- a/packages/legend-graph-extension-collection/tsconfig.json
+++ b/packages/legend-graph-extension-collection/tsconfig.json
@@ -15,6 +15,7 @@
     { "path": "../legend-extension-dsl-text" },
     { "path": "../legend-extension-dsl-data-space" },
     { "path": "../legend-extension-dsl-persistence" },
+    { "path": "../legend-extension-dsl-persistence-cloud" },
     { "path": "../legend-extension-external-format-json-schema" }
   ]
 }

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSLPersistenceCloud-basic.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSLPersistenceCloud-basic.pure
@@ -177,6 +177,10 @@ Persistence org::legend::ZooPersistence
 PersistenceContext org::legend::ZooPersistenceContext
 {
   persistence: org::legend::ZooPersistence;
+  platform: AwsGlue
+  #{
+    dataProcessingUnits: 10;
+  }#;
   serviceParameters:
   [
     connection=org::legend::ZooDbConnection

--- a/packages/legend-studio-app/tsconfig.build.json
+++ b/packages/legend-studio-app/tsconfig.build.json
@@ -18,6 +18,7 @@
     { "path": "../legend-extension-dsl-text/tsconfig.build.json" },
     { "path": "../legend-extension-dsl-data-space/tsconfig.build.json" },
     { "path": "../legend-extension-dsl-persistence/tsconfig.build.json" },
+    { "path": "../legend-extension-dsl-persistence-cloud/tsconfig.build.json" },
     { "path": "../legend-studio-extension-query-builder/tsconfig.build.json" },
     {
       "path": "../legend-extension-external-language-morphir/tsconfig.build.json"

--- a/packages/legend-studio-app/tsconfig.json
+++ b/packages/legend-studio-app/tsconfig.json
@@ -18,6 +18,7 @@
     { "path": "../legend-extension-dsl-text" },
     { "path": "../legend-extension-dsl-data-space" },
     { "path": "../legend-extension-dsl-persistence" },
+    { "path": "../legend-extension-dsl-persistence-cloud" },
     { "path": "../legend-studio-extension-query-builder" },
     { "path": "../legend-extension-external-language-morphir" }
   ]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -42,6 +42,9 @@
       "path": "packages/legend-extension-dsl-persistence/tsconfig.build.json"
     },
     {
+      "path": "packages/legend-extension-dsl-persistence-cloud/tsconfig.build.json"
+    },
+    {
       "path": "packages/legend-extension-external-format-json-schema/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,6 +53,9 @@
       "path": "packages/legend-extension-dsl-persistence"
     },
     {
+      "path": "packages/legend-extension-dsl-persistence-cloud"
+    },
+    {
       "path": "packages/legend-extension-external-format-json-schema"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,7 +2195,7 @@ __metadata:
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
     "@jest/globals": 28.1.2
-    "@types/react": 18.0.14
+    "@types/react": 18.0.15
     cross-env: 7.0.3
     eslint: 8.19.0
     jest: 28.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,6 +2183,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@finos/legend-extension-dsl-persistence-cloud@workspace:*, @finos/legend-extension-dsl-persistence-cloud@workspace:packages/legend-extension-dsl-persistence-cloud":
+  version: 0.0.0-use.local
+  resolution: "@finos/legend-extension-dsl-persistence-cloud@workspace:packages/legend-extension-dsl-persistence-cloud"
+  dependencies:
+    "@finos/legend-application": "workspace:*"
+    "@finos/legend-dev-utils": "workspace:*"
+    "@finos/legend-extension-dsl-persistence": "workspace:*"
+    "@finos/legend-graph": "workspace:*"
+    "@finos/legend-model-storage": "workspace:*"
+    "@finos/legend-shared": "workspace:*"
+    "@finos/legend-studio": "workspace:*"
+    "@jest/globals": 28.1.2
+    "@types/react": 18.0.14
+    cross-env: 7.0.3
+    eslint: 8.19.0
+    jest: 28.1.2
+    mobx: 6.6.1
+    npm-run-all: 4.1.5
+    react: 18.2.0
+    rimraf: 3.0.2
+    sass: 1.53.0
+    serializr: 2.0.5
+    typescript: 4.7.4
+  peerDependencies:
+    react: ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@finos/legend-extension-dsl-persistence@workspace:*, @finos/legend-extension-dsl-persistence@workspace:packages/legend-extension-dsl-persistence":
   version: 0.0.0-use.local
   resolution: "@finos/legend-extension-dsl-persistence@workspace:packages/legend-extension-dsl-persistence"
@@ -2362,6 +2390,7 @@ __metadata:
     "@finos/legend-extension-dsl-data-space": "workspace:*"
     "@finos/legend-extension-dsl-diagram": "workspace:*"
     "@finos/legend-extension-dsl-persistence": "workspace:*"
+    "@finos/legend-extension-dsl-persistence-cloud": "workspace:*"
     "@finos/legend-extension-dsl-text": "workspace:*"
     "@finos/legend-extension-external-format-json-schema": "workspace:*"
     "@finos/legend-extension-external-store-service": "workspace:*"
@@ -2632,6 +2661,7 @@ __metadata:
     "@finos/legend-extension-dsl-data-space": "workspace:*"
     "@finos/legend-extension-dsl-diagram": "workspace:*"
     "@finos/legend-extension-dsl-persistence": "workspace:*"
+    "@finos/legend-extension-dsl-persistence-cloud": "workspace:*"
     "@finos/legend-extension-dsl-text": "workspace:*"
     "@finos/legend-extension-external-language-morphir": "workspace:*"
     "@finos/legend-extension-external-store-service": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,11 +2194,11 @@ __metadata:
     "@finos/legend-model-storage": "workspace:*"
     "@finos/legend-shared": "workspace:*"
     "@finos/legend-studio": "workspace:*"
-    "@jest/globals": 28.1.2
+    "@jest/globals": 28.1.3
     "@types/react": 18.0.15
     cross-env: 7.0.3
-    eslint: 8.19.0
-    jest: 28.1.2
+    eslint: 8.20.0
+    jest: 28.1.3
     mobx: 6.6.1
     npm-run-all: 4.1.5
     react: 18.2.0


### PR DESCRIPTION
## Summary

Corresponding engine change (already merged and released):
https://github.com/finos/legend-engine/pull/798

This change provides support for AWS Glue-specific extensions to the persistence DSL.

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)
