### PR TITLE
fix two regressions introduced by #1572 and #1628

### DIFF
--- a/.changeset/modern-gifts-nail.md
+++ b/.changeset/modern-gifts-nail.md
@@ -1,0 +1,7 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-query-builder': patch
+---
+
+Fixed a regression introduced by #1572 where query execution with parameters of type `SimpleFunctionExpression` failed.
+Fixed a regression introduced by #1628 where failed to update mocked value after parameter's multiplicity is changed.

--- a/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
@@ -64,6 +64,8 @@ import {
   stub_PackageableRuntime,
   stub_Mapping,
   ParameterValue,
+  buildRawLambdaFromLambdaFunction,
+  SimpleFunctionExpression,
 } from '@finos/legend-graph';
 import { type Entity, parseGACoordinates } from '@finos/legend-storage';
 import { runtime_addMapping } from '../../../shared/modifier/DSL_Mapping_GraphModifierHelper.js';
@@ -79,6 +81,7 @@ import {
   service_setExecution,
 } from '../../../shared/modifier/DSL_Service_GraphModifierHelper.js';
 import {
+  buildParametersLetLambdaFunc,
   LambdaEditorState,
   LambdaParametersState,
   LambdaParameterState,
@@ -580,7 +583,7 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
       this.isRunningQuery = true;
       const promise =
         this.editorStore.graphManagerState.graphManager.executeMapping(
-          this.queryState.query,
+          this.getExecutionQuery(),
           this.selectedExecutionContextState.executionContext.mapping.value,
           this.selectedExecutionContextState.executionContext.runtime,
           this.editorStore.graphManagerState.graph,
@@ -609,16 +612,55 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
     }
   }
 
+  getExecutionQuery(): RawLambda {
+    const funcParameterStates = this.parameterState.parameterStates.filter(
+      (ps) =>
+        ps.value instanceof SimpleFunctionExpression &&
+        ps.parameter.multiplicity.upperBound,
+    );
+    // Hack query execution with parameters are of type SimpleFunctionExpression by using let statements
+    if (funcParameterStates.length > 0) {
+      const letlambdaFunction = buildParametersLetLambdaFunc(
+        this.editorStore.graphManagerState.graph,
+        funcParameterStates,
+      );
+      const letRawLambda = buildRawLambdaFromLambdaFunction(
+        letlambdaFunction,
+        this.editorStore.graphManagerState,
+      );
+      // reset parameters
+      if (
+        Array.isArray(this.queryState.query.body) &&
+        Array.isArray(letRawLambda.body)
+      ) {
+        letRawLambda.body = [
+          ...(letRawLambda.body as object[]),
+          ...(this.queryState.query.body as object[]),
+        ];
+        return letRawLambda;
+      }
+    }
+    return this.queryState.query;
+  }
+
   buildExecutionParameterValues(): ParameterValue[] {
-    return this.parameterState.parameterStates.map((queryParamState) => {
-      const paramValue = new ParameterValue();
-      paramValue.name = queryParamState.parameter.name;
-      paramValue.value =
-        this.editorStore.graphManagerState.graphManager.serializeValueSpecification(
-          guaranteeNonNullable(queryParamState.value),
-        );
-      return paramValue;
-    });
+    return this.parameterState.parameterStates
+      .filter(
+        (ps) =>
+          !(
+            ps.value instanceof SimpleFunctionExpression &&
+            ps.parameter.multiplicity.upperBound
+          ),
+      )
+      .map((queryParamState) => {
+        const paramValue = new ParameterValue();
+        paramValue.name = queryParamState.parameter.name;
+        paramValue.value =
+          this.editorStore.graphManagerState.graphManager.serializeValueSpecification(
+            guaranteeNonNullable(queryParamState.value),
+          );
+        return paramValue;
+      });
   }
 
   get serviceExecutionParameters():
@@ -821,6 +863,7 @@ export class MultiServicePureExecutionState extends ServicePureExecutionState {
       setIsRunningQuery: action,
       changeExecution: action,
       generatePlan: flow,
+      handleExecute: flow,
       runQuery: flow,
     });
 

--- a/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/ServiceExecutionState.ts
@@ -618,7 +618,7 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
    * Hack query execution with parameters that are of type SimpleFunctionExpression by using let statements
    * because Engine doesn't support processing SimpleFunctionExpression as parameter values.
    */
-  getFunctionParameterStates(): LambdaParameterState[] {
+  getParameterStatesWithFunctionValues(): LambdaParameterState[] {
     return this.parameterState.parameterStates.filter(
       (ps) =>
         ps.value instanceof SimpleFunctionExpression &&
@@ -629,7 +629,7 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
   }
 
   getExecutionQuery(): RawLambda {
-    const funcParameterStates = this.getFunctionParameterStates();
+    const funcParameterStates = this.getParameterStatesWithFunctionValues();
     if (funcParameterStates.length > 0) {
       const letlambdaFunction = buildParametersLetLambdaFunc(
         this.editorStore.graphManagerState.graph,
@@ -655,7 +655,7 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
   }
 
   buildExecutionParameterValues(): ParameterValue[] {
-    const funcParameterStates = this.getFunctionParameterStates();
+    const funcParameterStates = this.getParameterStatesWithFunctionValues();
     return this.parameterState.parameterStates
       .filter((ps) => !funcParameterStates.includes(ps))
       .map((queryParamState) => {

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -55,10 +55,7 @@ import {
 import { useDrag } from 'react-dnd';
 import { generateEnumerableNameFromToken } from '@finos/legend-shared';
 import { DEFAULT_VARIABLE_NAME } from '../stores/QueryBuilderConfig.js';
-import {
-  valueSpecification_setMultiplicity,
-  variableExpression_setName,
-} from '../stores/shared/ValueSpecificationModifierHelper.js';
+import { variableExpression_setName } from '../stores/shared/ValueSpecificationModifierHelper.js';
 import { LambdaParameterState } from '../stores/shared/LambdaParameterState.js';
 import { LambdaParameterValuesEditor } from './shared/LambdaParameterValuesEditor.js';
 
@@ -125,9 +122,7 @@ const VariableExpressionEditor = observer(
     const multilicityOptions: MultiplicityOption[] =
       validParamMultiplicityList.map(buildMultiplicityOption);
     const changeMultiplicity = (val: MultiplicityOption): void => {
-      if (multiplity !== val.value) {
-        valueSpecification_setMultiplicity(varState, val.value);
-      }
+      lambdaParameterState.changeMultiplicity(varState, val.value);
     };
 
     const close = (): void => {

--- a/packages/legend-query-builder/src/stores/QueryBuilderResultState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderResultState.ts
@@ -121,7 +121,7 @@ export class QueryBuilderResultState {
    * Hack query execution with parameters that are of type SimpleFunctionExpression by using let statements
    * because Engine doesn't support processing SimpleFunctionExpression as parameter values.
    */
-  getFunctionParameterStates(): LambdaParameterState[] {
+  getParameterStatesWithFunctionValues(): LambdaParameterState[] {
     return this.queryBuilderState.parametersState.parameterStates.filter(
       (ps) =>
         ps.value instanceof SimpleFunctionExpression &&
@@ -146,7 +146,7 @@ export class QueryBuilderResultState {
         this.queryBuilderState.unsupportedQueryState.rawLambda,
         'Lambda is required to execute query',
       );
-      const funcParameterStates = this.getFunctionParameterStates();
+      const funcParameterStates = this.getParameterStatesWithFunctionValues();
       if (
         !this.queryBuilderState.isParameterSupportDisabled &&
         funcParameterStates.length > 0
@@ -177,7 +177,7 @@ export class QueryBuilderResultState {
   }
 
   buildExecutionParameterValues(): ParameterValue[] {
-    const funcParameterStates = this.getFunctionParameterStates();
+    const funcParameterStates = this.getParameterStatesWithFunctionValues();
     return this.queryBuilderState.parametersState.parameterStates
       .filter((ps) => !funcParameterStates.includes(ps))
       .map((queryParamState) => {

--- a/packages/legend-query-builder/src/stores/QueryBuilderValueSpecificationBuilder.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderValueSpecificationBuilder.ts
@@ -161,6 +161,7 @@ export const buildLambdaFunction = (
     queryBuilderState.parametersState.parameterStates.length
   ) {
     // Hack query execution with parameters are of type SimpleFunctionExpression by using let statements
+    // because Engine doesn't support processing SimpleFunctionExpression as parameter values.
     const funcParameterStates =
       queryBuilderState.parametersState.parameterStates.filter(
         (ps) =>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Fixed a regression introduced by #1572 where query execution with parameters of type `SimpleFunctionExpression` failed.
Fixed a regression introduced by #1628 where failed to update mocked value after parameter's multiplcity is changed.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
Fixed a regression introduced by #1572 where query execution with parameters of type `SimpleFunctionExpression` failed : 

https://user-images.githubusercontent.com/73408381/200672889-7f0c254f-8853-450f-89c1-a32929508fb0.mov

Fixed a regression introduced by #1628 where failed to update mocked value after parameter's multiplcity is changed:

https://user-images.githubusercontent.com/73408381/200672947-327a449f-ab24-4c4b-b924-f2fc65c9a7c1.mov



<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
