### PR TITLE
Fix a bug where the `keys` dropdown is not updated correctly when switching tests

### DIFF
--- a/.changeset/wise-jars-complain.md
+++ b/.changeset/wise-jars-complain.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Fix a bug where the `keys` dropdown is not updated correctly when switching tests.

--- a/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestsEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestsEditor.tsx
@@ -282,9 +282,7 @@ const ServiceTestSetupEditor = observer(
     const selectedSerializationFormat = setupState.getSelectedFormatOption();
     const options = setupState.options;
     const keyOptions = setupState.keyOptions;
-    const [selectedKeys, setSelectedKeys] = useState<KeyOption[]>(
-      setupState.getSelectedKeyOptions(),
-    );
+    const selectedKeys = setupState.getSelectedKeyOptions();
     const isReadOnly =
       serviceTestState.suiteState.testableState.serviceEditorState.isReadOnly;
     const onSerializationFormatChange = (
@@ -298,7 +296,6 @@ const ServiceTestSetupEditor = observer(
     };
     const onKeyOptionChange = (val: KeyOption[]): void => {
       setupState.addServiceTestAssertKeys(val.map((op) => op.value));
-      setSelectedKeys(val);
     };
     const addParameter = (): void => {
       setupState.setShowNewParameterModal(true);


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Fix a bug where the `keys` dropdown is not updated correctly when switching tests
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
