### PR TITLE
Add default serialization format for service tests

### DIFF
--- a/.changeset/yellow-pandas-glow.md
+++ b/.changeset/yellow-pandas-glow.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Add default serialization format for service tests.

--- a/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/testable/ServiceTestEditorState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/element-editor-state/service/testable/ServiceTestEditorState.ts
@@ -50,19 +50,20 @@ import { generateVariableExpressionMockValue } from '@finos/legend-query-builder
 
 export enum SERIALIZATION_FORMAT {
   PURE = 'PURE',
-  // Temporary remove this option as it is currently not being read correctly.
-  // See https://github.com/finos/legend-engine/pull/799
-  // DEFAULT = 'DEFAULT',
+  DEFAULT = 'DEFAULT',
   PURE_TDSOBJECT = 'PURE_TDSOBJECT',
 }
 
 export enum SERIALIZATION_FORMAT_LABEL {
+  DEFAULT = 'DEFAULT',
   PURE = 'PURE',
   TDS = 'TDS',
 }
 
 const getSerializationFormatLabel = (val: string): string => {
   switch (val) {
+    case SERIALIZATION_FORMAT.DEFAULT:
+      return SERIALIZATION_FORMAT.DEFAULT;
     case SERIALIZATION_FORMAT.PURE:
       return SERIALIZATION_FORMAT.PURE;
     case SERIALIZATION_FORMAT.PURE_TDSOBJECT:
@@ -333,7 +334,10 @@ export class ServiceTestSetupState {
         label: getSerializationFormatLabel(test.serializationFormat),
       };
     }
-    return undefined;
+    return {
+      value: SERIALIZATION_FORMAT.DEFAULT,
+      label: SERIALIZATION_FORMAT.DEFAULT,
+    };
   }
 
   changeSerializationFormat(val: string | undefined): void {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Reverted the change we did for `DEFAULT` serialization fromat for service tests in #1293 
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
