### PR TITLE
Reset query loader state on closing

### DIFF
--- a/.changeset/rude-owls-cheat.md
+++ b/.changeset/rude-owls-cheat.md
@@ -2,4 +2,4 @@
 '@finos/legend-application-query': patch
 ---
 
-Fix a bug where query loader failed to reset 'Mine Only' button after exiting.
+Reset query loader state on closing.

--- a/.changeset/rude-owls-cheat.md
+++ b/.changeset/rude-owls-cheat.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Fix a bug where query loader failed to reset 'Mine Only' button after exiting.

--- a/packages/legend-application-query/src/components/QueryEditor.tsx
+++ b/packages/legend-application-query/src/components/QueryEditor.tsx
@@ -263,11 +263,7 @@ const QueryLoader = observer(
     // life-cycle
     const close = (): void => {
       editorStore.queryLoaderState.setIsQueryLoaderOpen(false);
-      if (isMineOnly) {
-        editorStore.queryLoaderState.setShowCurrentUserQueriesOnly(
-          !editorStore.queryLoaderState.showCurrentUserQueriesOnly,
-        );
-      }
+      editorStore.queryLoaderState.reset();
     };
     const onEnter = (): void => queryFinderRef.current?.focus();
 

--- a/packages/legend-application-query/src/components/QueryEditor.tsx
+++ b/packages/legend-application-query/src/components/QueryEditor.tsx
@@ -263,6 +263,11 @@ const QueryLoader = observer(
     // life-cycle
     const close = (): void => {
       editorStore.queryLoaderState.setIsQueryLoaderOpen(false);
+      if (isMineOnly) {
+        editorStore.queryLoaderState.setShowCurrentUserQueriesOnly(
+          !editorStore.queryLoaderState.showCurrentUserQueriesOnly,
+        );
+      }
     };
     const onEnter = (): void => queryFinderRef.current?.focus();
 

--- a/packages/legend-application-query/src/stores/QueryEditorStore.ts
+++ b/packages/legend-application-query/src/stores/QueryEditorStore.ts
@@ -257,6 +257,10 @@ export class QueryLoaderState {
       this.editorStore.applicationStore.notifyError(error);
     }
   }
+
+  reset(): void {
+    this.setShowCurrentUserQueriesOnly(false);
+  }
 }
 
 export abstract class QueryEditorStore {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Fix a bug where query loader failed to reset 'Mine Only' button after exiting

Reset query loader state on closing.
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

https://user-images.githubusercontent.com/73408381/195385445-454a0182-f262-404f-86ad-9c8815730fed.mov



<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
