### PR TITLE
fix: toogle text mode shortcut in viewer mode

### DIFF
--- a/.changeset/finicky-falcons-feign.md
+++ b/.changeset/finicky-falcons-feign.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+fix: toogle text mode shortcut in viewer mode

--- a/packages/legend-application-studio/src/stores/EditorStore.ts
+++ b/packages/legend-application-studio/src/stores/EditorStore.ts
@@ -330,14 +330,22 @@ export class EditorStore implements CommandRegistrar {
   }
 
   get isInitialized(): boolean {
-    return (
-      Boolean(
-        this.sdlcState.currentProject &&
-          this.sdlcState.currentWorkspace &&
-          this.sdlcState.currentRevision &&
-          this.sdlcState.remoteWorkspaceRevision,
-      ) && this.graphManagerState.systemBuildState.hasSucceeded
-    );
+    if (this.isInViewerMode) {
+      return (
+        Boolean(
+          this.sdlcState.currentProject && this.sdlcState.currentWorkspace,
+        ) && this.graphManagerState.systemBuildState.hasSucceeded
+      );
+    } else {
+      return (
+        Boolean(
+          this.sdlcState.currentProject &&
+            this.sdlcState.currentWorkspace &&
+            this.sdlcState.currentRevision &&
+            this.sdlcState.remoteWorkspaceRevision,
+        ) && this.graphManagerState.systemBuildState.hasSucceeded
+      );
+    }
   }
 
   get isInGrammarTextMode(): boolean {
@@ -438,10 +446,9 @@ export class EditorStore implements CommandRegistrar {
       key: LEGEND_STUDIO_COMMAND_KEY.TOGGLE_TEXT_MODE,
       trigger: this.createEditorCommandTrigger(
         () =>
-          this.isInViewerMode ||
-          (this.isInitialized &&
-            (!this.isInConflictResolutionMode ||
-              this.conflictResolutionState.hasResolvedAllConflicts)),
+          this.isInitialized &&
+          (!this.isInConflictResolutionMode ||
+            this.conflictResolutionState.hasResolvedAllConflicts),
       ),
       action: () => {
         flowResult(this.toggleTextMode()).catch(

--- a/packages/legend-application-studio/src/stores/EditorStore.ts
+++ b/packages/legend-application-studio/src/stores/EditorStore.ts
@@ -438,9 +438,10 @@ export class EditorStore implements CommandRegistrar {
       key: LEGEND_STUDIO_COMMAND_KEY.TOGGLE_TEXT_MODE,
       trigger: this.createEditorCommandTrigger(
         () =>
-          this.isInitialized &&
-          (!this.isInConflictResolutionMode ||
-            this.conflictResolutionState.hasResolvedAllConflicts),
+          this.isInViewerMode ||
+          (this.isInitialized &&
+            (!this.isInConflictResolutionMode ||
+              this.conflictResolutionState.hasResolvedAllConflicts)),
       ),
       action: () => {
         flowResult(this.toggleTextMode()).catch(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Restores shortcut fn+8 to switch to text mode for when users are in view only mode for workspaces.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
