### PR TITLE
sanitize ULRs before parsing query params

### DIFF
--- a/.changeset/mighty-dodos-explain.md
+++ b/.changeset/mighty-dodos-explain.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-shared': minor
+---
+
+Add `sanitizeURL` utility.

--- a/.changeset/smart-rules-appear.md
+++ b/.changeset/smart-rules-appear.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-shared': patch
+---

--- a/.changeset/wicked-phones-float.md
+++ b/.changeset/wicked-phones-float.md
@@ -1,0 +1,8 @@
+---
+'@finos/legend-application-query': patch
+'@finos/legend-application-query-deployment': patch
+'@finos/legend-application-studio-deployment': patch
+'@finos/legend-application-taxonomy-deployment': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-shared': patch
+---

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@finos/eslint-plugin-legend-studio": "workspace:*",
     "@finos/legend-dev-utils": "workspace:*",
     "@finos/stylelint-config-legend-studio": "workspace:*",
-    "@types/node": "18.11.5",
+    "@types/node": "18.11.6",
     "chalk": "5.1.2",
     "cross-env": "7.0.3",
     "envinfo": "7.8.1",

--- a/packages/legend-application-query-deployment/package.json
+++ b/packages/legend-application-query-deployment/package.json
@@ -45,7 +45,7 @@
     "rimraf": "3.0.2",
     "typescript": "4.8.4",
     "webpack": "5.74.0",
-    "webpack-bundle-analyzer": "4.6.1",
+    "webpack-bundle-analyzer": "4.7.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1"
   }

--- a/packages/legend-application-query/src/components/QueryEditor.tsx
+++ b/packages/legend-application-query/src/components/QueryEditor.tsx
@@ -39,7 +39,11 @@ import {
   CheckIcon,
   MenuContentItemLabel,
 } from '@finos/legend-art';
-import { debounce, getQueryParameters } from '@finos/legend-shared';
+import {
+  debounce,
+  getQueryParameters,
+  sanitizeURL,
+} from '@finos/legend-shared';
 import { observer } from 'mobx-react-lite';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -645,7 +649,7 @@ export const ServiceQueryCreator = observer(() => {
   const gav = params[LEGEND_QUERY_PATH_PARAM_TOKEN.GAV];
   const servicePath = params[LEGEND_QUERY_PATH_PARAM_TOKEN.SERVICE_PATH];
   const executionKey = getQueryParameters<ServiceQueryCreatorQueryParams>(
-    applicationStore.navigator.getCurrentAddress(),
+    sanitizeURL(applicationStore.navigator.getCurrentAddress()),
     true,
   )[LEGEND_QUERY_QUERY_PARAM_TOKEN.SERVICE_EXECUTION_KEY];
 

--- a/packages/legend-application-query/src/components/QuerySetup.tsx
+++ b/packages/legend-application-query/src/components/QuerySetup.tsx
@@ -31,7 +31,11 @@ import {
   CheckIcon,
   MenuContentDivider,
 } from '@finos/legend-art';
-import { getQueryParameters, guaranteeNonNullable } from '@finos/legend-shared';
+import {
+  getQueryParameters,
+  guaranteeNonNullable,
+  sanitizeURL,
+} from '@finos/legend-shared';
 import { observer, useLocalObservable } from 'mobx-react-lite';
 import React, { createContext, useContext, useEffect } from 'react';
 import {
@@ -251,7 +255,7 @@ export const QuerySetupLandingPage = withQuerySetupLandingPageStore(
     const setupStore = useQuerySetupLandingPageStore();
     const applicationStore = useLegendQueryApplicationStore();
     const params = getQueryParameters<QuerySetupQueryParams>(
-      applicationStore.navigator.getCurrentAddress(),
+      sanitizeURL(applicationStore.navigator.getCurrentAddress()),
       true,
     );
     const showAdvancedActions =

--- a/packages/legend-application-studio-deployment/package.json
+++ b/packages/legend-application-studio-deployment/package.json
@@ -45,7 +45,7 @@
     "rimraf": "3.0.2",
     "typescript": "4.8.4",
     "webpack": "5.74.0",
-    "webpack-bundle-analyzer": "4.6.1",
+    "webpack-bundle-analyzer": "4.7.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1"
   }

--- a/packages/legend-application-taxonomy-deployment/package.json
+++ b/packages/legend-application-taxonomy-deployment/package.json
@@ -45,7 +45,7 @@
     "rimraf": "3.0.2",
     "typescript": "4.8.4",
     "webpack": "5.74.0",
-    "webpack-bundle-analyzer": "4.6.1",
+    "webpack-bundle-analyzer": "4.7.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1"
   }

--- a/packages/legend-extension-dsl-data-space/src/components/query/DataSpaceQueryCreator.tsx
+++ b/packages/legend-extension-dsl-data-space/src/components/query/DataSpaceQueryCreator.tsx
@@ -15,7 +15,7 @@
  */
 
 import { observer, useLocalObservable } from 'mobx-react-lite';
-import { getQueryParameters } from '@finos/legend-shared';
+import { getQueryParameters, sanitizeURL } from '@finos/legend-shared';
 import { useApplicationStore, useParams } from '@finos/legend-application';
 import { useDepotServerClient } from '@finos/legend-server-depot';
 import {
@@ -82,7 +82,7 @@ export const DataSpaceQueryCreator = observer(() => {
     params[DATA_SPACE_QUERY_CREATOR_PATH_PARAM_TOKEN.EXECUTION_CONTEXT];
   const runtimePath = params[LEGEND_QUERY_PATH_PARAM_TOKEN.RUNTIME_PATH];
   const classPath = getQueryParameters<DataSpaceQueryEditorQueryParams>(
-    applicationStore.navigator.getCurrentAddress(),
+    sanitizeURL(applicationStore.navigator.getCurrentAddress()),
     true,
   )[DATA_SPACE_QUERY_CREATOR_QUERY_PARAM_TOKEN.CLASS_PATH];
 

--- a/packages/legend-shared/package.json
+++ b/packages/legend-shared/package.json
@@ -39,6 +39,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@braintree/sanitize-url": "6.0.1",
     "@types/lodash-es": "4.17.6",
     "@types/object-hash": "2.2.1",
     "@types/pako": "2.0.0",

--- a/packages/legend-shared/src/network/NetworkUtils.ts
+++ b/packages/legend-shared/src/network/NetworkUtils.ts
@@ -29,6 +29,7 @@ import {
   stringify as _stringifyQueryParams,
 } from 'query-string';
 import { returnUndefOnError } from '../error/ErrorUtils.js';
+import { sanitizeUrl } from '@braintree/sanitize-url';
 
 /**
  * Unlike the download call (GET requests) which is gziped, the upload call send uncompressed data which is in megabytes realms
@@ -554,3 +555,5 @@ export const buildUrl = (parts: string[]): string =>
   parts
     .map((part) => part.replaceAll(/^\/+/g, '').replaceAll(/\/+$/g, ''))
     .join(URL_SEPARATOR);
+
+export const sanitizeURL = (val: string): string => sanitizeUrl(val);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braintree/sanitize-url@npm:6.0.1":
+  version: 6.0.1
+  resolution: "@braintree/sanitize-url@npm:6.0.1"
+  checksum: 6f9221299aac0c841a17ecb1ebc60eb43c794f05b5136ca9b87116c8472b7e96f21e56ba2da8369f964112c6055fab791a37015bbea4bd5a189cc38206d214ad
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^6.1.1":
   version: 6.1.1
   resolution: "@changesets/apply-release-plan@npm:6.1.1"
@@ -2987,6 +2994,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/legend-shared@workspace:packages/legend-shared"
   dependencies:
+    "@braintree/sanitize-url": 6.0.1
     "@finos/legend-dev-utils": "workspace:*"
     "@jest/globals": 29.2.2
     "@types/lodash-es": 4.17.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,7 +2128,7 @@ __metadata:
     rimraf: 3.0.2
     typescript: 4.8.4
     webpack: 5.74.0
-    webpack-bundle-analyzer: 4.6.1
+    webpack-bundle-analyzer: 4.7.0
     webpack-cli: 4.10.0
     webpack-dev-server: 4.11.1
   languageName: unknown
@@ -2211,7 +2211,7 @@ __metadata:
     rimraf: 3.0.2
     typescript: 4.8.4
     webpack: 5.74.0
-    webpack-bundle-analyzer: 4.6.1
+    webpack-bundle-analyzer: 4.7.0
     webpack-cli: 4.10.0
     webpack-dev-server: 4.11.1
   languageName: unknown
@@ -2291,7 +2291,7 @@ __metadata:
     rimraf: 3.0.2
     typescript: 4.8.4
     webpack: 5.74.0
-    webpack-bundle-analyzer: 4.6.1
+    webpack-bundle-analyzer: 4.7.0
     webpack-cli: 4.10.0
     webpack-dev-server: 4.11.1
   languageName: unknown
@@ -4305,10 +4305,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.11.5":
-  version: 18.11.5
-  resolution: "@types/node@npm:18.11.5"
-  checksum: ac54e9287dd4549ea3dc8aabc0cf7bfa04c52f02925d7fd68414789617ec770f034c8ae2e111e8bd00d446a46fcac42587b5a316a1303e2f6ea094854248c9ff
+"@types/node@npm:18.11.6":
+  version: 18.11.6
+  resolution: "@types/node@npm:18.11.6"
+  checksum: 25713209b5f8758e782348514e7bd2342bd8edb38038380c66f37b41b12d6840763edb17d81f6451591791c9d59c8255be54591333fc302f473beadada0023e6
   languageName: node
   linkType: hard
 
@@ -10160,7 +10160,7 @@ __metadata:
     "@finos/eslint-plugin-legend-studio": "workspace:*"
     "@finos/legend-dev-utils": "workspace:*"
     "@finos/stylelint-config-legend-studio": "workspace:*"
-    "@types/node": 18.11.5
+    "@types/node": 18.11.6
     chalk: 5.1.2
     cross-env: 7.0.3
     envinfo: 7.8.1
@@ -15848,9 +15848,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:4.6.1":
-  version: 4.6.1
-  resolution: "webpack-bundle-analyzer@npm:4.6.1"
+"webpack-bundle-analyzer@npm:4.7.0":
+  version: 4.7.0
+  resolution: "webpack-bundle-analyzer@npm:4.7.0"
   dependencies:
     acorn: ^8.0.4
     acorn-walk: ^8.0.0
@@ -15863,7 +15863,7 @@ __metadata:
     ws: ^7.3.1
   bin:
     webpack-bundle-analyzer: lib/bin/analyzer.js
-  checksum: 4bc97ac6a1d9cd1f133444b0fc9d9091c97f4bd8388f97636ce27abd1ebffaa7dd45d29f6693661a666e77bcc08dff43ab7c2f5e2600a3101b956c94c1d038d0
+  checksum: 4ce3b379c61ce16b2219756843407cc99f2b82cd191f653043f1b705a3e32b3af03834af0dfded98ab852313a892a148bed1a8effaacd6440f028c19f41581f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- [x] sanitize ULRs before parsing query params: hopefully, this will close out flagged security problems like https://github.com/finos/legend-studio/security/code-scanning/36 https://github.com/finos/legend-studio/security/code-scanning/35 https://github.com/finos/legend-studio/security/code-scanning/34
- [x] bump dependencies

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)
