### PR TITLE
fix: visual indicator for system elements

### DIFF
--- a/.changeset/shiny-rockets-sing.md
+++ b/.changeset/shiny-rockets-sing.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application-studio': patch
+---

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/EnumerationMappingEditor.tsx
@@ -71,6 +71,7 @@ import {
 } from '../../../../stores/graphModifier/DSL_Mapping_GraphModifierHelper.js';
 import {
   buildElementOption,
+  getPackageableElementOptionFormatter,
   type PackageableElementOption,
 } from '@finos/legend-application';
 
@@ -151,6 +152,7 @@ const EnumerationMappingSourceSelectorModal = observer(
             placeholder={'Choose a data type or an enumeration...'}
             isClearable={true}
             filterOption={filterOption}
+            formatOptionLabel={getPackageableElementOptionFormatter({})}
           />
         </div>
       </Dialog>

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationSourceSelectorModal.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/InstanceSetImplementationSourceSelectorModal.tsx
@@ -45,6 +45,7 @@ import { useEditorStore } from '../../EditorStoreProvider.js';
 import {
   useApplicationStore,
   buildElementOption,
+  getPackageableElementOptionFormatter,
 } from '@finos/legend-application';
 
 export const getMappingElementSourceFilterText = (
@@ -205,6 +206,7 @@ export const InstanceSetImplementationSourceSelectorModal = observer(
             placeholder={`Select a source...`}
             isClearable={true}
             filterOption={filterOption}
+            formatOptionLabel={getPackageableElementOptionFormatter({})}
           />
         </div>
       </Dialog>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Pointed out by @Yasirmod17, when a user selects a source element from the mapping editor, there are no color indicators for what type it is. Therefore, adding `getPackageableElementOptionFormatter` to that selector input as well. 


For example, the elements below should have the lime green color designated for dependencies 
<img width="885" alt="image" src="https://user-images.githubusercontent.com/41248956/193838976-ef3269d8-7bf9-47ea-8657-8291d5db47aa.png">


<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [X] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
