### PR TITLE
Mastery ID refactoring to use identifiers.

### DIFF
--- a/.changeset/sixty-comics-return.md
+++ b/.changeset/sixty-comics-return.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-mastery': patch
+---

--- a/packages/legend-extension-dsl-mastery/src/components/studio/DSL_Mastery_CodeSnippets.ts
+++ b/packages/legend-extension-dsl-mastery/src/components/studio/DSL_Mastery_CodeSnippets.ts
@@ -38,8 +38,7 @@ export const SIMPLE_MASTER_RECORD_DEFINITION_SNIPPET = `MasterRecordDefinition \
    }
    recordSources:
    [
-     {
-       id: 'test-source-id';
+     test-source-id: {
        status: Development;
        description: 'Test Source Description';
        parseService: \${5:model::SomeParseService};
@@ -49,8 +48,7 @@ export const SIMPLE_MASTER_RECORD_DEFINITION_SNIPPET = `MasterRecordDefinition \
        stagedLoad: false;
        sequentialData: false;
        partitions: [
-         {
-           id: 'test-partition-1';
+         test-partition-1: {
            tags: [];
          }
        ]


### PR DESCRIPTION

## Summary
Adjust the code-completion templates for Mastery to account for identifiers being used for IDs.

Needs: https://github.com/finos/legend-engine/pull/1102

## How did you test this change?

No other changed required because the JSON protocol is unchanged, the engine code takes care of moving the ID to an identifier supplied as a name.
