### PR TITLE
minor improvements to service test editor

### DIFF
--- a/.changeset/quick-horses-jog.md
+++ b/.changeset/quick-horses-jog.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application-studio': patch
+---

--- a/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestDataEditor.tsx
@@ -212,12 +212,14 @@ export const NewConnectionDataModal = observer(
     const dataElementOptions = testDataState.editorStore.dataOptions;
     const newConnectionState = testDataState.newConnectionDataState;
     const dataElement = newConnectionState.dataElement;
-    const selectedOption = dataElement ? buildElementOption(dataElement) : null;
+    const selectedDataElement = dataElement
+      ? buildElementOption(dataElement)
+      : null;
     const onDataElementChange = (val: {
       label: string;
       value?: DataElement;
     }): void => {
-      if (val.value !== selectedOption?.value && val.value) {
+      if (val.value !== selectedDataElement?.value && val.value) {
         newConnectionState.setDataElement(val.value);
       }
     };
@@ -265,7 +267,7 @@ export const NewConnectionDataModal = observer(
     // external format
     const selectedEmbeddedType = newConnectionState.embeddedDataType
       ? {
-          label: prettyCONSTName(newConnectionState.embeddedDataType.label),
+          label: prettyCONSTName(newConnectionState.embeddedDataType.value),
           value: newConnectionState.embeddedDataType.value,
         }
       : undefined;
@@ -301,42 +303,67 @@ export const NewConnectionDataModal = observer(
       >
         <form
           onSubmit={handleSubmit}
-          className="modal modal--dark search-modal"
+          className="modal service-test-data-modal modal--dark"
         >
-          <div className="modal__title">Create a connection test data</div>
-          <div className="explorer__new-element-modal__driver">
-            <CustomSelectorInput
-              className="explorer__new-element-modal__driver__dropdown"
-              options={connectionOptions}
-              onChange={onConnectionSelectionChange}
-              value={selectedConnection}
-              isClearable={false}
-              darkMode={true}
-            />
+          <div className="modal__header">
+            <div className="modal__title">Create a connection test data</div>
           </div>
-          <div className="explorer__new-element-modal__driver">
-            <CustomSelectorInput
-              className="explorer__new-element-modal__driver__dropdown"
-              options={embeddedOptions}
-              onChange={onEmbeddedTypeChange}
-              value={selectedEmbeddedType}
-              isClearable={false}
-              darkMode={true}
-            />
-          </div>
-          {selectedEmbeddedType?.value === EmbeddedDataType.DATA_ELEMENT && (
-            <div className="explorer__new-element-modal__driver">
-              <CustomSelectorInput
-                className="panel__content__form__section__dropdown data-element-reference-editor__value__dropdown"
-                disabled={isReadOnly}
-                options={dataElementOptions}
-                onChange={onDataElementChange}
-                value={selectedOption}
-                darkMode={true}
-              />
+          <div className="modal__body">
+            <div className="panel__content__form__section">
+              <div className="panel__content__form__section__header__label">
+                Connection ID
+              </div>
+              <div className="panel__content__form__section__header__prompt">
+                Connection in runtime to povide test data for
+              </div>
+              <div className="explorer__new-element-modal__driver">
+                <CustomSelectorInput
+                  className="explorer__new-element-modal__driver__dropdown"
+                  options={connectionOptions}
+                  onChange={onConnectionSelectionChange}
+                  value={selectedConnection}
+                  isClearable={false}
+                  darkMode={true}
+                />
+              </div>
             </div>
-          )}
-          <div className="search-modal__actions">
+            <div className="panel__content__form__section">
+              <div className="panel__content__form__section__header__label">
+                Data Type
+              </div>
+              <div className="panel__content__form__section__header__prompt">
+                Test data type that will be loaded to your test connection
+              </div>
+              <div className="explorer__new-element-modal__driver">
+                <CustomSelectorInput
+                  className="explorer__new-element-modal__driver__dropdown"
+                  options={embeddedOptions}
+                  onChange={onEmbeddedTypeChange}
+                  value={selectedEmbeddedType}
+                  isClearable={false}
+                  darkMode={true}
+                />
+              </div>
+            </div>
+            {selectedEmbeddedType?.value === EmbeddedDataType.DATA_ELEMENT && (
+              <div className="panel__content__form__section">
+                <div className="panel__content__form__section__header__label">
+                  Data Element
+                </div>
+                <div className="explorer__new-element-modal__driver">
+                  <CustomSelectorInput
+                    className="panel__content__form__section__dropdown data-element-reference-editor__value__dropdown"
+                    disabled={isReadOnly}
+                    options={dataElementOptions}
+                    onChange={onDataElementChange}
+                    value={selectedDataElement}
+                    darkMode={true}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+          <div className="modal__footer">
             <button
               type="button"
               className="btn btn--dark"

--- a/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/testable/ServiceTestDataState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/testable/ServiceTestDataState.ts
@@ -44,6 +44,7 @@ import {
   isNonNullable,
   returnUndefOnError,
   getNullableFirstElement,
+  uniq,
 } from '@finos/legend-shared';
 import { action, flow, makeObservable, observable } from 'mobx';
 import type { EditorStore } from '../../../../EditorStore.js';
@@ -360,6 +361,6 @@ export class ServiceTestDataState {
     } else if (execution instanceof PureMultiExecution) {
       runtimes = execution.executionParameters.map((t) => t.runtime);
     }
-    return runtimes.flatMap(getAllIdentifiedConnectionsFromRuntime);
+    return uniq(runtimes.flatMap(getAllIdentifiedConnectionsFromRuntime));
   }
 }

--- a/packages/legend-application-studio/src/stores/shared/testable/TestableUtils.ts
+++ b/packages/legend-application-studio/src/stores/shared/testable/TestableUtils.ts
@@ -63,13 +63,14 @@ export const getAllIdentifiedConnectionsFromRuntime = (
 ): IdentifiedConnection[] => {
   const resolvedRuntimes: EngineRuntime[] = [];
   if (runtime instanceof RuntimePointer) {
-    const engineRuntime = runtime.packageableRuntime.value.runtimeValue;
-    resolvedRuntimes.push(engineRuntime);
+    resolvedRuntimes.push(runtime.packageableRuntime.value.runtimeValue);
   } else if (runtime instanceof EngineRuntime) {
     resolvedRuntimes.push(runtime);
   }
   return resolvedRuntimes
-    .flatMap((e) => e.connections.map((l) => l.storeConnections))
+    .flatMap((e) =>
+      e.connections.map((connection) => connection.storeConnections),
+    )
     .flat();
 };
 

--- a/packages/legend-application-studio/style/components/editor/_service-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_service-editor.scss
@@ -1149,3 +1149,7 @@
     }
   }
 }
+
+.service-test-data-modal {
+  width: 60rem;
+}


### PR DESCRIPTION
- Add description to create connection test data 
- fix showing same connection id 

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
