### PR TITLE
Revert "Support env keys selection for each test in multi-exec services (#1719)"

### DIFF
--- a/.changeset/strong-zoos-confess.md
+++ b/.changeset/strong-zoos-confess.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-art': patch
+'@finos/legend-graph': patch
+---

--- a/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/ServiceExecutionEditor.tsx
@@ -64,7 +64,6 @@ import { useEditorStore } from '../../EditorStoreProvider.js';
 import {
   type KeyedExecutionParameter,
   type Runtime,
-  type ServiceTest,
   Mapping,
   RuntimePointer,
   PackageableRuntime,
@@ -774,10 +773,6 @@ const ServicePureExecutionEditor = observer(
       servicePureExecutionState instanceof MultiServicePureExecutionState;
     const showChangeExecutionModal = (): void => {
       if (servicePureExecutionState instanceof MultiServicePureExecutionState) {
-        servicePureExecutionState.serviceEditorState.service.tests.forEach(
-          (suite) =>
-            suite.tests.forEach((st) => ((st as ServiceTest).keys = [])),
-        );
         servicePureExecutionState.setSingleExecutionKey(
           servicePureExecutionState.execution.executionParameters[0],
         );

--- a/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestsEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestsEditor.tsx
@@ -35,11 +35,7 @@ import {
   RefreshIcon,
   TimesIcon,
 } from '@finos/legend-art';
-import {
-  type ValueSpecification,
-  PrimitiveType,
-  PureMultiExecution,
-} from '@finos/legend-graph';
+import { type ValueSpecification, PrimitiveType } from '@finos/legend-graph';
 import { BasicValueSpecificationEditor } from '@finos/legend-query-builder';
 import {
   filterByType,
@@ -51,10 +47,9 @@ import { observer } from 'mobx-react-lite';
 import { forwardRef, useEffect, useState } from 'react';
 import type { ServiceTestSuiteState } from '../../../../../stores/editor-state/element-editor-state/service/testable/ServiceTestableState.js';
 import {
-  type KeyOption,
+  ServiceValueSpecificationTestParameterState,
   type ServiceTestSetupState,
   type ServiceTestState,
-  ServiceValueSpecificationTestParameterState,
 } from '../../../../../stores/editor-state/element-editor-state/service/testable/ServiceTestEditorState.js';
 import { TESTABLE_TEST_TAB } from '../../../../../stores/editor-state/element-editor-state/testable/TestableEditorState.js';
 import type { TestAssertionEditorState } from '../../../../../stores/editor-state/element-editor-state/testable/TestAssertionState.js';
@@ -281,24 +276,14 @@ const ServiceTestSetupEditor = observer(
     const format = test.serializationFormat;
     const selectedSerializationFormat = setupState.getSelectedFormatOption();
     const options = setupState.options;
-    const keyOptions = setupState.keyOptions;
-    const [selectedKeys, setSelectedKeys] = useState<KeyOption[]>(
-      setupState.getSelectedKeyOptions(),
-    );
     const isReadOnly =
       serviceTestState.suiteState.testableState.serviceEditorState.isReadOnly;
-    const onSerializationFormatChange = (
-      val: { label: string; value: string } | null,
-    ): void => {
+    const onChange = (val: { label: string; value: string } | null): void => {
       if (val === null) {
         setupState.changeSerializationFormat(undefined);
       } else if (val.value !== format) {
         setupState.changeSerializationFormat(val.value);
       }
-    };
-    const onKeyOptionChange = (val: KeyOption[]): void => {
-      setupState.addServiceTestAssertKeys(val.map((op) => op.value));
-      setSelectedKeys(val);
     };
     const addParameter = (): void => {
       setupState.setShowNewParameterModal(true);
@@ -322,27 +307,27 @@ const ServiceTestSetupEditor = observer(
         </div>
         <div className="service-test-editor__content">
           <ResizablePanelGroup orientation="horizontal">
-            <ResizablePanel size={230} minSize={28}>
+            <ResizablePanel size={200} minSize={28}>
               <div className="service-test-data-editor panel">
                 <div className="service-test-suite-editor__header">
                   <div className="service-test-suite-editor__header__title">
                     <div className="service-test-suite-editor__header__title__label">
-                      configuration
+                      serialization
                     </div>
                   </div>
                 </div>
-                <div className="service-test-editor__setup__configuration">
+                <div className="service-test-editor__setup__serialization">
                   <div className="panel__content__form__section">
                     <div className="panel__content__form__section__header__label">
                       Serialization Format
                     </div>
                     <div className="panel__content__form__section__header__prompt">
-                      Format to serialize execution result
+                      format to serialize execution result
                     </div>
                     <CustomSelectorInput
                       className="panel__content__form__section__dropdown"
                       options={options}
-                      onChange={onSerializationFormatChange}
+                      onChange={onChange}
                       value={selectedSerializationFormat}
                       isClearable={true}
                       escapeClearsValue={true}
@@ -350,30 +335,6 @@ const ServiceTestSetupEditor = observer(
                       disable={isReadOnly}
                     />
                   </div>
-                  {setupState.testState.testable.execution instanceof
-                    PureMultiExecution && (
-                    <div className="panel__content__form__section">
-                      <div className="panel__content__form__section__header__label">
-                        Keys
-                      </div>
-                      <div className="panel__content__form__section__header__prompt">
-                        Specify keys for each test to run assertions against
-                        selected env keys
-                      </div>
-                      <CustomSelectorInput
-                        className="panel__content__form__section__dropdown"
-                        options={keyOptions}
-                        onChange={onKeyOptionChange}
-                        value={selectedKeys}
-                        isClearable={true}
-                        escapeClearsValue={true}
-                        darkMode={true}
-                        isMulti={true}
-                        disable={isReadOnly}
-                        placeholder={'Choose keys...'}
-                      />
-                    </div>
-                  )}
                 </div>
               </div>
             </ResizablePanel>

--- a/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/testable/ServiceTestEditorState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/testable/ServiceTestEditorState.ts
@@ -23,13 +23,11 @@ import {
   ParameterValue,
   buildLambdaVariableExpressions,
   VariableExpression,
-  PureMultiExecution,
 } from '@finos/legend-graph';
 import { action, flow, makeObservable, observable } from 'mobx';
 import { TestableTestEditorState } from '../../testable/TestableEditorState.js';
 import type { ServiceTestSuiteState } from './ServiceTestableState.js';
 import {
-  service_addAssertKeyForTest,
   service_addParameterValue,
   service_deleteParameterValue,
   service_setParameterName,
@@ -75,11 +73,6 @@ const getSerializationFormatLabel = (val: string): string => {
 };
 
 export type SerializationFormatOption = {
-  value: string;
-  label: string;
-};
-
-export type KeyOption = {
   value: string;
   label: string;
 };
@@ -174,7 +167,6 @@ export class ServiceTestSetupState {
       setShowNewParameterModal: action,
       openNewParamModal: action,
       addParameterValue: action,
-      addServiceTestAssertKeys: action,
       syncWithQuery: action,
       removeParamValueState: action,
     });
@@ -199,30 +191,6 @@ export class ServiceTestSetupState {
       value: e,
       label: getSerializationFormatLabel(e),
     }));
-  }
-
-  get keyOptions(): KeyOption[] {
-    const keys =
-      this.testState.testable.execution instanceof PureMultiExecution
-        ? this.testState.testable.execution.executionParameters.map(
-            (p) => p.key,
-          )
-        : [];
-    return keys.map((k) => ({
-      value: k,
-      label: k,
-    }));
-  }
-
-  getSelectedKeyOptions(): KeyOption[] {
-    return this.testState.test.keys.map((k) => ({
-      value: k,
-      label: k,
-    }));
-  }
-
-  addServiceTestAssertKeys(val: string[]): void {
-    service_addAssertKeyForTest(this.testState.test, val);
   }
 
   get newParamOptions(): { value: string; label: string }[] {

--- a/packages/legend-application-studio/src/stores/shared/modifier/DSL_Service_GraphModifierHelper.ts
+++ b/packages/legend-application-studio/src/stores/shared/modifier/DSL_Service_GraphModifierHelper.ts
@@ -87,12 +87,6 @@ export const service_setSerializationFormat = action(
   },
 );
 
-export const service_addAssertKeyForTest = action(
-  (test: ServiceTest, keys: string[]) => {
-    test.keys = keys;
-  },
-);
-
 export const service_addTestSuite = action(
   (
     service: Service,

--- a/packages/legend-application-studio/style/components/editor/_service-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_service-editor.scss
@@ -1121,9 +1121,8 @@
   }
 
   &__setup {
-    &__configuration {
+    &__serialization {
       padding: 1rem;
-      overflow-y: scroll;
     }
 
     &__parameters {

--- a/packages/legend-art/style/components/_selector-input.scss
+++ b/packages/legend-art/style/components/_selector-input.scss
@@ -321,19 +321,6 @@
   &__option:active {
     background-color: var(--color-light-blue-450) !important;
   }
-
-  &__multi-value {
-    color: var(--color-dark-grey-250);
-    background: var(--color-dark-grey-400);
-
-    &__remove {
-      color: var(--color-dark-grey-250);
-    }
-
-    &__remove:hover {
-      background: var(--color-dark-grey-500);
-    }
-  }
 }
 
 .selector-input--has-error .selector-input--dark {

--- a/packages/legend-graph/src/graph/metamodel/pure/packageableElements/service/ServiceTest.ts
+++ b/packages/legend-graph/src/graph/metamodel/pure/packageableElements/service/ServiceTest.ts
@@ -22,7 +22,6 @@ import type { ParameterValue } from './ParameterValue.js';
 export class ServiceTest extends AtomicTest implements Hashable {
   serializationFormat: string | undefined;
   parameters: ParameterValue[] = [];
-  keys: string[] = [];
 
   get hashCode(): string {
     return hashArray([
@@ -30,7 +29,6 @@ export class ServiceTest extends AtomicTest implements Hashable {
       this.id,
       hashArray(this.assertions),
       hashArray(this.parameters),
-      hashArray(this.keys),
       this.serializationFormat ?? '',
     ]);
   }

--- a/packages/legend-graph/src/graphManager/__tests__/roundtripTestData/TEST_DATA__ServiceRoundtrip.ts
+++ b/packages/legend-graph/src/graphManager/__tests__/roundtripTestData/TEST_DATA__ServiceRoundtrip.ts
@@ -56,6 +56,19 @@ export const TEST_DATA__ServiceRoundtrip = [
     classifierPath: 'meta::pure::metamodel::type::Class',
   },
   {
+    path: 'test::tMapping',
+    content: {
+      _type: 'mapping',
+      classMappings: [],
+      enumerationMappings: [],
+      includedMappings: [],
+      name: 'tMapping',
+      package: 'test',
+      tests: [],
+    },
+    classifierPath: 'meta::pure::mapping::Mapping',
+  },
+  {
     path: 'my::map',
     content: {
       _type: 'mapping',
@@ -77,7 +90,11 @@ export const TEST_DATA__ServiceRoundtrip = [
                 body: [
                   {
                     _type: 'string',
-                    value: 'name',
+                    multiplicity: {
+                      lowerBound: 1,
+                      upperBound: 1,
+                    },
+                    values: ['name'],
                   },
                 ],
                 parameters: [],
@@ -96,287 +113,300 @@ export const TEST_DATA__ServiceRoundtrip = [
     classifierPath: 'meta::pure::mapping::Mapping',
   },
   {
-    path: 'test::tMapping',
-    content: {
-      _type: 'mapping',
-      classMappings: [],
-      enumerationMappings: [],
-      includedMappings: [],
-      name: 'tMapping',
-      package: 'test',
-      tests: [],
-    },
-    classifierPath: 'meta::pure::mapping::Mapping',
-  },
-  {
-    path: 'my::serviceWithTestSuiteWithMultipleTests',
+    path: 'test::pure::tService_Single',
     content: {
       _type: 'service',
+      stereotypes: [
+        {
+          profile: 'meta::pure::profiles::typemodifiers',
+          value: 'abstract',
+        },
+      ],
+      taggedValues: [
+        {
+          tag: {
+            profile: 'meta::pure::profiles::doc',
+            value: 'doc',
+          },
+          value: 'something',
+        },
+      ],
       autoActivateUpdates: true,
-      documentation: '',
+      documentation: 'this is just for context',
       execution: {
         _type: 'pureSingleExecution',
         func: {
           _type: 'lambda',
           body: [
             {
-              _type: 'func',
-              function: 'project',
+              _type: 'property',
               parameters: [
                 {
+                  _type: 'var',
+                  name: 'src',
+                },
+              ],
+              property: 'name',
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              class: 'tClass',
+              multiplicity: {
+                lowerBound: 1,
+                upperBound: 1,
+              },
+              name: 'src',
+            },
+          ],
+        },
+        mapping: 'tMapping',
+        runtime: {
+          _type: 'runtimePointer',
+          runtime: 'tRuntime',
+        },
+      },
+      name: 'tService_Single',
+      owners: [],
+      package: 'test::pure',
+      pattern: 'url/myUrl/',
+      test: {
+        _type: 'singleExecutionTest',
+        asserts: [
+          {
+            assert: {
+              _type: 'lambda',
+              body: [
+                {
                   _type: 'func',
-                  function: 'getAll',
+                  function: 'equal',
                   parameters: [
                     {
-                      _type: 'packageableElementPtr',
-                      fullPath: 'my::Person',
-                    },
-                  ],
-                },
-                {
-                  _type: 'collection',
-                  multiplicity: {
-                    lowerBound: 1,
-                    upperBound: 1,
-                  },
-                  values: [
-                    {
-                      _type: 'lambda',
-                      body: [
-                        {
-                          _type: 'property',
-                          parameters: [
-                            {
-                              _type: 'var',
-                              name: 'x',
-                            },
-                          ],
-                          property: 'givenNames',
-                        },
-                      ],
+                      _type: 'property',
                       parameters: [
                         {
                           _type: 'var',
-                          name: 'x',
+                          name: 'res',
                         },
                       ],
+                      property: 'name',
+                    },
+                    {
+                      _type: 'string',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      values: ['1'],
                     },
                   ],
                 },
+              ],
+              parameters: [
                 {
-                  _type: 'collection',
+                  _type: 'var',
+                  class: 'tClass',
                   multiplicity: {
                     lowerBound: 1,
                     upperBound: 1,
                   },
-                  values: [
-                    {
-                      _type: 'string',
-                      value: 'Given Names',
-                    },
-                  ],
+                  name: 'res',
                 },
               ],
             },
-          ],
-          parameters: [],
-        },
-        mapping: 'my::map',
-        runtime: {
-          _type: 'engineRuntime',
-          connections: [],
-          mappings: [
-            {
-              path: 'my::map',
-              type: 'MAPPING',
-            },
-          ],
-        },
-      },
-      name: 'serviceWithTestSuiteWithMultipleTests',
-      owners: [],
-      package: 'my',
-      pattern: '/e2a5e5a9-aac2-49c6-a539-fcdd61f69e9d',
-      testSuites: [
-        {
-          _type: 'serviceTestSuite',
-          id: 'testSuite1',
-          testData: {
-            connectionsTestData: [
-              {
-                data: {
-                  _type: 'externalFormat',
-                  contentType: 'application/json',
-                  data: '[{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}, {"employees":[{"firstName":"firstName 37","lastName":"lastName 78"}],"legalName":"legalName 20"}]',
-                },
-                id: 'connection1',
-              },
-            ],
           },
-          tests: [
-            {
-              _type: 'serviceTest',
-              assertions: [
-                {
-                  _type: 'equalToJson',
-                  expected: {
-                    _type: 'externalFormat',
-                    contentType: 'application/json',
-                    data: '{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}',
-                  },
-                  id: 'assert1',
-                },
-              ],
-              id: 'test1',
-              keys: [],
-            },
-            {
-              _type: 'serviceTest',
-              assertions: [
-                {
-                  _type: 'equalToJson',
-                  expected: {
-                    _type: 'externalFormat',
-                    contentType: 'application/json',
-                    data: 'data',
-                  },
-                  id: 'assert1',
-                },
-              ],
-              id: 'test2',
-              keys: [],
-            },
-          ],
-        },
-      ],
+        ],
+        data: 'moreThanData',
+      },
     },
     classifierPath: 'meta::legend::service::metamodel::Service',
   },
   {
-    path: 'my::serviceWithTestSuite',
+    path: 'test::pure::tService_Multi',
     content: {
       _type: 'service',
       autoActivateUpdates: true,
-      documentation: '',
+      documentation: 'this is just for context',
+      execution: {
+        _type: 'pureMultiExecution',
+        executionKey: 'env',
+        func: {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'property',
+              parameters: [
+                {
+                  _type: 'var',
+                  name: 'src',
+                },
+              ],
+              property: 'name',
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              class: 'tClass',
+              multiplicity: {
+                lowerBound: 1,
+                upperBound: 1,
+              },
+              name: 'src',
+            },
+          ],
+        },
+        executionParameters: [
+          {
+            key: 'QA',
+            mapping: 'tMapping',
+            runtime: {
+              _type: 'runtimePointer',
+              runtime: 'tRuntime',
+            },
+          },
+        ],
+      },
+      name: 'tService_Multi',
+      owners: [],
+      package: 'test::pure',
+      pattern: 'url/myUrl/',
+      test: {
+        _type: 'multiExecutionTest',
+        tests: [
+          {
+            asserts: [
+              {
+                assert: {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'func',
+                      function: 'equal',
+                      parameters: [
+                        {
+                          _type: 'property',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'res',
+                            },
+                          ],
+                          property: 'name',
+                        },
+                        {
+                          _type: 'string',
+                          multiplicity: {
+                            lowerBound: 1,
+                            upperBound: 1,
+                          },
+                          values: ['1'],
+                        },
+                      ],
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      class: 'tClass',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      name: 'res',
+                    },
+                  ],
+                },
+              },
+            ],
+            data: 'moreData',
+            key: 'QA',
+          },
+        ],
+      },
+    },
+    classifierPath: 'meta::legend::service::metamodel::Service',
+  },
+  {
+    path: 'test::pure::tService_SingleWithEmbeddedRuntime',
+    content: {
+      _type: 'service',
+      autoActivateUpdates: true,
+      documentation: 'this is just for context',
       execution: {
         _type: 'pureSingleExecution',
         func: {
           _type: 'lambda',
           body: [
             {
-              _type: 'func',
-              function: 'project',
+              _type: 'property',
               parameters: [
                 {
-                  _type: 'func',
-                  function: 'getAll',
-                  parameters: [
-                    {
-                      _type: 'packageableElementPtr',
-                      fullPath: 'my::Person',
-                    },
-                  ],
+                  _type: 'var',
+                  name: 'src',
+                },
+              ],
+              property: 'name',
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              class: 'tClass',
+              multiplicity: {
+                lowerBound: 1,
+                upperBound: 1,
+              },
+              name: 'src',
+            },
+          ],
+        },
+        mapping: 'tMapping',
+        runtime: {
+          _type: 'engineRuntime',
+          connections: [
+            {
+              store: {
+                path: 'ModelStore',
+                type: 'STORE',
+              },
+              storeConnections: [
+                {
+                  connection: {
+                    _type: 'connectionPointer',
+                    connection: 'myConnection',
+                  },
+                  id: 'id1',
                 },
                 {
-                  _type: 'collection',
-                  multiplicity: {
-                    lowerBound: 1,
-                    upperBound: 1,
+                  connection: {
+                    _type: 'JsonModelConnection',
+                    class: 'tClass',
+                    url: 'my_url',
                   },
-                  values: [
-                    {
-                      _type: 'lambda',
-                      body: [
-                        {
-                          _type: 'property',
-                          parameters: [
-                            {
-                              _type: 'var',
-                              name: 'x',
-                            },
-                          ],
-                          property: 'givenNames',
-                        },
-                      ],
-                      parameters: [
-                        {
-                          _type: 'var',
-                          name: 'x',
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  _type: 'collection',
-                  multiplicity: {
-                    lowerBound: 1,
-                    upperBound: 1,
-                  },
-                  values: [
-                    {
-                      _type: 'string',
-                      value: 'Given Names',
-                    },
-                  ],
+                  id: 'id3',
                 },
               ],
             },
           ],
-          parameters: [],
-        },
-        mapping: 'my::map',
-        runtime: {
-          _type: 'engineRuntime',
-          connections: [],
           mappings: [
             {
-              path: 'my::map',
+              path: 'tMapping',
               type: 'MAPPING',
             },
           ],
         },
       },
-      name: 'serviceWithTestSuite',
+      name: 'tService_SingleWithEmbeddedRuntime',
       owners: [],
-      package: 'my',
-      pattern: '/e2a5e5a9-aac2-49c6-a539-fcdd61f69e9d',
-      testSuites: [
-        {
-          _type: 'serviceTestSuite',
-          id: 'testSuite1',
-          testData: {
-            connectionsTestData: [
-              {
-                data: {
-                  _type: 'externalFormat',
-                  contentType: 'application/json',
-                  data: '[{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}, {"employees":[{"firstName":"firstName 37","lastName":"lastName 78"}],"legalName":"legalName 20"}]',
-                },
-                id: 'connection1',
-              },
-            ],
-          },
-          tests: [
-            {
-              _type: 'serviceTest',
-              assertions: [
-                {
-                  _type: 'equalToJson',
-                  expected: {
-                    _type: 'externalFormat',
-                    contentType: 'application/json',
-                    data: '{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}',
-                  },
-                  id: 'assert1',
-                },
-              ],
-              id: 'test1',
-              keys: [],
-            },
-          ],
-        },
-      ],
+      package: 'test::pure',
+      pattern: 'url/myUrl/',
+      test: {
+        _type: 'singleExecutionTest',
+        asserts: [],
+        data: 'moreThanData',
+      },
     },
     classifierPath: 'meta::legend::service::metamodel::Service',
   },
@@ -444,7 +474,11 @@ export const TEST_DATA__ServiceRoundtrip = [
                   values: [
                     {
                       _type: 'string',
-                      value: 'Given Names',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      values: ['Given Names'],
                     },
                   ],
                 },
@@ -473,215 +507,40 @@ export const TEST_DATA__ServiceRoundtrip = [
     classifierPath: 'meta::legend::service::metamodel::Service',
   },
   {
-    path: 'test::pure::tService_Single',
+    path: 'test::myConnection',
     content: {
-      _type: 'service',
-      autoActivateUpdates: true,
-      documentation: 'this is just for context',
-      execution: {
-        _type: 'pureSingleExecution',
-        func: {
-          _type: 'lambda',
-          body: [
-            {
-              _type: 'property',
-              parameters: [
-                {
-                  _type: 'var',
-                  name: 'src',
-                },
-              ],
-              property: 'name',
-            },
-          ],
-          parameters: [
-            {
-              _type: 'var',
-              class: 'test::tClass',
-              multiplicity: {
-                lowerBound: 1,
-                upperBound: 1,
-              },
-              name: 'src',
-            },
-          ],
-        },
-        mapping: 'test::tMapping',
-        runtime: {
-          _type: 'runtimePointer',
-          runtime: 'test::tRuntime',
-        },
+      _type: 'connection',
+      connectionValue: {
+        _type: 'JsonModelConnection',
+        class: 'test::tClass',
+        url: 'dummy',
       },
-      name: 'tService_Single',
-      owners: [],
-      package: 'test::pure',
-      pattern: 'url/myUrl/',
-      stereotypes: [
-        {
-          profile: 'meta::pure::profiles::typemodifiers',
-          value: 'abstract',
-        },
-      ],
-      taggedValues: [
-        {
-          tag: {
-            profile: 'meta::pure::profiles::doc',
-            value: 'doc',
-          },
-          value: 'something',
-        },
-      ],
-      test: {
-        _type: 'singleExecutionTest',
-        asserts: [
-          {
-            assert: {
-              _type: 'lambda',
-              body: [
-                {
-                  _type: 'func',
-                  function: 'equal',
-                  parameters: [
-                    {
-                      _type: 'property',
-                      parameters: [
-                        {
-                          _type: 'var',
-                          name: 'res',
-                        },
-                      ],
-                      property: 'name',
-                    },
-                    {
-                      _type: 'string',
-                      value: '1',
-                    },
-                  ],
-                },
-              ],
-              parameters: [
-                {
-                  _type: 'var',
-                  class: 'test::tClass',
-                  multiplicity: {
-                    lowerBound: 1,
-                    upperBound: 1,
-                  },
-                  name: 'res',
-                },
-              ],
-            },
-          },
-        ],
-        data: 'moreThanData',
-      },
+      name: 'myConnection',
+      package: 'test',
     },
-    classifierPath: 'meta::legend::service::metamodel::Service',
+    classifierPath: 'meta::pure::runtime::PackageableConnection',
   },
   {
-    path: 'test::pure::tService_Multi',
+    path: 'test::tRuntime',
     content: {
-      _type: 'service',
-      autoActivateUpdates: true,
-      documentation: 'this is just for context',
-      execution: {
-        _type: 'pureMultiExecution',
-        executionKey: 'env',
-        executionParameters: [
+      _type: 'runtime',
+      name: 'tRuntime',
+      package: 'test',
+      runtimeValue: {
+        _type: 'engineRuntime',
+        connections: [],
+        mappings: [
           {
-            key: 'QA',
-            mapping: 'test::tMapping',
-            runtime: {
-              _type: 'runtimePointer',
-              runtime: 'test::tRuntime',
-            },
-          },
-        ],
-        func: {
-          _type: 'lambda',
-          body: [
-            {
-              _type: 'property',
-              parameters: [
-                {
-                  _type: 'var',
-                  name: 'src',
-                },
-              ],
-              property: 'name',
-            },
-          ],
-          parameters: [
-            {
-              _type: 'var',
-              class: 'test::tClass',
-              multiplicity: {
-                lowerBound: 1,
-                upperBound: 1,
-              },
-              name: 'src',
-            },
-          ],
-        },
-      },
-      name: 'tService_Multi',
-      owners: [],
-      package: 'test::pure',
-      pattern: 'url/myUrl/',
-      test: {
-        _type: 'multiExecutionTest',
-        tests: [
-          {
-            asserts: [
-              {
-                assert: {
-                  _type: 'lambda',
-                  body: [
-                    {
-                      _type: 'func',
-                      function: 'equal',
-                      parameters: [
-                        {
-                          _type: 'property',
-                          parameters: [
-                            {
-                              _type: 'var',
-                              name: 'res',
-                            },
-                          ],
-                          property: 'name',
-                        },
-                        {
-                          _type: 'string',
-                          value: '1',
-                        },
-                      ],
-                    },
-                  ],
-                  parameters: [
-                    {
-                      _type: 'var',
-                      class: 'test::tClass',
-                      multiplicity: {
-                        lowerBound: 1,
-                        upperBound: 1,
-                      },
-                      name: 'res',
-                    },
-                  ],
-                },
-              },
-            ],
-            data: 'moreData',
-            key: 'QA',
+            path: 'test::tMapping',
+            type: 'MAPPING',
           },
         ],
       },
     },
-    classifierPath: 'meta::legend::service::metamodel::Service',
+    classifierPath: 'meta::pure::runtime::PackageableRuntime',
   },
   {
-    path: 'my::serviceWithTestSuiteWithParams',
+    path: 'my::serviceWithTestSuite',
     content: {
       _type: 'service',
       autoActivateUpdates: true,
@@ -744,7 +603,11 @@ export const TEST_DATA__ServiceRoundtrip = [
                   values: [
                     {
                       _type: 'string',
-                      value: 'Given Names',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      values: ['Given Names'],
                     },
                   ],
                 },
@@ -765,7 +628,7 @@ export const TEST_DATA__ServiceRoundtrip = [
           ],
         },
       },
-      name: 'serviceWithTestSuiteWithParams',
+      name: 'serviceWithTestSuite',
       owners: [],
       package: 'my',
       pattern: '/e2a5e5a9-aac2-49c6-a539-fcdd61f69e9d',
@@ -800,23 +663,152 @@ export const TEST_DATA__ServiceRoundtrip = [
                 },
               ],
               id: 'test1',
-              keys: [],
+            },
+          ],
+        },
+      ],
+    },
+    classifierPath: 'meta::legend::service::metamodel::Service',
+  },
+  {
+    path: 'my::serviceWithTestSuiteWithMultipleTests',
+    content: {
+      _type: 'service',
+      autoActivateUpdates: true,
+      documentation: '',
+      execution: {
+        _type: 'pureSingleExecution',
+        func: {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'project',
               parameters: [
                 {
-                  name: 'stringParam',
-                  value: {
-                    _type: 'string',
-                    value: 'dummy',
-                  },
+                  _type: 'func',
+                  function: 'getAll',
+                  parameters: [
+                    {
+                      _type: 'packageableElementPtr',
+                      fullPath: 'my::Person',
+                    },
+                  ],
                 },
                 {
-                  name: 'stringOptionalParam',
-                  value: {
-                    _type: 'string',
-                    value: 'dummy',
+                  _type: 'collection',
+                  multiplicity: {
+                    lowerBound: 1,
+                    upperBound: 1,
                   },
+                  values: [
+                    {
+                      _type: 'lambda',
+                      body: [
+                        {
+                          _type: 'property',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                          property: 'givenNames',
+                        },
+                      ],
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'collection',
+                  multiplicity: {
+                    lowerBound: 1,
+                    upperBound: 1,
+                  },
+                  values: [
+                    {
+                      _type: 'string',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      values: ['Given Names'],
+                    },
+                  ],
                 },
               ],
+            },
+          ],
+          parameters: [],
+        },
+        mapping: 'my::map',
+        runtime: {
+          _type: 'engineRuntime',
+          connections: [],
+          mappings: [
+            {
+              path: 'my::map',
+              type: 'MAPPING',
+            },
+          ],
+        },
+      },
+      name: 'serviceWithTestSuiteWithMultipleTests',
+      owners: [],
+      package: 'my',
+      pattern: '/e2a5e5a9-aac2-49c6-a539-fcdd61f69e9d',
+      testSuites: [
+        {
+          _type: 'serviceTestSuite',
+          id: 'testSuite1',
+          testData: {
+            connectionsTestData: [
+              {
+                data: {
+                  _type: 'externalFormat',
+                  contentType: 'application/json',
+                  data: '[{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}, {"employees":[{"firstName":"firstName 37","lastName":"lastName 78"}],"legalName":"legalName 20"}]',
+                },
+                id: 'connection1',
+              },
+            ],
+          },
+          tests: [
+            {
+              _type: 'serviceTest',
+              assertions: [
+                {
+                  _type: 'equalToJson',
+                  expected: {
+                    _type: 'externalFormat',
+                    contentType: 'application/json',
+                    data: '{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}',
+                  },
+                  id: 'assert1',
+                },
+              ],
+              id: 'test1',
+            },
+            {
+              _type: 'serviceTest',
+              assertions: [
+                {
+                  _type: 'equalToJson',
+                  expected: {
+                    _type: 'externalFormat',
+                    contentType: 'application/json',
+                    data: 'data',
+                  },
+                  id: 'assert1',
+                },
+              ],
+              id: 'test2',
             },
           ],
         },
@@ -888,7 +880,11 @@ export const TEST_DATA__ServiceRoundtrip = [
                   values: [
                     {
                       _type: 'string',
-                      value: 'Given Names',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      values: ['Given Names'],
                     },
                   ],
                 },
@@ -940,7 +936,11 @@ export const TEST_DATA__ServiceRoundtrip = [
                             },
                             {
                               _type: 'string',
-                              value: 'dummy',
+                              multiplicity: {
+                                lowerBound: 1,
+                                upperBound: 1,
+                              },
+                              values: ['dummy'],
                             },
                             {
                               _type: 'collection',
@@ -961,17 +961,29 @@ export const TEST_DATA__ServiceRoundtrip = [
                                     values: [
                                       {
                                         _type: 'string',
-                                        value: 'Fred',
+                                        multiplicity: {
+                                          lowerBound: 1,
+                                          upperBound: 1,
+                                        },
+                                        values: ['Fred'],
                                       },
                                       {
                                         _type: 'string',
-                                        value: 'William',
+                                        multiplicity: {
+                                          lowerBound: 1,
+                                          upperBound: 1,
+                                        },
+                                        values: ['William'],
                                       },
                                     ],
                                   },
                                   key: {
                                     _type: 'string',
-                                    value: 'givenNames',
+                                    multiplicity: {
+                                      lowerBound: 1,
+                                      upperBound: 1,
+                                    },
+                                    values: ['givenNames'],
                                   },
                                 },
                               ],
@@ -1009,7 +1021,6 @@ export const TEST_DATA__ServiceRoundtrip = [
                 },
               ],
               id: 'test1',
-              keys: [],
             },
           ],
         },
@@ -1018,119 +1029,203 @@ export const TEST_DATA__ServiceRoundtrip = [
     classifierPath: 'meta::legend::service::metamodel::Service',
   },
   {
-    path: 'test::pure::tService_SingleWithEmbeddedRuntime',
+    path: 'my::serviceWithTestSuiteWithParams',
     content: {
       _type: 'service',
       autoActivateUpdates: true,
-      documentation: 'this is just for context',
+      documentation: '',
       execution: {
         _type: 'pureSingleExecution',
         func: {
           _type: 'lambda',
           body: [
             {
-              _type: 'property',
+              _type: 'func',
+              function: 'project',
               parameters: [
                 {
-                  _type: 'var',
-                  name: 'src',
+                  _type: 'func',
+                  function: 'getAll',
+                  parameters: [
+                    {
+                      _type: 'packageableElementPtr',
+                      fullPath: 'my::Person',
+                    },
+                  ],
+                },
+                {
+                  _type: 'collection',
+                  multiplicity: {
+                    lowerBound: 1,
+                    upperBound: 1,
+                  },
+                  values: [
+                    {
+                      _type: 'lambda',
+                      body: [
+                        {
+                          _type: 'property',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                          property: 'givenNames',
+                        },
+                      ],
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'collection',
+                  multiplicity: {
+                    lowerBound: 1,
+                    upperBound: 1,
+                  },
+                  values: [
+                    {
+                      _type: 'string',
+                      multiplicity: {
+                        lowerBound: 1,
+                        upperBound: 1,
+                      },
+                      values: ['Given Names'],
+                    },
+                  ],
                 },
               ],
-              property: 'name',
             },
           ],
-          parameters: [
-            {
-              _type: 'var',
-              class: 'test::tClass',
-              multiplicity: {
-                lowerBound: 1,
-                upperBound: 1,
-              },
-              name: 'src',
-            },
-          ],
+          parameters: [],
         },
-        mapping: 'test::tMapping',
+        mapping: 'my::map',
         runtime: {
           _type: 'engineRuntime',
-          connections: [
-            {
-              store: {
-                path: 'ModelStore',
-                type: 'STORE',
-              },
-              storeConnections: [
-                {
-                  connection: {
-                    _type: 'connectionPointer',
-                    connection: 'test::myConnection',
-                  },
-                  id: 'id1',
-                },
-                {
-                  connection: {
-                    _type: 'JsonModelConnection',
-                    class: 'test::tClass',
-                    url: 'my_url',
-                  },
-                  id: 'id3',
-                },
-              ],
-            },
-          ],
+          connections: [],
           mappings: [
             {
-              path: 'test::tMapping',
+              path: 'my::map',
               type: 'MAPPING',
             },
           ],
         },
       },
-      name: 'tService_SingleWithEmbeddedRuntime',
+      name: 'serviceWithTestSuiteWithParams',
       owners: [],
-      package: 'test::pure',
-      pattern: 'url/myUrl/',
-      test: {
-        _type: 'singleExecutionTest',
-        asserts: [],
-        data: 'moreThanData',
-      },
+      package: 'my',
+      pattern: '/e2a5e5a9-aac2-49c6-a539-fcdd61f69e9d',
+      testSuites: [
+        {
+          _type: 'serviceTestSuite',
+          id: 'testSuite1',
+          testData: {
+            connectionsTestData: [
+              {
+                data: {
+                  _type: 'externalFormat',
+                  contentType: 'application/json',
+                  data: '[{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}, {"employees":[{"firstName":"firstName 37","lastName":"lastName 78"}],"legalName":"legalName 20"}]',
+                },
+                id: 'connection1',
+              },
+            ],
+          },
+          tests: [
+            {
+              _type: 'serviceTest',
+              assertions: [
+                {
+                  _type: 'equalToJson',
+                  expected: {
+                    _type: 'externalFormat',
+                    contentType: 'application/json',
+                    data: '{"employees":[{"firstName":"firstName 36","lastName":"lastName 77"}],"legalName":"legalName 19"}',
+                  },
+                  id: 'assert1',
+                },
+              ],
+              id: 'test1',
+              parameters: [
+                {
+                  name: 'stringParam',
+                  value: {
+                    _type: 'string',
+                    multiplicity: {
+                      lowerBound: 1,
+                      upperBound: 1,
+                    },
+                    values: ['dummy'],
+                  },
+                },
+                {
+                  name: 'stringOptionalParam',
+                  value: {
+                    _type: 'string',
+                    multiplicity: {
+                      lowerBound: 1,
+                      upperBound: 1,
+                    },
+                    values: ['dummy'],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     classifierPath: 'meta::legend::service::metamodel::Service',
   },
   {
-    path: 'test::tRuntime',
+    path: '__internal__::SectionIndex',
     content: {
-      _type: 'runtime',
-      name: 'tRuntime',
-      package: 'test',
-      runtimeValue: {
-        _type: 'engineRuntime',
-        connections: [],
-        mappings: [
-          {
-            path: 'test::tMapping',
-            type: 'MAPPING',
-          },
-        ],
-      },
+      _type: 'sectionIndex',
+      name: 'SectionIndex',
+      package: '__internal__',
+      sections: [
+        {
+          _type: 'importAware',
+          imports: [],
+          elements: ['test::tClass'],
+          parserName: 'Pure',
+        },
+        {
+          _type: 'importAware',
+          imports: [],
+          elements: ['test::tMapping'],
+          parserName: 'Mapping',
+        },
+        {
+          _type: 'importAware',
+          imports: [],
+          elements: ['test::myConnection'],
+          parserName: 'Connection',
+        },
+        {
+          _type: 'importAware',
+          imports: [],
+          elements: ['test::tRuntime'],
+          parserName: 'Runtime',
+        },
+        {
+          _type: 'importAware',
+          imports: ['test'],
+          elements: [
+            'test::pure::tService_Single',
+            'test::pure::tService_Multi',
+            'test::pure::tService_SingleWithEmbeddedRuntime',
+          ],
+          parserName: 'Service',
+        },
+      ],
     },
-    classifierPath: 'meta::pure::runtime::PackageableRuntime',
-  },
-  {
-    path: 'test::myConnection',
-    content: {
-      _type: 'connection',
-      connectionValue: {
-        _type: 'JsonModelConnection',
-        class: 'test::tClass',
-        element: 'ModelStore',
-        url: 'dummy',
-      },
-      name: 'myConnection',
-      package: 'test',
-    },
-    classifierPath: 'meta::pure::runtime::PackageableConnection',
+    classifierPath: 'meta::pure::metamodel::section::SectionIndex',
   },
 ];

--- a/packages/legend-graph/src/graphManager/action/changeDetection/DSL_Service_ObserverHelper.ts
+++ b/packages/legend-graph/src/graphManager/action/changeDetection/DSL_Service_ObserverHelper.ts
@@ -105,7 +105,6 @@ export const observe_ServiceTest = skipObserved(
       serializationFormat: observable,
       assertions: observable,
       parameters: observable,
-      keys: observable,
       hashCode: computed,
     });
 

--- a/packages/legend-graph/src/graphManager/protocol/pure/v1/model/packageableElements/service/V1_ServiceTest.ts
+++ b/packages/legend-graph/src/graphManager/protocol/pure/v1/model/packageableElements/service/V1_ServiceTest.ts
@@ -22,7 +22,6 @@ import type { V1_ParameterValue } from './V1_ParameterValue.js';
 export class V1_ServiceTest extends V1_AtomicTest implements Hashable {
   serializationFormat: string | undefined;
   parameters: V1_ParameterValue[] = [];
-  keys: string[] = [];
 
   get hashCode(): string {
     return hashArray([
@@ -30,7 +29,6 @@ export class V1_ServiceTest extends V1_AtomicTest implements Hashable {
       this.id,
       hashArray(this.assertions),
       hashArray(this.parameters),
-      hashArray(this.keys),
       this.serializationFormat ?? '',
     ]);
   }

--- a/packages/legend-graph/src/graphManager/protocol/pure/v1/transformation/pureGraph/from/V1_ServiceTransformer.ts
+++ b/packages/legend-graph/src/graphManager/protocol/pure/v1/transformation/pureGraph/from/V1_ServiceTransformer.ts
@@ -109,7 +109,6 @@ export const V1_transformServiceTest = (
   serviceTest.parameters = element.parameters.map((parameter) =>
     V1_transformParameterValue(parameter),
   );
-  serviceTest.keys = element.keys;
   serviceTest.assertions = element.assertions.map((assertion) =>
     V1_transformTestAssertion(assertion),
   );

--- a/packages/legend-graph/src/graphManager/protocol/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
+++ b/packages/legend-graph/src/graphManager/protocol/pure/v1/transformation/pureGraph/to/helpers/V1_ServiceBuilderHelper.ts
@@ -120,7 +120,6 @@ export const V1_buildServiceTest = (
   serviceTest.parameters = element.parameters.map((parameter) =>
     buildParameterValue(parameter),
   );
-  serviceTest.keys = element.keys;
   serviceTest.assertions = element.assertions.map((assertion) =>
     V1_buildTestAssertion(assertion, serviceTest, context),
   );

--- a/packages/legend-graph/src/graphManager/protocol/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ServiceSerializationHelper.ts
+++ b/packages/legend-graph/src/graphManager/protocol/pure/v1/transformation/pureProtocol/serializationHelpers/V1_ServiceSerializationHelper.ts
@@ -134,7 +134,6 @@ export const V1_serviceTestModelSchema = createModelSchema(V1_ServiceTest, {
     ),
   ),
   id: primitive(),
-  keys: list(primitive()),
   parameters: custom(
     (values) =>
       serializeArray(


### PR DESCRIPTION

This reverts commit 52c69421f39e9677da261200ba226bd95a93b8fe.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
