### PR TITLE
feat: add visual indicator for system elements in selector dropdowns

### DIFF
--- a/.changeset/chilled-timers-peel.md
+++ b/.changeset/chilled-timers-peel.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-query': patch
+---
+
+add indicator for system elements [#457](https://github.com/finos/legend-studio/issues/457)

--- a/.changeset/chilled-timers-peel.md
+++ b/.changeset/chilled-timers-peel.md
@@ -1,6 +1,9 @@
 ---
-'@finos/legend-application': patch
-'@finos/legend-application-query': patch
+'@finos/legend-application': minor
+'@finos/legend-application-query': minor
+'@finos/legend-art': minor
+'@finos/legend-graph': minor
+'@finos/legend-application-studio': minor
 ---
 
-add indicator for system elements [#457](https://github.com/finos/legend-studio/issues/457)
+add indicator for system elements ([#457](https://github.com/finos/legend-studio/issues/457)).

--- a/.changeset/chilled-timers-peel.md
+++ b/.changeset/chilled-timers-peel.md
@@ -2,4 +2,4 @@
 '@finos/legend-art': minor
 ---
 
-Add color indicator for `PackageableElementOption` elements depending on type ([#457](https://github.com/finos/legend-studio/issues/457)).
+Add indicator for `PackageableElementOption` to show the graph the elements belong to (i.e. `system`, `dependencies`, etc.) ([#457](https://github.com/finos/legend-studio/issues/457)).

--- a/.changeset/clever-phones-travel.md
+++ b/.changeset/clever-phones-travel.md
@@ -1,5 +1,8 @@
 ---
-'@finos/legend-art': minor
+'@finos/legend-graph': minor
+'@finos/legend-application-studio': minor
+'@finos/legend-application': minor
+'@finos/legend-application-query': minor
 ---
 
 Add color indicator for `PackageableElementOption` elements depending on type ([#457](https://github.com/finos/legend-studio/issues/457)).

--- a/.changeset/clever-phones-travel.md
+++ b/.changeset/clever-phones-travel.md
@@ -5,4 +5,3 @@
 '@finos/legend-application-query': minor
 ---
 
-Add color indicator for `PackageableElementOption` elements depending on type ([#457](https://github.com/finos/legend-studio/issues/457)).

--- a/.changeset/clever-phones-travel.md
+++ b/.changeset/clever-phones-travel.md
@@ -1,7 +1,6 @@
 ---
-'@finos/legend-graph': minor
-'@finos/legend-application-studio': minor
-'@finos/legend-application': minor
-'@finos/legend-application-query': minor
+'@finos/legend-graph': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-application': patch
+'@finos/legend-application-query': patch
 ---
-

--- a/packages/legend-application-query/src/components/QueryBuilderFunctionsExplorerPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderFunctionsExplorerPanel.tsx
@@ -263,6 +263,7 @@ const QueryBuilderFunctionsExplorerTreeNodeContainer = observer(
     ) : (
       <div />
     );
+
     const iconPackageColor = isDependencyTreeNode(node)
       ? 'color--dependency'
       : '';

--- a/packages/legend-application-query/src/components/QueryBuilderParameterPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderParameterPanel.tsx
@@ -195,6 +195,7 @@ const VariableExpressionEditor = observer(
                 darkMode={true}
                 formatOptionLabel={getPackageableElementOptionalFormatter({
                   darkMode: true,
+                  graphManagerStatePackage: queryBuilderState.graphManagerState,
                 })}
               />
             </div>

--- a/packages/legend-application-query/src/components/QueryBuilderParameterPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderParameterPanel.tsx
@@ -46,7 +46,7 @@ import {
   variableExpression_setName,
   LambdaParameterState,
   LambdaParameterValuesEditor,
-  getPackageableElementOptionalFormatter,
+  getPackageableElementOptionFormatter,
 } from '@finos/legend-application';
 import { useDrag, useDragLayer } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -193,9 +193,9 @@ const VariableExpressionEditor = observer(
                 onChange={changeType}
                 value={selectedType}
                 darkMode={true}
-                formatOptionLabel={getPackageableElementOptionalFormatter({
+                formatOptionLabel={getPackageableElementOptionFormatter({
                   darkMode: true,
-                  graphManagerStatePackage: queryBuilderState.graphManagerState,
+                  graphManagerState: queryBuilderState.graphManagerState,
                 })}
               />
             </div>

--- a/packages/legend-application-query/src/components/QueryBuilderSetupPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderSetupPanel.tsx
@@ -271,6 +271,7 @@ export const QueryBuilderSetupPanel = observer(
               filterOption={elementFilterOption}
               formatOptionLabel={getPackageableElementOptionalFormatter({
                 darkMode: true,
+                graphManagerStatePackage: queryBuilderState.graphManagerState,
               })}
             />
             <button
@@ -306,6 +307,7 @@ export const QueryBuilderSetupPanel = observer(
               filterOption={elementFilterOption}
               formatOptionLabel={getPackageableElementOptionalFormatter({
                 darkMode: true,
+                graphManagerStatePackage: queryBuilderState.graphManagerState,
               })}
             />
           </div>

--- a/packages/legend-application-query/src/components/QueryBuilderSetupPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderSetupPanel.tsx
@@ -46,7 +46,7 @@ import {
 } from '@finos/legend-graph';
 import {
   type PackageableElementOption,
-  getPackageableElementOptionalFormatter,
+  getPackageableElementOptionFormatter,
   buildElementOption,
 } from '@finos/legend-application';
 import { MilestoningParametersEditor } from './QueryBuilderMilestoneEditor.js';
@@ -269,9 +269,9 @@ export const QueryBuilderSetupPanel = observer(
               darkMode={true}
               disabled={!isQuerySupported || querySetupState.classIsReadOnly}
               filterOption={elementFilterOption}
-              formatOptionLabel={getPackageableElementOptionalFormatter({
+              formatOptionLabel={getPackageableElementOptionFormatter({
                 darkMode: true,
-                graphManagerStatePackage: queryBuilderState.graphManagerState,
+                graphManagerState: queryBuilderState.graphManagerState,
               })}
             />
             <button
@@ -305,9 +305,9 @@ export const QueryBuilderSetupPanel = observer(
               value={selectedMappingOption}
               darkMode={true}
               filterOption={elementFilterOption}
-              formatOptionLabel={getPackageableElementOptionalFormatter({
+              formatOptionLabel={getPackageableElementOptionFormatter({
                 darkMode: true,
-                graphManagerStatePackage: queryBuilderState.graphManagerState,
+                graphManagerState: queryBuilderState.graphManagerState,
               })}
             />
           </div>

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
@@ -235,7 +235,9 @@ export const NewMappingElementModal = observer(() => {
               filterOption={filterOption}
               onChange={handleTargetChange}
               value={selectedOption}
-              formatOptionLabel={getPackageableElementOptionalFormatter()}
+              formatOptionLabel={getPackageableElementOptionalFormatter({
+                graphManagerStatePackage: editorStore.graphManagerState,
+              })}
               placeholder="Choose a target"
               isClearable={true}
             />

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/NewMappingElementModal.tsx
@@ -45,7 +45,7 @@ import {
 } from '@finos/legend-graph';
 import { BASIC_SET_IMPLEMENTATION_TYPE } from '../../../../stores/shared/ModelUtil.js';
 import {
-  getPackageableElementOptionalFormatter,
+  getPackageableElementOptionFormatter,
   type PackageableElementOption,
 } from '@finos/legend-application';
 
@@ -235,8 +235,8 @@ export const NewMappingElementModal = observer(() => {
               filterOption={filterOption}
               onChange={handleTargetChange}
               value={selectedOption}
-              formatOptionLabel={getPackageableElementOptionalFormatter({
-                graphManagerStatePackage: editorStore.graphManagerState,
+              formatOptionLabel={getPackageableElementOptionFormatter({
+                graphManagerState: editorStore.graphManagerState,
               })}
               placeholder="Choose a target"
               isClearable={true}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -45,7 +45,6 @@ import {
 import { LEGEND_STUDIO_TEST_ID } from '../../../LegendStudioTestID.js';
 import { PropertyEditor } from './PropertyEditor.js';
 import { StereotypeSelector } from './StereotypeSelector.js';
-import { TaggedValueEditor } from './TaggedValueEditor.js';
 import { UML_EDITOR_TAB } from '../../../../stores/editor-state/element-editor-state/UMLEditorState.js';
 import { ClassEditorState } from '../../../../stores/editor-state/element-editor-state/ClassEditorState.js';
 import { flowResult } from 'mobx';
@@ -117,6 +116,7 @@ import {
   getClassPropertyType,
 } from '../../../../stores/shared/ModelUtil.js';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../../stores/LegendStudioApplicationNavigationContext.js';
+import { TaggedValueEditor } from './TaggedValueEditor.js';
 
 const PropertyBasicEditor = observer(
   (props: {
@@ -242,7 +242,9 @@ const PropertyBasicEditor = observer(
             value={selectedPropertyType}
             placeholder={'Choose a data type or enumeration'}
             filterOption={filterOption}
-            formatOptionLabel={getPackageableElementOptionalFormatter()}
+            formatOptionLabel={getPackageableElementOptionalFormatter({
+              graphManagerStatePackage: editorStore.graphManagerState,
+            })}
           />
         )}
         {!isIndirectProperty && !isReadOnly && !isEditingType && (
@@ -519,7 +521,9 @@ const DerivedPropertyBasicEditor = observer(
               value={selectedPropertyType}
               placeholder="Choose a data type or enumeration"
               filterOption={filterOption}
-              formatOptionLabel={getPackageableElementOptionalFormatter()}
+              formatOptionLabel={getPackageableElementOptionalFormatter({
+                graphManagerStatePackage: editorStore.graphManagerState,
+              })}
             />
           )}
           {!isInheritedProperty && !isReadOnly && !isEditingType && (
@@ -769,12 +773,14 @@ const ConstraintEditor = observer(
 
 const SuperTypeEditor = observer(
   (props: {
+    editorState: ClassEditorState;
     _class: Class;
     superType: GenericTypeReference;
     deleteSuperType: () => void;
     isReadOnly: boolean;
   }) => {
-    const { superType, _class, deleteSuperType, isReadOnly } = props;
+    const { superType, _class, editorState, deleteSuperType, isReadOnly } =
+      props;
     const editorStore = useEditorStore();
     // Type
     const superTypeOptions = editorStore.classOptions.filter(
@@ -809,7 +815,9 @@ const SuperTypeEditor = observer(
           value={selectedType}
           placeholder={'Choose a class'}
           filterOption={filterOption}
-          formatOptionLabel={getPackageableElementOptionalFormatter()}
+          formatOptionLabel={getPackageableElementOptionalFormatter({
+            graphManagerStatePackage: editorState.editorStore.graphManagerState,
+          })}
         />
         <button
           className="uml-element-editor__basic__detail-btn"
@@ -1095,6 +1103,7 @@ const SupertypesEditor = observer(
           <SuperTypeEditor
             key={superType.value._UUID}
             superType={superType}
+            editorState={editorState}
             _class={_class}
             deleteSuperType={deleteSuperType(superType)}
             isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -83,7 +83,7 @@ import {
 import { StudioLambdaEditor } from '../../../shared/StudioLambdaEditor.js';
 import {
   ApplicationNavigationContextData,
-  getPackageableElementOptionalFormatter,
+  getPackageableElementOptionFormatter,
   useApplicationNavigationContext,
   useApplicationStore,
   type PackageableElementOption,
@@ -242,8 +242,8 @@ const PropertyBasicEditor = observer(
             value={selectedPropertyType}
             placeholder={'Choose a data type or enumeration'}
             filterOption={filterOption}
-            formatOptionLabel={getPackageableElementOptionalFormatter({
-              graphManagerStatePackage: editorStore.graphManagerState,
+            formatOptionLabel={getPackageableElementOptionFormatter({
+              graphManagerState: editorStore.graphManagerState,
             })}
           />
         )}
@@ -521,8 +521,8 @@ const DerivedPropertyBasicEditor = observer(
               value={selectedPropertyType}
               placeholder="Choose a data type or enumeration"
               filterOption={filterOption}
-              formatOptionLabel={getPackageableElementOptionalFormatter({
-                graphManagerStatePackage: editorStore.graphManagerState,
+              formatOptionLabel={getPackageableElementOptionFormatter({
+                graphManagerState: editorStore.graphManagerState,
               })}
             />
           )}
@@ -773,14 +773,12 @@ const ConstraintEditor = observer(
 
 const SuperTypeEditor = observer(
   (props: {
-    editorState: ClassEditorState;
     _class: Class;
     superType: GenericTypeReference;
     deleteSuperType: () => void;
     isReadOnly: boolean;
   }) => {
-    const { superType, _class, editorState, deleteSuperType, isReadOnly } =
-      props;
+    const { superType, _class, deleteSuperType, isReadOnly } = props;
     const editorStore = useEditorStore();
     // Type
     const superTypeOptions = editorStore.classOptions.filter(
@@ -815,8 +813,8 @@ const SuperTypeEditor = observer(
           value={selectedType}
           placeholder={'Choose a class'}
           filterOption={filterOption}
-          formatOptionLabel={getPackageableElementOptionalFormatter({
-            graphManagerStatePackage: editorState.editorStore.graphManagerState,
+          formatOptionLabel={getPackageableElementOptionFormatter({
+            graphManagerState: editorStore.graphManagerState,
           })}
         />
         <button

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -1101,7 +1101,6 @@ const SupertypesEditor = observer(
           <SuperTypeEditor
             key={superType.value._UUID}
             superType={superType}
-            editorState={editorState}
             _class={_class}
             deleteSuperType={deleteSuperType(superType)}
             isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -250,8 +250,14 @@ const NewPureModelConnectionDriverEditor = observer(
             onChange={onClassSelectionChange}
             value={selectedClassOption}
             darkMode={true}
+            // formatOptionLabel={getPackageableElementOptionalFormatter({
+            //   darkMode: true,
+            //   graphManagerState: newConnectionDriver.editorStore.graphManagerState,
+            // })}
             formatOptionLabel={getPackageableElementOptionalFormatter({
               darkMode: true,
+              graphManagerStatePackage:
+                newConnectionDriver.editorStore.graphManagerState,
             })}
           />
         </div>

--- a/packages/legend-application-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/CreateNewElementModal.tsx
@@ -41,7 +41,7 @@ import {
 import type { FileGenerationTypeOption } from '../../../stores/editor-state/GraphGenerationState.js';
 import { flowResult } from 'mobx';
 import {
-  getPackageableElementOptionalFormatter,
+  getPackageableElementOptionFormatter,
   useApplicationStore,
   type PackageableElementOption,
 } from '@finos/legend-application';
@@ -250,14 +250,9 @@ const NewPureModelConnectionDriverEditor = observer(
             onChange={onClassSelectionChange}
             value={selectedClassOption}
             darkMode={true}
-            // formatOptionLabel={getPackageableElementOptionalFormatter({
-            //   darkMode: true,
-            //   graphManagerState: newConnectionDriver.editorStore.graphManagerState,
-            // })}
-            formatOptionLabel={getPackageableElementOptionalFormatter({
+            formatOptionLabel={getPackageableElementOptionFormatter({
               darkMode: true,
-              graphManagerStatePackage:
-                newConnectionDriver.editorStore.graphManagerState,
+              graphManagerState: editorStore.graphManagerState,
             })}
           />
         </div>

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -71,21 +71,10 @@ import {
   Package,
   isValidFullPath,
   isValidPath,
-  getElementRootPackage,
 } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
 import { PACKAGEABLE_ELEMENT_TYPE } from '../../../stores/shared/ModelUtil.js';
 import { useLegendStudioApplicationStore } from '../../LegendStudioBaseStoreProvider.js';
-
-const isGeneratedPackageTreeNode = (node: PackageTreeNodeData): boolean =>
-  getElementRootPackage(node.packageableElement).name ===
-  ROOT_PACKAGE_NAME.MODEL_GENERATION;
-const isSystemPackageTreeNode = (node: PackageTreeNodeData): boolean =>
-  getElementRootPackage(node.packageableElement).name ===
-  ROOT_PACKAGE_NAME.SYSTEM;
-const isDependencyTreeNode = (node: PackageTreeNodeData): boolean =>
-  getElementRootPackage(node.packageableElement).name ===
-  ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT;
 
 const ElementRenamer = observer(() => {
   const editorStore = useEditorStore();
@@ -375,13 +364,19 @@ const PackageTreeNodeContainer = observer(
     ) : (
       <ChevronRightIcon />
     );
-    const iconPackageColor = isGeneratedPackageTreeNode(node)
+
+    const iconPackageColor = editorStore.graphManagerState.isGeneratedElement(
+      node.packageableElement,
+    )
       ? 'color--generated'
-      : isSystemPackageTreeNode(node)
+      : editorStore.graphManagerState.isSystemElement(node.packageableElement)
       ? 'color--system'
-      : isDependencyTreeNode(node)
+      : editorStore.graphManagerState.isDependencyElement(
+          node.packageableElement,
+        )
       ? 'color--dependency'
       : '';
+
     const nodeIcon = isPackage ? (
       node.isOpen ? (
         <div className={iconPackageColor}>
@@ -693,10 +688,12 @@ const ProjectExplorerActionPanel = observer((props: { disabled: boolean }) => {
     });
     editorStore.explorerTreeState.setTreeData({ ...treeData });
   };
+
   const isImmutablePackageTreeNode = (node: PackageTreeNodeData): boolean =>
-    isGeneratedPackageTreeNode(node) ||
-    isSystemPackageTreeNode(node) ||
-    isDependencyTreeNode(node);
+    editorStore.graphManagerState.isGeneratedElement(node.packageableElement) ||
+    editorStore.graphManagerState.isSystemElement(node.packageableElement) ||
+    editorStore.graphManagerState.isDependencyElement(node.packageableElement);
+
   const showModelLoader = (): void =>
     editorStore.openState(editorStore.modelLoaderState);
 

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -18,7 +18,6 @@ import type {
   PackageableElement,
   GraphManagerState,
 } from '@finos/legend-graph';
-import { useState } from 'react';
 import type { PackageableElementOption } from '../../stores/shared/PackageableElementOption.js';
 
 export const getPackageableElementOptionFormatter = (props: {

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -18,11 +18,12 @@ import type {
   PackageableElement,
   GraphManagerState,
 } from '@finos/legend-graph';
+import { useState } from 'react';
 import type { PackageableElementOption } from '../../stores/shared/PackageableElementOption.js';
 
-export const getPackageableElementOptionalFormatter = (props: {
+export const getPackageableElementOptionFormatter = (props: {
   darkMode?: boolean;
-  graphManagerStatePackage: GraphManagerState;
+  graphManagerState: GraphManagerState;
 }): ((
   option: PackageableElementOption<PackageableElement>,
 ) => React.ReactNode) =>
@@ -35,25 +36,24 @@ export const getPackageableElementOptionalFormatter = (props: {
 
     const element = option.value;
 
-    const optionColor = props.graphManagerStatePackage.isPrimitiveTypeElement(
-      element,
-    )
+    const optionColor = props.graphManagerState.isPrimitiveTypeElement(element)
       ? 'primitive'
-      : props.graphManagerStatePackage.isSystemElement(element)
+      : props.graphManagerState.isSystemElement(element)
       ? 'system'
-      : props.graphManagerStatePackage.isGeneratedElement(element)
+      : props.graphManagerState.isGeneratedElement(element)
       ? 'generated'
-      : props.graphManagerStatePackage.isMainElement(element)
+      : props.graphManagerState.isMainElement(element)
       ? 'generated'
-      : props.graphManagerStatePackage.isDependencyElement(element)
+      : props.graphManagerState.isDependencyElement(element)
       ? 'dependency'
       : '';
 
     return (
       <div className={className}>
-        <span
+        <div
+          title={`${optionColor} element`}
           className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${optionColor}`}
-        ></span>
+        ></div>
         <div className={`${className}__name`}>{option.label}</div>
         {option.value.package && (
           <div className={`${className}__tag`}>{option.value.path}</div>

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -20,6 +20,40 @@ import type {
 } from '@finos/legend-graph';
 import type { PackageableElementOption } from '../../stores/shared/PackageableElementOption.js';
 
+const optionColorClassName = (
+  element: PackageableElement,
+  graphManagerState: GraphManagerState,
+): string => {
+  switch (true) {
+    case graphManagerState.isSystemElement(element):
+      return 'system';
+    case graphManagerState.isGeneratedElement(element):
+      return 'generated';
+    case graphManagerState.isMainGraphElement(element):
+      return 'main';
+    case graphManagerState.isDependencyElement(element):
+      return 'dependency';
+    default:
+      return '';
+  }
+};
+
+const optionToolTip = (
+  element: PackageableElement,
+  graphManagerState: GraphManagerState,
+): string | undefined => {
+  switch (true) {
+    case graphManagerState.isSystemElement(element):
+      return 'system element';
+    case graphManagerState.isGeneratedElement(element):
+      return 'generated element';
+    case graphManagerState.isDependencyElement(element):
+      return 'dependency element';
+    default:
+      return undefined;
+  }
+};
+
 export const getPackageableElementOptionFormatter = (props: {
   darkMode?: boolean;
   graphManagerState: GraphManagerState;
@@ -33,44 +67,14 @@ export const getPackageableElementOptionFormatter = (props: {
       ? 'packageable-element-format-option-label--dark'
       : 'packageable-element-format-option-label';
 
-    const getColor = (element: PackageableElement): string => {
-      switch (true) {
-        case props.graphManagerState.isSystemElement(element):
-          return 'system';
-        case props.graphManagerState.isGeneratedElement(element):
-          return 'generated';
-        case props.graphManagerState.isMainGraphElement(element):
-          return 'main';
-        case props.graphManagerState.isDependencyElement(element):
-          return 'dependency';
-        default:
-          return '';
-      }
-    };
-
-    const getToolTip = (element: PackageableElement): string => {
-      switch (true) {
-        case props.graphManagerState.isSystemElement(element):
-          return 'system';
-        case props.graphManagerState.isGeneratedElement(element):
-          return 'generated';
-        case props.graphManagerState.isMainGraphElement(element):
-          return '';
-        case props.graphManagerState.isDependencyElement(element):
-          return 'dependency';
-        default:
-          return '';
-      }
-    };
-
-    const optionColor = getColor(option.value);
-    const toolTip = getToolTip(option.value);
-
     return (
       <div className={className}>
         <div
-          title={`${toolTip} element`}
-          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${optionColor}`}
+          title={`${optionToolTip(option.value, props.graphManagerState)}`}
+          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${optionColorClassName(
+            option.value,
+            props.graphManagerState,
+          )}`}
         ></div>
         <div className={`${className}__name`}>{option.label}</div>
         {option.value.package && (

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -23,36 +23,28 @@ import type { PackageableElementOption } from '../../stores/shared/PackageableEl
 const optionColorClassName = (
   element: PackageableElement,
   graphManagerState: GraphManagerState,
-): string => {
-  switch (true) {
-    case graphManagerState.isSystemElement(element):
-      return 'system';
-    case graphManagerState.isGeneratedElement(element):
-      return 'generated';
-    case graphManagerState.isMainGraphElement(element):
-      return 'main';
-    case graphManagerState.isDependencyElement(element):
-      return 'dependency';
-    default:
-      return '';
-  }
-};
+): string =>
+  graphManagerState.isSystemElement(element)
+    ? 'system'
+    : graphManagerState.isGeneratedElement(element)
+    ? 'generated'
+    : graphManagerState.isMainGraphElement(element)
+    ? 'main'
+    : graphManagerState.isDependencyElement(element)
+    ? 'dependency'
+    : '';
 
 const optionToolTip = (
   element: PackageableElement,
   graphManagerState: GraphManagerState,
-): string | undefined => {
-  switch (true) {
-    case graphManagerState.isSystemElement(element):
-      return 'system element';
-    case graphManagerState.isGeneratedElement(element):
-      return 'generated element';
-    case graphManagerState.isDependencyElement(element):
-      return 'dependency element';
-    default:
-      return undefined;
-  }
-};
+): string | undefined =>
+  graphManagerState.isSystemElement(element)
+    ? 'system element'
+    : graphManagerState.isGeneratedElement(element)
+    ? 'generated element'
+    : graphManagerState.isDependencyElement(element)
+    ? 'dependency element'
+    : undefined;
 
 export const getPackageableElementOptionFormatter = (props: {
   darkMode?: boolean;

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -25,12 +25,26 @@ export const getPackageableElementOptionalFormatter = (props?: {
   function PackageableElementOptionLabel(
     option: PackageableElementOption<PackageableElement>,
   ): React.ReactNode {
+    let optionType = '';
+    //if no package, label type system
+    if (
+      option.value.package === undefined ||
+      option.value.package.name === 'meta'
+    ) {
+      optionType = 'system';
+    } else {
+      optionType = 'generated';
+    }
+
     const className = props?.darkMode
       ? 'packageable-element-format-option-label--dark'
       : 'packageable-element-format-option-label';
 
     return (
       <div className={className}>
+        <span
+          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type__${optionType}`}
+        ></span>
         <div className={`${className}__name`}>{option.label}</div>
         {option.value.package && (
           <div className={`${className}__tag`}>{option.value.path}</div>

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -14,36 +14,45 @@
  * limitations under the License.
  */
 
-import type { PackageableElement } from '@finos/legend-graph';
+import type {
+  PackageableElement,
+  GraphManagerState,
+} from '@finos/legend-graph';
 import type { PackageableElementOption } from '../../stores/shared/PackageableElementOption.js';
 
-export const getPackageableElementOptionalFormatter = (props?: {
+export const getPackageableElementOptionalFormatter = (props: {
   darkMode?: boolean;
+  graphManagerStatePackage: GraphManagerState;
 }): ((
   option: PackageableElementOption<PackageableElement>,
 ) => React.ReactNode) =>
   function PackageableElementOptionLabel(
     option: PackageableElementOption<PackageableElement>,
   ): React.ReactNode {
-    let optionType = '';
-    //if no package, label type system
-    if (
-      option.value.package === undefined ||
-      option.value.package.name === 'meta'
-    ) {
-      optionType = 'system';
-    } else {
-      optionType = 'generated';
-    }
-
-    const className = props?.darkMode
+    const className = props.darkMode
       ? 'packageable-element-format-option-label--dark'
       : 'packageable-element-format-option-label';
+
+    const element = option.value;
+
+    const optionColor = props.graphManagerStatePackage.isPrimitiveTypeElement(
+      element,
+    )
+      ? 'primitive'
+      : props.graphManagerStatePackage.isSystemElement(element)
+      ? 'system'
+      : props.graphManagerStatePackage.isGeneratedElement(element)
+      ? 'generated'
+      : props.graphManagerStatePackage.isMainElement(element)
+      ? 'generated'
+      : props.graphManagerStatePackage.isDependencyElement(element)
+      ? 'dependency'
+      : '';
 
     return (
       <div className={className}>
         <span
-          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type__${optionType}`}
+          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${optionColor}`}
         ></span>
         <div className={`${className}__name`}>{option.label}</div>
         {option.value.package && (

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -33,24 +33,43 @@ export const getPackageableElementOptionFormatter = (props: {
       ? 'packageable-element-format-option-label--dark'
       : 'packageable-element-format-option-label';
 
-    const element = option.value;
+    const getColor = (element: PackageableElement): string => {
+      switch (true) {
+        case props.graphManagerState.isSystemElement(element):
+          return 'system';
+        case props.graphManagerState.isGeneratedElement(element):
+          return 'generated';
+        case props.graphManagerState.isMainGraphElement(element):
+          return 'main';
+        case props.graphManagerState.isDependencyElement(element):
+          return 'dependency';
+        default:
+          return '';
+      }
+    };
 
-    const optionColor = props.graphManagerState.isPrimitiveTypeElement(element)
-      ? 'primitive'
-      : props.graphManagerState.isSystemElement(element)
-      ? 'system'
-      : props.graphManagerState.isGeneratedElement(element)
-      ? 'generated'
-      : props.graphManagerState.isMainElement(element)
-      ? 'generated'
-      : props.graphManagerState.isDependencyElement(element)
-      ? 'dependency'
-      : '';
+    const getToolTip = (element: PackageableElement): string => {
+      switch (true) {
+        case props.graphManagerState.isSystemElement(element):
+          return 'system';
+        case props.graphManagerState.isGeneratedElement(element):
+          return 'generated';
+        case props.graphManagerState.isMainGraphElement(element):
+          return '';
+        case props.graphManagerState.isDependencyElement(element):
+          return 'dependency';
+        default:
+          return '';
+      }
+    };
+
+    const optionColor = getColor(option.value);
+    const toolTip = getToolTip(option.value);
 
     return (
       <div className={className}>
         <div
-          title={`${optionColor} element`}
+          title={`${toolTip} element`}
           className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${optionColor}`}
         ></div>
         <div className={`${className}__name`}>{option.label}</div>

--- a/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
+++ b/packages/legend-application/src/components/shared/PackageableElementOptionRenderer.tsx
@@ -20,7 +20,7 @@ import type {
 } from '@finos/legend-graph';
 import type { PackageableElementOption } from '../../stores/shared/PackageableElementOption.js';
 
-const optionColorClassName = (
+const classifyElementGraphArea = (
   element: PackageableElement,
   graphManagerState: GraphManagerState,
 ): string =>
@@ -34,7 +34,7 @@ const optionColorClassName = (
     ? 'dependency'
     : '';
 
-const optionToolTip = (
+const generateOptionTooltipText = (
   element: PackageableElement,
   graphManagerState: GraphManagerState,
 ): string | undefined =>
@@ -62,8 +62,11 @@ export const getPackageableElementOptionFormatter = (props: {
     return (
       <div className={className}>
         <div
-          title={`${optionToolTip(option.value, props.graphManagerState)}`}
-          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${optionColorClassName(
+          title={`${generateOptionTooltipText(
+            option.value,
+            props.graphManagerState,
+          )}`}
+          className={`packageable-element-format-option-label-type packageable-element-format-option-label-type--${classifyElementGraphArea(
             option.value,
             props.graphManagerState,
           )}`}

--- a/packages/legend-application/style/components/shared/_packageable-element-format-option.scss
+++ b/packages/legend-application/style/components/shared/_packageable-element-format-option.scss
@@ -47,12 +47,20 @@
   height: 3.2rem;
   padding: 0 0 0 0.5rem;
 
-  &__system {
+  &--system {
     background-color: var(--color-system);
   }
 
-  &__generated {
+  &--generated {
     background-color: var(--color-generated);
+  }
+
+  &--primitive {
+    background-color: var(--color-primitive);
+  }
+
+  &--dependency {
+    background-color: var(--color-dependency);
   }
 }
 

--- a/packages/legend-application/style/components/shared/_packageable-element-format-option.scss
+++ b/packages/legend-application/style/components/shared/_packageable-element-format-option.scss
@@ -41,6 +41,21 @@
   }
 }
 
+.packageable-element-format-option-label-type {
+  background-color: var(--color-dark-grey-300);
+  margin: -1rem 0.8rem -1rem -1.2rem;
+  height: 3.2rem;
+  padding: 0 0 0 0.5rem;
+
+  &__system {
+    background-color: var(--color-system);
+  }
+
+  &__generated {
+    background-color: var(--color-generated);
+  }
+}
+
 .packageable-element-format-option-label--dark {
   @include flexVCenter;
 

--- a/packages/legend-application/style/components/shared/_packageable-element-format-option.scss
+++ b/packages/legend-application/style/components/shared/_packageable-element-format-option.scss
@@ -55,8 +55,8 @@
     background-color: var(--color-generated);
   }
 
-  &--primitive {
-    background-color: var(--color-primitive);
+  &--main {
+    background-color: transparent;
   }
 
   &--dependency {

--- a/packages/legend-art/style/base/_variables.scss
+++ b/packages/legend-art/style/base/_variables.scss
@@ -50,6 +50,7 @@
   --color-magenta-100: #bb619b;
   --color-magenta-300: #8c4268;
   --color-pink-0: #ffc0cb;
+  --color-pink-100: #ffa7c4;
   --color-pink-200: #f05577;
   --color-pink-300: #d14664;
   --color-pink-380: #c5375f;

--- a/packages/legend-graph/src/graphManager/GraphManagerState.ts
+++ b/packages/legend-graph/src/graphManager/GraphManagerState.ts
@@ -76,6 +76,38 @@ export class BasicGraphManagerState {
    * methods here so that we can load plugins.
    */
 
+  isDependencyElement(
+    element: PackageableElement,
+  ): element is PackageableElement {
+    return (
+      getElementRootPackage(element).name ===
+      ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT
+    );
+  }
+
+  isGeneratedElement(
+    element: PackageableElement,
+  ): element is PackageableElement {
+    return (
+      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MODEL_GENERATION
+    );
+  }
+
+  isSystemElement(element: PackageableElement): element is PackageableElement {
+    return (
+      element instanceof PrimitiveType ||
+      element instanceof Unit ||
+      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.SYSTEM ||
+      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.CORE
+    );
+  }
+
+  isMainGraphElement(
+    element: PackageableElement,
+  ): element is PackageableElement {
+    return getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MAIN;
+  }
+
   isInstanceSetImplementation(
     setImplementation:
       | EnumerationMapping
@@ -169,37 +201,6 @@ export class GraphManagerState extends BasicGraphManagerState {
   coreModel: CoreModel;
   systemModel: SystemModel;
   graph: PureModel;
-
-  isPrimitiveTypeElement(
-    element: PackageableElement,
-  ): element is PackageableElement {
-    return element instanceof PrimitiveType || element instanceof Unit;
-  }
-
-  isDependencyElement(
-    element: PackageableElement,
-  ): element is PackageableElement {
-    return (
-      getElementRootPackage(element).name ===
-      ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT
-    );
-  }
-
-  isGeneratedElement(
-    element: PackageableElement,
-  ): element is PackageableElement {
-    return (
-      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MODEL_GENERATION
-    );
-  }
-
-  isSystemElement(element: PackageableElement): element is PackageableElement {
-    return getElementRootPackage(element).name === ROOT_PACKAGE_NAME.SYSTEM;
-  }
-
-  isMainElement(element: PackageableElement): element is PackageableElement {
-    return getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MAIN;
-  }
 
   systemBuildState = ActionState.create();
   dependenciesBuildState = ActionState.create();

--- a/packages/legend-graph/src/graphManager/GraphManagerState.ts
+++ b/packages/legend-graph/src/graphManager/GraphManagerState.ts
@@ -48,6 +48,8 @@ import { EmbeddedRelationalInstanceSetImplementation } from '../graph/metamodel/
 import { InlineEmbeddedRelationalInstanceSetImplementation } from '../graph/metamodel/pure/packageableElements/store/relational/mapping/InlineEmbeddedRelationalInstanceSetImplementation.js';
 import { OtherwiseEmbeddedRelationalInstanceSetImplementation } from '../graph/metamodel/pure/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation.js';
 import { buildPureGraphManager } from '../graphManager/protocol/pure/PureGraphManagerBuilder.js';
+import { PrimitiveType } from '../graph/metamodel/pure/packageableElements/domain/PrimitiveType.js';
+import { Unit } from '../graph/metamodel/pure/packageableElements/domain/Measure.js';
 
 export class BasicGraphManagerState {
   pluginManager: GraphManagerPluginManager;
@@ -172,6 +174,11 @@ export class GraphManagerState extends BasicGraphManagerState {
   dependenciesBuildState = ActionState.create();
   graphBuildState = ActionState.create();
   generationsBuildState = ActionState.create();
+  isPrimitiveTypeElement: (element: PackageableElement) => boolean;
+  isGeneratedElement: (element: PackageableElement) => boolean;
+  isSystemElement: (element: PackageableElement) => boolean;
+  isDependencyElement: (element: PackageableElement) => boolean;
+  isMainElement: (element: PackageableElement) => boolean;
 
   constructor(pluginManager: GraphManagerPluginManager, log: Log) {
     super(pluginManager, log);
@@ -191,6 +198,28 @@ export class GraphManagerState extends BasicGraphManagerState {
     this.coreModel = new CoreModel(extensionElementClasses);
     this.graph = this.createEmptyGraph();
     this.graphManager = buildPureGraphManager(this.pluginManager, log);
+
+    this.isPrimitiveTypeElement = (element: PackageableElement): boolean => {
+      if (element instanceof PrimitiveType || element instanceof Unit) {
+        return true;
+      } else {
+        return false;
+      }
+    };
+
+    this.isDependencyElement = (element: PackageableElement): boolean =>
+      getElementRootPackage(element).name ===
+      ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT;
+
+    this.isGeneratedElement = (element: PackageableElement): boolean =>
+      getElementRootPackage(element).name ===
+      ROOT_PACKAGE_NAME.MODEL_GENERATION;
+
+    this.isSystemElement = (element: PackageableElement): boolean =>
+      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.SYSTEM;
+
+    this.isMainElement = (element: PackageableElement): boolean =>
+      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MAIN;
 
     this.systemBuildState.setMessageFormatter(
       (message: string) => `[system] ${message}`,

--- a/packages/legend-graph/src/graphManager/GraphManagerState.ts
+++ b/packages/legend-graph/src/graphManager/GraphManagerState.ts
@@ -49,7 +49,6 @@ import { InlineEmbeddedRelationalInstanceSetImplementation } from '../graph/meta
 import { OtherwiseEmbeddedRelationalInstanceSetImplementation } from '../graph/metamodel/pure/packageableElements/store/relational/mapping/OtherwiseEmbeddedRelationalInstanceSetImplementation.js';
 import { buildPureGraphManager } from '../graphManager/protocol/pure/PureGraphManagerBuilder.js';
 import { PrimitiveType } from '../graph/metamodel/pure/packageableElements/domain/PrimitiveType.js';
-import { Unit } from '../graph/metamodel/pure/packageableElements/domain/Measure.js';
 
 export class BasicGraphManagerState {
   pluginManager: GraphManagerPluginManager;
@@ -96,7 +95,6 @@ export class BasicGraphManagerState {
   isSystemElement(element: PackageableElement): element is PackageableElement {
     return (
       element instanceof PrimitiveType ||
-      element instanceof Unit ||
       getElementRootPackage(element).name === ROOT_PACKAGE_NAME.SYSTEM ||
       getElementRootPackage(element).name === ROOT_PACKAGE_NAME.CORE
     );

--- a/packages/legend-graph/src/graphManager/GraphManagerState.ts
+++ b/packages/legend-graph/src/graphManager/GraphManagerState.ts
@@ -170,15 +170,36 @@ export class GraphManagerState extends BasicGraphManagerState {
   systemModel: SystemModel;
   graph: PureModel;
 
+  isPrimitiveTypeElement(
+    element: PackageableElement,
+  ): element is PackageableElement {
+    return element instanceof PrimitiveType || element instanceof Unit;
+  }
+
+  isDependencyElement(
+    element: PackageableElement,
+  ): element is PackageableElement {
+    return element.name === ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT;
+  }
+
+  isGeneratedElement(
+    element: PackageableElement,
+  ): element is PackageableElement {
+    return element.name === ROOT_PACKAGE_NAME.MODEL_GENERATION;
+  }
+
+  isSystemElement(element: PackageableElement): element is PackageableElement {
+    return element.name === ROOT_PACKAGE_NAME.SYSTEM;
+  }
+
+  isMainElement(element: PackageableElement): element is PackageableElement {
+    return element.name === ROOT_PACKAGE_NAME.MAIN;
+  }
+
   systemBuildState = ActionState.create();
   dependenciesBuildState = ActionState.create();
   graphBuildState = ActionState.create();
   generationsBuildState = ActionState.create();
-  isPrimitiveTypeElement: (element: PackageableElement) => boolean;
-  isGeneratedElement: (element: PackageableElement) => boolean;
-  isSystemElement: (element: PackageableElement) => boolean;
-  isDependencyElement: (element: PackageableElement) => boolean;
-  isMainElement: (element: PackageableElement) => boolean;
 
   constructor(pluginManager: GraphManagerPluginManager, log: Log) {
     super(pluginManager, log);
@@ -198,28 +219,6 @@ export class GraphManagerState extends BasicGraphManagerState {
     this.coreModel = new CoreModel(extensionElementClasses);
     this.graph = this.createEmptyGraph();
     this.graphManager = buildPureGraphManager(this.pluginManager, log);
-
-    this.isPrimitiveTypeElement = (element: PackageableElement): boolean => {
-      if (element instanceof PrimitiveType || element instanceof Unit) {
-        return true;
-      } else {
-        return false;
-      }
-    };
-
-    this.isDependencyElement = (element: PackageableElement): boolean =>
-      getElementRootPackage(element).name ===
-      ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT;
-
-    this.isGeneratedElement = (element: PackageableElement): boolean =>
-      getElementRootPackage(element).name ===
-      ROOT_PACKAGE_NAME.MODEL_GENERATION;
-
-    this.isSystemElement = (element: PackageableElement): boolean =>
-      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.SYSTEM;
-
-    this.isMainElement = (element: PackageableElement): boolean =>
-      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MAIN;
 
     this.systemBuildState.setMessageFormatter(
       (message: string) => `[system] ${message}`,

--- a/packages/legend-graph/src/graphManager/GraphManagerState.ts
+++ b/packages/legend-graph/src/graphManager/GraphManagerState.ts
@@ -179,21 +179,26 @@ export class GraphManagerState extends BasicGraphManagerState {
   isDependencyElement(
     element: PackageableElement,
   ): element is PackageableElement {
-    return element.name === ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT;
+    return (
+      getElementRootPackage(element).name ===
+      ROOT_PACKAGE_NAME.PROJECT_DEPENDENCY_ROOT
+    );
   }
 
   isGeneratedElement(
     element: PackageableElement,
   ): element is PackageableElement {
-    return element.name === ROOT_PACKAGE_NAME.MODEL_GENERATION;
+    return (
+      getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MODEL_GENERATION
+    );
   }
 
   isSystemElement(element: PackageableElement): element is PackageableElement {
-    return element.name === ROOT_PACKAGE_NAME.SYSTEM;
+    return getElementRootPackage(element).name === ROOT_PACKAGE_NAME.SYSTEM;
   }
 
   isMainElement(element: PackageableElement): element is PackageableElement {
-    return element.name === ROOT_PACKAGE_NAME.MAIN;
+    return getElementRootPackage(element).name === ROOT_PACKAGE_NAME.MAIN;
   }
 
   systemBuildState = ActionState.create();


### PR DESCRIPTION
<h2> Summary </h2> 

Fixes [#457](https://github.com/finos/legend-studio/issues/457)

<h2> How did you test this change? </h2>
 

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


During selector dropdown, the elements have a new class that has visual color indicator depending on what element type is (`system`, `dependencies`, `main`, etc.) 

![Kapture 2022-08-10 at 10 08 33](https://user-images.githubusercontent.com/41248956/183922609-31267224-5345-48ea-8c1d-2d8e1b6e43ca.gif)



Color Previews: 
system: `--color-dark-grey-400`
generated: `--color-light-blue-200`
reasoning: (grey feels like default, light blue is the same color as the arrow button)  
<img width="220" alt="image" src="https://user-images.githubusercontent.com/41248956/183116272-8cae7f82-58a7-4596-ad77-09cc7e42a842.png">

system: `--color-dark-grey-500`
generated: `--color-pink-100`
reasoning: (grey feels like default, pink taken from [legend docs](https://legend.finos.org/docs/overview/legend-overview) --color-primary-0) 
<img width="204" alt="image" src="https://user-images.githubusercontent.com/41248956/183117820-adfb0ee0-b83e-4022-9370-ac4610b28a5d.png">

system: `--color-light-grey-300`
generated: `--color-purple-200`
<img width="202" alt="image" src="https://user-images.githubusercontent.com/41248956/183118306-54e7e5c9-d382-4cd4-b15e-ed0eb147a553.png">




