### PR TITLE
make scrollbar lighter in dark mode selector

### DIFF
--- a/.changeset/silent-bobcats-poke.md
+++ b/.changeset/silent-bobcats-poke.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-art': patch
+---
+
+make scrollbar color lighter in dark mode selector

--- a/packages/legend-art/src/components/CustomSelectorInput.tsx
+++ b/packages/legend-art/src/components/CustomSelectorInput.tsx
@@ -78,7 +78,9 @@ const CustomMenuList: React.FC<{
   if (children.length) {
     return (
       <FixedSizeList
-        className={selectProps.darkMode ? 'selector-menu--dark' : ''}
+        className={
+          selectProps.darkMode ? 'scrollbar--light selector-menu--dark' : ''
+        }
         ref={listRef}
         width="100%"
         height={Math.min(children.length, MAX_OPTIONS_LENGTH) * ROW_HEIGHT}

--- a/packages/legend-art/style/base/_normalize.scss
+++ b/packages/legend-art/style/base/_normalize.scss
@@ -121,6 +121,10 @@ input[type='number']::-webkit-outer-spin-button {
   background: var(--color-dark-shade-100);
 }
 
+.scrollbar--light::-webkit-scrollbar-thumb {
+  background: var(--color-light-shade-100);
+}
+
 ::-webkit-scrollbar-thumb:window-inactive {
   background: var(--color-dark-shade-100);
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->


## Summary

Previously, the contrast for selector inputs' scrollbar in dark mode was very low and therefore made it harder for users to differentiate. Lightening the scrollbar in dark mode for better contrast 

Prev: 
<img width="365" alt="image" src="https://user-images.githubusercontent.com/41248956/200610429-3ccb8e18-6cb8-46da-b10b-44aeb63a150a.png">

New: 
<img width="367" alt="image" src="https://user-images.githubusercontent.com/41248956/200610162-8d4cfb2d-521a-4f28-86e1-593a296d309a.png">

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
