### PR TITLE
fix hashStrings bug when generating test data

### DIFF
--- a/.changeset/kind-hats-brush.md
+++ b/.changeset/kind-hats-brush.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-graph': patch
+---

--- a/packages/legend-graph/src/graphManager/protocol/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/graphManager/protocol/pure/v1/V1_PureGraphManager.ts
@@ -2011,7 +2011,7 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       testDataGenerationExecuteInput,
     );
     testDataGenerationExecuteInput.parameters = parameters;
-    testDataGenerationExecuteInput.hashValues = Boolean(
+    testDataGenerationExecuteInput.hashStrings = Boolean(
       options?.anonymizeGeneratedData,
     );
     return this.engine.generateExecuteTestData(testDataGenerationExecuteInput);

--- a/packages/legend-graph/src/graphManager/protocol/pure/v1/engine/execution/V1_ExecuteInput.ts
+++ b/packages/legend-graph/src/graphManager/protocol/pure/v1/engine/execution/V1_ExecuteInput.ts
@@ -64,7 +64,7 @@ export class V1_ExecuteInput {
 
 export class V1_TestDataGenerationExecutionInput extends V1_ExecuteInput {
   parameters: (string | number | boolean)[] = [];
-  hashValues = false;
+  hashStrings = false;
 
   static override readonly serialization = new SerializationFactory(
     createModelSchema(V1_TestDataGenerationExecutionInput, {
@@ -77,7 +77,7 @@ export class V1_TestDataGenerationExecutionInput extends V1_ExecuteInput {
         () => SKIP,
       ),
       context: usingModelSchema(V1_rawBaseExecutionContextModelSchema),
-      hashValues: primitive(),
+      hashStrings: primitive(),
       parameters: list(primitive()),
     }),
   );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

- [x] fix `hashValues` to `hashStrings` introduced by https://github.com/finos/legend-studio/pull/1388

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
