### PR TITLE
Fix a bug where query-builder crash when right-clicking the result panel if current query is not supported in form mode

### DIFF
--- a/.changeset/thin-kings-sniff.md
+++ b/.changeset/thin-kings-sniff.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Fix a bug where UI crashed when right-clicking the result panel if the current query is not supported in form mode. ([#1490](https://github.com/finos/legend-studio/issues/1490)).

--- a/.changeset/thin-kings-sniff.md
+++ b/.changeset/thin-kings-sniff.md
@@ -2,4 +2,4 @@
 '@finos/legend-query-builder': patch
 ---
 
-Fix a bug where UI crashed when right-clicking the result panel if the current query is not supported in form mode. ([#1490](https://github.com/finos/legend-studio/issues/1490)).
+Fix a bug where query-builder crash when right-clicking the result panel row/cell if the current query is not supported in form mode. ([#1490](https://github.com/finos/legend-studio/issues/1490)).

--- a/packages/legend-query-builder/src/components/QueryBuilderResultPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderResultPanel.tsx
@@ -325,7 +325,9 @@ const QueryBuilderGridResult = observer(
           ) : null
         }
         disabled={
-          !(fetchStructureImplementation instanceof QueryBuilderProjectionState)
+          !(
+            fetchStructureImplementation instanceof QueryBuilderProjectionState
+          ) || !queryBuilderState.isQuerySupported
         }
         menuProps={{ elevation: 7 }}
         key={executionResult._UUID}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Fixes https://github.com/finos/legend-studio/issues/1490
If the current query is not supported in form mode, right-click result panel won't trigger the dropdown.
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

https://user-images.githubusercontent.com/73408381/191792215-1a660638-f3ad-44bd-adf7-4e256edf588f.mov


<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
