### PR TITLE
feat: allow DnD to rearrange properties/supertypes/etc

### DIFF
--- a/.changeset/poor-stingrays-dance.md
+++ b/.changeset/poor-stingrays-dance.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-query': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+'@finos/legend-shared': patch
+---

--- a/.changeset/tame-moles-call.md
+++ b/.changeset/tame-moles-call.md
@@ -1,0 +1,8 @@
+---
+'@finos/legend-application-query': minor
+'@finos/legend-application-studio': minor
+'@finos/legend-graph': minor
+'@finos/legend-shared': minor
+---
+
+Allow re-arrange elements (class properties, tagged values, etc.) ([#303](https://github.com/finos/legend-studio/pull/303)).

--- a/.changeset/tame-moles-call.md
+++ b/.changeset/tame-moles-call.md
@@ -1,8 +1,5 @@
 ---
-'@finos/legend-application-query': minor
 '@finos/legend-application-studio': minor
-'@finos/legend-graph': minor
-'@finos/legend-shared': minor
 ---
 
-Allow re-arrange elements (class properties, tagged values, etc.) ([#303](https://github.com/finos/legend-studio/pull/303)).
+Allow re-arranging sub-elements (class properties, tagged values, etc.) in UML editors ([#303](https://github.com/finos/legend-studio/pull/303)).

--- a/packages/legend-application-query/src/components/QueryBuilderProjectionPanel.tsx
+++ b/packages/legend-application-query/src/components/QueryBuilderProjectionPanel.tsx
@@ -38,7 +38,6 @@ import {
 } from '../stores/QueryBuilderExplorerState.js';
 import {
   type DropTargetMonitor,
-  type XYCoord,
   useDragLayer,
   useDrag,
   useDrop,
@@ -342,8 +341,7 @@ const QueryBuilderProjectionColumnEditor = observer(
           ((hoverBoundingReact?.bottom ?? 0) - (hoverBoundingReact?.top ?? 0)) /
           2;
         const dragDistance =
-          (monitor.getClientOffset() as XYCoord).y -
-          (hoverBoundingReact?.top ?? 0);
+          (monitor.getClientOffset()?.y ?? 0) - (hoverBoundingReact?.top ?? 0);
         if (dragIndex < hoverIndex && dragDistance < distanceThreshold) {
           return;
         }

--- a/packages/legend-application-studio/src/components/editor/edit-panel/FunctionEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/FunctionEditor.tsx
@@ -82,7 +82,7 @@ import {
   annotatedElement_addStereotype,
   annotatedElement_deleteStereotype,
   annotatedElement_deleteTaggedValue,
-  function_arrangeParameter,
+  function_swapParameters,
 } from '../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import {
   rawVariableExpression_setMultiplicity,
@@ -114,13 +114,9 @@ export const getFunctionParameterType = (
   );
 };
 
-class FunctionParameterDragSource {
+type FunctionParameterDragSource = {
   parameter: RawVariableExpression;
-
-  constructor(parameter: RawVariableExpression) {
-    this.parameter = parameter;
-  }
-}
+};
 
 enum FUNCTION_PARAMETER_DND_TYPE {
   PARAMETER = 'PARAMETER',
@@ -193,7 +189,7 @@ const ParameterBasicEditor = observer(
       (item: FunctionParameterDragSource, monitor: DropTargetMonitor): void => {
         const draggingParameter = item.parameter;
         const hoveredParameter = parameter;
-        function_arrangeParameter(_func, draggingParameter, hoveredParameter);
+        function_swapParameters(_func, draggingParameter, hoveredParameter);
       },
       [_func, parameter],
     );
@@ -265,7 +261,7 @@ const ParameterBasicEditor = observer(
                 <LockIcon />
               </div>
             )}
-            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+            <div className="uml-element-editor__drag-handler">
               <VerticalDragHandleIcon />
             </div>
             <input

--- a/packages/legend-application-studio/src/components/editor/edit-panel/FunctionEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/FunctionEditor.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   FunctionEditorState,
@@ -29,7 +29,7 @@ import {
   prettyCONSTName,
   UnsupportedOperationError,
 } from '@finos/legend-shared';
-import { useDrop } from 'react-dnd';
+import { type DropTargetMonitor, useDrag, useDrop } from 'react-dnd';
 import {
   clsx,
   CustomSelectorInput,
@@ -38,6 +38,7 @@ import {
   PlusIcon,
   TimesIcon,
   ArrowCircleRightIcon,
+  VerticalDragHandleIcon,
 } from '@finos/legend-art';
 import { LEGEND_STUDIO_TEST_ID } from '../../LegendStudioTestID.js';
 import { StereotypeSelector } from './uml-editor/StereotypeSelector.js';
@@ -81,6 +82,7 @@ import {
   annotatedElement_addStereotype,
   annotatedElement_deleteStereotype,
   annotatedElement_deleteTaggedValue,
+  function_arrangeParameter,
 } from '../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import {
   rawVariableExpression_setMultiplicity,
@@ -88,6 +90,7 @@ import {
   rawVariableExpression_setType,
 } from '../../../stores/graphModifier/ValueSpecificationGraphModifierHelper.js';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../stores/LegendStudioApplicationNavigationContext.js';
+import { getEmptyImage } from 'react-dnd-html5-backend';
 
 enum FUNCTION_PARAMETER_TYPE {
   CLASS = 'CLASS',
@@ -111,13 +114,27 @@ export const getFunctionParameterType = (
   );
 };
 
+class FunctionParameterDragSource {
+  parameter: RawVariableExpression;
+
+  constructor(parameter: RawVariableExpression) {
+    this.parameter = parameter;
+  }
+}
+
+enum FUNCTION_PARAMETER_DND_TYPE {
+  PARAMETER = 'PARAMETER',
+}
+
 const ParameterBasicEditor = observer(
   (props: {
     parameter: RawVariableExpression;
+    _func: ConcreteFunctionDefinition;
     deleteParameter: () => void;
     isReadOnly: boolean;
   }) => {
-    const { parameter, deleteParameter, isReadOnly } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const { parameter, _func, deleteParameter, isReadOnly } = props;
     const editorStore = useEditorStore();
     // Name
     const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) =>
@@ -170,6 +187,53 @@ const ParameterBasicEditor = observer(
         );
       }
     };
+
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: FunctionParameterDragSource, monitor: DropTargetMonitor): void => {
+        const draggingParameter = item.parameter;
+        const hoveredParameter = parameter;
+        function_arrangeParameter(_func, draggingParameter, hoveredParameter);
+      },
+      [_func, parameter],
+    );
+
+    const [{ isBeingDraggedParameter }, dropConnector] = useDrop(
+      () => ({
+        accept: [FUNCTION_PARAMETER_DND_TYPE.PARAMETER],
+        hover: (
+          item: FunctionParameterDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): {
+          isBeingDraggedParameter: RawVariableExpression | undefined;
+        } => ({
+          isBeingDraggedParameter:
+            monitor.getItem<FunctionParameterDragSource | null>()?.parameter,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = parameter === isBeingDraggedParameter;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: FUNCTION_PARAMETER_DND_TYPE.PARAMETER,
+        item: (): FunctionParameterDragSource => ({
+          parameter: parameter,
+        }),
+      }),
+      [parameter],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     const changeLowerBound: React.ChangeEventHandler<HTMLInputElement> = (
       event,
     ) => {
@@ -183,128 +247,147 @@ const ParameterBasicEditor = observer(
       updateMultiplicity(lowerBound, event.target.value);
     };
     return (
-      <div className="property-basic-editor">
-        {isReadOnly && (
-          <div className="property-basic-editor__lock">
-            <LockIcon />
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">
+                {parameter.name}
+              </div>
+            </div>
           </div>
         )}
-        <input
-          className="property-basic-editor__name"
-          disabled={isReadOnly}
-          value={parameter.name}
-          spellCheck={false}
-          onChange={changeValue}
-          placeholder={`Property name`}
-        />
-        {!isReadOnly && isEditingType && (
-          <CustomSelectorInput
-            className="property-basic-editor__type"
-            options={typeOptions}
-            onChange={changeType}
-            value={selectedType}
-            placeholder={'Choose a data type or enumeration'}
-            filterOption={filterOption}
-          />
-        )}
-        {!isReadOnly && !isEditingType && (
-          <div
-            className={clsx(
-              'property-basic-editor__type',
-              'property-basic-editor__type--show-click-hint',
-              `background--${typeName.toLowerCase()}`,
-              {
-                'property-basic-editor__type--has-visit-btn':
-                  typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE,
-              },
-            )}
-          >
-            {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
-              <div className="property-basic-editor__type__abbr">
-                {getElementIcon(editorStore, paramType)}
+
+        {!isBeingDragged && (
+          <div className="property-basic-editor">
+            {isReadOnly && (
+              <div className="property-basic-editor__lock">
+                <LockIcon />
               </div>
             )}
-            <div className="property-basic-editor__type__label">
-              {paramType.name}
+            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <VerticalDragHandleIcon />
             </div>
-            <div
-              className="property-basic-editor__type__label property-basic-editor__type__label--hover"
-              onClick={(): void => setIsEditingType(true)}
-            >
-              Click to edit
-            </div>
-            {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
-              <button
-                data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
-                className="property-basic-editor__type__visit-btn"
-                onClick={openElement}
-                tabIndex={-1}
-                title={'Visit element'}
+            <input
+              className="property-basic-editor__name"
+              disabled={isReadOnly}
+              value={parameter.name}
+              spellCheck={false}
+              onChange={changeValue}
+              placeholder={`Property name`}
+            />
+            {!isReadOnly && isEditingType && (
+              <CustomSelectorInput
+                className="property-basic-editor__type"
+                options={typeOptions}
+                onChange={changeType}
+                value={selectedType}
+                placeholder={'Choose a data type or enumeration'}
+                filterOption={filterOption}
+              />
+            )}
+            {!isReadOnly && !isEditingType && (
+              <div
+                className={clsx(
+                  'property-basic-editor__type',
+                  'property-basic-editor__type--show-click-hint',
+                  `background--${typeName.toLowerCase()}`,
+                  {
+                    'property-basic-editor__type--has-visit-btn':
+                      typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE,
+                  },
+                )}
               >
-                <ArrowCircleRightIcon />
+                {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
+                  <div className="property-basic-editor__type__abbr">
+                    {getElementIcon(editorStore, paramType)}
+                  </div>
+                )}
+                <div className="property-basic-editor__type__label">
+                  {paramType.name}
+                </div>
+                <div
+                  className="property-basic-editor__type__label property-basic-editor__type__label--hover"
+                  onClick={(): void => setIsEditingType(true)}
+                >
+                  Click to edit
+                </div>
+                {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
+                  <button
+                    data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
+                    className="property-basic-editor__type__visit-btn"
+                    onClick={openElement}
+                    tabIndex={-1}
+                    title={'Visit element'}
+                  >
+                    <ArrowCircleRightIcon />
+                  </button>
+                )}
+              </div>
+            )}
+            {isReadOnly && (
+              <div
+                className={clsx(
+                  'property-basic-editor__type',
+                  `background--${typeName.toLowerCase()}`,
+                  {
+                    'property-basic-editor__type--has-visit-btn':
+                      typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE,
+                  },
+                )}
+              >
+                {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
+                  <div className="property-basic-editor__type__abbr">
+                    {getElementIcon(editorStore, paramType)}
+                  </div>
+                )}
+                <div className="property-basic-editor__type__label">
+                  {paramType.name}
+                </div>
+                {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
+                  <button
+                    data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
+                    className="property-basic-editor__type__visit-btn"
+                    onClick={openElement}
+                    tabIndex={-1}
+                    title={'Visit element'}
+                  >
+                    <ArrowCircleRightIcon />
+                  </button>
+                )}
+              </div>
+            )}
+            <div className="property-basic-editor__multiplicity">
+              <input
+                className="property-basic-editor__multiplicity-bound"
+                disabled={isReadOnly}
+                spellCheck={false}
+                value={lowerBound}
+                onChange={changeLowerBound}
+              />
+              <div className="property-basic-editor__multiplicity__range">
+                ..
+              </div>
+              <input
+                className="property-basic-editor__multiplicity-bound"
+                disabled={isReadOnly}
+                spellCheck={false}
+                value={upperBound}
+                onChange={changeUpperBound}
+              />
+            </div>
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteParameter}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
               </button>
             )}
           </div>
-        )}
-        {isReadOnly && (
-          <div
-            className={clsx(
-              'property-basic-editor__type',
-              `background--${typeName.toLowerCase()}`,
-              {
-                'property-basic-editor__type--has-visit-btn':
-                  typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE,
-              },
-            )}
-          >
-            {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
-              <div className="property-basic-editor__type__abbr">
-                {getElementIcon(editorStore, paramType)}
-              </div>
-            )}
-            <div className="property-basic-editor__type__label">
-              {paramType.name}
-            </div>
-            {typeName !== FUNCTION_PARAMETER_TYPE.PRIMITIVE && (
-              <button
-                data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
-                className="property-basic-editor__type__visit-btn"
-                onClick={openElement}
-                tabIndex={-1}
-                title={'Visit element'}
-              >
-                <ArrowCircleRightIcon />
-              </button>
-            )}
-          </div>
-        )}
-        <div className="property-basic-editor__multiplicity">
-          <input
-            className="property-basic-editor__multiplicity-bound"
-            disabled={isReadOnly}
-            spellCheck={false}
-            value={lowerBound}
-            onChange={changeLowerBound}
-          />
-          <div className="property-basic-editor__multiplicity__range">..</div>
-          <input
-            className="property-basic-editor__multiplicity-bound"
-            disabled={isReadOnly}
-            spellCheck={false}
-            value={upperBound}
-            onChange={changeUpperBound}
-          />
-        </div>
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteParameter}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
         )}
       </div>
     );
@@ -591,6 +674,7 @@ export const FunctionMainEditor = observer(
               <ParameterBasicEditor
                 key={param._UUID}
                 parameter={param}
+                _func={functionElement}
                 deleteParameter={deleteParameter(param)}
                 isReadOnly={isReadOnly}
               />
@@ -804,6 +888,7 @@ export const FunctionEditor = observer(() => {
               >
                 {functionElement.taggedValues.map((taggedValue) => (
                   <TaggedValueEditor
+                    annotatedElement={functionElement}
                     key={taggedValue._UUID}
                     taggedValue={taggedValue}
                     deleteValue={_deleteTaggedValue(taggedValue)}
@@ -823,6 +908,7 @@ export const FunctionEditor = observer(() => {
                 {functionElement.stereotypes.map((stereotype) => (
                   <StereotypeSelector
                     key={stereotype.value._UUID}
+                    annotatedElement={functionElement}
                     stereotype={stereotype}
                     deleteStereotype={_deleteStereotype(stereotype)}
                     isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/GenerationSpecificationEditor.tsx
@@ -25,7 +25,6 @@ import {
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import {
   type DropTargetMonitor,
-  type XYCoord,
   useDragLayer,
   useDrag,
   useDrop,
@@ -164,8 +163,7 @@ const ModelGenerationItem = observer(
           ((hoverBoundingReact?.bottom ?? 0) - (hoverBoundingReact?.top ?? 0)) /
           2;
         const dragDistance =
-          (monitor.getClientOffset() as XYCoord).y -
-          (hoverBoundingReact?.top ?? 0);
+          (monitor.getClientOffset()?.y ?? 0) - (hoverBoundingReact?.top ?? 0);
         if (dragIndex < hoverIndex && dragDistance < distanceThreshold) {
           return;
         }

--- a/packages/legend-application-studio/src/components/editor/edit-panel/data-editor/DataElementEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/data-editor/DataElementEditor.tsx
@@ -318,6 +318,7 @@ export const DataElementEditor = observer(() => {
                   {dataElement.stereotypes.map((stereotype) => (
                     <StereotypeSelector
                       key={stereotype.value._UUID}
+                      annotatedElement={dataElement}
                       stereotype={stereotype}
                       deleteStereotype={_deleteStereotype(stereotype)}
                       isReadOnly={isReadOnly}
@@ -365,6 +366,7 @@ export const DataElementEditor = observer(() => {
                 >
                   {dataElement.taggedValues.map((taggedValue) => (
                     <TaggedValueEditor
+                      annotatedElement={dataElement}
                       key={taggedValue._UUID}
                       taggedValue={taggedValue}
                       deleteValue={deleteTaggedValue(taggedValue)}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/AssociationEditor.tsx
@@ -512,6 +512,7 @@ export const AssociationEditor = observer(
                   >
                     {association.taggedValues.map((taggedValue) => (
                       <TaggedValueEditor
+                        annotatedElement={association}
                         key={taggedValue._UUID}
                         taggedValue={taggedValue}
                         deleteValue={_deleteTaggedValue(taggedValue)}
@@ -531,6 +532,7 @@ export const AssociationEditor = observer(
                     {association.stereotypes.map((stereotype) => (
                       <StereotypeSelector
                         key={stereotype.value._UUID}
+                        annotatedElement={association}
                         stereotype={stereotype}
                         deleteStereotype={_deleteStereotype(stereotype)}
                         isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ClassEditor.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import { isNonNullable, prettyCONSTName } from '@finos/legend-shared';
-import { useDrop } from 'react-dnd';
 import {
   CORE_DND_TYPE,
   type ElementDragSource,
@@ -38,6 +37,7 @@ import {
   PlusIcon,
   TimesIcon,
   LongArrowRightIcon,
+  VerticalDragHandleIcon,
   ArrowCircleRightIcon,
   FireIcon,
   StickArrowCircleRightIcon,
@@ -45,9 +45,11 @@ import {
 import { LEGEND_STUDIO_TEST_ID } from '../../../LegendStudioTestID.js';
 import { PropertyEditor } from './PropertyEditor.js';
 import { StereotypeSelector } from './StereotypeSelector.js';
+import { TaggedValueEditor } from './TaggedValueEditor.js';
 import { UML_EDITOR_TAB } from '../../../../stores/editor-state/element-editor-state/UMLEditorState.js';
 import { ClassEditorState } from '../../../../stores/editor-state/element-editor-state/ClassEditorState.js';
-import { flowResult } from 'mobx';
+import { action, flowResult, makeObservable, observable } from 'mobx';
+import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
 import { useEditorStore } from '../../EditorStoreProvider.js';
 import {
   type StereotypeReference,
@@ -109,6 +111,10 @@ import {
   property_setName,
   property_setGenericType,
   property_setMultiplicity,
+  class_arrangeProperty,
+  class_arrangeDerivedProperty,
+  class_arrangeConstraint,
+  class_arrangeSuperTypes,
   setGenericTypeReferenceValue,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import {
@@ -116,7 +122,19 @@ import {
   getClassPropertyType,
 } from '../../../../stores/shared/ModelUtil.js';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../../stores/LegendStudioApplicationNavigationContext.js';
-import { TaggedValueEditor } from './TaggedValueEditor.js';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+
+class ClassPropertyDragSource {
+  property: Property;
+
+  constructor(property: Property) {
+    this.property = property;
+  }
+}
+
+enum CLASS_PROPERTY_DND_TYPE {
+  PROPERTY = 'PROPERTY',
+}
 
 const PropertyBasicEditor = observer(
   (props: {
@@ -126,7 +144,9 @@ const PropertyBasicEditor = observer(
     deleteProperty: () => void;
     isReadOnly: boolean;
   }) => {
+    const ref = useRef<HTMLDivElement>(null);
     const { property, _class, editorState, deleteProperty, isReadOnly } = props;
+
     const editorStore = useEditorStore();
     const isInheritedProperty =
       property._OWNER instanceof Class && property._OWNER !== _class;
@@ -136,6 +156,7 @@ const PropertyBasicEditor = observer(
       _class.properties.filter((p) => p.name === val.name).length >= 2;
     const selectProperty = (): void =>
       editorState.setSelectedProperty(property);
+
     // Name
     const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
       property_setName(property, event.target.value);
@@ -193,6 +214,51 @@ const PropertyBasicEditor = observer(
       setUpperBound(event.target.value);
       updateMultiplicity(lowerBound, event.target.value);
     };
+
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: ClassPropertyDragSource, monitor: DropTargetMonitor): void => {
+        const draggingProperty = item.property;
+        const hoveredProperty = property;
+        class_arrangeProperty(_class, draggingProperty, hoveredProperty);
+      },
+      [_class, property],
+    );
+
+    const [{ isBeingDraggedProperty }, dropConnector] = useDrop(
+      () => ({
+        accept: [CLASS_PROPERTY_DND_TYPE.PROPERTY],
+        hover: (
+          item: ClassPropertyDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedProperty: Property | undefined } => ({
+          isBeingDraggedProperty:
+            monitor.getItem<ClassPropertyDragSource | null>()?.property,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = property === isBeingDraggedProperty;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: CLASS_PROPERTY_DND_TYPE.PROPERTY,
+        item: (): ClassPropertyDragSource => ({
+          property: property,
+        }),
+      }),
+      [property],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     // Other
     const openElement = (): void => {
       if (!(propertyType instanceof PrimitiveType)) {
@@ -206,179 +272,211 @@ const PropertyBasicEditor = observer(
     const visitOwner = (): void => editorStore.openElement(property._OWNER);
 
     return (
-      <div className="property-basic-editor">
-        {isIndirectProperty && (
-          <div className="property-basic-editor__name--with-lock">
-            <div className="property-basic-editor__name--with-lock__icon">
-              <LockIcon />
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">
+                {property.name}
+              </div>
             </div>
-            <span className="property-basic-editor__name--with-lock__name">
-              {property.name}
-            </span>
           </div>
         )}
-        {!isIndirectProperty && (
-          <div className="input-group__input property-basic-editor__input">
-            <InputWithInlineValidation
-              className="property-basic-editor__input--with-validation input-group__input"
-              disabled={isReadOnly}
-              value={property.name}
-              spellCheck={false}
-              onChange={changeValue}
-              placeholder={`Property name`}
-              validationErrorMessage={
-                isPropertyDuplicated(property)
-                  ? 'Duplicated property'
-                  : undefined
-              }
-            />
-          </div>
-        )}
-        {!isIndirectProperty && !isReadOnly && isEditingType && (
-          <CustomSelectorInput
-            className="property-basic-editor__type"
-            options={propertyTypeOptions}
-            onChange={changePropertyType}
-            value={selectedPropertyType}
-            placeholder={'Choose a data type or enumeration'}
-            filterOption={filterOption}
-            formatOptionLabel={getPackageableElementOptionFormatter({
-              graphManagerState: editorStore.graphManagerState,
-            })}
-          />
-        )}
-        {!isIndirectProperty && !isReadOnly && !isEditingType && (
-          <div
-            className={clsx(
-              'property-basic-editor__type',
-              'property-basic-editor__type--show-click-hint',
-              `background--${propertyTypeName.toLowerCase()}`,
-              {
-                'property-basic-editor__type--has-visit-btn':
-                  propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
-              },
-            )}
-          >
-            {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
-              <div className="property-basic-editor__type__abbr">
-                {getElementIcon(editorStore, propertyType)}
+        {!isBeingDragged && (
+          <div className="property-basic-editor">
+            {!isIndirectProperty && (
+              <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+                <VerticalDragHandleIcon />
               </div>
             )}
-            <div className="property-basic-editor__type__label">
-              {propertyType.name}
+            {isIndirectProperty && (
+              <div className="property-basic-editor__name--with-lock">
+                <div className="property-basic-editor__name--with-lock__icon">
+                  <LockIcon />
+                </div>
+                <span className="property-basic-editor__name--with-lock__name">
+                  {property.name}
+                </span>
+              </div>
+            )}
+            {!isIndirectProperty && (
+              <div className="input-group__input property-basic-editor__input">
+                <InputWithInlineValidation
+                  className="property-basic-editor__input--with-validation input-group__input"
+                  disabled={isReadOnly}
+                  value={property.name}
+                  spellCheck={false}
+                  onChange={changeValue}
+                  placeholder={`Property name`}
+                  validationErrorMessage={
+                    isPropertyDuplicated(property)
+                      ? 'Duplicated property'
+                      : undefined
+                  }
+                />
+              </div>
+            )}
+            {!isIndirectProperty && !isReadOnly && isEditingType && (
+              <CustomSelectorInput
+                className="property-basic-editor__type"
+                options={propertyTypeOptions}
+                onChange={changePropertyType}
+                value={selectedPropertyType}
+                placeholder={'Choose a data type or enumeration'}
+                filterOption={filterOption}
+                formatOptionLabel={getPackageableElementOptionFormatter({
+                  graphManagerState: editorStore.graphManagerState,
+                })}
+              />
+            )}
+            {!isIndirectProperty && !isReadOnly && !isEditingType && (
+              <div
+                className={clsx(
+                  'property-basic-editor__type',
+                  'property-basic-editor__type--show-click-hint',
+                  `background--${propertyTypeName.toLowerCase()}`,
+                  {
+                    'property-basic-editor__type--has-visit-btn':
+                      propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
+                  },
+                )}
+              >
+                {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                  <div className="property-basic-editor__type__abbr">
+                    {getElementIcon(editorStore, propertyType)}
+                  </div>
+                )}
+                <div className="property-basic-editor__type__label">
+                  {propertyType.name}
+                </div>
+                <div
+                  data-testid={
+                    LEGEND_STUDIO_TEST_ID.PROPERTY_BASIC_EDITOR__TYPE__LABEL_HOVER
+                  }
+                  className="property-basic-editor__type__label property-basic-editor__type__label--hover"
+                  onClick={(): void => setIsEditingType(true)}
+                >
+                  Click to edit
+                </div>
+                {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                  <button
+                    data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
+                    className="property-basic-editor__type__visit-btn"
+                    onClick={openElement}
+                    tabIndex={-1}
+                    title={'Visit element'}
+                  >
+                    <ArrowCircleRightIcon />
+                  </button>
+                )}
+              </div>
+            )}
+            {(isIndirectProperty || isReadOnly) && (
+              <div
+                className={clsx(
+                  'property-basic-editor__type',
+                  `background--${propertyTypeName.toLowerCase()}`,
+                  {
+                    'property-basic-editor__type--has-visit-btn':
+                      propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
+                  },
+                )}
+              >
+                {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                  <div className="property-basic-editor__type__abbr">
+                    {getElementIcon(editorStore, propertyType)}
+                  </div>
+                )}
+                <div className="property-basic-editor__type__label">
+                  {propertyType.name}
+                </div>
+                {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                  <button
+                    data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
+                    className="property-basic-editor__type__visit-btn"
+                    onClick={openElement}
+                    tabIndex={-1}
+                    title={'Visit element'}
+                  >
+                    <ArrowCircleRightIcon />
+                  </button>
+                )}
+              </div>
+            )}
+            <div className="property-basic-editor__multiplicity">
+              <input
+                className="property-basic-editor__multiplicity-bound"
+                disabled={isIndirectProperty || isReadOnly}
+                spellCheck={false}
+                value={lowerBound}
+                onChange={changeLowerBound}
+              />
+              <div className="property-basic-editor__multiplicity__range">
+                ..
+              </div>
+              <input
+                className="property-basic-editor__multiplicity-bound"
+                disabled={isIndirectProperty || isReadOnly}
+                spellCheck={false}
+                value={upperBound}
+                onChange={changeUpperBound}
+              />
             </div>
-            <div
-              data-testid={
-                LEGEND_STUDIO_TEST_ID.PROPERTY_BASIC_EDITOR__TYPE__LABEL_HOVER
-              }
-              className="property-basic-editor__type__label property-basic-editor__type__label--hover"
-              onClick={(): void => setIsEditingType(true)}
-            >
-              Click to edit
-            </div>
-            {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+            {!isIndirectProperty && (
               <button
-                data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
-                className="property-basic-editor__type__visit-btn"
-                onClick={openElement}
+                className="uml-element-editor__basic__detail-btn"
+                onClick={selectProperty}
                 tabIndex={-1}
-                title={'Visit element'}
+                title={'See detail'}
+              >
+                <LongArrowRightIcon />
+              </button>
+            )}
+            {isIndirectProperty && (
+              <button
+                className="uml-element-editor__visit-parent-element-btn"
+                onClick={visitOwner}
+                tabIndex={-1}
+                title={`Visit ${
+                  isInheritedProperty ? 'super type class' : 'association'
+                } '${property._OWNER.path}'`}
               >
                 <ArrowCircleRightIcon />
               </button>
             )}
-          </div>
-        )}
-        {(isIndirectProperty || isReadOnly) && (
-          <div
-            className={clsx(
-              'property-basic-editor__type',
-              `background--${propertyTypeName.toLowerCase()}`,
-              {
-                'property-basic-editor__type--has-visit-btn':
-                  propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
-              },
+            {isIndirectProperty && (
+              <div className="property-basic-editor__locked-property-end-block"></div>
             )}
-          >
-            {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
-              <div className="property-basic-editor__type__abbr">
-                {getElementIcon(editorStore, propertyType)}
-              </div>
-            )}
-            <div className="property-basic-editor__type__label">
-              {propertyType.name}
-            </div>
-            {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+            {!isIndirectProperty && !isReadOnly && (
               <button
-                data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
-                className="property-basic-editor__type__visit-btn"
-                onClick={openElement}
+                className={clsx('uml-element-editor__remove-btn', {
+                  'uml-element-editor__remove-btn--hidden': isIndirectProperty,
+                })}
+                onClick={deleteProperty}
                 tabIndex={-1}
-                title={'Visit element'}
+                title={'Remove'}
               >
-                <ArrowCircleRightIcon />
+                <TimesIcon />
               </button>
             )}
           </div>
-        )}
-        <div className="property-basic-editor__multiplicity">
-          <input
-            className="property-basic-editor__multiplicity-bound"
-            disabled={isIndirectProperty || isReadOnly}
-            spellCheck={false}
-            value={lowerBound}
-            onChange={changeLowerBound}
-          />
-          <div className="property-basic-editor__multiplicity__range">..</div>
-          <input
-            className="property-basic-editor__multiplicity-bound"
-            disabled={isIndirectProperty || isReadOnly}
-            spellCheck={false}
-            value={upperBound}
-            onChange={changeUpperBound}
-          />
-        </div>
-        {!isIndirectProperty && (
-          <button
-            className="uml-element-editor__basic__detail-btn"
-            onClick={selectProperty}
-            tabIndex={-1}
-            title={'See detail'}
-          >
-            <LongArrowRightIcon />
-          </button>
-        )}
-        {isIndirectProperty && (
-          <button
-            className="uml-element-editor__visit-parent-element-btn"
-            onClick={visitOwner}
-            tabIndex={-1}
-            title={`Visit ${
-              isInheritedProperty ? 'super type class' : 'association'
-            } '${property._OWNER.path}'`}
-          >
-            <ArrowCircleRightIcon />
-          </button>
-        )}
-        {isIndirectProperty && (
-          <div className="property-basic-editor__locked-property-end-block"></div>
-        )}
-        {!isIndirectProperty && !isReadOnly && (
-          <button
-            className={clsx('uml-element-editor__remove-btn', {
-              'uml-element-editor__remove-btn--hidden': isIndirectProperty,
-            })}
-            onClick={deleteProperty}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
         )}
       </div>
     );
   },
 );
+
+class ClassDerivedPropertyDragSource {
+  derivedProperty: DerivedProperty;
+
+  constructor(derivedProperty: DerivedProperty) {
+    this.derivedProperty = derivedProperty;
+  }
+}
+
+enum CLASS_DERIVED_PROPERTY_DND_TYPE {
+  PROPERTY = 'PROPERTY',
+}
 
 const DerivedPropertyBasicEditor = observer(
   (props: {
@@ -388,6 +486,7 @@ const DerivedPropertyBasicEditor = observer(
     deleteDerivedProperty: () => void;
     isReadOnly: boolean;
   }) => {
+    const ref = useRef<HTMLDivElement>(null);
     const {
       derivedProperty,
       _class,
@@ -464,6 +563,72 @@ const DerivedPropertyBasicEditor = observer(
       setUpperBound(event.target.value);
       updateMultiplicity(lowerBound, event.target.value);
     };
+
+    // Drag and Drop
+    const handleHover = useCallback(
+      (
+        item: ClassDerivedPropertyDragSource,
+        monitor: DropTargetMonitor,
+      ): void => {
+        const draggingProperty = item.derivedProperty;
+        const hoveredProperty = derivedProperty;
+
+        const dragIndex = _class.derivedProperties.findIndex(
+          (e) => e === item.derivedProperty,
+        );
+        const hoverIndex = _class.derivedProperties.findIndex(
+          (e) => e === derivedProperty,
+        );
+        // move the item being hovered on when the dragged item position is beyond the its middle point
+        const hoverBoundingReact = ref.current?.getBoundingClientRect();
+        const distanceThreshold =
+          ((hoverBoundingReact?.bottom ?? 0) - (hoverBoundingReact?.top ?? 0)) /
+          2;
+        const dragDistance =
+          (monitor.getClientOffset()?.y ?? 0) - (hoverBoundingReact?.top ?? 0);
+        if (dragIndex < hoverIndex && dragDistance < distanceThreshold) {
+          return;
+        }
+        class_arrangeDerivedProperty(_class, draggingProperty, hoveredProperty);
+      },
+      [_class, derivedProperty],
+    );
+
+    const [{ isBeingDraggedProperty }, dropConnector] = useDrop(
+      () => ({
+        accept: [CLASS_DERIVED_PROPERTY_DND_TYPE.PROPERTY],
+        hover: (
+          item: ClassDerivedPropertyDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedProperty: Property | undefined } => ({
+          isBeingDraggedProperty:
+            monitor.getItem<ClassDerivedPropertyDragSource | null>()
+              ?.derivedProperty,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = derivedProperty === isBeingDraggedProperty;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: CLASS_DERIVED_PROPERTY_DND_TYPE.PROPERTY,
+        item: (): ClassDerivedPropertyDragSource => ({
+          derivedProperty: derivedProperty,
+        }),
+      }),
+      [derivedProperty],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     // Action
     const onLambdaEditorFocus = (): void =>
       applicationStore.navigationContextService.push(
@@ -486,186 +651,233 @@ const DerivedPropertyBasicEditor = observer(
     });
 
     return (
-      <div
-        className={clsx('derived-property-editor', {
-          backdrop__element:
-            dpState.parserError && !isInheritedProperty && !isReadOnly,
-        })}
-      >
-        <div className="property-basic-editor">
-          {isInheritedProperty && (
-            <div className="property-basic-editor__name--with-lock">
-              <div className="property-basic-editor__name--with-lock__icon">
-                <LockIcon />
-              </div>
-              <span className="property-basic-editor__name--with-lock__name">
-                {derivedProperty.name}
-              </span>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd--padding">
+            <div className="uml-element-editor__dnd__name">
+              {derivedProperty.name}
             </div>
-          )}
-          {!isInheritedProperty && (
-            <input
-              disabled={isReadOnly}
-              spellCheck={false}
-              className="property-basic-editor__name property-basic-editor__qualififed-property__name"
-              value={derivedProperty.name}
-              placeholder="Property name"
-              onChange={changeValue}
-            />
-          )}
-          {!isInheritedProperty && !isReadOnly && isEditingType && (
-            <CustomSelectorInput
-              className="property-basic-editor__type property-basic-editor__qualififed-property__type"
-              options={propertyTypeOptions}
-              onChange={changePropertyType}
-              value={selectedPropertyType}
-              placeholder="Choose a data type or enumeration"
-              filterOption={filterOption}
-              formatOptionLabel={getPackageableElementOptionFormatter({
-                graphManagerState: editorStore.graphManagerState,
-              })}
-            />
-          )}
-          {!isInheritedProperty && !isReadOnly && !isEditingType && (
-            <div
-              className={clsx(
-                'property-basic-editor__type',
-                'property-basic-editor__type--show-click-hint',
-                `background--${propertyTypeName.toLowerCase()}`,
-                {
-                  'property-basic-editor__type--has-visit-btn':
-                    propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
-                },
-              )}
-            >
-              {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
-                <div className="property-basic-editor__type__abbr">
-                  {getElementIcon(editorStore, propertyType)}
-                </div>
-              )}
-              <div className="property-basic-editor__type__label">
-                {propertyType.name}
-              </div>
-              <div
-                data-testid={
-                  LEGEND_STUDIO_TEST_ID.PROPERTY_BASIC_EDITOR__TYPE__LABEL_HOVER
-                }
-                className="property-basic-editor__type__label property-basic-editor__type__label--hover"
-                onClick={(): void => setIsEditingType(true)}
-              >
-                Click to edit
-              </div>
-              {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
-                <button
-                  data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
-                  className="property-basic-editor__type__visit-btn"
-                  onClick={openElement}
-                  tabIndex={-1}
-                  title="Visit element"
-                >
-                  <ArrowCircleRightIcon />
-                </button>
-              )}
-            </div>
-          )}
-          {(isInheritedProperty || isReadOnly) && (
-            <div
-              className={clsx(
-                'property-basic-editor__type',
-                `background--${propertyTypeName.toLowerCase()}`,
-                {
-                  'property-basic-editor__type--has-visit-btn':
-                    propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
-                },
-              )}
-            >
-              {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
-                <div className="property-basic-editor__type__abbr">
-                  {getElementIcon(editorStore, propertyType)}
-                </div>
-              )}
-              <div className="property-basic-editor__type__label">
-                {propertyType.name}
-              </div>
-              {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
-                <button
-                  data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
-                  className="property-basic-editor__type__visit-btn"
-                  onClick={openElement}
-                  tabIndex={-1}
-                  title="Visit element"
-                >
-                  <ArrowCircleRightIcon />
-                </button>
-              )}
-            </div>
-          )}
-          <div className="property-basic-editor__multiplicity">
-            <input
-              className="property-basic-editor__multiplicity-bound"
-              spellCheck={false}
-              disabled={isInheritedProperty || isReadOnly}
-              value={lowerBound}
-              onChange={changeLowerBound}
-            />
-            <div className="property-basic-editor__multiplicity__range">..</div>
-            <input
-              className="property-basic-editor__multiplicity-bound"
-              spellCheck={false}
-              disabled={isInheritedProperty || isReadOnly}
-              value={upperBound}
-              onChange={changeUpperBound}
-            />
           </div>
-          {!isInheritedProperty && (
-            <button
-              className="uml-element-editor__basic__detail-btn"
-              onClick={selectDerivedProperty}
-              tabIndex={-1}
-              title="See detail"
-            >
-              <LongArrowRightIcon />
-            </button>
-          )}
-          {isInheritedProperty && (
-            <button
-              className="uml-element-editor__visit-parent-element-btn"
-              onClick={visitOwner}
-              tabIndex={-1}
-              title={`Visit super type class ${derivedProperty._OWNER.path}`}
-            >
-              <ArrowCircleRightIcon />
-            </button>
-          )}
-          {!isInheritedProperty && !isReadOnly && (
-            <button
-              className={clsx('uml-element-editor__remove-btn', {
-                'uml-element-editor__remove-btn--hidden': isInheritedProperty,
-              })}
-              onClick={remove}
-              tabIndex={-1}
-              title="Remove"
-            >
-              <TimesIcon />
-            </button>
-          )}
-        </div>
-        <div onFocus={onLambdaEditorFocus}>
-          <StudioLambdaEditor
-            disabled={
-              editorState.classState.isConvertingDerivedPropertyLambdaObjects ||
-              isInheritedProperty ||
-              isReadOnly
-            }
-            lambdaEditorState={dpState}
-            forceBackdrop={hasParserError}
-            expectedType={propertyType}
-          />
-        </div>
+        )}
+
+        {!isBeingDragged && (
+          <div
+            className={clsx('derived-property-editor', {
+              backdrop__element:
+                dpState.parserError && !isInheritedProperty && !isReadOnly,
+            })}
+          >
+            <div className="property-basic-editor">
+              {isInheritedProperty && (
+                <div className="property-basic-editor__name--with-lock">
+                  <div className="property-basic-editor__name--with-lock__icon">
+                    <LockIcon />
+                  </div>
+                  <span className="property-basic-editor__name--with-lock__name">
+                    {derivedProperty.name}
+                  </span>
+                </div>
+              )}
+              {!isInheritedProperty && (
+                <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+                  <VerticalDragHandleIcon />
+                </div>
+              )}
+              {!isInheritedProperty && (
+                <input
+                  disabled={isReadOnly}
+                  spellCheck={false}
+                  className="property-basic-editor__name property-basic-editor__qualififed-property__name"
+                  value={derivedProperty.name}
+                  placeholder="Property name"
+                  onChange={changeValue}
+                />
+              )}
+              {!isInheritedProperty && !isReadOnly && isEditingType && (
+                <CustomSelectorInput
+                  className="property-basic-editor__type property-basic-editor__qualififed-property__type"
+                  options={propertyTypeOptions}
+                  onChange={changePropertyType}
+                  value={selectedPropertyType}
+                  placeholder="Choose a data type or enumeration"
+                  filterOption={filterOption}
+                  formatOptionLabel={getPackageableElementOptionFormatter({
+                    graphManagerState: editorStore.graphManagerState,
+                  })}
+                />
+              )}
+              {!isInheritedProperty && !isReadOnly && !isEditingType && (
+                <div
+                  className={clsx(
+                    'property-basic-editor__type',
+                    'property-basic-editor__type--show-click-hint',
+                    `background--${propertyTypeName.toLowerCase()}`,
+                    {
+                      'property-basic-editor__type--has-visit-btn':
+                        propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
+                    },
+                  )}
+                >
+                  {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                    <div className="property-basic-editor__type__abbr">
+                      {getElementIcon(editorStore, propertyType)}
+                    </div>
+                  )}
+                  <div className="property-basic-editor__type__label">
+                    {propertyType.name}
+                  </div>
+                  <div
+                    data-testid={
+                      LEGEND_STUDIO_TEST_ID.PROPERTY_BASIC_EDITOR__TYPE__LABEL_HOVER
+                    }
+                    className="property-basic-editor__type__label property-basic-editor__type__label--hover"
+                    onClick={(): void => setIsEditingType(true)}
+                  >
+                    Click to edit
+                  </div>
+                  {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                    <button
+                      data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
+                      className="property-basic-editor__type__visit-btn"
+                      onClick={openElement}
+                      tabIndex={-1}
+                      title="Visit element"
+                    >
+                      <ArrowCircleRightIcon />
+                    </button>
+                  )}
+                </div>
+              )}
+              {(isInheritedProperty || isReadOnly) && (
+                <div
+                  className={clsx(
+                    'property-basic-editor__type',
+                    `background--${propertyTypeName.toLowerCase()}`,
+                    {
+                      'property-basic-editor__type--has-visit-btn':
+                        propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE,
+                    },
+                  )}
+                >
+                  {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                    <div className="property-basic-editor__type__abbr">
+                      {getElementIcon(editorStore, propertyType)}
+                    </div>
+                  )}
+                  <div className="property-basic-editor__type__label">
+                    {propertyType.name}
+                  </div>
+                  {propertyTypeName !== CLASS_PROPERTY_TYPE.PRIMITIVE && (
+                    <button
+                      data-testid={LEGEND_STUDIO_TEST_ID.TYPE_VISIT}
+                      className="property-basic-editor__type__visit-btn"
+                      onClick={openElement}
+                      tabIndex={-1}
+                      title="Visit element"
+                    >
+                      <ArrowCircleRightIcon />
+                    </button>
+                  )}
+                </div>
+              )}
+              <div className="property-basic-editor__multiplicity">
+                <input
+                  className="property-basic-editor__multiplicity-bound"
+                  spellCheck={false}
+                  disabled={isInheritedProperty || isReadOnly}
+                  value={lowerBound}
+                  onChange={changeLowerBound}
+                />
+                <div className="property-basic-editor__multiplicity__range">
+                  ..
+                </div>
+                <input
+                  className="property-basic-editor__multiplicity-bound"
+                  spellCheck={false}
+                  disabled={isInheritedProperty || isReadOnly}
+                  value={upperBound}
+                  onChange={changeUpperBound}
+                />
+              </div>
+              {!isInheritedProperty && (
+                <button
+                  className="uml-element-editor__basic__detail-btn"
+                  onClick={selectDerivedProperty}
+                  tabIndex={-1}
+                  title="See detail"
+                >
+                  <LongArrowRightIcon />
+                </button>
+              )}
+              {isInheritedProperty && (
+                <button
+                  className="uml-element-editor__visit-parent-element-btn"
+                  onClick={visitOwner}
+                  tabIndex={-1}
+                  title={`Visit super type class ${derivedProperty._OWNER.path}`}
+                >
+                  <ArrowCircleRightIcon />
+                </button>
+              )}
+              {!isInheritedProperty && !isReadOnly && (
+                <button
+                  className={clsx('uml-element-editor__remove-btn', {
+                    'uml-element-editor__remove-btn--hidden':
+                      isInheritedProperty,
+                  })}
+                  onClick={remove}
+                  tabIndex={-1}
+                  title="Remove"
+                >
+                  <TimesIcon />
+                </button>
+              )}
+            </div>
+            <div onFocus={onLambdaEditorFocus}>
+              <StudioLambdaEditor
+                disabled={
+                  editorState.classState
+                    .isConvertingDerivedPropertyLambdaObjects ||
+                  isInheritedProperty ||
+                  isReadOnly
+                }
+                lambdaEditorState={dpState}
+                forceBackdrop={hasParserError}
+                expectedType={propertyType}
+              />
+            </div>
+          </div>
+        )}
       </div>
     );
   },
 );
+
+class ClassSuperTypeDragSource {
+  superType: GenericTypeReference;
+  isBeingDragged = false;
+
+  constructor(superType: GenericTypeReference) {
+    makeObservable(this, {
+      isBeingDragged: observable,
+      setIsBeingDragged: action,
+    });
+
+    this.superType = superType;
+  }
+
+  setIsBeingDragged(val: boolean): void {
+    this.isBeingDragged = val;
+  }
+}
+
+enum CLASS_SUPER_TYPE_DND_TYPE {
+  SUPER_TYPE = 'SUPER_TYPE',
+}
+
+enum CLASS_CONSTRAINT_DND_TYPE {
+  CONSTRAINT = 'CONSTRAINT',
+}
 
 const ConstraintEditor = observer(
   (props: {
@@ -673,10 +885,18 @@ const ConstraintEditor = observer(
     _class: Class;
     constraint: Constraint;
     deleteConstraint: () => void;
+    projectionConstraintState: ClassConstraintDragSource;
     isReadOnly: boolean;
   }) => {
-    const { constraint, _class, deleteConstraint, editorState, isReadOnly } =
-      props;
+    const ref = useRef<HTMLDivElement>(null);
+    const {
+      constraint,
+      _class,
+      deleteConstraint,
+      projectionConstraintState,
+      editorState,
+      isReadOnly,
+    } = props;
     const editorStore = useEditorStore();
     const applicationStore = useApplicationStore();
     const hasParserError = editorState.classState.constraintStates.some(
@@ -688,6 +908,59 @@ const ConstraintEditor = observer(
     // Name
     const changeName: React.ChangeEventHandler<HTMLInputElement> = (event) =>
       constraint_setName(constraint, event.target.value);
+
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: ClassConstraintDragSource, monitor: DropTargetMonitor): void => {
+        const draggingProperty = item.constraint;
+        const hoveredProperty = constraint;
+        class_arrangeConstraint(_class, draggingProperty, hoveredProperty);
+      },
+      [_class, constraint],
+    );
+
+    const [{ isBeingDraggedProperty }, dropConnector] = useDrop(
+      () => ({
+        accept: [CLASS_CONSTRAINT_DND_TYPE.CONSTRAINT],
+        hover: (
+          item: ClassConstraintDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedProperty: Constraint | undefined } => ({
+          isBeingDraggedProperty:
+            monitor.getItem<ClassConstraintDragSource | null>()?.constraint,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged =
+      projectionConstraintState.constraint === isBeingDraggedProperty;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: CLASS_CONSTRAINT_DND_TYPE.CONSTRAINT,
+        item: (): ClassConstraintDragSource => {
+          projectionConstraintState.setIsBeingDragged(true);
+          return {
+            constraint: constraint,
+            isBeingDragged: projectionConstraintState.isBeingDragged,
+            setIsBeingDragged: action,
+          };
+        },
+        end: (item: ClassConstraintDragSource | undefined): void =>
+          projectionConstraintState.setIsBeingDragged(false),
+      }),
+      [projectionConstraintState],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     // Actions
     const onLambdaEditorFocus = (): void =>
       applicationStore.navigationContextService.push(
@@ -705,80 +978,125 @@ const ConstraintEditor = observer(
 
     return (
       <div
+        ref={ref}
         className={clsx('constraint-editor', {
           backdrop__element: constraintState.parserError,
         })}
       >
-        <div className="constraint-editor__content">
-          {isInheritedConstraint && (
-            <div className="constraint-editor__content__name--with-lock">
-              <div className="constraint-editor__content__name--with-lock__icon">
-                <LockIcon />
-              </div>
-              <span className="constraint-editor__content__name--with-lock__name">
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd--tall">
+            <div className="uml-element-editor__dnd--padding ">
+              <div className="uml-element-editor__dnd__name">
                 {constraint.name}
-              </span>
+              </div>
             </div>
-          )}
-          {!isInheritedConstraint && (
-            <input
-              className="constraint-editor__content__name"
-              spellCheck={false}
-              disabled={isReadOnly || isInheritedConstraint}
-              value={constraint.name}
-              onChange={changeName}
-              placeholder="Constraint name"
-            />
-          )}
-          {isInheritedConstraint && (
-            <button
-              className="uml-element-editor__visit-parent-element-btn"
-              onClick={visitOwner}
-              tabIndex={-1}
-              title={`Visit super type class ${constraint._OWNER.path}`}
-            >
-              <ArrowCircleRightIcon />
-            </button>
-          )}
-          {!isInheritedConstraint && !isReadOnly && (
-            <button
-              className="uml-element-editor__remove-btn"
-              disabled={isInheritedConstraint}
-              onClick={remove}
-              tabIndex={-1}
-              title="Remove"
-            >
-              <TimesIcon />
-            </button>
-          )}
-        </div>
-        <div onFocus={onLambdaEditorFocus}>
-          <StudioLambdaEditor
-            disabled={
-              editorState.classState.isConvertingConstraintLambdaObjects ||
-              isReadOnly ||
-              isInheritedConstraint
-            }
-            lambdaEditorState={constraintState}
-            forceBackdrop={hasParserError}
-            expectedType={editorStore.graphManagerState.graph.getPrimitiveType(
-              PRIMITIVE_TYPE.BOOLEAN,
-            )}
-          />
-        </div>
+          </div>
+        )}
+        {!isBeingDragged && (
+          <>
+            <div className="constraint-editor__content">
+              {!isInheritedConstraint && (
+                <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+                  <VerticalDragHandleIcon />
+                </div>
+              )}
+              {isInheritedConstraint && (
+                <div className="constraint-editor__content__name--with-lock">
+                  <div className="constraint-editor__content__name--with-lock__icon">
+                    <LockIcon />
+                  </div>
+                  <span className="constraint-editor__content__name--with-lock__name">
+                    {constraint.name}
+                  </span>
+                </div>
+              )}
+              {!isInheritedConstraint && (
+                <input
+                  className="constraint-editor__content__name"
+                  spellCheck={false}
+                  disabled={isReadOnly || isInheritedConstraint}
+                  value={constraint.name}
+                  onChange={changeName}
+                  placeholder="Constraint name"
+                />
+              )}
+              {isInheritedConstraint && (
+                <button
+                  className="uml-element-editor__visit-parent-element-btn"
+                  onClick={visitOwner}
+                  tabIndex={-1}
+                  title={`Visit super type class ${constraint._OWNER.path}`}
+                >
+                  <ArrowCircleRightIcon />
+                </button>
+              )}
+              {!isInheritedConstraint && !isReadOnly && (
+                <button
+                  className="uml-element-editor__remove-btn"
+                  disabled={isInheritedConstraint}
+                  onClick={remove}
+                  tabIndex={-1}
+                  title="Remove"
+                >
+                  <TimesIcon />
+                </button>
+              )}
+            </div>
+            <div onFocus={onLambdaEditorFocus}>
+              <StudioLambdaEditor
+                disabled={
+                  editorState.classState.isConvertingConstraintLambdaObjects ||
+                  isReadOnly ||
+                  isInheritedConstraint
+                }
+                lambdaEditorState={constraintState}
+                forceBackdrop={hasParserError}
+                expectedType={editorStore.graphManagerState.graph.getPrimitiveType(
+                  PRIMITIVE_TYPE.BOOLEAN,
+                )}
+              />
+            </div>
+          </>
+        )}
       </div>
     );
   },
 );
 
+class ClassConstraintDragSource {
+  constraint: Constraint;
+  isBeingDragged = false;
+
+  constructor(constraint: Constraint) {
+    makeObservable(this, {
+      isBeingDragged: observable,
+      setIsBeingDragged: action,
+    });
+
+    this.constraint = constraint;
+  }
+
+  setIsBeingDragged(val: boolean): void {
+    this.isBeingDragged = val;
+  }
+}
+
 const SuperTypeEditor = observer(
   (props: {
     _class: Class;
     superType: GenericTypeReference;
+    projectionSuperTypeState: ClassSuperTypeDragSource;
     deleteSuperType: () => void;
     isReadOnly: boolean;
   }) => {
-    const { superType, _class, deleteSuperType, isReadOnly } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const {
+      superType,
+      _class,
+      projectionSuperTypeState,
+      deleteSuperType,
+      isReadOnly,
+    } = props;
     const editorStore = useEditorStore();
     // Type
     const superTypeOptions = editorStore.classOptions.filter(
@@ -791,6 +1109,59 @@ const SuperTypeEditor = observer(
         // Ensure there is no loop (might be expensive)
         !getAllSuperclasses(classOption.value).includes(_class),
     );
+
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: ClassSuperTypeDragSource, monitor: DropTargetMonitor): void => {
+        const draggingProperty = item.superType;
+        const hoveredProperty = superType;
+        class_arrangeSuperTypes(_class, draggingProperty, hoveredProperty);
+      },
+      [_class, superType],
+    );
+
+    const [{ isBeingDraggedProperty }, dropConnector] = useDrop(
+      () => ({
+        accept: [CLASS_SUPER_TYPE_DND_TYPE.SUPER_TYPE],
+        hover: (
+          item: ClassSuperTypeDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedProperty: GenericTypeReference | undefined } => ({
+          isBeingDraggedProperty:
+            monitor.getItem<ClassSuperTypeDragSource | null>()?.superType,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged =
+      projectionSuperTypeState.superType === isBeingDraggedProperty;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: CLASS_SUPER_TYPE_DND_TYPE.SUPER_TYPE,
+        item: (): ClassSuperTypeDragSource => {
+          projectionSuperTypeState.setIsBeingDragged(true);
+          return {
+            superType: superType,
+            isBeingDragged: projectionSuperTypeState.isBeingDragged,
+            setIsBeingDragged: action,
+          };
+        },
+        end: (item: ClassSuperTypeDragSource | undefined): void =>
+          projectionSuperTypeState.setIsBeingDragged(false),
+      }),
+      [projectionSuperTypeState],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     const rawType = superType.value.rawType;
     const filterOption = createFilter({
       ignoreCase: true,
@@ -804,37 +1175,53 @@ const SuperTypeEditor = observer(
     const visitDerivationSource = (): void => editorStore.openElement(rawType);
 
     return (
-      <div className="super-type-editor">
-        <CustomSelectorInput
-          className="super-type-editor__class"
-          disabled={isReadOnly}
-          options={superTypeOptions}
-          onChange={changeType}
-          value={selectedType}
-          placeholder={'Choose a class'}
-          filterOption={filterOption}
-          formatOptionLabel={getPackageableElementOptionFormatter({
-            graphManagerState: editorStore.graphManagerState,
-          })}
-        />
-        <button
-          className="uml-element-editor__basic__detail-btn"
-          onClick={visitDerivationSource}
-          tabIndex={-1}
-          title={'Visit super type'}
-        >
-          <LongArrowRightIcon />
-        </button>
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteSuperType}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">
+                {selectedType.label}
+              </div>
+            </div>
+          </div>
+        )}
+        {!isBeingDragged && (
+          <div className="super-type-editor">
+            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <VerticalDragHandleIcon />
+            </div>
+            <CustomSelectorInput
+              className="super-type-editor__class"
+              disabled={isReadOnly}
+              options={superTypeOptions}
+              onChange={changeType}
+              value={selectedType}
+              placeholder={'Choose a class'}
+              filterOption={filterOption}
+              formatOptionLabel={getPackageableElementOptionFormatter({
+                graphManagerState: editorStore.graphManagerState,
+              })}
+            />
+            <button
+              className="uml-element-editor__basic__detail-btn"
+              onClick={visitDerivationSource}
+              tabIndex={-1}
+              title={'Visit super type'}
+            >
+              <LongArrowRightIcon />
+            </button>
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteSuperType}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
+              </button>
+            )}
+          </div>
         )}
       </div>
     );
@@ -854,6 +1241,7 @@ const PropertiesEditor = observer(
           editorState.setSelectedProperty(undefined);
         }
       };
+
     const indirectProperties = getAllClassProperties(_class)
       .filter((property) => !_class.properties.includes(property))
       .sort((p1, p2) => p1.name.localeCompare(p2.name))
@@ -1024,6 +1412,9 @@ const ConstraintsEditor = observer(
             <ConstraintEditor
               key={constraint._UUID}
               constraint={constraint}
+              projectionConstraintState={
+                new ClassConstraintDragSource(constraint)
+              }
               _class={_class}
               editorState={editorState}
               deleteConstraint={deleteConstraint(constraint)}
@@ -1101,6 +1492,7 @@ const SupertypesEditor = observer(
           <SuperTypeEditor
             key={superType.value._UUID}
             superType={superType}
+            projectionSuperTypeState={new ClassSuperTypeDragSource(superType)}
             _class={_class}
             deleteSuperType={deleteSuperType(superType)}
             isReadOnly={isReadOnly}
@@ -1110,6 +1502,18 @@ const SupertypesEditor = observer(
     );
   },
 );
+
+export class AllTaggedValueDragSource {
+  taggedValue: TaggedValue;
+
+  constructor(taggedValue: TaggedValue) {
+    this.taggedValue = taggedValue;
+  }
+}
+
+export enum CLASS_TAGGED_VALUE_DND_TYPE {
+  TAGGED_VALUE = 'TAGGED_VALUE',
+}
 
 const TaggedValuesEditor = observer(
   (props: { _class: Class; editorState: ClassEditorState }) => {
@@ -1153,6 +1557,7 @@ const TaggedValuesEditor = observer(
       >
         {_class.taggedValues.map((taggedValue) => (
           <TaggedValueEditor
+            annotatedElement={_class}
             key={taggedValue._UUID}
             taggedValue={taggedValue}
             deleteValue={deleteTaggedValue(taggedValue)}
@@ -1163,6 +1568,14 @@ const TaggedValuesEditor = observer(
     );
   },
 );
+
+export class AllStereotypeDragSource {
+  stereotype: StereotypeReference;
+
+  constructor(stereotype: StereotypeReference) {
+    this.stereotype = stereotype;
+  }
+}
 
 const StereotypesEditor = observer(
   (props: { _class: Class; editorState: ClassEditorState }) => {
@@ -1208,7 +1621,8 @@ const StereotypesEditor = observer(
       >
         {_class.stereotypes.map((stereotype) => (
           <StereotypeSelector
-            key={stereotype.value._UUID}
+            key={stereotype._UUID}
+            annotatedElement={_class}
             stereotype={stereotype}
             deleteStereotype={deleteStereotype(stereotype)}
             isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   UMLEditorState,
   UML_EDITOR_TAB,
 } from '../../../../stores/editor-state/element-editor-state/UMLEditorState.js';
-import { useDrop } from 'react-dnd';
+import { type DropTargetMonitor, useDrag, useDrop } from 'react-dnd';
 import {
   CORE_DND_TYPE,
   type ElementDragSource,
@@ -42,6 +42,7 @@ import {
   LockIcon,
   FireIcon,
   StickArrowCircleRightIcon,
+  VerticalDragHandleIcon,
 } from '@finos/legend-art';
 import { LEGEND_STUDIO_TEST_ID } from '../../../LegendStudioTestID.js';
 import { StereotypeSelector } from './StereotypeSelector.js';
@@ -68,18 +69,35 @@ import {
   annotatedElement_deleteTaggedValue,
   enum_deleteValue,
   enum_addValue,
+  enum_arrangeValues,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import { useApplicationNavigationContext } from '@finos/legend-application';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../../stores/LegendStudioApplicationNavigationContext.js';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+
+export class EnumValueDragSource {
+  _enum: Enum;
+
+  constructor(_enum: Enum) {
+    this._enum = _enum;
+  }
+}
+
+enum ENUEMRATION_VALUE_DND_TYPE {
+  ENUMERATION = 'ENUMERATION',
+}
 
 const EnumBasicEditor = observer(
   (props: {
+    _parentEnumerations: Enum[];
     _enum: Enum;
     selectValue: () => void;
     deleteValue: () => void;
     isReadOnly: boolean;
   }) => {
-    const { _enum, selectValue, deleteValue, isReadOnly } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const { _enum, _parentEnumerations, selectValue, deleteValue, isReadOnly } =
+      props;
     const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
       enum_setName(_enum, event.target.value);
     };
@@ -87,37 +105,98 @@ const EnumBasicEditor = observer(
       _enum._OWNER.values.filter((value) => value.name === val.name).length >=
       2;
 
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: EnumValueDragSource, monitor: DropTargetMonitor): void => {
+        const draggingEnumeration = item._enum;
+        const hoveredEnumeration = _enum;
+        enum_arrangeValues(
+          _parentEnumerations,
+          draggingEnumeration,
+          hoveredEnumeration,
+        );
+      },
+      [_parentEnumerations, _enum],
+    );
+
+    const [{ isBeingDraggedEnumeration }, dropConnector] = useDrop(
+      () => ({
+        accept: [ENUEMRATION_VALUE_DND_TYPE.ENUMERATION],
+        hover: (item: EnumValueDragSource, monitor: DropTargetMonitor): void =>
+          handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedEnumeration: Enum | undefined } => ({
+          isBeingDraggedEnumeration:
+            monitor.getItem<EnumValueDragSource | null>()?._enum,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = _enum === isBeingDraggedEnumeration;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: ENUEMRATION_VALUE_DND_TYPE.ENUMERATION,
+        item: (): EnumValueDragSource => ({
+          _enum: _enum,
+        }),
+      }),
+      [_enum],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     return (
-      <div className="enum-basic-editor">
-        <InputWithInlineValidation
-          className="enum-basic-editor__name input-group__input"
-          spellCheck={false}
-          disabled={isReadOnly}
-          value={_enum.name}
-          onChange={changeValue}
-          placeholder={`Enum name`}
-          validationErrorMessage={
-            isEnumValueDuplicated(_enum) ? 'Duplicated enum' : undefined
-          }
-        />
-        <button
-          className="uml-element-editor__basic__detail-btn"
-          onClick={selectValue}
-          tabIndex={-1}
-          title={'See detail'}
-        >
-          <LongArrowRightIcon />
-        </button>
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteValue}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">{_enum.name}</div>
+            </div>
+          </div>
+        )}
+
+        {!isBeingDragged && (
+          <div className="enum-basic-editor">
+            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <VerticalDragHandleIcon />
+            </div>
+            <InputWithInlineValidation
+              className="enum-basic-editor__name input-group__input"
+              spellCheck={false}
+              disabled={isReadOnly}
+              value={_enum.name}
+              onChange={changeValue}
+              placeholder={`Enum name`}
+              validationErrorMessage={
+                isEnumValueDuplicated(_enum) ? 'Duplicated enum' : undefined
+              }
+            />
+            <button
+              className="uml-element-editor__basic__detail-btn"
+              onClick={selectValue}
+              tabIndex={-1}
+              title={'See detail'}
+            >
+              <LongArrowRightIcon />
+            </button>
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteValue}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
+              </button>
+            )}
+          </div>
         )}
       </div>
     );
@@ -281,6 +360,7 @@ const EnumEditor = observer(
               >
                 {_enum.taggedValues.map((taggedValue) => (
                   <TaggedValueEditor
+                    annotatedElement={_enum}
                     key={taggedValue._UUID}
                     taggedValue={taggedValue}
                     deleteValue={_deleteTaggedValue(taggedValue)}
@@ -300,6 +380,7 @@ const EnumEditor = observer(
                 {_enum.stereotypes.map((stereotype) => (
                   <StereotypeSelector
                     key={stereotype.value._UUID}
+                    annotatedElement={_enum}
                     stereotype={stereotype}
                     deleteStereotype={_deleteStereotype(stereotype)}
                     isReadOnly={isReadOnly}
@@ -433,6 +514,7 @@ export const EnumerationEditor = observer(
       }),
       [handleDropStereotype],
     );
+
     // Generation
     const generationParentElementPath =
       editorStore.graphState.graphGenerationState.findGenerationParentPath(
@@ -526,6 +608,7 @@ export const EnumerationEditor = observer(
                       <EnumBasicEditor
                         key={enumValue._UUID}
                         _enum={enumValue}
+                        _parentEnumerations={enumeration.values}
                         deleteValue={deleteValue(enumValue)}
                         selectValue={selectValue(enumValue)}
                         isReadOnly={isReadOnly}
@@ -543,6 +626,7 @@ export const EnumerationEditor = observer(
                   >
                     {enumeration.taggedValues.map((taggedValue) => (
                       <TaggedValueEditor
+                        annotatedElement={enumeration}
                         key={taggedValue._UUID}
                         taggedValue={taggedValue}
                         deleteValue={_deleteTaggedValue(taggedValue)}
@@ -562,6 +646,7 @@ export const EnumerationEditor = observer(
                     {enumeration.stereotypes.map((stereotype) => (
                       <StereotypeSelector
                         key={stereotype.value._UUID}
+                        annotatedElement={enumeration}
                         stereotype={stereotype}
                         deleteStereotype={_deleteStereotype(stereotype)}
                         isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/EnumerationEditor.tsx
@@ -69,19 +69,15 @@ import {
   annotatedElement_deleteTaggedValue,
   enum_deleteValue,
   enum_addValue,
-  enum_arrangeValues,
+  enum_swapValues,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import { useApplicationNavigationContext } from '@finos/legend-application';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../../stores/LegendStudioApplicationNavigationContext.js';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 
-export class EnumValueDragSource {
+type EnumValueDragSource = {
   _enum: Enum;
-
-  constructor(_enum: Enum) {
-    this._enum = _enum;
-  }
-}
+};
 
 enum ENUEMRATION_VALUE_DND_TYPE {
   ENUMERATION = 'ENUMERATION',
@@ -110,7 +106,7 @@ const EnumBasicEditor = observer(
       (item: EnumValueDragSource, monitor: DropTargetMonitor): void => {
         const draggingEnumeration = item._enum;
         const hoveredEnumeration = _enum;
-        enum_arrangeValues(
+        enum_swapValues(
           _parentEnumerations,
           draggingEnumeration,
           hoveredEnumeration,
@@ -163,7 +159,7 @@ const EnumBasicEditor = observer(
 
         {!isBeingDragged && (
           <div className="enum-basic-editor">
-            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+            <div className="uml-element-editor__drag-handler">
               <VerticalDragHandleIcon />
             </div>
             <InputWithInlineValidation

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
@@ -26,15 +26,16 @@ import {
   PlusIcon,
   TimesIcon,
   LockIcon,
+  VerticalDragHandleIcon,
 } from '@finos/legend-art';
 import { LEGEND_STUDIO_TEST_ID } from '../../../LegendStudioTestID.js';
 import { useEditorStore } from '../../EditorStoreProvider.js';
 import {
   type Profile,
-  type Tag,
   type Stereotype,
   stub_Tag,
   stub_Stereotype,
+  type Tag,
 } from '@finos/legend-graph';
 import {
   profile_addTag,
@@ -42,55 +43,146 @@ import {
   profile_deleteTag,
   profile_deleteStereotype,
   tagStereotype_setValue,
+  profile_arrangeTags,
+  profile_arrangeStereotypes,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import { useApplicationNavigationContext } from '@finos/legend-application';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../../stores/LegendStudioApplicationNavigationContext.js';
+import { useRef, useCallback, useEffect } from 'react';
+import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+
+class TagValueDragSource {
+  tag: Tag;
+
+  constructor(tag: Tag) {
+    this.tag = tag;
+  }
+}
+
+enum TAG_DND_TYPE {
+  TAG = 'TAG',
+}
 
 const TagBasicEditor = observer(
-  (props: { tag: Tag; deleteValue: () => void; isReadOnly: boolean }) => {
-    const { tag, deleteValue, isReadOnly } = props;
+  (props: {
+    tag: Tag;
+    deleteValue: () => void;
+    _profile: Profile;
+    isReadOnly: boolean;
+  }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const { tag, _profile, deleteValue, isReadOnly } = props;
     const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
       tagStereotype_setValue(tag, event.target.value);
     };
     const isTagDuplicated = (val: Tag): boolean =>
       tag._OWNER.p_tags.filter((t) => t.value === val.value).length >= 2;
 
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: TagValueDragSource, monitor: DropTargetMonitor): void => {
+        const draggingTag = item.tag;
+        const hoveredTag = tag;
+        profile_arrangeTags(_profile, draggingTag, hoveredTag);
+      },
+      [_profile, tag],
+    );
+
+    const [{ isBeingDraggedTag }, dropConnector] = useDrop(
+      () => ({
+        accept: [TAG_DND_TYPE.TAG],
+        hover: (item: TagValueDragSource, monitor: DropTargetMonitor): void =>
+          handleHover(item, monitor),
+        collect: (monitor): { isBeingDraggedTag: Tag | undefined } => ({
+          isBeingDraggedTag: monitor.getItem<TagValueDragSource | null>()?.tag,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = tag === isBeingDraggedTag;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: TAG_DND_TYPE.TAG,
+        item: (): TagValueDragSource => ({
+          tag: tag,
+        }),
+      }),
+      [tag],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     return (
-      <div className="tag-basic-editor">
-        <InputWithInlineValidation
-          className="tag-basic-editor__value input-group__input"
-          spellCheck={false}
-          disabled={isReadOnly}
-          value={tag.value}
-          onChange={changeValue}
-          placeholder={`Tag value`}
-          validationErrorMessage={
-            isTagDuplicated(tag) ? 'Duplicated tag' : undefined
-          }
-        />
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteValue}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">{tag.value}</div>
+            </div>
+          </div>
+        )}
+
+        {!isBeingDragged && (
+          <div className="tag-basic-editor">
+            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <VerticalDragHandleIcon />
+            </div>
+            <InputWithInlineValidation
+              className="tag-basic-editor__value input-group__input"
+              spellCheck={false}
+              disabled={isReadOnly}
+              value={tag.value}
+              onChange={changeValue}
+              placeholder={`Tag value`}
+              validationErrorMessage={
+                isTagDuplicated(tag) ? 'Duplicated tag' : undefined
+              }
+            />
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteValue}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
+              </button>
+            )}
+          </div>
         )}
       </div>
     );
   },
 );
 
+class StereotypeProfileDragSource {
+  stereotype: Stereotype;
+
+  constructor(stereotype: Stereotype) {
+    this.stereotype = stereotype;
+  }
+}
+
+enum STEREOTYPE_DND_TYPE {
+  STEREOTYPE = 'STEREOTYPE',
+}
+
 const StereotypeBasicEditor = observer(
   (props: {
     stereotype: Stereotype;
     deleteStereotype: () => void;
+    _profile: Profile;
     isReadOnly: boolean;
   }) => {
-    const { stereotype, deleteStereotype, isReadOnly } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const { stereotype, _profile, deleteStereotype, isReadOnly } = props;
     const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
       tagStereotype_setValue(stereotype, event.target.value);
     };
@@ -98,31 +190,90 @@ const StereotypeBasicEditor = observer(
       stereotype._OWNER.p_stereotypes.filter((s) => s.value === val.value)
         .length >= 2;
 
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: StereotypeProfileDragSource, monitor: DropTargetMonitor): void => {
+        const draggingTag = item.stereotype;
+        const hoveredTag = stereotype;
+        profile_arrangeStereotypes(_profile, draggingTag, hoveredTag);
+      },
+      [_profile, stereotype],
+    );
+
+    const [{ isBeingDraggedTag }, dropConnector] = useDrop(
+      () => ({
+        accept: [STEREOTYPE_DND_TYPE.STEREOTYPE],
+        hover: (
+          item: StereotypeProfileDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (monitor): { isBeingDraggedTag: Tag | undefined } => ({
+          isBeingDraggedTag:
+            monitor.getItem<StereotypeProfileDragSource | null>()?.stereotype,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = stereotype === isBeingDraggedTag;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: STEREOTYPE_DND_TYPE.STEREOTYPE,
+        item: (): StereotypeProfileDragSource => ({
+          stereotype: stereotype,
+        }),
+      }),
+      [stereotype],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     return (
-      <div className="stereotype-basic-editor">
-        <InputWithInlineValidation
-          className="stereotype-basic-editor__value input-group__input"
-          spellCheck={false}
-          disabled={isReadOnly}
-          value={stereotype.value}
-          onChange={changeValue}
-          placeholder={`Stereotype value`}
-          validationErrorMessage={
-            isStereotypeDuplicated(stereotype)
-              ? 'Duplicated stereotype'
-              : undefined
-          }
-        />
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteStereotype}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">
+                {stereotype.value}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!isBeingDragged && (
+          <div className="stereotype-basic-editor">
+            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <VerticalDragHandleIcon />
+            </div>
+            <InputWithInlineValidation
+              className="stereotype-basic-editor__value input-group__input"
+              spellCheck={false}
+              disabled={isReadOnly}
+              value={stereotype.value}
+              onChange={changeValue}
+              placeholder={`Stereotype value`}
+              validationErrorMessage={
+                isStereotypeDuplicated(stereotype)
+                  ? 'Duplicated stereotype'
+                  : undefined
+              }
+            />
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteStereotype}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
+              </button>
+            )}
+          </div>
         )}
       </div>
     );
@@ -225,6 +376,7 @@ export const ProfileEditor = observer((props: { profile: Profile }) => {
                 <TagBasicEditor
                   key={tag._UUID}
                   tag={tag}
+                  _profile={profile}
                   deleteValue={deleteTag(tag)}
                   isReadOnly={isReadOnly}
                 />
@@ -236,6 +388,7 @@ export const ProfileEditor = observer((props: { profile: Profile }) => {
               {profile.p_stereotypes.map((stereotype) => (
                 <StereotypeBasicEditor
                   key={stereotype._UUID}
+                  _profile={profile}
                   stereotype={stereotype}
                   deleteStereotype={deleteStereotype(stereotype)}
                   isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/ProfileEditor.tsx
@@ -43,8 +43,8 @@ import {
   profile_deleteTag,
   profile_deleteStereotype,
   tagStereotype_setValue,
-  profile_arrangeTags,
-  profile_arrangeStereotypes,
+  profile_swapTags,
+  profile_swapStereotypes,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import { useApplicationNavigationContext } from '@finos/legend-application';
 import { LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY } from '../../../../stores/LegendStudioApplicationNavigationContext.js';
@@ -52,13 +52,9 @@ import { useRef, useCallback, useEffect } from 'react';
 import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 
-class TagValueDragSource {
+type TagDragSource = {
   tag: Tag;
-
-  constructor(tag: Tag) {
-    this.tag = tag;
-  }
-}
+};
 
 enum TAG_DND_TYPE {
   TAG = 'TAG',
@@ -81,10 +77,10 @@ const TagBasicEditor = observer(
 
     // Drag and Drop
     const handleHover = useCallback(
-      (item: TagValueDragSource, monitor: DropTargetMonitor): void => {
+      (item: TagDragSource, monitor: DropTargetMonitor): void => {
         const draggingTag = item.tag;
         const hoveredTag = tag;
-        profile_arrangeTags(_profile, draggingTag, hoveredTag);
+        profile_swapTags(_profile, draggingTag, hoveredTag);
       },
       [_profile, tag],
     );
@@ -92,10 +88,10 @@ const TagBasicEditor = observer(
     const [{ isBeingDraggedTag }, dropConnector] = useDrop(
       () => ({
         accept: [TAG_DND_TYPE.TAG],
-        hover: (item: TagValueDragSource, monitor: DropTargetMonitor): void =>
+        hover: (item: TagDragSource, monitor: DropTargetMonitor): void =>
           handleHover(item, monitor),
         collect: (monitor): { isBeingDraggedTag: Tag | undefined } => ({
-          isBeingDraggedTag: monitor.getItem<TagValueDragSource | null>()?.tag,
+          isBeingDraggedTag: monitor.getItem<TagDragSource | null>()?.tag,
         }),
       }),
       [handleHover],
@@ -105,7 +101,7 @@ const TagBasicEditor = observer(
     const [, dragConnector, dragPreviewConnector] = useDrag(
       () => ({
         type: TAG_DND_TYPE.TAG,
-        item: (): TagValueDragSource => ({
+        item: (): TagDragSource => ({
           tag: tag,
         }),
       }),
@@ -130,7 +126,7 @@ const TagBasicEditor = observer(
 
         {!isBeingDragged && (
           <div className="tag-basic-editor">
-            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+            <div className="uml-element-editor__drag-handler">
               <VerticalDragHandleIcon />
             </div>
             <InputWithInlineValidation
@@ -162,13 +158,9 @@ const TagBasicEditor = observer(
   },
 );
 
-class StereotypeProfileDragSource {
+type StereotypeDragSource = {
   stereotype: Stereotype;
-
-  constructor(stereotype: Stereotype) {
-    this.stereotype = stereotype;
-  }
-}
+};
 
 enum STEREOTYPE_DND_TYPE {
   STEREOTYPE = 'STEREOTYPE',
@@ -192,10 +184,10 @@ const StereotypeBasicEditor = observer(
 
     // Drag and Drop
     const handleHover = useCallback(
-      (item: StereotypeProfileDragSource, monitor: DropTargetMonitor): void => {
+      (item: StereotypeDragSource, monitor: DropTargetMonitor): void => {
         const draggingTag = item.stereotype;
         const hoveredTag = stereotype;
-        profile_arrangeStereotypes(_profile, draggingTag, hoveredTag);
+        profile_swapStereotypes(_profile, draggingTag, hoveredTag);
       },
       [_profile, stereotype],
     );
@@ -203,13 +195,11 @@ const StereotypeBasicEditor = observer(
     const [{ isBeingDraggedTag }, dropConnector] = useDrop(
       () => ({
         accept: [STEREOTYPE_DND_TYPE.STEREOTYPE],
-        hover: (
-          item: StereotypeProfileDragSource,
-          monitor: DropTargetMonitor,
-        ): void => handleHover(item, monitor),
+        hover: (item: StereotypeDragSource, monitor: DropTargetMonitor): void =>
+          handleHover(item, monitor),
         collect: (monitor): { isBeingDraggedTag: Tag | undefined } => ({
-          isBeingDraggedTag:
-            monitor.getItem<StereotypeProfileDragSource | null>()?.stereotype,
+          isBeingDraggedTag: monitor.getItem<StereotypeDragSource | null>()
+            ?.stereotype,
         }),
       }),
       [handleHover],
@@ -219,7 +209,7 @@ const StereotypeBasicEditor = observer(
     const [, dragConnector, dragPreviewConnector] = useDrag(
       () => ({
         type: STEREOTYPE_DND_TYPE.STEREOTYPE,
-        item: (): StereotypeProfileDragSource => ({
+        item: (): StereotypeDragSource => ({
           stereotype: stereotype,
         }),
       }),
@@ -246,7 +236,7 @@ const StereotypeBasicEditor = observer(
 
         {!isBeingDragged && (
           <div className="stereotype-basic-editor">
-            <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+            <div className="uml-element-editor__drag-handler">
               <VerticalDragHandleIcon />
             </div>
             <InputWithInlineValidation

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/PropertyEditor.tsx
@@ -205,6 +205,7 @@ export const PropertyEditor = observer(
               >
                 {property.taggedValues.map((taggedValue) => (
                   <TaggedValueEditor
+                    annotatedElement={property}
                     key={taggedValue._UUID}
                     taggedValue={taggedValue}
                     deleteValue={_deleteTaggedValue(taggedValue)}
@@ -224,6 +225,7 @@ export const PropertyEditor = observer(
                 {property.stereotypes.map((stereotype) => (
                   <StereotypeSelector
                     key={stereotype.value._UUID}
+                    annotatedElement={property}
                     stereotype={stereotype}
                     deleteStereotype={_deleteStereotype(stereotype)}
                     isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   CustomSelectorInput,
   createFilter,
   TimesIcon,
   ArrowCircleRightIcon,
+  VerticalDragHandleIcon,
 } from '@finos/legend-art';
 import { useEditorStore } from '../../EditorStoreProvider.js';
 import {
@@ -28,9 +29,19 @@ import {
   type StereotypeReference,
   type Stereotype,
   isStubbed_PackageableElement,
+  type AnnotatedElement,
 } from '@finos/legend-graph';
-import { stereotypeReference_setValue } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
+import {
+  annotatedElement_arrangeStereotypes,
+  stereotypeReference_setValue,
+} from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import type { PackageableElementOption } from '@finos/legend-application';
+import {
+  type AllStereotypeDragSource,
+  CLASS_TAGGED_VALUE_DND_TYPE,
+} from './ClassEditor.js';
+import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
 
 interface StereotypeOption {
   label: string;
@@ -39,13 +50,22 @@ interface StereotypeOption {
 
 export const StereotypeSelector = observer(
   (props: {
+    annotatedElement: AnnotatedElement;
     stereotype: StereotypeReference;
     deleteStereotype: () => void;
     isReadOnly: boolean;
     darkTheme?: boolean;
   }) => {
-    const { stereotype, deleteStereotype, isReadOnly, darkTheme } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const {
+      annotatedElement,
+      stereotype,
+      deleteStereotype,
+      isReadOnly,
+      darkTheme,
+    } = props;
     const editorStore = useEditorStore();
+
     // Profile
     const profileOptions = editorStore.profileOptions.filter(
       (p) => p.value.p_stereotypes.length,
@@ -59,6 +79,7 @@ export const StereotypeSelector = observer(
     const [selectedProfile, setSelectedProfile] = useState<
       PackageableElementOption<Profile>
     >({ value: stereotype.value._OWNER, label: stereotype.value._OWNER.name });
+
     const changeProfile = (val: PackageableElementOption<Profile>): void => {
       if (val.value.p_stereotypes.length) {
         setSelectedProfile(val);
@@ -86,55 +107,121 @@ export const StereotypeSelector = observer(
     };
     const updateStereotype = (val: StereotypeOption): void =>
       stereotypeReference_setValue(stereotype, val.value);
+
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: AllStereotypeDragSource, monitor: DropTargetMonitor): void => {
+        const draggingProperty = item.stereotype;
+        const hoveredProperty = stereotype;
+        annotatedElement_arrangeStereotypes(
+          annotatedElement,
+          draggingProperty,
+          hoveredProperty,
+        );
+      },
+      [annotatedElement, stereotype],
+    );
+
+    const [{ isBeingDraggedStereotype }, dropConnector] = useDrop(
+      () => ({
+        accept: [CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE],
+        hover: (
+          item: AllStereotypeDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedStereotype: StereotypeReference | undefined } => ({
+          isBeingDraggedStereotype:
+            monitor.getItem<AllStereotypeDragSource | null>()?.stereotype,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = stereotype === isBeingDraggedStereotype;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE,
+        item: (): AllStereotypeDragSource => ({
+          stereotype: stereotype,
+        }),
+      }),
+      [stereotype],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     return (
-      <div className="stereotype-selector">
-        <div
-          className={`stereotype-selector__profile ${
-            darkTheme ? 'stereotype-selector-dark-theme' : ''
-          }`}
-        >
-          <CustomSelectorInput
-            className="stereotype-selector__profile__selector"
-            disabled={isReadOnly}
-            options={profileOptions}
-            onChange={changeProfile}
-            value={selectedProfile}
-            placeholder={'Choose a profile'}
-            filterOption={filterOption}
-            darkMode={Boolean(darkTheme)}
-          />
-          <button
-            className={`stereotype-selector__profile__visit-btn ${
-              darkTheme ? 'stereotype-selector-dark-theme' : ''
-            }`}
-            disabled={isStubbed_PackageableElement(stereotype.value._OWNER)}
-            onClick={visitProfile}
-            tabIndex={-1}
-            title={'Visit profile'}
-          >
-            <ArrowCircleRightIcon />
-          </button>
-        </div>
-        <CustomSelectorInput
-          className="stereotype-selector__stereotype"
-          disabled={isReadOnly}
-          options={stereotypeOptions}
-          onChange={updateStereotype}
-          value={selectedStereotype}
-          placeholder={'Choose a stereotype'}
-          filterOption={stereotypeFilterOption}
-          darkMode={darkTheme ?? false}
-        />
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteStereotype}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd__container">
+            <div className="uml-element-editor__dnd ">
+              <div className="uml-element-editor__dnd__name">
+                {selectedStereotype.label}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!isBeingDragged && (
+          <div className="stereotype-selector">
+            <div
+              className={`stereotype-selector__profile ${
+                darkTheme ? 'stereotype-selector-dark-theme' : ''
+              } stereotype-selector__profile`}
+            >
+              <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+                <VerticalDragHandleIcon />
+              </div>
+              <CustomSelectorInput
+                className="stereotype-selector__profile__selector"
+                disabled={isReadOnly}
+                options={profileOptions}
+                onChange={changeProfile}
+                value={selectedProfile}
+                placeholder={'Choose a profile'}
+                filterOption={filterOption}
+                darkMode={Boolean(darkTheme)}
+              />
+              <button
+                className={`stereotype-selector__profile__visit-btn ${
+                  darkTheme ? 'stereotype-selector-dark-theme' : ''
+                }`}
+                disabled={isStubbed_PackageableElement(stereotype.value._OWNER)}
+                onClick={visitProfile}
+                tabIndex={-1}
+                title={'Visit profile'}
+              >
+                <ArrowCircleRightIcon />
+              </button>
+            </div>
+            <CustomSelectorInput
+              className="stereotype-selector__stereotype"
+              disabled={isReadOnly}
+              options={stereotypeOptions}
+              onChange={updateStereotype}
+              value={selectedStereotype}
+              placeholder={'Choose a stereotype'}
+              filterOption={stereotypeFilterOption}
+              darkMode={darkTheme ?? false}
+            />
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteStereotype}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
+              </button>
+            )}
+          </div>
         )}
       </div>
     );

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/StereotypeSelector.tsx
@@ -32,14 +32,10 @@ import {
   type AnnotatedElement,
 } from '@finos/legend-graph';
 import {
-  annotatedElement_arrangeStereotypes,
+  annotatedElement_swapStereotypes,
   stereotypeReference_setValue,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import type { PackageableElementOption } from '@finos/legend-application';
-import {
-  type AllStereotypeDragSource,
-  CLASS_TAGGED_VALUE_DND_TYPE,
-} from './ClassEditor.js';
 import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 
@@ -47,6 +43,14 @@ interface StereotypeOption {
   label: string;
   value: Stereotype;
 }
+
+enum TAGGED_VALUE_DND_TYPE {
+  TAGGED_VALUE = 'TAGGED_VALUE',
+}
+
+type StereotypeDragSource = {
+  stereotype: StereotypeReference;
+};
 
 export const StereotypeSelector = observer(
   (props: {
@@ -110,10 +114,10 @@ export const StereotypeSelector = observer(
 
     // Drag and Drop
     const handleHover = useCallback(
-      (item: AllStereotypeDragSource, monitor: DropTargetMonitor): void => {
+      (item: StereotypeDragSource, monitor: DropTargetMonitor): void => {
         const draggingProperty = item.stereotype;
         const hoveredProperty = stereotype;
-        annotatedElement_arrangeStereotypes(
+        annotatedElement_swapStereotypes(
           annotatedElement,
           draggingProperty,
           hoveredProperty,
@@ -124,16 +128,14 @@ export const StereotypeSelector = observer(
 
     const [{ isBeingDraggedStereotype }, dropConnector] = useDrop(
       () => ({
-        accept: [CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE],
-        hover: (
-          item: AllStereotypeDragSource,
-          monitor: DropTargetMonitor,
-        ): void => handleHover(item, monitor),
+        accept: [TAGGED_VALUE_DND_TYPE.TAGGED_VALUE],
+        hover: (item: StereotypeDragSource, monitor: DropTargetMonitor): void =>
+          handleHover(item, monitor),
         collect: (
           monitor,
         ): { isBeingDraggedStereotype: StereotypeReference | undefined } => ({
           isBeingDraggedStereotype:
-            monitor.getItem<AllStereotypeDragSource | null>()?.stereotype,
+            monitor.getItem<StereotypeDragSource | null>()?.stereotype,
         }),
       }),
       [handleHover],
@@ -142,8 +144,8 @@ export const StereotypeSelector = observer(
 
     const [, dragConnector, dragPreviewConnector] = useDrag(
       () => ({
-        type: CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE,
-        item: (): AllStereotypeDragSource => ({
+        type: TAGGED_VALUE_DND_TYPE.TAGGED_VALUE,
+        item: (): StereotypeDragSource => ({
           stereotype: stereotype,
         }),
       }),
@@ -175,7 +177,7 @@ export const StereotypeSelector = observer(
                 darkTheme ? 'stereotype-selector-dark-theme' : ''
               } stereotype-selector__profile`}
             >
-              <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <div className="uml-element-editor__drag-handler">
                 <VerticalDragHandleIcon />
               </div>
               <CustomSelectorInput

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   clsx,
@@ -24,6 +24,7 @@ import {
   TimesIcon,
   ArrowCircleRightIcon,
   LongArrowAltUpIcon,
+  VerticalDragHandleIcon,
 } from '@finos/legend-art';
 import { useEditorStore } from '../../EditorStoreProvider.js';
 import {
@@ -31,12 +32,20 @@ import {
   type Tag,
   type Profile,
   isStubbed_PackageableElement,
+  type AnnotatedElement,
 } from '@finos/legend-graph';
 import {
   taggedValue_setValue,
   taggedValue_setTag,
+  annotatedElement_arrangeTaggedValues,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import type { PackageableElementOption } from '@finos/legend-application';
+import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+import {
+  type AllTaggedValueDragSource,
+  CLASS_TAGGED_VALUE_DND_TYPE,
+} from './ClassEditor.js';
 
 interface TagOption {
   label: string;
@@ -45,12 +54,20 @@ interface TagOption {
 
 export const TaggedValueEditor = observer(
   (props: {
+    annotatedElement: AnnotatedElement;
     taggedValue: TaggedValue;
     deleteValue: () => void;
     isReadOnly: boolean;
     darkTheme?: boolean;
   }) => {
-    const { taggedValue, deleteValue, isReadOnly, darkTheme } = props;
+    const ref = useRef<HTMLDivElement>(null);
+    const {
+      annotatedElement,
+      taggedValue,
+      deleteValue,
+      isReadOnly,
+      darkTheme,
+    } = props;
     const editorStore = useEditorStore();
     // Name
     const changeValue: React.ChangeEventHandler<
@@ -101,98 +118,161 @@ export const TaggedValueEditor = observer(
     const [isExpanded, setIsExpanded] = useState(false);
     const toggleExpandedMode = (): void => setIsExpanded(!isExpanded);
 
+    // Drag and Drop
+    const handleHover = useCallback(
+      (item: AllTaggedValueDragSource, monitor: DropTargetMonitor): void => {
+        const draggingProperty = item.taggedValue;
+        const hoveredProperty = taggedValue;
+        annotatedElement_arrangeTaggedValues(
+          annotatedElement,
+          draggingProperty,
+          hoveredProperty,
+        );
+      },
+      [annotatedElement, taggedValue],
+    );
+
+    const [{ isBeingDraggedTaggedValue }, dropConnector] = useDrop(
+      () => ({
+        accept: [CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE],
+        hover: (
+          item: AllTaggedValueDragSource,
+          monitor: DropTargetMonitor,
+        ): void => handleHover(item, monitor),
+        collect: (
+          monitor,
+        ): { isBeingDraggedTaggedValue: TaggedValue | undefined } => ({
+          isBeingDraggedTaggedValue:
+            monitor.getItem<AllTaggedValueDragSource | null>()?.taggedValue,
+        }),
+      }),
+      [handleHover],
+    );
+    const isBeingDragged = taggedValue === isBeingDraggedTaggedValue;
+
+    const [, dragConnector, dragPreviewConnector] = useDrag(
+      () => ({
+        type: CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE,
+        item: (): AllTaggedValueDragSource => ({
+          taggedValue: taggedValue,
+        }),
+      }),
+      [taggedValue],
+    );
+    dragConnector(dropConnector(ref));
+
+    // hide default HTML5 preview image
+    useEffect(() => {
+      dragPreviewConnector(getEmptyImage(), { captureDraggingState: true });
+    }, [dragPreviewConnector]);
+
     return (
-      <div className="tagged-value-editor">
-        <div
-          className={`tagged-value-editor__profile ${
-            darkTheme ? 'tagged-value-editor-dark-theme' : ''
-          }`}
-        >
-          <CustomSelectorInput
-            className="tagged-value-editor__profile__selector"
-            disabled={isReadOnly}
-            options={profileOptions}
-            onChange={changeProfile}
-            value={selectedProfile}
-            placeholder={'Choose a profile'}
-            filterOption={profileFilterOption}
-            darkMode={darkTheme ?? false}
-          />
-          <button
-            className={`tagged-value-editor__profile__visit-btn ${
-              darkTheme ? 'tagged-value-editor-dark-theme' : ''
-            }`}
-            disabled={isStubbed_PackageableElement(
-              taggedValue.tag.value._OWNER,
-            )}
-            onClick={visitProfile}
-            tabIndex={-1}
-            title={'Visit profile'}
-          >
-            <ArrowCircleRightIcon />
-          </button>
-        </div>
-        <CustomSelectorInput
-          className="tagged-value-editor__tag"
-          disabled={isReadOnly}
-          options={tagOptions}
-          onChange={changeTag}
-          value={selectedTag}
-          placeholder={'Choose a tag'}
-          filterOption={tagFilterOption}
-          darkMode={Boolean(darkTheme)}
-        />
-        {!isReadOnly && (
-          <button
-            className="uml-element-editor__remove-btn"
-            disabled={isReadOnly}
-            onClick={deleteValue}
-            tabIndex={-1}
-            title={'Remove'}
-          >
-            <TimesIcon />
-          </button>
+      <div ref={ref}>
+        {isBeingDragged && (
+          <div className="uml-element-editor__dnd--padding ">
+            <div className="uml-element-editor__dnd__name">
+              {taggedValue.value}
+            </div>
+          </div>
         )}
-        <div
-          className={clsx('tagged-value-editor__value', {
-            'tagged-value-editor__value__expanded': isExpanded,
-          })}
-        >
-          {isExpanded && (
-            <textarea
-              className={`tagged-value-editor__value__input ${
+
+        {!isBeingDragged && (
+          <div className="tagged-value-editor">
+            <div
+              className={`tagged-value-editor__profile ${
                 darkTheme ? 'tagged-value-editor-dark-theme' : ''
               }`}
-              spellCheck={false}
+            >
+              <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+                <VerticalDragHandleIcon />
+              </div>
+              <CustomSelectorInput
+                className="tagged-value-editor__profile__selector"
+                disabled={isReadOnly}
+                options={profileOptions}
+                onChange={changeProfile}
+                value={selectedProfile}
+                placeholder={'Choose a profile'}
+                filterOption={profileFilterOption}
+                darkMode={darkTheme ?? false}
+              />
+              <button
+                className={`tagged-value-editor__profile__visit-btn ${
+                  darkTheme ? 'tagged-value-editor-dark-theme' : ''
+                }`}
+                disabled={isStubbed_PackageableElement(
+                  taggedValue.tag.value._OWNER,
+                )}
+                onClick={visitProfile}
+                tabIndex={-1}
+                title={'Visit profile'}
+              >
+                <ArrowCircleRightIcon />
+              </button>
+            </div>
+            <CustomSelectorInput
+              className="tagged-value-editor__tag"
               disabled={isReadOnly}
-              value={taggedValue.value}
-              onChange={changeValue}
-              placeholder={`Value`}
+              options={tagOptions}
+              onChange={changeTag}
+              value={selectedTag}
+              placeholder={'Choose a tag'}
+              filterOption={tagFilterOption}
+              darkMode={Boolean(darkTheme)}
             />
-          )}
-          {!isExpanded && (
-            <input
-              className={`tagged-value-editor__value__input ${
-                darkTheme ? 'tagged-value-editor-dark-theme' : ''
-              }`}
-              spellCheck={false}
-              disabled={isReadOnly}
-              value={taggedValue.value}
-              onChange={changeValue}
-              placeholder={`Value`}
-            />
-          )}
-          <button
-            className={`tagged-value-editor__value__expand-btn ${
-              darkTheme ? 'tagged-value-editor-dark-theme' : ''
-            }`}
-            onClick={toggleExpandedMode}
-            tabIndex={-1}
-            title={'Expand/Collapse'}
-          >
-            {isExpanded ? <LongArrowAltUpIcon /> : <MoreVerticalIcon />}
-          </button>
-        </div>
+            {!isReadOnly && (
+              <button
+                className="uml-element-editor__remove-btn"
+                disabled={isReadOnly}
+                onClick={deleteValue}
+                tabIndex={-1}
+                title={'Remove'}
+              >
+                <TimesIcon />
+              </button>
+            )}
+            <div
+              className={clsx('tagged-value-editor__value', {
+                'tagged-value-editor__value__expanded': isExpanded,
+              })}
+            >
+              {isExpanded && (
+                <textarea
+                  className={`tagged-value-editor__value__input ${
+                    darkTheme ? 'tagged-value-editor-dark-theme' : ''
+                  }`}
+                  spellCheck={false}
+                  disabled={isReadOnly}
+                  value={taggedValue.value}
+                  onChange={changeValue}
+                  placeholder={`Value`}
+                />
+              )}
+              {!isExpanded && (
+                <input
+                  className={`tagged-value-editor__value__input ${
+                    darkTheme ? 'tagged-value-editor-dark-theme' : ''
+                  }`}
+                  spellCheck={false}
+                  disabled={isReadOnly}
+                  value={taggedValue.value}
+                  onChange={changeValue}
+                  placeholder={`Value`}
+                />
+              )}
+              <button
+                className={`tagged-value-editor__value__expand-btn ${
+                  darkTheme ? 'tagged-value-editor-dark-theme' : ''
+                }`}
+                onClick={toggleExpandedMode}
+                tabIndex={-1}
+                title={'Expand/Collapse'}
+              >
+                {isExpanded ? <LongArrowAltUpIcon /> : <MoreVerticalIcon />}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     );
   },

--- a/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/uml-editor/TaggedValueEditor.tsx
@@ -37,20 +37,24 @@ import {
 import {
   taggedValue_setValue,
   taggedValue_setTag,
-  annotatedElement_arrangeTaggedValues,
+  annotatedElement_swapTaggedValues,
 } from '../../../../stores/graphModifier/DomainGraphModifierHelper.js';
 import type { PackageableElementOption } from '@finos/legend-application';
 import { type DropTargetMonitor, useDrop, useDrag } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
-import {
-  type AllTaggedValueDragSource,
-  CLASS_TAGGED_VALUE_DND_TYPE,
-} from './ClassEditor.js';
 
 interface TagOption {
   label: string;
   value: Tag;
 }
+
+enum TAGGED_VALUE_DND_TYPE {
+  TAGGED_VALUE = 'TAGGED_VALUE',
+}
+
+type TaggedValueDragSource = {
+  taggedValue: TaggedValue;
+};
 
 export const TaggedValueEditor = observer(
   (props: {
@@ -120,10 +124,10 @@ export const TaggedValueEditor = observer(
 
     // Drag and Drop
     const handleHover = useCallback(
-      (item: AllTaggedValueDragSource, monitor: DropTargetMonitor): void => {
+      (item: TaggedValueDragSource, monitor: DropTargetMonitor): void => {
         const draggingProperty = item.taggedValue;
         const hoveredProperty = taggedValue;
-        annotatedElement_arrangeTaggedValues(
+        annotatedElement_swapTaggedValues(
           annotatedElement,
           draggingProperty,
           hoveredProperty,
@@ -134,16 +138,16 @@ export const TaggedValueEditor = observer(
 
     const [{ isBeingDraggedTaggedValue }, dropConnector] = useDrop(
       () => ({
-        accept: [CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE],
+        accept: [TAGGED_VALUE_DND_TYPE.TAGGED_VALUE],
         hover: (
-          item: AllTaggedValueDragSource,
+          item: TaggedValueDragSource,
           monitor: DropTargetMonitor,
         ): void => handleHover(item, monitor),
         collect: (
           monitor,
         ): { isBeingDraggedTaggedValue: TaggedValue | undefined } => ({
           isBeingDraggedTaggedValue:
-            monitor.getItem<AllTaggedValueDragSource | null>()?.taggedValue,
+            monitor.getItem<TaggedValueDragSource | null>()?.taggedValue,
         }),
       }),
       [handleHover],
@@ -152,8 +156,8 @@ export const TaggedValueEditor = observer(
 
     const [, dragConnector, dragPreviewConnector] = useDrag(
       () => ({
-        type: CLASS_TAGGED_VALUE_DND_TYPE.TAGGED_VALUE,
-        item: (): AllTaggedValueDragSource => ({
+        type: TAGGED_VALUE_DND_TYPE.TAGGED_VALUE,
+        item: (): TaggedValueDragSource => ({
           taggedValue: taggedValue,
         }),
       }),
@@ -183,7 +187,7 @@ export const TaggedValueEditor = observer(
                 darkTheme ? 'tagged-value-editor-dark-theme' : ''
               }`}
             >
-              <div className="uml-element-editor__drag-handler" tabIndex={-1}>
+              <div className="uml-element-editor__drag-handler">
                 <VerticalDragHandleIcon />
               </div>
               <CustomSelectorInput

--- a/packages/legend-application-studio/src/stores/graphModifier/DomainGraphModifierHelper.ts
+++ b/packages/legend-application-studio/src/stores/graphModifier/DomainGraphModifierHelper.ts
@@ -91,7 +91,7 @@ export const class_addProperty = action(
   },
 );
 
-export const class_arrangeProperty = action(
+export const class_swapProperties = action(
   (_class: Class, sourceProperty: Property, targetProperty: Property): void => {
     swapEntry(_class.properties, sourceProperty, targetProperty);
   },
@@ -108,7 +108,7 @@ export const class_addDerivedProperty = action(
   },
 );
 
-export const class_arrangeDerivedProperty = action(
+export const class_swapDerivedProperties = action(
   (
     _class: Class,
     sourceProperty: DerivedProperty,
@@ -128,7 +128,7 @@ export const class_deleteConstraint = action(
     deleteEntry(_class.constraints, val);
   },
 );
-export const class_arrangeConstraint = action(
+export const class_swapConstraints = action(
   (
     _class: Class,
     sourceConstraint: Constraint,
@@ -148,7 +148,7 @@ export const class_deleteSuperType = action(
     deleteEntry(_class.generalizations, val);
   },
 );
-export const class_arrangeSuperTypes = action(
+export const class_swapSuperTypes = action(
   (
     _class: Class,
     sourceSuperType: GenericTypeReference,
@@ -248,7 +248,7 @@ export const tagStereotype_setValue = action(
   },
 );
 
-export const annotatedElement_arrangeTaggedValues = action(
+export const annotatedElement_swapTaggedValues = action(
   (
     annotatedElement: AnnotatedElement,
     sourceTaggedValue: TaggedValue,
@@ -262,7 +262,7 @@ export const annotatedElement_arrangeTaggedValues = action(
   },
 );
 
-export const annotatedElement_arrangeStereotypes = action(
+export const annotatedElement_swapStereotypes = action(
   (
     annotatedElement: AnnotatedElement,
     sourceStereotype: StereotypeReference,
@@ -321,13 +321,13 @@ export const profile_deleteStereotype = action(
   },
 );
 
-export const profile_arrangeTags = action(
+export const profile_swapTags = action(
   (profile: Profile, sourceTag: Tag, targetTag: Tag): void => {
     swapEntry(profile.p_tags, sourceTag, targetTag);
   },
 );
 
-export const profile_arrangeStereotypes = action(
+export const profile_swapStereotypes = action(
   (
     profile: Profile,
     sourceStereotype: Stereotype,
@@ -360,7 +360,7 @@ export const function_setReturnMultiplicity = action(
   },
 );
 
-export const function_arrangeParameter = action(
+export const function_swapParameters = action(
   (
     _func: ConcreteFunctionDefinition,
     sourceParameter: RawVariableExpression,
@@ -392,7 +392,7 @@ export const enumValueReference_setValue = action(
   },
 );
 
-export const enum_arrangeValues = action(
+export const enum_swapValues = action(
   (enumeration: Enum[], sourceEnum: Enum, targetEnum: Enum): void => {
     swapEntry(enumeration, sourceEnum, targetEnum);
   },

--- a/packages/legend-application-studio/src/stores/graphModifier/DomainGraphModifierHelper.ts
+++ b/packages/legend-application-studio/src/stores/graphModifier/DomainGraphModifierHelper.ts
@@ -19,6 +19,7 @@ import {
   assertTrue,
   deleteEntry,
   guaranteeType,
+  swapEntry,
 } from '@finos/legend-shared';
 import { action } from 'mobx';
 import {
@@ -90,6 +91,12 @@ export const class_addProperty = action(
   },
 );
 
+export const class_arrangeProperty = action(
+  (_class: Class, sourceProperty: Property, targetProperty: Property): void => {
+    swapEntry(_class.properties, sourceProperty, targetProperty);
+  },
+);
+
 export const class_deleteDerivedProperty = action(
   (_class: Class, val: DerivedProperty): void => {
     deleteEntry(_class.derivedProperties, val);
@@ -100,6 +107,17 @@ export const class_addDerivedProperty = action(
     addUniqueEntry(_class.derivedProperties, observe_DerivedProperty(val));
   },
 );
+
+export const class_arrangeDerivedProperty = action(
+  (
+    _class: Class,
+    sourceProperty: DerivedProperty,
+    targetProperty: DerivedProperty,
+  ): void => {
+    swapEntry(_class.derivedProperties, sourceProperty, targetProperty);
+  },
+);
+
 export const class_addContraint = action(
   (_class: Class, val: Constraint): void => {
     addUniqueEntry(_class.constraints, observe_Constraint(val));
@@ -110,6 +128,16 @@ export const class_deleteConstraint = action(
     deleteEntry(_class.constraints, val);
   },
 );
+export const class_arrangeConstraint = action(
+  (
+    _class: Class,
+    sourceConstraint: Constraint,
+    targetConstraint: Constraint,
+  ): void => {
+    swapEntry(_class.constraints, sourceConstraint, targetConstraint);
+  },
+);
+
 export const class_addSuperType = action(
   (_class: Class, val: GenericTypeReference): void => {
     addUniqueEntry(_class.generalizations, observe_GenericTypeReference(val));
@@ -118,6 +146,15 @@ export const class_addSuperType = action(
 export const class_deleteSuperType = action(
   (_class: Class, val: GenericTypeReference): void => {
     deleteEntry(_class.generalizations, val);
+  },
+);
+export const class_arrangeSuperTypes = action(
+  (
+    _class: Class,
+    sourceSuperType: GenericTypeReference,
+    targetSuperType: GenericTypeReference,
+  ): void => {
+    swapEntry(_class.generalizations, sourceSuperType, targetSuperType);
   },
 );
 export const class_addSubclass = action((_class: Class, val: Class): void => {
@@ -211,6 +248,30 @@ export const tagStereotype_setValue = action(
   },
 );
 
+export const annotatedElement_arrangeTaggedValues = action(
+  (
+    annotatedElement: AnnotatedElement,
+    sourceTaggedValue: TaggedValue,
+    targetTaggedValue: TaggedValue,
+  ): void => {
+    swapEntry(
+      annotatedElement.taggedValues,
+      sourceTaggedValue,
+      targetTaggedValue,
+    );
+  },
+);
+
+export const annotatedElement_arrangeStereotypes = action(
+  (
+    annotatedElement: AnnotatedElement,
+    sourceStereotype: StereotypeReference,
+    targetStereotype: StereotypeReference,
+  ): void => {
+    swapEntry(annotatedElement.stereotypes, sourceStereotype, targetStereotype);
+  },
+);
+
 // --------------------------------------------- DerivedProperty -------------------------------------
 
 export const derivedProperty_setBody = (
@@ -260,6 +321,22 @@ export const profile_deleteStereotype = action(
   },
 );
 
+export const profile_arrangeTags = action(
+  (profile: Profile, sourceTag: Tag, targetTag: Tag): void => {
+    swapEntry(profile.p_tags, sourceTag, targetTag);
+  },
+);
+
+export const profile_arrangeStereotypes = action(
+  (
+    profile: Profile,
+    sourceStereotype: Stereotype,
+    targetStereotype: Stereotype,
+  ): void => {
+    swapEntry(profile.p_stereotypes, sourceStereotype, targetStereotype);
+  },
+);
+
 // --------------------------------------------- Function -------------------------------------
 
 export const function_deleteParameter = action(
@@ -283,6 +360,16 @@ export const function_setReturnMultiplicity = action(
   },
 );
 
+export const function_arrangeParameter = action(
+  (
+    _func: ConcreteFunctionDefinition,
+    sourceParameter: RawVariableExpression,
+    targetParameter: RawVariableExpression,
+  ): void => {
+    swapEntry(_func.parameters, sourceParameter, targetParameter);
+  },
+);
+
 // --------------------------------------------- Enumeration -------------------------------------
 
 export const enum_setName = action((val: Enum, value: string): void => {
@@ -302,6 +389,12 @@ export const enumValueReference_setValue = action(
   (ref: EnumValueReference, value: Enum): void => {
     ref.value = observe_Enum(value);
     packageableElementReference_setValue(ref.ownerReference, value._OWNER);
+  },
+);
+
+export const enum_arrangeValues = action(
+  (enumeration: Enum[], sourceEnum: Enum, targetEnum: Enum): void => {
+    swapEntry(enumeration, sourceEnum, targetEnum);
   },
 );
 

--- a/packages/legend-application-studio/style/components/editor/uml-editor/_class-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/uml-editor/_class-editor.scss
@@ -29,7 +29,7 @@
 }
 
 .derived-property-editor {
-  padding: 1rem;
+  padding: 1rem 3.5rem 1rem 1rem;
   background: var(--color-light-grey-0);
   border-radius: 0.2rem;
 
@@ -41,6 +41,10 @@
 .property-basic-editor {
   margin-top: 0.5rem;
   display: flex;
+
+  &:hover {
+    background: var(--color-light-grey-200);
+  }
 
   &__lock {
     @include flexVCenter;

--- a/packages/legend-application-studio/style/components/editor/uml-editor/_uml-element-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/uml-editor/_uml-element-editor.scss
@@ -16,6 +16,43 @@
 
 @use 'mixins' as *;
 
+.uml-element-editor__dnd {
+  border: 0.2rem dashed var(--color-dark-grey-250);
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0.5rem 1rem 0.5rem 2rem;
+
+  &__container {
+    height: 2.8rem !important;
+    margin: 0.5rem 0;
+  }
+
+  &--padding {
+    margin: 1rem;
+    border: 0.2rem dashed var(--color-dark-grey-250);
+    padding: 1rem;
+  }
+
+  &--tall {
+    height: 7rem !important;
+    padding-top: 1rem;
+  }
+
+  &__name {
+    @include flexVCenter;
+
+    display: inline-flex;
+    color: var(--color-white);
+    height: 2rem;
+    padding: 0.5rem;
+    font-size: 1.2rem;
+    margin-top: 0.5rem;
+    background: var(--color-blue-200);
+    border-radius: 0.2rem;
+  }
+}
+
 .uml-element-editor {
   height: 100%;
   width: 100%;
@@ -178,6 +215,28 @@
       font-size: 2rem;
       color: var(--color-light-grey-100);
     }
+  }
+
+  &__drag-handler {
+    @include flexCenter;
+
+    flex: 0;
+    height: 2.8rem;
+    color: var(--color-dark-grey-500);
+    border-radius: 0.2rem;
+    margin-left: 0;
+    padding-top: 0.1rem;
+    padding-left: 0.5rem;
+    margin-right: 0.5rem;
+    cursor: pointer;
+  }
+
+  &__drag-handler:hover {
+    color: var(--color-dark-grey-400);
+  }
+
+  &__drag-handler:active {
+    color: var(--color-dark-grey-200);
   }
 
   &__remove-btn {

--- a/packages/legend-application-studio/style/components/editor/uml-editor/_uml-element-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/uml-editor/_uml-element-editor.scss
@@ -235,10 +235,6 @@
     color: var(--color-dark-grey-400);
   }
 
-  &__drag-handler:active {
-    color: var(--color-dark-grey-200);
-  }
-
   &__remove-btn {
     @include flexCenter;
 

--- a/packages/legend-graph/src/graph/metamodel/pure/Reference.ts
+++ b/packages/legend-graph/src/graph/metamodel/pure/Reference.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { uuid } from '@finos/legend-shared';
+
 /**
  * Reference implies pointer-based relationship in the protocol. This means that during graph-building,
  * we figure out/infer the reference using pointer of some form. Take the following example:
@@ -53,6 +55,8 @@
  *    but for simplicity sake, we will just swap out to use new a new reference
  */
 export abstract class Reference {
+  readonly _UUID = uuid();
+
   abstract value: unknown;
 }
 

--- a/packages/legend-shared/src/CommonUtils.ts
+++ b/packages/legend-shared/src/CommonUtils.ts
@@ -310,6 +310,23 @@ export const changeEntry = <T>(
   return false;
 };
 
+export const swapEntry = <T>(
+  array: T[],
+  entryOne: T,
+  entryTwo: T,
+  comparator = (val1: T, val2: T): boolean => val1 === val2,
+): boolean => {
+  const idxX = array.findIndex((entry) => comparator(entry, entryOne));
+  const idxY = array.findIndex((entry) => comparator(entry, entryTwo));
+
+  if (idxX !== -1 && idxY !== -1) {
+    array[idxX] = entryTwo;
+    array[idxY] = entryOne;
+    return true;
+  }
+  return false;
+};
+
 export const deleteEntry = <T>(
   array: T[],
   entryToDelete: T,


### PR DESCRIPTION
<h2> Summary </h2> 

Fixes [#303](https://github.com/finos/legend-studio/issues/303)

<hr>

D&D For: 

- Class: Properties, Derived Properties, Constraints, Tagged Values, Stereotypes
- Enumeration: Values, Tagged Values, Stereotypes
- Function: General Parameters, Tagged Values, Stereotypes
- Association: Tagged Values, Stereotypes
- Profile: Tags, Stereotypes
- Properties: Tagged Values, Stereotypes 

<h2> How did you test this change? </h2>
 

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

![Kapture 2022-08-04 at 14 38 00](https://user-images.githubusercontent.com/41248956/182928200-5a585bd2-e388-4427-b5ab-62436571ea2a.gif)
Derived Properties: 
![Kapture 2022-08-04 at 14 32 53](https://user-images.githubusercontent.com/41248956/182926720-05ea9645-9c4f-40c4-8bba-acf61987caee.gif)
Stereotypes within Class Properties: 
![Kapture 2022-08-04 at 01 47 32](https://user-images.githubusercontent.com/41248956/182772282-709cbcb2-4123-4cb5-a8af-1dee48a61977.gif)

