### PR TITLE
Fix a bug that fails to display subtypes if a propertyMapping of type parent directly points to a child classMapping

### DIFF
--- a/.changeset/smart-tigers-watch.md
+++ b/.changeset/smart-tigers-watch.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Fix a bug that fails to display subtypes if a propertyMapping of type parent directly points to a child classMapping ([#1437](https://github.com/finos/legend-studio/issues/1437)).

--- a/packages/legend-application-query/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-application-query/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -319,6 +319,13 @@ const generateSubtypeNodeMappingData = (
           (mappedProperty[0] as EntityMappedProperty).entityPath,
         ),
       };
+    } else if (parentMappingData.mappedEntity.path === subclass.path) {
+      return {
+        mapped: true,
+        mappedEntity: modelCoverageAnalysisResult.__ENTITIES_INDEX.get(
+          parentMappingData.mappedEntity.path,
+        ),
+      };
     }
   }
   return { mapped: false };

--- a/packages/legend-application-query/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-application-query/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -322,9 +322,7 @@ const generateSubtypeNodeMappingData = (
     } else if (parentMappingData.mappedEntity.path === subclass.path) {
       return {
         mapped: true,
-        mappedEntity: modelCoverageAnalysisResult.__ENTITIES_INDEX.get(
-          parentMappingData.mappedEntity.path,
-        ),
+        mappedEntity: parentMappingData.mappedEntity,
       };
     }
   }


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->
Fixes https://github.com/finos/legend-studio/issues/1437

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
<img width="990" alt="Screen Shot 2022-08-25 at 3 32 04 PM" src="https://user-images.githubusercontent.com/73408381/186753673-25e71e90-d4d6-4a49-86a8-e371ca5cc2aa.png">

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
