### PR TITLE
Pure IDE: improve and more features

### DIFF
--- a/.changeset/loud-pumas-kneel.md
+++ b/.changeset/loud-pumas-kneel.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-studio': patch
+---

--- a/.changeset/mighty-pumpkins-collect.md
+++ b/.changeset/mighty-pumpkins-collect.md
@@ -1,0 +1,24 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-query': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-application-taxonomy': patch
+'@finos/legend-dev-utils': patch
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-extension-dsl-diagram': patch
+'@finos/legend-extension-dsl-mastery': patch
+'@finos/legend-extension-dsl-persistence': patch
+'@finos/legend-extension-dsl-persistence-cloud': patch
+'@finos/legend-extension-dsl-service': patch
+'@finos/legend-extension-dsl-text': patch
+'@finos/legend-extension-store-flat-data': patch
+'@finos/legend-extension-store-relational': patch
+'@finos/legend-extension-store-service-store': patch
+'@finos/legend-graph': patch
+'@finos/legend-query-builder': patch
+'@finos/legend-server-depot': patch
+'@finos/legend-server-sdlc': patch
+'@finos/legend-shared': patch
+'@finos/stylelint-config-legend-studio': patch
+---

--- a/.changeset/real-dots-crash.md
+++ b/.changeset/real-dots-crash.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-studio': patch
+---

--- a/.changeset/silly-pianos-leave.md
+++ b/.changeset/silly-pianos-leave.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---

--- a/.changeset/small-grapes-suffer.md
+++ b/.changeset/small-grapes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-studio': patch
+---

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@finos/eslint-plugin-legend-studio": "workspace:*",
     "@finos/legend-dev-utils": "workspace:*",
     "@finos/stylelint-config-legend-studio": "workspace:*",
-    "@types/node": "18.11.12",
+    "@types/node": "18.11.13",
     "chalk": "5.2.0",
     "cross-env": "7.0.3",
     "envinfo": "7.8.1",
@@ -113,7 +113,7 @@
     "semver": "7.3.8",
     "sort-package-json": "2.1.0",
     "stylelint": "14.16.0",
-    "typedoc": "0.23.21",
+    "typedoc": "0.23.22",
     "typescript": "4.9.4",
     "yargs": "17.6.2"
   },

--- a/packages/legend-application-pure-ide/package.json
+++ b/packages/legend-application-pure-ide/package.json
@@ -56,7 +56,7 @@
     "react": "18.2.0",
     "react-dnd": "16.0.1",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-application-pure-ide/src/components/Core_LegendPureIDEApplicationPlugin.tsx
+++ b/packages/legend-application-pure-ide/src/components/Core_LegendPureIDEApplicationPlugin.tsx
@@ -23,6 +23,7 @@ import { LegendPureIDEApplicationPlugin } from '../stores/LegendPureIDEApplicati
 import {
   LEGEND_PURE_IDE_COMMAND_CONFIG,
   LEGEND_PURE_IDE_DIAGRAM_EDITOR_COMMAND_CONFIG,
+  LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_CONFIG,
 } from '../stores/LegendPureIDECommand.js';
 
 export class Core_LegendPureIDEApplicationPlugin extends LegendPureIDEApplicationPlugin {
@@ -35,6 +36,7 @@ export class Core_LegendPureIDEApplicationPlugin extends LegendPureIDEApplicatio
   override getExtraKeyedCommandConfigEntries(): KeyedCommandConfigEntry[] {
     return [
       LEGEND_PURE_IDE_COMMAND_CONFIG,
+      LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_CONFIG,
       LEGEND_PURE_IDE_DIAGRAM_EDITOR_COMMAND_CONFIG,
     ].flatMap((data) => collectKeyedCommandConfigEntriesFromConfig(data));
   }

--- a/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
@@ -117,7 +117,29 @@ const SearchResultEntryDisplay = observer(
                 title="Go to Result"
                 onClick={goToResult(coordinate)}
               >
-                {`line: ${coordinate.startLine} - column: ${coordinate.startColumn}`}
+                {coordinate.preview && (
+                  <div className="search-panel__entry__content__item__label__content">
+                    <div className="search-panel__entry__content__item__label__coordinates">
+                      {`[${coordinate.startLine}:${coordinate.startColumn}]`}
+                    </div>
+                    <div className="search-panel__entry__content__item__label__preview">
+                      <span className="search-panel__entry__content__item__label__preview__text">
+                        {coordinate.preview.before}
+                      </span>
+                      <span className="search-panel__entry__content__item__label__preview__text--found">
+                        {coordinate.preview.found.replaceAll(/\n/g, '\u21B5')}
+                      </span>
+                      <span className="search-panel__entry__content__item__label__preview__text">
+                        {coordinate.preview.after}
+                      </span>
+                    </div>
+                  </div>
+                )}
+                {!coordinate.preview && (
+                  <>
+                    {`line: ${coordinate.startLine} - column: ${coordinate.startColumn}`}
+                  </>
+                )}
               </div>
               <div className="search-panel__entry__content__item__actions">
                 <button

--- a/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
@@ -35,7 +35,7 @@ import type {
   CandidateWithPackageImported,
   CandidateWithPackageNotImported,
 } from '../../../server/models/Execution.js';
-import { getUsageConceptLabel } from '../../../server/models/Usage.js';
+import { getConceptInfoLabel } from '../../../server/models/Usage.js';
 import {
   ArrowCircleRightIcon,
   BlankPanelContent,
@@ -188,7 +188,7 @@ const UsageResultDisplay = observer(
     const { usageState } = props;
     if (!usageState.searchEntries.length) {
       return (
-        <BlankPanelContent>{`No usages found for ${getUsageConceptLabel(
+        <BlankPanelContent>{`No usages found for ${getConceptInfoLabel(
           usageState.usageConcept,
         )}`}</BlankPanelContent>
       );
@@ -199,7 +199,7 @@ const UsageResultDisplay = observer(
           usageState.numberOfResults
         } usages(s) in ${
           usageState.numberOfFiles
-        } files for ${getUsageConceptLabel(usageState.usageConcept)}`}</div>
+        } files for ${getConceptInfoLabel(usageState.usageConcept)}`}</div>
         {usageState.searchEntries.map((searchEntry) => (
           <SearchResultEntryDisplay
             key={searchEntry.uuid}

--- a/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
@@ -22,7 +22,7 @@ import type {
 import {
   FileCoordinate,
   trimPathLeadingSlash,
-} from '../../../server/models/PureFile.js';
+} from '../../../server/models/File.js';
 import { flowResult } from 'mobx';
 import {
   type SearchResultState,

--- a/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/aux-panel/SearchPanel.tsx
@@ -126,7 +126,7 @@ const SearchResultEntryDisplay = observer(
                       <span className="search-panel__entry__content__item__label__preview__text">
                         {coordinate.preview.before}
                       </span>
-                      <span className="search-panel__entry__content__item__label__preview__text--found">
+                      <span className="search-panel__entry__content__item__label__preview__text search-panel__entry__content__item__label__preview__text--found">
                         {coordinate.preview.found.replaceAll(/\n/g, '\u21B5')}
                       </span>
                       <span className="search-panel__entry__content__item__label__preview__text">

--- a/packages/legend-application-pure-ide/src/components/editor/aux-panel/TestRunnerPanel.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/aux-panel/TestRunnerPanel.tsx
@@ -62,7 +62,7 @@ import {
 } from '@finos/legend-shared';
 import { useApplicationStore } from '@finos/legend-application';
 import { useEditorStore } from '../EditorStoreProvider.js';
-import { FileCoordinate } from '../../../server/models/PureFile.js';
+import { FileCoordinate } from '../../../server/models/File.js';
 import { ELEMENT_PATH_DELIMITER } from '@finos/legend-graph';
 
 const TestTreeNodeContainer = observer(

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/DiagramEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/DiagramEditor.tsx
@@ -53,7 +53,7 @@ import {
   ZoomOutIcon,
 } from '@finos/legend-art';
 import { useEditorStore } from '../EditorStoreProvider.js';
-import { FileCoordinate } from '../../../server/models/PureFile.js';
+import { FileCoordinate } from '../../../server/models/File.js';
 
 const DiagramEditorDiagramCanvas = observer(
   forwardRef<

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/EditPanel.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/EditPanel.tsx
@@ -17,7 +17,8 @@
 import { useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { FileEditorState } from '../../../stores/FileEditorState.js';
-import { FileEditor } from './FileEditor.js';
+import { GenericFileEditor } from './GenericFileEditor.js';
+import { PureFileEditor } from './PureFileEditor.js';
 import {
   clsx,
   FileAltIcon,
@@ -27,7 +28,11 @@ import {
 import { DiagramEditorState } from '../../../stores/DiagramEditorState.js';
 import { DiagramEditor } from './DiagramEditor.js';
 import { useEditorStore } from '../EditorStoreProvider.js';
-import { TabManager, type TabState } from '@finos/legend-application';
+import {
+  EDITOR_LANGUAGE,
+  TabManager,
+  type TabState,
+} from '@finos/legend-application';
 import { PURE_DiagramIcon } from '../shared/ConceptIconUtils.js';
 
 export const EditPanelSplashScreen: React.FC = () => {
@@ -87,7 +92,10 @@ export const EditPanel = observer(() => {
   const currentTab = editorStore.tabManagerState.currentTab;
   const renderActiveEditorState = (): React.ReactNode => {
     if (currentTab instanceof FileEditorState) {
-      return <FileEditor editorState={currentTab} />;
+      if (currentTab.textEditorState.language === EDITOR_LANGUAGE.PURE) {
+        return <PureFileEditor editorState={currentTab} />;
+      }
+      return <GenericFileEditor editorState={currentTab} />;
     } else if (currentTab instanceof DiagramEditorState) {
       return <DiagramEditor diagramEditorState={currentTab} />;
     }

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/FileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/FileEditor.tsx
@@ -47,6 +47,7 @@ import {
   collectExtraInlineSnippetSuggestions,
   collectParserElementSnippetSuggestions,
   collectParserKeywordSuggestions,
+  getCopyrightHeaderSuggestions,
 } from '../../../stores/FileEditorUtils.js';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { flowResult } from 'mobx';
@@ -216,6 +217,8 @@ export const FileEditor = observer(
         triggerCharacters: ['#'],
         provideCompletionItems: (model, position) => {
           let suggestions: monacoLanguagesAPI.CompletionItem[] = [];
+
+          suggestions = suggestions.concat(getCopyrightHeaderSuggestions());
 
           // suggestions for parser keyword
           suggestions = suggestions.concat(

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/FileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/FileEditor.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../../stores/FileEditorUtils.js';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { flowResult } from 'mobx';
-import { FileCoordinate } from '../../../server/models/PureFile.js';
+import { FileCoordinate } from '../../../server/models/File.js';
 
 export const FileEditor = observer(
   (props: { editorState: FileEditorState }) => {

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/GenericFileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/GenericFileEditor.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { editor as monacoEditorAPI } from 'monaco-editor';
+import type { FileEditorState } from '../../../stores/FileEditorState.js';
+import { EDITOR_THEME, useApplicationStore } from '@finos/legend-application';
+import {
+  clsx,
+  getBaseTextEditorOptions,
+  moveCursorToPosition,
+  useResizeDetector,
+  WordWrapIcon,
+} from '@finos/legend-art';
+import { useEditorStore } from '../EditorStoreProvider.js';
+
+export const GenericFileEditor = observer(
+  (props: { editorState: FileEditorState }) => {
+    const { editorState } = props;
+    const editorStore = useEditorStore();
+    const applicationStore = useApplicationStore();
+    const textInputRef = useRef<HTMLDivElement>(null);
+    const [editor, setEditor] = useState<
+      monacoEditorAPI.IStandaloneCodeEditor | undefined
+    >();
+    const content = editorState.file.content;
+    const { ref, width, height } = useResizeDetector<HTMLDivElement>();
+
+    useEffect(() => {
+      if (!editor && textInputRef.current) {
+        const element = textInputRef.current;
+        const newEditor = monacoEditorAPI.create(element, {
+          ...getBaseTextEditorOptions(),
+          theme: EDITOR_THEME.LEGEND,
+          wordWrap: editorState.textEditorState.wrapText ? 'on' : 'off',
+        });
+
+        newEditor.onDidChangeModelContent(() => {
+          const currentVal = newEditor.getValue();
+          if (currentVal !== editorState.file.content) {
+            // the assertion above is to ensure we don't accidentally clear error on initialization of the editor
+            editorState.clearError(); // clear error on content change/typing
+          }
+          editorState.file.setContent(currentVal);
+        });
+        // Restore the editor model and view state
+        newEditor.setModel(editorState.textEditorState.model);
+        if (editorState.textEditorState.viewState) {
+          newEditor.restoreViewState(editorState.textEditorState.viewState);
+        }
+        newEditor.focus(); // focus on the editor initially
+        editorState.textEditorState.setEditor(newEditor);
+        setEditor(newEditor);
+      }
+    }, [editorStore, applicationStore, editorState, editor]);
+
+    if (editor) {
+      // Set the value of the editor
+      const currentValue = editor.getValue();
+      if (currentValue !== content) {
+        editor.setValue(content);
+      }
+      if (editorState.textEditorState.forcedCursorPosition) {
+        moveCursorToPosition(
+          editor,
+          editorState.textEditorState.forcedCursorPosition,
+        );
+        editorState.textEditorState.setForcedCursorPosition(undefined);
+      }
+    }
+
+    useEffect(() => {
+      if (width !== undefined && height !== undefined) {
+        editor?.layout({ width, height });
+      }
+    }, [editor, width, height]);
+
+    // clean up
+    useEffect(
+      () => (): void => {
+        if (editor) {
+          // persist editor view state (cursor, scroll, etc.) to restore on re-open
+          editorState.textEditorState.setViewState(
+            editor.saveViewState() ?? undefined,
+          );
+          // NOTE: dispose the editor to prevent potential memory-leak
+          editor.dispose();
+        }
+      },
+      [editorState, editor],
+    );
+
+    return (
+      <div className="panel edit-panel file-editor">
+        <div className="panel__header file-editor__header">
+          <div className="file-editor__header__actions">
+            <button
+              className={clsx('file-editor__header__action', {
+                'file-editor__header__action--active':
+                  editorState.textEditorState.wrapText,
+              })}
+              tabIndex={-1}
+              onClick={(): void =>
+                editorState.textEditorState.setWrapText(
+                  !editorState.textEditorState.wrapText,
+                )
+              }
+              title="Toggle Text Wrap"
+            >
+              <WordWrapIcon className="file-editor__icon--text-wrap" />
+            </button>
+          </div>
+        </div>
+        <div className="panel__content file-editor__content">
+          <div ref={ref} className="text-editor__container">
+            <div className="text-editor__body" ref={textInputRef} />
+          </div>
+        </div>
+      </div>
+    );
+  },
+);

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/GenericFileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/GenericFileEditor.tsx
@@ -74,13 +74,6 @@ export const GenericFileEditor = observer(
       if (currentValue !== content) {
         editor.setValue(content);
       }
-      if (editorState.textEditorState.forcedCursorPosition) {
-        moveCursorToPosition(
-          editor,
-          editorState.textEditorState.forcedCursorPosition,
-        );
-        editorState.textEditorState.setForcedCursorPosition(undefined);
-      }
     }
 
     useEffect(() => {
@@ -88,6 +81,18 @@ export const GenericFileEditor = observer(
         editor?.layout({ width, height });
       }
     }, [editor, width, height]);
+
+    useEffect(() => {
+      if (editor) {
+        if (editorState.textEditorState.forcedCursorPosition) {
+          moveCursorToPosition(
+            editor,
+            editorState.textEditorState.forcedCursorPosition,
+          );
+          editorState.textEditorState.setForcedCursorPosition(undefined);
+        }
+      }
+    }, [editor, editorState, editorState.textEditorState.forcedCursorPosition]);
 
     // clean up
     useEffect(

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/PureFileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/PureFileEditor.tsx
@@ -37,9 +37,7 @@ import {
 } from '@finos/legend-application';
 import {
   clsx,
-  ContextMenu,
   getBaseTextEditorOptions,
-  MenuContent,
   moveCursorToPosition,
   useResizeDetector,
   WordWrapIcon,
@@ -55,7 +53,7 @@ import { guaranteeNonNullable } from '@finos/legend-shared';
 import { flowResult } from 'mobx';
 import { FileCoordinate } from '../../../server/models/File.js';
 
-export const FileEditor = observer(
+export const PureFileEditor = observer(
   (props: { editorState: FileEditorState }) => {
     const { editorState } = props;
     const suggestionProviderDisposer = useRef<IDisposable | undefined>(
@@ -391,14 +389,11 @@ export const FileEditor = observer(
             </button>
           </div>
         </div>
-        <ContextMenu
-          className="panel__content file-editor__content"
-          content={<MenuContent>asd</MenuContent>}
-        >
+        <div className="panel__content file-editor__content">
           <div ref={ref} className="text-editor__container">
             <div className="text-editor__body" ref={textInputRef} />
           </div>
-        </ContextMenu>
+        </div>
       </div>
     );
   },

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/PureFileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/PureFileEditor.tsx
@@ -199,13 +199,13 @@ export const PureFileEditor = observer(
       if (currentValue !== content) {
         editor.setValue(content);
       }
-      if (editorState.textEditorState.forcedCursorPosition) {
-        moveCursorToPosition(
-          editor,
-          editorState.textEditorState.forcedCursorPosition,
-        );
-        editorState.textEditorState.setForcedCursorPosition(undefined);
-      }
+      // if (editorState.textEditorState.forcedCursorPosition) {
+      //   moveCursorToPosition(
+      //     editor,
+      //     editorState.textEditorState.forcedCursorPosition,
+      //   );
+      //   editorState.textEditorState.setForcedCursorPosition(undefined);
+      // }
     }
 
     const textTokens = editor
@@ -349,6 +349,18 @@ export const PureFileEditor = observer(
         editor?.layout({ width, height });
       }
     }, [editor, width, height]);
+
+    useEffect(() => {
+      if (editor) {
+        if (editorState.textEditorState.forcedCursorPosition) {
+          moveCursorToPosition(
+            editor,
+            editorState.textEditorState.forcedCursorPosition,
+          );
+          editorState.textEditorState.setForcedCursorPosition(undefined);
+        }
+      }
+    }, [editor, editorState, editorState.textEditorState.forcedCursorPosition]);
 
     // clean up
     useEffect(

--- a/packages/legend-application-pure-ide/src/components/editor/shared/ConceptIconUtils.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/shared/ConceptIconUtils.tsx
@@ -67,6 +67,7 @@ export const getConceptIcon = (type: string): React.ReactNode => {
     case ConceptType.ASSOCIATION:
       return <PURE_AssociationIcon />;
     case ConceptType.PROPERTY:
+    case ConceptType.QUALIFIED_PROPERTY:
       return <PURE_PropertyIcon />;
     case ConceptType.ENUMERATION:
       return <PURE_EnumerationIcon />;

--- a/packages/legend-application-pure-ide/src/components/editor/shared/ConceptIconUtils.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/shared/ConceptIconUtils.tsx
@@ -18,7 +18,6 @@ import {
   AtomIcon,
   DatabaseIcon,
   FunctionIcon,
-  PURE_AssociationIcon,
   PURE_ClassIcon,
   PURE_EnumerationIcon,
   PURE_FunctionIcon,
@@ -54,6 +53,10 @@ const PURE_DatabaseIcon: React.FC = () => (
   <div className="icon icon--database">
     <DatabaseIcon />
   </div>
+);
+
+export const PURE_AssociationIcon: React.FC = () => (
+  <div className="icon color--association color--pure-association">A</div>
 );
 
 export const getConceptIcon = (type: string): React.ReactNode => {

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
@@ -46,6 +46,7 @@ import { useEditorStore } from '../EditorStoreProvider.js';
 import { getConceptIcon } from '../shared/ConceptIconUtils.js';
 import { RenameConceptPrompt } from './RenameConceptPrompt.js';
 import { extractElementNameFromPath } from '@finos/legend-graph';
+import { MoveElementPrompt } from './MoveElementPrompt.js';
 
 const ConceptExplorerContextMenu = observer(
   forwardRef<
@@ -59,8 +60,10 @@ const ConceptExplorerContextMenu = observer(
     const nodeType = node.data.li_attr.pureType;
     const editorStore = useEditorStore();
     const applicationStore = useApplicationStore();
-    const rename = (): void =>
+    const renameConcept = (): void =>
       editorStore.conceptTreeState.setNodeForRenameConcept(node);
+    const moveElement = (): void =>
+      editorStore.conceptTreeState.setNodeForMoveElement(node);
     const runTests = (): void => {
       flowResult(editorStore.executeTests(node.data.li_attr.pureId)).catch(
         applicationStore.alertUnhandledError,
@@ -91,7 +94,10 @@ const ConceptExplorerContextMenu = observer(
 
     return (
       <MenuContent ref={ref}>
-        <MenuContentItem onClick={rename}>Rename</MenuContentItem>
+        <MenuContentItem onClick={renameConcept}>Rename</MenuContentItem>
+        {node.data.li_attr instanceof ElementConceptAttribute && (
+          <MenuContentItem onClick={moveElement}>Move</MenuContentItem>
+        )}
         {nodeType === ConceptType.PACKAGE && (
           <MenuContentItem onClick={runTests}>Run tests</MenuContentItem>
         )}
@@ -342,6 +348,9 @@ const FileExplorerTree = observer(() => {
       />
       {treeState.nodeForRenameConcept && (
         <RenameConceptPrompt node={treeState.nodeForRenameConcept} />
+      )}
+      {treeState.nodeForMoveElement && (
+        <MoveElementPrompt node={treeState.nodeForMoveElement} />
       )}
     </div>
   );

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
@@ -44,6 +44,7 @@ import { isNonNullable } from '@finos/legend-shared';
 import { useDrag } from 'react-dnd';
 import { useEditorStore } from '../EditorStoreProvider.js';
 import { getConceptIcon } from '../shared/ConceptIconUtils.js';
+import { RenameConceptPrompt } from './RenameConceptPrompt.js';
 
 const ConceptExplorerContextMenu = observer(
   forwardRef<
@@ -58,11 +59,11 @@ const ConceptExplorerContextMenu = observer(
     const editorStore = useEditorStore();
     const applicationStore = useApplicationStore();
     const rename = (): void =>
-      applicationStore.notifyUnsupportedFeature('Rename');
-    const renamePackage = (): void =>
-      applicationStore.notifyUnsupportedFeature('Rename package');
-    const renameProperty = (): void =>
-      applicationStore.notifyUnsupportedFeature('Rename property');
+      editorStore.conceptTreeState.setNodeForRenameConcept(node);
+    //  {
+    //   flowResult(editorStore.rename)
+    // };
+    // applicationStore.notifyUnsupportedFeature('Rename property');
     const runTests = (): void => {
       flowResult(editorStore.executeTests(node.data.li_attr.pureId)).catch(
         applicationStore.alertUnhandledError,
@@ -78,16 +79,7 @@ const ConceptExplorerContextMenu = observer(
 
     return (
       <MenuContent ref={ref}>
-        {nodeType === ConceptType.PACKAGE && (
-          <MenuContentItem onClick={renamePackage}>Rename</MenuContentItem>
-        )}
-        {nodeType === ConceptType.PROPERTY && (
-          <MenuContentItem onClick={renameProperty}>Rename</MenuContentItem>
-        )}
-        {nodeType !== ConceptType.PACKAGE &&
-          nodeType !== ConceptType.PROPERTY && (
-            <MenuContentItem onClick={rename}>Rename</MenuContentItem>
-          )}
+        <MenuContentItem onClick={rename}>Rename</MenuContentItem>
         {nodeType === ConceptType.PACKAGE && (
           <MenuContentItem onClick={runTests}>Run tests</MenuContentItem>
         )}
@@ -125,11 +117,9 @@ const ConceptTreeNodeContainer: React.FC<
     useState(false);
   const { onNodeOpen, onNodeExpand, onNodeCompress, viewConceptSource } =
     innerProps;
-  const isExpandable = [
-    ConceptType.PACKAGE,
-    ConceptType.CLASS,
-    ConceptType.ASSOCIATION,
-  ].includes(node.data.li_attr.pureType as ConceptType);
+  const isExpandable = [ConceptType.PACKAGE, ConceptType.CLASS].includes(
+    node.data.li_attr.pureType as ConceptType,
+  );
   const selectNode: React.MouseEventHandler = (event) => {
     event.stopPropagation();
     event.preventDefault();
@@ -299,6 +289,9 @@ const FileExplorerTree = observer(() => {
           viewConceptSource,
         }}
       />
+      {treeState.nodeForRenameConcept && (
+        <RenameConceptPrompt node={treeState.nodeForRenameConcept} />
+      )}
     </div>
   );
 });

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
@@ -61,14 +61,25 @@ const ConceptExplorerContextMenu = observer(
     const applicationStore = useApplicationStore();
     const rename = (): void =>
       editorStore.conceptTreeState.setNodeForRenameConcept(node);
-    //  {
-    //   flowResult(editorStore.rename)
-    // };
-    // applicationStore.notifyUnsupportedFeature('Rename property');
     const runTests = (): void => {
       flowResult(editorStore.executeTests(node.data.li_attr.pureId)).catch(
         applicationStore.alertUnhandledError,
       );
+    };
+    const findUsages = (): void => {
+      const nodeAttribute = node.data.li_attr;
+      if (
+        nodeAttribute instanceof ElementConceptAttribute ||
+        nodeAttribute instanceof PropertyConceptAttribute
+      ) {
+        editorStore.findUsages(
+          new FileCoordinate(
+            nodeAttribute.file,
+            Number.parseInt(nodeAttribute.line, 10),
+            Number.parseInt(nodeAttribute.column, 10),
+          ),
+        );
+      }
     };
     const viewSource = (): void => viewConceptSource(node);
     const serviceJSON = (): void => {
@@ -88,6 +99,10 @@ const ConceptExplorerContextMenu = observer(
           <MenuContentItem onClick={serviceJSON}>
             Service (JSON)
           </MenuContentItem>
+        )}
+        {(node.data.li_attr instanceof PropertyConceptAttribute ||
+          node.data.li_attr instanceof ElementConceptAttribute) && (
+          <MenuContentItem onClick={findUsages}>Find Usages</MenuContentItem>
         )}
         {nodeType !== ConceptType.PACKAGE && (
           <MenuContentItem onClick={viewSource}>View Source</MenuContentItem>

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
@@ -23,7 +23,7 @@ import {
   ConceptType,
 } from '../../../server/models/ConceptTree.js';
 import { flowResult } from 'mobx';
-import { FileCoordinate } from '../../../server/models/PureFile.js';
+import { FileCoordinate } from '../../../server/models/File.js';
 import { useApplicationStore } from '@finos/legend-application';
 import {
   type TreeNodeContainerProps,
@@ -37,6 +37,8 @@ import {
   CircleNotchIcon,
   RefreshIcon,
   CompressIcon,
+  MenuContent,
+  MenuContentItem,
 } from '@finos/legend-art';
 import { isNonNullable } from '@finos/legend-shared';
 import { useDrag } from 'react-dnd';
@@ -66,8 +68,6 @@ const ConceptExplorerContextMenu = observer(
         applicationStore.alertUnhandledError,
       );
     };
-    const move = (): void =>
-      applicationStore.notifyUnsupportedFeature('Move file');
     const viewSource = (): void => viewConceptSource(node);
     const serviceJSON = (): void => {
       window.open(
@@ -77,48 +77,29 @@ const ConceptExplorerContextMenu = observer(
     };
 
     return (
-      <div ref={ref} className="explorer__context-menu">
+      <MenuContent ref={ref}>
         {nodeType === ConceptType.PACKAGE && (
-          <div className="explorer__context-menu__item" onClick={renamePackage}>
-            Rename
-          </div>
+          <MenuContentItem onClick={renamePackage}>Rename</MenuContentItem>
         )}
         {nodeType === ConceptType.PROPERTY && (
-          <div
-            className="explorer__context-menu__item"
-            onClick={renameProperty}
-          >
-            Rename
-          </div>
+          <MenuContentItem onClick={renameProperty}>Rename</MenuContentItem>
         )}
         {nodeType !== ConceptType.PACKAGE &&
           nodeType !== ConceptType.PROPERTY && (
-            <div className="explorer__context-menu__item" onClick={rename}>
-              Rename
-            </div>
+            <MenuContentItem onClick={rename}>Rename</MenuContentItem>
           )}
         {nodeType === ConceptType.PACKAGE && (
-          <div className="explorer__context-menu__item" onClick={runTests}>
-            Run tests
-          </div>
+          <MenuContentItem onClick={runTests}>Run tests</MenuContentItem>
         )}
-        {nodeType !== ConceptType.PACKAGE &&
-          nodeType !== ConceptType.PROPERTY && (
-            <div className="explorer__context-menu__item" onClick={move}>
-              Move
-            </div>
-          )}
         {nodeType === ConceptType.FUNCTION && (
-          <div className="explorer__context-menu__item" onClick={serviceJSON}>
+          <MenuContentItem onClick={serviceJSON}>
             Service (JSON)
-          </div>
+          </MenuContentItem>
         )}
         {nodeType !== ConceptType.PACKAGE && (
-          <div className="explorer__context-menu__item" onClick={viewSource}>
-            View Source
-          </div>
+          <MenuContentItem onClick={viewSource}>View Source</MenuContentItem>
         )}
-      </div>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
@@ -142,15 +142,25 @@ const ConceptTreeNodeContainer: React.FC<
   ).includes(node.data.li_attr.pureType);
   const nodeLabel =
     node.data.li_attr.pureType === ConceptType.QUALIFIED_PROPERTY ? (
-      `${node.label}(...)`
+      <>
+        {node.label}
+        <span className="explorer__package-tree__node__label__tag">(...)</span>
+      </>
     ) : isAssociationPropertyNode ? (
       <>
         {node.label}
-        <span className="explorer__package-tree__node__label__property-from-association-tag">
+        <span className="explorer__package-tree__node__label__tag">
           {extractElementNameFromPath(
             guaranteeType(node.data.li_attr, PropertyConceptAttribute)
               .classPath,
           )}
+        </span>
+      </>
+    ) : node.label.includes('(') ? (
+      <>
+        {node.label.substring(0, node.label.indexOf('('))}
+        <span className="explorer__package-tree__node__label__tag">
+          {node.label.substring(node.label.indexOf('('))}
         </span>
       </>
     ) : (

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewDirectoryPrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewDirectoryPrompt.tsx
@@ -20,67 +20,83 @@ import { flowResult } from 'mobx';
 import { useApplicationStore } from '@finos/legend-application';
 import { useEditorStore } from '../EditorStoreProvider.js';
 import { Dialog } from '@finos/legend-art';
+import type { DirectoryTreeNode } from '../../../server/models/DirectoryTree.js';
 
-export const CreateNewDirectoryPrompt = observer(() => {
-  const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore();
-  const currentNode = editorStore.directoryTreeState.nodeForCreateNewDirectory;
-  const [value, setValue] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
-  // actions
-  const closeModal = (): void =>
-    editorStore.directoryTreeState.setNodeForCreateNewDirectory(undefined);
-  const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event,
-  ): void => setValue(event.target.value);
-  const create = (
-    event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
-  ): void => {
-    if (!currentNode) {
-      return;
-    }
-    event.preventDefault();
-    closeModal();
-    flowResult(
-      editorStore.createNewDirectory(
-        `${currentNode.data.li_attr.path}/${value}`,
-      ),
-    ).catch(applicationStore.alertUnhandledError);
-  };
-  const handleEnter = (): void => {
-    setValue('');
-    inputRef.current?.focus();
-  };
+const DIRECTORY_NAME_PATTERN = /[a-zA-z0-9_]+/;
+const DEFAULT_DIRECTORY_NAME = 'untitled';
 
-  return (
-    <Dialog
-      open={Boolean(currentNode)}
-      onClose={closeModal}
-      TransitionProps={{
-        onEnter: handleEnter,
-      }}
-      classes={{ container: 'command-modal__container' }}
-      PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
-    >
-      <div className="modal modal--dark command-modal">
-        <div className="modal__title">Create a new directory</div>
-        <div className="command-modal__content">
-          <form className="command-modal__content__form" onSubmit={create}>
-            <input
-              ref={inputRef}
-              className="command-modal__content__input input--dark"
-              onChange={onValueChange}
-              value={value}
-            />
-          </form>
-          <button
-            className="command-modal__content__submit-btn btn--dark"
-            onClick={create}
-          >
-            Create
-          </button>
+export const CreateNewDirectoryPrompt = observer(
+  (props: { node: DirectoryTreeNode }) => {
+    const { node } = props;
+    const editorStore = useEditorStore();
+    const applicationStore = useApplicationStore();
+    const [value, setValue] = useState(DEFAULT_DIRECTORY_NAME);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // validation
+    const isValidValue = Boolean(value.match(DIRECTORY_NAME_PATTERN));
+    const isUnique = !node.childrenIds
+      ?.map((id) => editorStore.directoryTreeState.getTreeData().nodes.get(id))
+      .filter((n) => n?.data.text === value).length;
+    const error = !isValidValue
+      ? 'Invalid directory name'
+      : !isUnique
+      ? 'Already existed'
+      : undefined;
+
+    // actions
+    const closeModal = (): void =>
+      editorStore.directoryTreeState.setNodeForCreateNewDirectory(undefined);
+    const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
+      event,
+    ): void => setValue(event.target.value);
+    const create = (
+      event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
+    ): void => {
+      event.preventDefault();
+      closeModal();
+      flowResult(
+        editorStore.createNewDirectory(`${node.data.li_attr.path}/${value}`),
+      ).catch(applicationStore.alertUnhandledError);
+    };
+    const handleEnter = (): void => inputRef.current?.focus();
+
+    return (
+      <Dialog
+        open={true}
+        onClose={closeModal}
+        TransitionProps={{
+          onEnter: handleEnter,
+        }}
+        classes={{ container: 'command-modal__container' }}
+        PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
+      >
+        <div className="modal modal--dark command-modal">
+          <div className="modal__title">Create a new directory</div>
+          <div className="command-modal__content">
+            <form className="command-modal__content__form" onSubmit={create}>
+              <div className="input-group command-modal__content__input">
+                <input
+                  ref={inputRef}
+                  className="input input--dark"
+                  onChange={onValueChange}
+                  value={value}
+                  spellCheck={false}
+                />
+                {error && (
+                  <div className="input-group__error-message">{error}</div>
+                )}
+              </div>
+            </form>
+            <button
+              className="command-modal__content__submit-btn btn--dark"
+              onClick={create}
+            >
+              Create
+            </button>
+          </div>
         </div>
-      </div>
-    </Dialog>
-  );
-});
+      </Dialog>
+    );
+  },
+);

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewDirectoryPrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewDirectoryPrompt.tsx
@@ -21,15 +21,15 @@ import { useApplicationStore } from '@finos/legend-application';
 import { useEditorStore } from '../EditorStoreProvider.js';
 import { Dialog } from '@finos/legend-art';
 
-export const CreateNewFileCommand = observer(() => {
+export const CreateNewDirectoryPrompt = observer(() => {
   const editorStore = useEditorStore();
   const applicationStore = useApplicationStore();
-  const currentNode = editorStore.directoryTreeState.nodeForCreateNewFile;
+  const currentNode = editorStore.directoryTreeState.nodeForCreateNewDirectory;
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   // actions
   const closeModal = (): void =>
-    editorStore.directoryTreeState.setNodeForCreateNewFile(undefined);
+    editorStore.directoryTreeState.setNodeForCreateNewDirectory(undefined);
   const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
     event,
   ): void => setValue(event.target.value);
@@ -42,7 +42,9 @@ export const CreateNewFileCommand = observer(() => {
     event.preventDefault();
     closeModal();
     flowResult(
-      editorStore.createNewFile(`${currentNode.data.li_attr.path}/${value}`),
+      editorStore.createNewDirectory(
+        `${currentNode.data.li_attr.path}/${value}`,
+      ),
     ).catch(applicationStore.alertUnhandledError);
   };
   const handleEnter = (): void => {
@@ -61,7 +63,7 @@ export const CreateNewFileCommand = observer(() => {
       PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
     >
       <div className="modal modal--dark command-modal">
-        <div className="modal__title">Create a new file</div>
+        <div className="modal__title">Create a new directory</div>
         <div className="command-modal__content">
           <form className="command-modal__content__form" onSubmit={create}>
             <input

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewFilePrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewFilePrompt.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { flowResult } from 'mobx';
+import { useApplicationStore } from '@finos/legend-application';
+import { useEditorStore } from '../EditorStoreProvider.js';
+import { Dialog } from '@finos/legend-art';
+
+export const CreateNewFilePrompt = observer(() => {
+  const editorStore = useEditorStore();
+  const applicationStore = useApplicationStore();
+  const currentNode = editorStore.directoryTreeState.nodeForCreateNewFile;
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  // actions
+  const closeModal = (): void =>
+    editorStore.directoryTreeState.setNodeForCreateNewFile(undefined);
+  const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
+    event,
+  ): void => setValue(event.target.value);
+  const create = (
+    event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
+  ): void => {
+    if (!currentNode) {
+      return;
+    }
+    event.preventDefault();
+    closeModal();
+    flowResult(
+      editorStore.createNewFile(`${currentNode.data.li_attr.path}/${value}`),
+    ).catch(applicationStore.alertUnhandledError);
+  };
+  const handleEnter = (): void => {
+    setValue('');
+    inputRef.current?.focus();
+  };
+
+  return (
+    <Dialog
+      open={Boolean(currentNode)}
+      onClose={closeModal}
+      TransitionProps={{
+        onEnter: handleEnter,
+      }}
+      classes={{ container: 'command-modal__container' }}
+      PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
+    >
+      <div className="modal modal--dark command-modal">
+        <div className="modal__title">Create a new file</div>
+        <div className="command-modal__content">
+          <form className="command-modal__content__form" onSubmit={create}>
+            <input
+              ref={inputRef}
+              className="command-modal__content__input input--dark"
+              onChange={onValueChange}
+              value={value}
+            />
+          </form>
+          <button
+            className="command-modal__content__submit-btn btn--dark"
+            onClick={create}
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+});

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewFilePrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/CreateNewFilePrompt.tsx
@@ -20,65 +20,83 @@ import { flowResult } from 'mobx';
 import { useApplicationStore } from '@finos/legend-application';
 import { useEditorStore } from '../EditorStoreProvider.js';
 import { Dialog } from '@finos/legend-art';
+import type { DirectoryTreeNode } from '../../../server/models/DirectoryTree.js';
 
-export const CreateNewFilePrompt = observer(() => {
-  const editorStore = useEditorStore();
-  const applicationStore = useApplicationStore();
-  const currentNode = editorStore.directoryTreeState.nodeForCreateNewFile;
-  const [value, setValue] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
-  // actions
-  const closeModal = (): void =>
-    editorStore.directoryTreeState.setNodeForCreateNewFile(undefined);
-  const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event,
-  ): void => setValue(event.target.value);
-  const create = (
-    event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
-  ): void => {
-    if (!currentNode) {
-      return;
-    }
-    event.preventDefault();
-    closeModal();
-    flowResult(
-      editorStore.createNewFile(`${currentNode.data.li_attr.path}/${value}`),
-    ).catch(applicationStore.alertUnhandledError);
-  };
-  const handleEnter = (): void => {
-    setValue('');
-    inputRef.current?.focus();
-  };
+const FILE_NAME_PATTERN = /[a-zA-z0-9_]+(?:.[a-zA-z0-9_]+)*/;
+const DEFAULT_FILE_NAME = 'untitled.pure';
 
-  return (
-    <Dialog
-      open={Boolean(currentNode)}
-      onClose={closeModal}
-      TransitionProps={{
-        onEnter: handleEnter,
-      }}
-      classes={{ container: 'command-modal__container' }}
-      PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
-    >
-      <div className="modal modal--dark command-modal">
-        <div className="modal__title">Create a new file</div>
-        <div className="command-modal__content">
-          <form className="command-modal__content__form" onSubmit={create}>
-            <input
-              ref={inputRef}
-              className="command-modal__content__input input--dark"
-              onChange={onValueChange}
-              value={value}
-            />
-          </form>
-          <button
-            className="command-modal__content__submit-btn btn--dark"
-            onClick={create}
-          >
-            Create
-          </button>
+export const CreateNewFilePrompt = observer(
+  (props: { node: DirectoryTreeNode }) => {
+    const { node } = props;
+    const editorStore = useEditorStore();
+    const applicationStore = useApplicationStore();
+    const [value, setValue] = useState(DEFAULT_FILE_NAME);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // validation
+    const isValidValue = Boolean(value.match(FILE_NAME_PATTERN));
+    const isUnique = !node.childrenIds
+      ?.map((id) => editorStore.directoryTreeState.getTreeData().nodes.get(id))
+      .filter((n) => n?.data.text === value).length;
+    const error = !isValidValue
+      ? 'Invalid file name'
+      : !isUnique
+      ? 'Already existed'
+      : undefined;
+
+    // actions
+    const closeModal = (): void =>
+      editorStore.directoryTreeState.setNodeForCreateNewFile(undefined);
+    const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
+      event,
+    ): void => setValue(event.target.value);
+    const create = (
+      event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
+    ): void => {
+      event.preventDefault();
+      closeModal();
+      flowResult(
+        editorStore.createNewFile(`${node.data.li_attr.path}/${value}`),
+      ).catch(applicationStore.alertUnhandledError);
+    };
+    const handleEnter = (): void => inputRef.current?.focus();
+
+    return (
+      <Dialog
+        open={true}
+        onClose={closeModal}
+        TransitionProps={{
+          onEnter: handleEnter,
+        }}
+        classes={{ container: 'command-modal__container' }}
+        PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
+      >
+        <div className="modal modal--dark command-modal">
+          <div className="modal__title">Create a new file</div>
+          <div className="command-modal__content">
+            <form className="command-modal__content__form" onSubmit={create}>
+              <div className="input-group command-modal__content__input">
+                <input
+                  ref={inputRef}
+                  className="input input--dark"
+                  onChange={onValueChange}
+                  value={value}
+                  spellCheck={false}
+                />
+                {error && (
+                  <div className="input-group__error-message">{error}</div>
+                )}
+              </div>
+            </form>
+            <button
+              className="command-modal__content__submit-btn btn--dark"
+              onClick={create}
+            >
+              Create
+            </button>
+          </div>
         </div>
-      </div>
-    </Dialog>
-  );
-});
+      </Dialog>
+    );
+  },
+);

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/DirectoryTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/DirectoryTreeExplorer.tsx
@@ -37,6 +37,7 @@ import {
   FileAltIcon,
   FolderIcon,
   FolderOpenIcon,
+  WrenchIcon,
 } from '@finos/legend-art';
 import { isNonNullable } from '@finos/legend-shared';
 import type { DirectoryTreeNode } from '../../../server/models/DirectoryTree.js';
@@ -122,8 +123,11 @@ const FileTreeNodeContainer: React.FC<
   const [isSelectedFromContextMenu, setIsSelectedFromContextMenu] =
     useState(false);
   const { onNodeOpen, onNodeExpand, onNodeCompress } = innerProps;
+  const isPlatformDirectory = node.data.li_attr.path === '/platform';
   const isFolder = node.data.isFolderNode;
-  const nodeIcon = isFolder ? (
+  const nodeIcon = isPlatformDirectory ? (
+    <WrenchIcon className="explorer__icon--platform" />
+  ) : isFolder ? (
     node.isOpen ? (
       <div>
         <FolderOpenIcon />
@@ -218,7 +222,7 @@ const FileTreeNodeContainer: React.FC<
           className="tree-view__node__label explorer__package-tree__node__label"
           tabIndex={-1}
         >
-          {node.label}
+          {isPlatformDirectory ? 'platform' : node.label}
         </button>
       </div>
     </ContextMenu>

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/DirectoryTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/DirectoryTreeExplorer.tsx
@@ -47,6 +47,7 @@ import {
   type DirectoryTreeNode,
 } from '../../../server/models/DirectoryTree.js';
 import { useEditorStore } from '../EditorStoreProvider.js';
+import { RenameFilePrompt } from './RenameFilePrompt.js';
 
 const FileExplorerContextMenu = observer(
   forwardRef<
@@ -74,7 +75,7 @@ const FileExplorerContextMenu = observer(
       ).catch(applicationStore.alertUnhandledError);
     };
     const renameFile = (): void =>
-      applicationStore.notifyUnsupportedFeature('Rename');
+      editorStore.directoryTreeState.setNodeForRenameFile(node);
 
     return (
       <MenuContent ref={ref}>
@@ -273,8 +274,15 @@ const FileExplorerTree = observer(() => {
           onNodeCompress,
         }}
       />
-      <CreateNewFilePrompt />
-      <CreateNewDirectoryPrompt />
+      {treeState.nodeForCreateNewFile && (
+        <CreateNewFilePrompt node={treeState.nodeForCreateNewFile} />
+      )}
+      {treeState.nodeForCreateNewDirectory && (
+        <CreateNewDirectoryPrompt node={treeState.nodeForCreateNewDirectory} />
+      )}
+      {treeState.nodeForRenameFile && (
+        <RenameFilePrompt node={treeState.nodeForRenameFile} />
+      )}
     </div>
   );
 });

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/MoveElementPrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/MoveElementPrompt.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useApplicationStore } from '@finos/legend-application';
+import { useEditorStore } from '../EditorStoreProvider.js';
+import { Dialog } from '@finos/legend-art';
+import {
+  type ConceptTreeNode,
+  ElementConceptAttribute,
+} from '../../../server/models/ConceptTree.js';
+import { extractPackagePathFromPath } from '@finos/legend-graph';
+import { guaranteeType } from '@finos/legend-shared';
+
+const PACKAGE_PATH_PATTERN =
+  /^(?:(?:[a-zA-Z0-9_][a-zA-Z0-9_$]*)*::)*[a-zA-Z0-9_][a-zA-Z0-9_$]*$/;
+
+export const MoveElementPrompt = observer(
+  (props: { node: ConceptTreeNode }) => {
+    const { node } = props;
+    const editorStore = useEditorStore();
+    const applicationStore = useApplicationStore();
+    const packagePath =
+      extractPackagePathFromPath(node.data.li_attr.pureId) ?? '';
+    const [value, setValue] = useState(packagePath);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // validation
+    const isValidValue = Boolean(value.match(PACKAGE_PATH_PATTERN));
+    const isSameValue = packagePath === value;
+    const error = !isValidValue ? 'Invalid path' : undefined;
+
+    // actions
+    const closeModal = (): void =>
+      editorStore.conceptTreeState.setNodeForMoveElement(undefined);
+    const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
+      event,
+    ): void => setValue(event.target.value);
+    const rename = (
+      event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
+    ): void => {
+      event.preventDefault();
+      if (isSameValue) {
+        return;
+      }
+      editorStore.conceptTreeState
+        .movePackageableElements(
+          [guaranteeType(node.data.li_attr, ElementConceptAttribute)],
+          value,
+        )
+        .catch(applicationStore.alertUnhandledError)
+        .finally(() => closeModal());
+    };
+    const handleEnter = (): void => inputRef.current?.focus();
+
+    return (
+      <Dialog
+        open={true}
+        onClose={closeModal}
+        TransitionProps={{
+          onEnter: handleEnter,
+        }}
+        classes={{ container: 'command-modal__container' }}
+        PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
+      >
+        <div className="modal modal--dark command-modal">
+          <div className="modal__title">Move element</div>
+          <div className="command-modal__content">
+            <form className="command-modal__content__form" onSubmit={rename}>
+              <div className="input-group command-modal__content__input">
+                <input
+                  ref={inputRef}
+                  className="input input--dark"
+                  onChange={onValueChange}
+                  value={value}
+                  spellCheck={false}
+                />
+                {error && (
+                  <div className="input-group__error-message">{error}</div>
+                )}
+              </div>
+            </form>
+            <button
+              disabled={isSameValue}
+              className="command-modal__content__submit-btn btn--dark"
+              onClick={rename}
+            >
+              Move
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    );
+  },
+);

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/RenameConceptPrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/RenameConceptPrompt.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useApplicationStore } from '@finos/legend-application';
+import { useEditorStore } from '../EditorStoreProvider.js';
+import { Dialog } from '@finos/legend-art';
+import type { ConceptTreeNode } from '../../../server/models/ConceptTree.js';
+
+const IDENTIFIER_PATTERN = /^[a-zA-Z0-9_][a-zA-Z0-9_$]*/;
+
+export const RenameConceptPrompt = observer(
+  (props: { node: ConceptTreeNode }) => {
+    const { node } = props;
+    const editorStore = useEditorStore();
+    const applicationStore = useApplicationStore();
+    const conceptName = node.data.li_attr.pureName ?? node.data.li_attr.pureId;
+    const [value, setValue] = useState(conceptName);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // validation
+    const isValidValue = Boolean(value.match(IDENTIFIER_PATTERN));
+    const isSameValue = conceptName === value;
+    const error = !isValidValue ? 'Invalid path' : undefined;
+
+    // actions
+    const closeModal = (): void =>
+      editorStore.conceptTreeState.setNodeForRenameConcept(undefined);
+    const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
+      event,
+    ): void => setValue(event.target.value);
+    const rename = (
+      event: React.FormEvent<HTMLFormElement | HTMLButtonElement>,
+    ): void => {
+      event.preventDefault();
+      if (isSameValue) {
+        return;
+      }
+      editorStore.conceptTreeState
+        .renameConcept(node, value)
+        .catch(applicationStore.alertUnhandledError)
+        .finally(() => closeModal());
+    };
+    const handleEnter = (): void => inputRef.current?.focus();
+
+    return (
+      <Dialog
+        open={true}
+        onClose={closeModal}
+        TransitionProps={{
+          onEnter: handleEnter,
+        }}
+        classes={{ container: 'command-modal__container' }}
+        PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
+      >
+        <div className="modal modal--dark command-modal">
+          <div className="modal__title">Rename concept</div>
+          <div className="command-modal__content">
+            <form className="command-modal__content__form" onSubmit={rename}>
+              <div className="input-group command-modal__content__input">
+                <input
+                  ref={inputRef}
+                  className="input input--dark"
+                  onChange={onValueChange}
+                  value={value}
+                  spellCheck={false}
+                />
+                {error && (
+                  <div className="input-group__error-message">{error}</div>
+                )}
+              </div>
+            </form>
+            <button
+              disabled={isSameValue}
+              className="command-modal__content__submit-btn btn--dark"
+              onClick={rename}
+            >
+              Rename
+            </button>
+          </div>
+        </div>
+      </Dialog>
+    );
+  },
+);

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/RenameFilePrompt.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/RenameFilePrompt.tsx
@@ -21,15 +21,15 @@ import { useApplicationStore } from '@finos/legend-application';
 import { useEditorStore } from '../EditorStoreProvider.js';
 import { Dialog } from '@finos/legend-art';
 
-export const CreateNewDirectoryCommand = observer(() => {
+export const RenameFilePrompt = observer(() => {
   const editorStore = useEditorStore();
   const applicationStore = useApplicationStore();
-  const currentNode = editorStore.directoryTreeState.nodeForCreateNewDirectory;
+  const currentNode = editorStore.directoryTreeState.nodeForCreateNewFile;
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   // actions
   const closeModal = (): void =>
-    editorStore.directoryTreeState.setNodeForCreateNewDirectory(undefined);
+    editorStore.directoryTreeState.setNodeForCreateNewFile(undefined);
   const onValueChange: React.ChangeEventHandler<HTMLInputElement> = (
     event,
   ): void => setValue(event.target.value);
@@ -42,9 +42,7 @@ export const CreateNewDirectoryCommand = observer(() => {
     event.preventDefault();
     closeModal();
     flowResult(
-      editorStore.createNewDirectory(
-        `${currentNode.data.li_attr.path}/${value}`,
-      ),
+      editorStore.createNewFile(`${currentNode.data.li_attr.path}/${value}`),
     ).catch(applicationStore.alertUnhandledError);
   };
   const handleEnter = (): void => {
@@ -63,7 +61,7 @@ export const CreateNewDirectoryCommand = observer(() => {
       PaperProps={{ classes: { root: 'command-modal__inner-container' } }}
     >
       <div className="modal modal--dark command-modal">
-        <div className="modal__title">Create a new directory</div>
+        <div className="modal__title">Create a new file</div>
         <div className="command-modal__content">
           <form className="command-modal__content__form" onSubmit={create}>
             <input

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -254,8 +254,9 @@ export class PureClient {
     this.networkClient.post(`${this.baseUrl}/updateSource`, updateInputs);
 
   createFile = (path: string): Promise<PlainObject<CommandResult>> =>
-    this.networkClient.get(
+    this.networkClient.post(
       `${this.baseUrl}/newFile/${path}`,
+      undefined,
       undefined,
       undefined,
       {
@@ -266,8 +267,9 @@ export class PureClient {
     );
 
   createFolder = (path: string): Promise<PlainObject<CommandResult>> =>
-    this.networkClient.get(
+    this.networkClient.post(
       `${this.baseUrl}/newFolder/${path}`,
+      undefined,
       undefined,
       undefined,
       {
@@ -277,9 +279,23 @@ export class PureClient {
       },
     );
 
+  renameFile = (
+    oldPath: string,
+    newPath: string,
+  ): Promise<PlainObject<CommandResult>> =>
+    this.networkClient.post(
+      `${this.baseUrl}/renameFile`,
+      {
+        oldPath,
+        newPath,
+      },
+      undefined,
+    );
+
   deleteDirectoryOrFile = (path: string): Promise<PlainObject<CommandResult>> =>
-    this.networkClient.get(
+    this.networkClient.delete(
       `${this.baseUrl}/deleteFile/${path}`,
+      undefined,
       undefined,
       undefined,
       {

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -45,6 +45,10 @@ import type {
   DiagramClassInfo,
   DiagramInfo,
 } from '../server/models/DiagramInfo.js';
+import type {
+  SourceModificationResult,
+  UpdateSourceInput,
+} from './models/Source.js';
 
 export class PureClient {
   private networkClient: NetworkClient;
@@ -243,6 +247,11 @@ export class PureClient {
       func,
       param,
     });
+
+  updateSource = (
+    updateInputs: UpdateSourceInput[],
+  ): Promise<PlainObject<SourceModificationResult>> =>
+    this.networkClient.post(`${this.baseUrl}/updateSource`, updateInputs);
 
   createFile = (path: string): Promise<PlainObject<CommandResult>> =>
     this.networkClient.get(

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -26,7 +26,10 @@ import type {
   ExecutionResult,
 } from '../server/models/Execution.js';
 import type { FileData } from '../server/models/PureFile.js';
-import type { SearchResultEntry } from '../server/models/SearchEntry.js';
+import type {
+  SearchResultCoordinate,
+  SearchResultEntry,
+} from '../server/models/SearchEntry.js';
 import type {
   AbstractTestRunnerCheckResult,
   TestRunnerCancelResult,
@@ -183,6 +186,14 @@ export class PureClient {
         regex: isRegExp,
         limit,
       },
+    );
+
+  getTextSearchPreview = (
+    coordinates: SearchResultCoordinate[],
+  ): Promise<PlainObject<SearchResultCoordinate>[]> =>
+    this.networkClient.post(
+      `${this.baseUrl}/getTextSearchPreview`,
+      coordinates,
     );
 
   checkTestRunner = (

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -25,7 +25,7 @@ import type {
   ExecutionActivity,
   ExecutionResult,
 } from '../server/models/Execution.js';
-import type { FileData } from '../server/models/PureFile.js';
+import type { FileData } from './models/File.js';
 import type {
   SearchResultCoordinate,
   SearchResultEntry,

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -34,7 +34,7 @@ import type {
   AbstractTestRunnerCheckResult,
   TestRunnerCancelResult,
 } from '../server/models/Test.js';
-import type { Usage, UsageConcept } from '../server/models/Usage.js';
+import type { Usage, ConceptInfo } from '../server/models/Usage.js';
 import type { CommandResult } from '../server/models/Command.js';
 import {
   guaranteeNonNullable,
@@ -49,6 +49,7 @@ import type {
   SourceModificationResult,
   UpdateSourceInput,
 } from './models/Source.js';
+import type { RenameConceptInput } from './models/RenameConcept.js';
 
 export class PureClient {
   private networkClient: NetworkClient;
@@ -213,9 +214,7 @@ export class PureClient {
       },
     );
 
-  cancelTestRunner = (
-    testRunnerId: number,
-  ): Promise<PlainObject<TestRunnerCancelResult>> =>
+  cancelTestRunner = (testRunnerId: number): Promise<TestRunnerCancelResult> =>
     this.networkClient.get(
       `${this.baseUrl}/testRunnerCancel`,
       undefined,
@@ -226,13 +225,13 @@ export class PureClient {
       },
     );
 
-  getConceptPath = (
+  getConceptInfo = (
     file: string,
     line: number,
     column: number,
-  ): Promise<PlainObject<UsageConcept>> =>
+  ): Promise<ConceptInfo> =>
     this.networkClient.get(
-      `${this.baseUrl}/getConceptPath`,
+      `${this.baseUrl}/getConceptInfo`,
       undefined,
       undefined,
       {
@@ -242,16 +241,22 @@ export class PureClient {
       },
     );
 
-  getUsages = (func: string, param: string[]): Promise<PlainObject<Usage>[]> =>
+  getUsages = (
+    func: string,
+    param: string[],
+  ): Promise<PlainObject<Usage>[] | PlainObject<Usage>> =>
     this.networkClient.get(`${this.baseUrl}/execute`, undefined, undefined, {
       func,
       param,
     });
 
+  renameConcept = (input: RenameConceptInput): Promise<void> =>
+    this.networkClient.put(`${this.baseUrl}/renameConcept`, input);
+
   updateSource = (
     updateInputs: UpdateSourceInput[],
   ): Promise<PlainObject<SourceModificationResult>> =>
-    this.networkClient.post(`${this.baseUrl}/updateSource`, updateInputs);
+    this.networkClient.put(`${this.baseUrl}/updateSource`, updateInputs);
 
   createFile = (path: string): Promise<PlainObject<CommandResult>> =>
     this.networkClient.post(
@@ -283,7 +288,7 @@ export class PureClient {
     oldPath: string,
     newPath: string,
   ): Promise<PlainObject<CommandResult>> =>
-    this.networkClient.post(
+    this.networkClient.put(
       `${this.baseUrl}/renameFile`,
       {
         oldPath,

--- a/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
+++ b/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
@@ -157,4 +157,5 @@ createModelSchema(ConceptNode, {
 export interface ConceptTreeNode extends TreeNodeData {
   data: ConceptNode;
   isLoading: boolean;
+  parent?: ConceptTreeNode;
 }

--- a/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
+++ b/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
@@ -23,6 +23,7 @@ import {
   custom,
   SKIP,
   deserialize,
+  optional,
 } from 'serializr';
 
 export enum ConceptType {
@@ -32,6 +33,7 @@ export enum ConceptType {
   CLASS = 'Class',
   ASSOCIATION = 'Association',
   PROPERTY = 'Property',
+  QUALIFIED_PROPERTY = 'QualifiedProperty',
   ENUMERATION = 'Enumeration',
   ENUM_VALUE = 'Enum',
   MEASURE = 'Measure',
@@ -46,6 +48,7 @@ export enum ConceptType {
 abstract class ConceptAttribute {
   pureId!: string;
   pureType!: string;
+  pureName?: string;
   // test?: string; // boolean
 
   get id(): string {
@@ -67,6 +70,7 @@ createModelSchema(PackageConceptAttribute, {
 
 export class PropertyConceptAttribute extends ConceptAttribute {
   declare pureId: string;
+  declare pureName: string;
   declare pureType: string;
   RO!: string; // boolean
   classPath!: string;
@@ -81,6 +85,7 @@ export class PropertyConceptAttribute extends ConceptAttribute {
 
 createModelSchema(PropertyConceptAttribute, {
   pureId: primitive(),
+  pureName: primitive(),
   pureType: primitive(),
   RO: primitive(),
   classPath: primitive(),
@@ -102,6 +107,7 @@ export class ElementConceptAttribute extends ConceptAttribute {
 
 createModelSchema(ElementConceptAttribute, {
   pureId: primitive(),
+  pureName: optional(primitive()),
   pureType: primitive(),
   RO: primitive(),
   notpublic: primitive(),

--- a/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
+++ b/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
@@ -96,6 +96,7 @@ createModelSchema(PropertyConceptAttribute, {
 
 export class ElementConceptAttribute extends ConceptAttribute {
   declare pureId: string;
+  declare pureName: string;
   declare pureType: string;
   RO!: string; // boolean
   notpublic!: boolean;

--- a/packages/legend-application-pure-ide/src/server/models/DiagramInfo.ts
+++ b/packages/legend-application-pure-ide/src/server/models/DiagramInfo.ts
@@ -51,7 +51,11 @@ import {
   getOwnProperty,
   AggregationKind,
 } from '@finos/legend-graph';
-import { addUniqueEntry, guaranteeNonNullable } from '@finos/legend-shared';
+import {
+  addUniqueEntry,
+  guaranteeNonNullable,
+  type PlainObject,
+} from '@finos/legend-shared';
 import {
   createModelSchema,
   primitive,
@@ -76,7 +80,7 @@ import { SourceInformation } from './SourceInformation.js';
  */
 const TEMPORARY__diagramInfoSourceInformationSerializationSchema = custom(
   () => SKIP,
-  (json): SourceInformation => {
+  (json: PlainObject): SourceInformation => {
     json.sourceId = json.source;
     return deserialize(SourceInformation, json);
   },

--- a/packages/legend-application-pure-ide/src/server/models/DiagramInfo.ts
+++ b/packages/legend-application-pure-ide/src/server/models/DiagramInfo.ts
@@ -58,6 +58,9 @@ import {
   object,
   list,
   optional,
+  deserialize,
+  custom,
+  SKIP,
 } from 'serializr';
 import { SourceInformation } from './SourceInformation.js';
 
@@ -66,6 +69,18 @@ import { SourceInformation } from './SourceInformation.js';
 // We don't intend to build Pure graph from these serialization models, hence, we never really want to export them
 // to use outside of this file; their sole purpose is to get the result from the diagram info endpoints
 // to convert to Legend protocol model to use in Legend Studio diagram renderer
+
+/**
+ * Unfortunately, diagram analysis endpoint now return malformed source-information so we need to have this hacky
+ * surgery before properly deserialize it.
+ */
+const TEMPORARY__diagramInfoSourceInformationSerializationSchema = custom(
+  () => SKIP,
+  (json): SourceInformation => {
+    json.sourceId = json.source;
+    return deserialize(SourceInformation, json);
+  },
+);
 
 class PURE__Profile {
   package!: string;
@@ -151,7 +166,7 @@ class PURE__PackageableElementPointer {
 createModelSchema(PURE__PackageableElementPointer, {
   name: primitive(),
   package: primitive(),
-  sourceInformation: object(SourceInformation),
+  sourceInformation: TEMPORARY__diagramInfoSourceInformationSerializationSchema,
 });
 
 class PURE__Class {
@@ -173,7 +188,7 @@ createModelSchema(PURE__Class, {
   package: primitive(),
   properties: list(object(PURE__Property)),
   qualifiedProperties: list(object(PURE__Property)),
-  sourceInformation: object(SourceInformation),
+  sourceInformation: TEMPORARY__diagramInfoSourceInformationSerializationSchema,
   stereotypes: list(object(PURE__Steoreotype)),
   taggedValues: list(object(PURE__TaggedValue)),
 });
@@ -294,7 +309,7 @@ createModelSchema(PURE__Diagram, {
   generalizationViews: list(object(PURE__GeneralizationView)),
   package: primitive(),
   propertyViews: list(object(PURE__PropertyView)),
-  sourceInformation: object(SourceInformation),
+  sourceInformation: TEMPORARY__diagramInfoSourceInformationSerializationSchema,
   stereotypes: list(object(PURE__Steoreotype)),
   taggedValues: list(object(PURE__TaggedValue)),
   typeViews: list(object(PURE__TypeView)),

--- a/packages/legend-application-pure-ide/src/server/models/DirectoryTree.ts
+++ b/packages/legend-application-pure-ide/src/server/models/DirectoryTree.ts
@@ -65,9 +65,11 @@ export class DirectoryNode {
   get isFolderNode(): boolean {
     return this.li_attr instanceof FolderDirectoryAttribute;
   }
+
   get isFileNode(): boolean {
     return this.li_attr instanceof FileDirectoryAttribute;
   }
+
   getNodeAttribute<T extends DirectoryAttribute>(clazz: Clazz<T>): T {
     return guaranteeType(
       this.li_attr,

--- a/packages/legend-application-pure-ide/src/server/models/File.ts
+++ b/packages/legend-application-pure-ide/src/server/models/File.ts
@@ -21,7 +21,7 @@ import type { ExecutionError } from './ExecutionError.js';
 export const trimPathLeadingSlash = (path: string): string =>
   path.startsWith('/') ? path.substring(1, path.length) : path;
 
-export class PureFile {
+export class File {
   content!: string;
 
   constructor() {
@@ -36,7 +36,7 @@ export class PureFile {
   }
 }
 
-createModelSchema(PureFile, {
+createModelSchema(File, {
   content: primitive(),
 });
 

--- a/packages/legend-application-pure-ide/src/server/models/MovePackageableElements.ts
+++ b/packages/legend-application-pure-ide/src/server/models/MovePackageableElements.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MovePackageableElementsInput {
+  pureName: string;
+  pureType: string;
+  sourcePackage: string;
+  destinationPackage: string;
+  sourceInformations: {
+    sourceId: string;
+    line: number;
+    column: number;
+  }[];
+}
+
+export interface ChildPackageableElementInfo {
+  pureName: string;
+  pureId: string;
+  pureType: string;
+}

--- a/packages/legend-application-pure-ide/src/server/models/RenameConcept.ts
+++ b/packages/legend-application-pure-ide/src/server/models/RenameConcept.ts
@@ -14,24 +14,13 @@
  * limitations under the License.
  */
 
-import { createModelSchema, primitive } from 'serializr';
-
-export class SourceInformation {
-  sourceId!: string;
-  line!: number;
-  column!: number;
-  startLine!: number;
-  startColumn!: number;
-  endLine!: number;
-  endColumn!: number;
+export interface RenameConceptInput {
+  oldName: string;
+  newName: string;
+  pureType: string;
+  sourceInformations: {
+    sourceId: string;
+    line: number;
+    column: number;
+  }[];
 }
-
-createModelSchema(SourceInformation, {
-  column: primitive(),
-  endLine: primitive(),
-  endColumn: primitive(),
-  line: primitive(),
-  sourceId: primitive(),
-  startLine: primitive(),
-  startColumn: primitive(),
-});

--- a/packages/legend-application-pure-ide/src/server/models/SearchEntry.ts
+++ b/packages/legend-application-pure-ide/src/server/models/SearchEntry.ts
@@ -21,6 +21,7 @@ import {
   deserialize,
   list,
   object,
+  optional,
   primitive,
 } from 'serializr';
 
@@ -28,19 +29,35 @@ export abstract class SearchEntry {
   uuid = uuid();
 }
 
+export class SearchResultPreview {
+  before!: string;
+  found!: string;
+  after!: string;
+}
+
+createModelSchema(SearchResultPreview, {
+  after: primitive(),
+  before: primitive(),
+  found: primitive(),
+});
+
 export class SearchResultCoordinate {
   uuid = uuid();
+  sourceId!: string;
   startLine!: number;
   startColumn!: number;
   endLine!: number;
   endColumn!: number;
+  preview?: SearchResultPreview | undefined;
 
   constructor(
+    sourceId: string,
     startLine: number,
     startColumn: number,
     endLine: number,
     endColumn: number,
   ) {
+    this.sourceId = sourceId;
     this.startLine = startLine;
     this.startColumn = startColumn;
     this.endLine = endLine;
@@ -49,10 +66,12 @@ export class SearchResultCoordinate {
 }
 
 createModelSchema(SearchResultCoordinate, {
+  sourceId: primitive(),
   startLine: primitive(),
   startColumn: primitive(),
   endLine: primitive(),
   endColumn: primitive(),
+  preview: optional(object(SearchResultPreview)),
 });
 
 export class SearchResultEntry extends SearchEntry {

--- a/packages/legend-application-pure-ide/src/server/models/Source.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Source.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface UpdateSourceInput {
+  path: string;
+  line: number;
+  column: number;
+  message: string;
+  add: boolean;
+}
+
+export interface SourceModificationResult {
+  text: string;
+  modifiedFiles: string[];
+}

--- a/packages/legend-application-pure-ide/src/server/models/Usage.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Usage.ts
@@ -19,13 +19,14 @@ import { createModelSchema, primitive } from 'serializr';
 export interface ConceptInfo {
   path: string;
   owner?: string;
-  type?: string;
+  pureName: string;
+  pureType: string;
 }
 
 export enum FIND_USAGE_FUNCTION_PATH {
   ENUM = 'meta::pure::ide::findusages::findUsagesForEnum_String_1__String_1__SourceInformation_MANY_',
   PROPERTY = 'meta::pure::ide::findusages::findUsagesForProperty_String_1__String_1__SourceInformation_MANY_',
-  PATH = 'meta::pure::ide::findusages::findUsagesForPath_String_1__SourceInformation_MANY_',
+  ELEMENT = 'meta::pure::ide::findusages::findUsagesForPath_String_1__SourceInformation_MANY_',
 }
 
 export const getConceptInfoLabel = (usageConcept: ConceptInfo): string =>

--- a/packages/legend-application-pure-ide/src/server/models/Usage.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Usage.ts
@@ -15,7 +15,6 @@
  */
 
 import { createModelSchema, primitive } from 'serializr';
-import { SourceInformation } from './SourceInformation.js';
 
 export interface ConceptInfo {
   path: string;

--- a/packages/legend-application-pure-ide/src/server/models/Usage.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Usage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createModelSchema, primitive } from 'serializr';
+import { createModelSchema, list, object, primitive } from 'serializr';
 
 export interface ConceptInfo {
   path: string;
@@ -27,6 +27,7 @@ export enum FIND_USAGE_FUNCTION_PATH {
   ENUM = 'meta::pure::ide::findusages::findUsagesForEnum_String_1__String_1__SourceInformation_MANY_',
   PROPERTY = 'meta::pure::ide::findusages::findUsagesForProperty_String_1__String_1__SourceInformation_MANY_',
   ELEMENT = 'meta::pure::ide::findusages::findUsagesForPath_String_1__SourceInformation_MANY_',
+  MULTIPLE_PATHS = 'meta::pure::ide::findusages::findUsagesForMultiplePaths_String_1__Pair_MANY_',
 }
 
 export const getConceptInfoLabel = (usageConcept: ConceptInfo): string =>
@@ -52,4 +53,14 @@ createModelSchema(Usage, {
   startColumn: primitive(),
   endLine: primitive(),
   endColumn: primitive(),
+});
+
+export class PackageableElementUsage {
+  first!: string;
+  second!: Usage[];
+}
+
+createModelSchema(PackageableElementUsage, {
+  first: primitive(),
+  second: list(object(Usage)),
 });

--- a/packages/legend-application-pure-ide/src/server/models/Usage.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Usage.ts
@@ -15,14 +15,21 @@
  */
 
 import { createModelSchema, primitive } from 'serializr';
+import { SourceInformation } from './SourceInformation.js';
 
-export interface UsageConcept {
+export interface ConceptInfo {
   path: string;
   owner?: string;
   type?: string;
 }
 
-export const getUsageConceptLabel = (usageConcept: UsageConcept): string =>
+export enum FIND_USAGE_FUNCTION_PATH {
+  ENUM = 'meta::pure::ide::findusages::findUsagesForEnum_String_1__String_1__SourceInformation_MANY_',
+  PROPERTY = 'meta::pure::ide::findusages::findUsagesForProperty_String_1__String_1__SourceInformation_MANY_',
+  PATH = 'meta::pure::ide::findusages::findUsagesForPath_String_1__SourceInformation_MANY_',
+}
+
+export const getConceptInfoLabel = (usageConcept: ConceptInfo): string =>
   `'${usageConcept.path}'${
     usageConcept.owner ? ` of '${usageConcept.owner}'` : ''
   }`;
@@ -35,7 +42,6 @@ export class Usage {
   startColumn!: number;
   endLine!: number;
   endColumn!: number;
-  // __TYPE: "meta::pure::functions::meta::SourceInformation"
 }
 
 createModelSchema(Usage, {

--- a/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
+++ b/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
@@ -213,44 +213,6 @@ export class ConceptTreeState extends TreeState<ConceptTreeNode, ConceptNode> {
         // sourceEdit(sourceInformations, oldName, newName, pureType)
         return;
       }
-      case ConceptType.ENUM_VALUE: {
-        console.log(attr);
-        // const usages = await this.editorStore.findConceptUsages(
-        //   FIND_USAGE_FUNCTION_PATH.PROPERTY,
-        //   [`'${attr.classPath}'`, `'${attr.pureId}'`],
-        // );
-        // await flowResult(
-        //   this.editorStore.renameConcept(
-        //     oldName,
-        //     newName,
-        //     attr.pureType,
-        //     usages.map(usageToSourceInformation),
-        //   ),
-        // );
-
-        // source!: string;
-        // line!: number;
-        // column!: number;
-        // startLine!: number;
-        // startColumn!: number;
-        // endLine!: number;
-        // endColumn!: number;
-        // concept.type === 'enum'
-        //   ? FIND_USAGE_FUNCTION_PATH.ENUM
-        //   : concept.type === 'property'
-        //   ? FIND_USAGE_FUNCTION_PATH.PROPERTY
-        //   : FIND_USAGE_FUNCTION_PATH.PATH,
-        // (concept.owner ? [`'${concept.owner}'`] : []).concat(
-        //   `'${concept.path}'`,
-        // oldName: pureName
-        // pureIde
-        // pureType
-        // classPath
-        // newName: value
-
-        // sourceEdit(sourceInformations, oldName, newName, pureType)
-        return;
-      }
       case ConceptType.PACKAGE: {
         return;
       }

--- a/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
+++ b/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
@@ -106,6 +106,7 @@ export class ConceptTreeState extends TreeState<ConceptTreeNode, ConceptNode> {
         id,
         label: childNode.text,
         isLoading: false,
+        parent: node,
       });
     });
     node.childrenIds = childrenIds;

--- a/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
+++ b/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
@@ -33,7 +33,10 @@ import {
   type GeneratorFn,
 } from '@finos/legend-shared';
 import type { TreeData } from '@finos/legend-art';
-import { FIND_USAGE_FUNCTION_PATH } from '../server/models/Usage.js';
+import {
+  FIND_USAGE_FUNCTION_PATH,
+  type Usage,
+} from '../server/models/Usage.js';
 
 export class ConceptTreeState extends TreeState<ConceptTreeNode, ConceptNode> {
   readonly loadConceptActivity = ActionState.create();
@@ -173,52 +176,31 @@ export class ConceptTreeState extends TreeState<ConceptTreeNode, ConceptNode> {
   async renameConcept(node: ConceptTreeNode, newName: string): Promise<void> {
     const attr = node.data.li_attr;
     const oldName = attr.pureName ?? attr.pureId;
+    let usages: Usage[] = [];
     switch (attr.pureType) {
       case ConceptType.PROPERTY:
       case ConceptType.QUALIFIED_PROPERTY: {
         assertType(attr, PropertyConceptAttribute);
-        const usages = await this.editorStore.findConceptUsages(
+        usages = await this.editorStore.findConceptUsages(
           FIND_USAGE_FUNCTION_PATH.PROPERTY,
           [`'${attr.classPath}'`, `'${attr.pureId}'`],
         );
-        await flowResult(
-          this.editorStore.renameConcept(
-            oldName,
-            newName,
-            attr.pureType,
-            usages,
-          ),
-        );
-
-        // source!: string;
-        // line!: number;
-        // column!: number;
-        // startLine!: number;
-        // startColumn!: number;
-        // endLine!: number;
-        // endColumn!: number;
-        // concept.type === 'enum'
-        //   ? FIND_USAGE_FUNCTION_PATH.ENUM
-        //   : concept.type === 'property'
-        //   ? FIND_USAGE_FUNCTION_PATH.PROPERTY
-        //   : FIND_USAGE_FUNCTION_PATH.PATH,
-        // (concept.owner ? [`'${concept.owner}'`] : []).concat(
-        //   `'${concept.path}'`,
-        // oldName: pureName
-        // pureIde
-        // pureType
-        // classPath
-        // newName: value
-
-        // sourceEdit(sourceInformations, oldName, newName, pureType)
-        return;
+        break;
       }
       case ConceptType.PACKAGE: {
+        // unsupported!
         return;
       }
       default: {
-        return;
+        usages = await this.editorStore.findConceptUsages(
+          FIND_USAGE_FUNCTION_PATH.PATH,
+          [`'${attr.pureId}'`],
+        );
+        break;
       }
     }
+    await flowResult(
+      this.editorStore.renameConcept(oldName, newName, attr.pureType, usages),
+    );
   }
 }

--- a/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
+++ b/packages/legend-application-pure-ide/src/stores/ConceptTreeState.ts
@@ -24,7 +24,7 @@ import {
 } from '../server/models/ConceptTree.js';
 import { action, flow, flowResult, makeObservable, observable } from 'mobx';
 import type { EditorStore } from './EditorStore.js';
-import { FileCoordinate } from '../server/models/PureFile.js';
+import { FileCoordinate } from '../server/models/File.js';
 import type { ConceptActivity } from '../server/models/Initialization.js';
 import { ActionState, type GeneratorFn } from '@finos/legend-shared';
 import type { TreeData } from '@finos/legend-art';

--- a/packages/legend-application-pure-ide/src/stores/DiagramEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/DiagramEditorState.ts
@@ -186,7 +186,7 @@ export class DiagramEditorState
       )?.sourceInformation;
       if (sourceInformation) {
         const coordinate = new FileCoordinate(
-          sourceInformation.source,
+          sourceInformation.sourceId,
           sourceInformation.startLine,
           sourceInformation.startColumn,
         );

--- a/packages/legend-application-pure-ide/src/stores/DiagramEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/DiagramEditorState.ts
@@ -47,10 +47,7 @@ import {
   addClassToGraph,
   buildGraphFromDiagramInfo,
 } from '../server/models/DiagramInfo.js';
-import {
-  FileCoordinate,
-  trimPathLeadingSlash,
-} from '../server/models/PureFile.js';
+import { FileCoordinate, trimPathLeadingSlash } from '../server/models/File.js';
 import type { EditorStore } from './EditorStore.js';
 import { EditorTabState } from './EditorTabManagerState.js';
 import { LEGEND_PURE_IDE_DIAGRAM_EDITOR_COMMAND_KEY } from './LegendPureIDECommand.js';

--- a/packages/legend-application-pure-ide/src/stores/DirectoryTreeState.ts
+++ b/packages/legend-application-pure-ide/src/stores/DirectoryTreeState.ts
@@ -22,7 +22,7 @@ import {
 } from '../server/models/DirectoryTree.js';
 import { action, flow, flowResult, makeObservable, observable } from 'mobx';
 import type { EditorStore } from './EditorStore.js';
-import type { FileCoordinate } from '../server/models/PureFile.js';
+import type { FileCoordinate } from '../server/models/File.js';
 import { ACTIVITY_MODE } from './EditorConfig.js';
 import {
   type GeneratorFn,
@@ -49,14 +49,17 @@ export class DirectoryTreeState extends TreeState<
 > {
   nodeForCreateNewFile?: DirectoryTreeNode | undefined;
   nodeForCreateNewDirectory?: DirectoryTreeNode | undefined;
+  nodeForRenameFile?: DirectoryTreeNode | undefined;
 
   constructor(editorStore: EditorStore) {
     super(editorStore);
     makeObservable(this, {
       nodeForCreateNewFile: observable,
       nodeForCreateNewDirectory: observable,
+      nodeForRenameFile: observable,
       setNodeForCreateNewFile: action,
       setNodeForCreateNewDirectory: action,
+      setNodeForRenameFile: action,
       revealPath: flow,
     });
   }
@@ -77,6 +80,14 @@ export class DirectoryTreeState extends TreeState<
       'Node selected for creating a new directory from must be a directory',
     );
     this.nodeForCreateNewDirectory = value;
+  };
+
+  setNodeForRenameFile = (value: DirectoryTreeNode | undefined): void => {
+    assertTrue(
+      !value || value.data.isFileNode,
+      'Node selected for renaming must be a file',
+    );
+    this.nodeForRenameFile = value;
   };
 
   async getRootNodes(): Promise<DirectoryNode[]> {

--- a/packages/legend-application-pure-ide/src/stores/EditorStore.ts
+++ b/packages/legend-application-pure-ide/src/stores/EditorStore.ts
@@ -1091,6 +1091,9 @@ export class EditorStore implements CommandRegistrar {
       this.setConsoleText(
         `Sucessfully renamed concept. Please re-compile the code`,
       );
+      this.applicationStore.notifyWarning(
+        `Please re-compile the code after refacting`,
+      );
     } catch {
       this.applicationStore.notifyError(`Can't rename concept '${oldName}'`);
     }
@@ -1129,14 +1132,17 @@ export class EditorStore implements CommandRegistrar {
           add,
         },
       ])) as SourceModificationResult;
-      this.setConsoleText(
-        `Sucessfully updated file. Please re-compile the code`,
-      );
       if (result.modifiedFiles.length) {
         for (const file of result.modifiedFiles) {
           yield flowResult(this.reloadFile(file));
         }
       }
+      this.setConsoleText(
+        `Sucessfully updated file. Please re-compile the code`,
+      );
+      this.applicationStore.notifyWarning(
+        `Please re-compile the code after refacting`,
+      );
     } catch {
       this.applicationStore.notifyError(`Can't update file: ${path}`);
     }

--- a/packages/legend-application-pure-ide/src/stores/EditorStore.ts
+++ b/packages/legend-application-pure-ide/src/stores/EditorStore.ts
@@ -21,9 +21,9 @@ import { serialize, deserialize } from 'serializr';
 import {
   FileCoordinate,
   FileErrorCoordinate,
-  PureFile,
+  File,
   trimPathLeadingSlash,
-} from '../server/models/PureFile.js';
+} from '../server/models/File.js';
 import { DirectoryTreeState } from './DirectoryTreeState.js';
 import { ConceptTreeState } from './ConceptTreeState.js';
 import {
@@ -497,7 +497,7 @@ export class EditorStore implements CommandRegistrar {
       yield flowResult(this.checkIfSessionWakingUp());
       editorState = new FileEditorState(
         this,
-        deserialize(PureFile, yield this.client.getFile(filePath)),
+        deserialize(File, yield this.client.getFile(filePath)),
         filePath,
       );
     }
@@ -518,9 +518,7 @@ export class EditorStore implements CommandRegistrar {
     yield Promise.all(
       this.tabManagerState.tabs.map(async (tab) => {
         if (tab instanceof FileEditorState && tab.filePath === filePath) {
-          tab.setFile(
-            deserialize(PureFile, await this.client.getFile(filePath)),
-          );
+          tab.setFile(deserialize(File, await this.client.getFile(filePath)));
         } else if (
           tab instanceof DiagramEditorState &&
           tab.filePath === filePath

--- a/packages/legend-application-pure-ide/src/stores/EditorStore.ts
+++ b/packages/legend-application-pure-ide/src/stores/EditorStore.ts
@@ -98,7 +98,6 @@ import { ExecutionError } from '../server/models/ExecutionError.js';
 import { ELEMENT_PATH_DELIMITER } from '@finos/legend-graph';
 import type { SourceModificationResult } from '../server/models/Source.js';
 import { ConceptType } from '../server/models/ConceptTree.js';
-import type { ChildPackageableElementInfo } from '../server/models/MovePackageableElements.js';
 
 export class EditorStore implements CommandRegistrar {
   readonly applicationStore: LegendPureIDEApplicationStore;
@@ -765,7 +764,9 @@ export class EditorStore implements CommandRegistrar {
 
   *executeTests(path: string, relevantTestsOnly?: boolean): GeneratorFn<void> {
     if (relevantTestsOnly) {
-      this.applicationStore.notifyUnsupportedFeature(`Run relevant tests`);
+      this.applicationStore.notifyUnsupportedFeature(
+        `Run relevant tests! (reason: VCS required)`,
+      );
       return;
     }
     if (this.testRunState.isInProgress) {

--- a/packages/legend-application-pure-ide/src/stores/EditorStore.ts
+++ b/packages/legend-application-pure-ide/src/stores/EditorStore.ts
@@ -950,7 +950,7 @@ export class EditorStore implements CommandRegistrar {
           message,
           add,
         },
-      ])) as unknown as SourceModificationResult;
+      ])) as SourceModificationResult;
       this.setConsoleText(result.text);
       if (result.modifiedFiles.length) {
         for (const file of result.modifiedFiles) {

--- a/packages/legend-application-pure-ide/src/stores/EditorStore.ts
+++ b/packages/legend-application-pure-ide/src/stores/EditorStore.ts
@@ -1092,7 +1092,10 @@ export class EditorStore implements CommandRegistrar {
       );
       const editorStatesToClose = this.tabManagerState.tabs.filter(
         (tab) =>
-          tab instanceof FileEditorState && tab.filePath.startsWith(path),
+          tab instanceof FileEditorState &&
+          (isDirectory
+            ? tab.filePath.startsWith(`${path}/`)
+            : tab.filePath === path),
       );
       editorStatesToClose.forEach((tab) => this.tabManagerState.closeTab(tab));
       await flowResult(this.directoryTreeState.refreshTreeData());

--- a/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
@@ -27,20 +27,28 @@ import {
 } from '@finos/legend-art';
 import { DIRECTORY_PATH_DELIMITER } from '@finos/legend-graph';
 import {
+  assertErrorThrown,
   getNullableLastElement,
   guaranteeNonNullable,
+  IllegalStateError,
+  type GeneratorFn,
 } from '@finos/legend-shared';
-import { action, flowResult, makeObservable, observable } from 'mobx';
+import { action, flow, flowResult, makeObservable, observable } from 'mobx';
 import { editor as monacoEditorAPI } from 'monaco-editor';
+import { ConceptType } from '../server/models/ConceptTree.js';
 import {
   FileCoordinate,
   type File,
   trimPathLeadingSlash,
   type FileErrorCoordinate,
 } from '../server/models/File.js';
+import {
+  type ConceptInfo,
+  FIND_USAGE_FUNCTION_PATH,
+} from '../server/models/Usage.js';
 import type { EditorStore } from './EditorStore.js';
 import { EditorTabState } from './EditorTabManagerState.js';
-import { LEGEND_PURE_IDE_COMMAND_KEY } from './LegendPureIDECommand.js';
+import { LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY } from './LegendPureIDECommand.js';
 
 const getFileEditorLanguage = (filePath: string): string => {
   const extension = getNullableLastElement(filePath.split('.'));
@@ -114,20 +122,40 @@ class FileTextEditorState {
   }
 }
 
+export class FileEditorRenameConceptState {
+  readonly fileEditorState: FileEditorState;
+  readonly concept: ConceptInfo;
+  readonly coordinate: FileCoordinate;
+
+  constructor(
+    fileEditorState: FileEditorState,
+    concept: ConceptInfo,
+    coordiate: FileCoordinate,
+  ) {
+    this.fileEditorState = fileEditorState;
+    this.concept = concept;
+    this.coordinate = coordiate;
+  }
+}
+
 export class FileEditorState
   extends EditorTabState
   implements CommandRegistrar
 {
-  file: File;
   readonly filePath: string;
   readonly textEditorState!: FileTextEditorState;
+
+  file: File;
+  renameConceptState: FileEditorRenameConceptState | undefined;
 
   constructor(editorStore: EditorStore, file: File, filePath: string) {
     super(editorStore);
 
     makeObservable(this, {
       file: observable,
+      renameConceptState: observable,
       setFile: action,
+      setConceptToRenameState: flow,
     });
 
     this.file = file;
@@ -162,6 +190,21 @@ export class FileEditorState
     this.file = value;
   }
 
+  *setConceptToRenameState(
+    coordinate: FileCoordinate | undefined,
+  ): GeneratorFn<void> {
+    if (!coordinate) {
+      this.renameConceptState = undefined;
+      return;
+    }
+    const concept = (yield this.editorStore.getConceptInfo(coordinate)) as
+      | ConceptInfo
+      | undefined;
+    this.renameConceptState = concept
+      ? new FileEditorRenameConceptState(this, concept, coordinate)
+      : undefined;
+  }
+
   showError(coordinate: FileErrorCoordinate): void {
     setErrorMarkers(
       this.textEditorState.model,
@@ -183,8 +226,13 @@ export class FileEditorState
   }
 
   registerCommands(): void {
+    if (this.textEditorState.language !== EDITOR_LANGUAGE.PURE) {
+      throw new IllegalStateError(
+        `File editor commands should only be used for Pure files`,
+      );
+    }
     this.editorStore.applicationStore.commandCenter.registerCommand({
-      key: LEGEND_PURE_IDE_COMMAND_KEY.GO_TO_DEFINITION,
+      key: LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.GO_TO_DEFINITION,
       trigger: () => Boolean(this.textEditorState.editor?.hasTextFocus()),
       action: () => {
         const currentPosition = this.textEditorState.editor?.getPosition();
@@ -202,7 +250,7 @@ export class FileEditorState
       },
     });
     this.editorStore.applicationStore.commandCenter.registerCommand({
-      key: LEGEND_PURE_IDE_COMMAND_KEY.GO_BACK,
+      key: LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.GO_BACK,
       action: () => {
         flowResult(this.editorStore.navigateBack()).catch(
           this.editorStore.applicationStore.alertUnhandledError,
@@ -210,7 +258,7 @@ export class FileEditorState
       },
     });
     this.editorStore.applicationStore.commandCenter.registerCommand({
-      key: LEGEND_PURE_IDE_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE,
+      key: LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE,
       trigger: () => Boolean(this.textEditorState.editor?.hasTextFocus()),
       action: () => {
         const currentPosition = this.textEditorState.editor?.getPosition();
@@ -228,7 +276,7 @@ export class FileEditorState
       },
     });
     this.editorStore.applicationStore.commandCenter.registerCommand({
-      key: LEGEND_PURE_IDE_COMMAND_KEY.FIND_USAGES,
+      key: LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.FIND_USAGES,
       trigger: () => Boolean(this.textEditorState.editor?.hasTextFocus()),
       action: () => {
         const currentPosition = this.textEditorState.editor?.getPosition();
@@ -244,14 +292,78 @@ export class FileEditorState
         }
       },
     });
+    this.editorStore.applicationStore.commandCenter.registerCommand({
+      key: LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.RENAME_CONCEPT,
+      trigger: () => Boolean(this.textEditorState.editor?.hasTextFocus()),
+      action: () => {
+        const currentPosition = this.textEditorState.editor?.getPosition();
+        if (currentPosition) {
+          const coordinate = new FileCoordinate(
+            this.filePath,
+            currentPosition.lineNumber,
+            currentPosition.column,
+          );
+          flowResult(this.setConceptToRenameState(coordinate)).catch(
+            this.editorStore.applicationStore.alertUnhandledError,
+          );
+        }
+      },
+    });
+  }
+
+  async renameConcept(newName: string): Promise<void> {
+    if (!this.renameConceptState) {
+      return;
+    }
+    const concept = this.renameConceptState.concept;
+    try {
+      this.editorStore.applicationStore.setBlockingAlert({
+        message: 'Finding concept usages...',
+        showLoading: true,
+      });
+      const usages = await this.editorStore.findConceptUsages(
+        concept.pureType === ConceptType.ENUM_VALUE
+          ? FIND_USAGE_FUNCTION_PATH.ENUM
+          : concept.pureType === ConceptType.PROPERTY ||
+            concept.pureType === ConceptType.QUALIFIED_PROPERTY
+          ? FIND_USAGE_FUNCTION_PATH.PROPERTY
+          : FIND_USAGE_FUNCTION_PATH.ELEMENT,
+        (concept.owner ? [`'${concept.owner}'`] : []).concat(
+          `'${concept.path}'`,
+        ),
+      );
+      await flowResult(
+        this.editorStore.renameConcept(
+          concept.pureName,
+          newName,
+          concept.pureType,
+          usages,
+        ),
+      );
+      this.textEditorState.setForcedCursorPosition({
+        lineNumber: this.renameConceptState.coordinate.line,
+        column: this.renameConceptState.coordinate.column,
+      });
+    } catch (error) {
+      assertErrorThrown(error);
+      this.editorStore.applicationStore.notifyError(error);
+    } finally {
+      this.editorStore.applicationStore.setBlockingAlert(undefined);
+    }
   }
 
   deregisterCommands(): void {
+    if (this.textEditorState.language !== EDITOR_LANGUAGE.PURE) {
+      throw new IllegalStateError(
+        `File editor commands should only be used for Pure files`,
+      );
+    }
     [
-      LEGEND_PURE_IDE_COMMAND_KEY.GO_TO_DEFINITION,
-      LEGEND_PURE_IDE_COMMAND_KEY.GO_BACK,
-      LEGEND_PURE_IDE_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE,
-      LEGEND_PURE_IDE_COMMAND_KEY.FIND_USAGES,
+      LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.GO_TO_DEFINITION,
+      LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.GO_BACK,
+      LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE,
+      LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.FIND_USAGES,
+      LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.RENAME_CONCEPT,
     ].forEach((key) =>
       this.editorStore.applicationStore.commandCenter.deregisterCommand(key),
     );

--- a/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
@@ -34,10 +34,10 @@ import { action, flowResult, makeObservable, observable } from 'mobx';
 import { editor as monacoEditorAPI } from 'monaco-editor';
 import {
   FileCoordinate,
-  type PureFile,
+  type File,
   trimPathLeadingSlash,
   type FileErrorCoordinate,
-} from '../server/models/PureFile.js';
+} from '../server/models/File.js';
 import type { EditorStore } from './EditorStore.js';
 import { EditorTabState } from './EditorTabManagerState.js';
 import { LEGEND_PURE_IDE_COMMAND_KEY } from './LegendPureIDECommand.js';
@@ -98,11 +98,11 @@ export class FileEditorState
   extends EditorTabState
   implements CommandRegistrar
 {
-  file: PureFile;
+  file: File;
   readonly filePath: string;
   readonly textEditorState = new FileTextEditorState(this);
 
-  constructor(editorStore: EditorStore, file: PureFile, filePath: string) {
+  constructor(editorStore: EditorStore, file: File, filePath: string) {
     super(editorStore);
 
     makeObservable(this, {
@@ -121,6 +121,7 @@ export class FileEditorState
   override get description(): string | undefined {
     return `File: ${trimPathLeadingSlash(this.filePath)}`;
   }
+
   get fileName(): string {
     return guaranteeNonNullable(
       getNullableLastElement(this.filePath.split(DIRECTORY_PATH_DELIMITER)),
@@ -136,7 +137,7 @@ export class FileEditorState
     this.textEditorState.model.dispose();
   }
 
-  setFile(value: PureFile): void {
+  setFile(value: File): void {
     this.file = value;
   }
 

--- a/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
@@ -188,6 +188,24 @@ export class FileEditorState
       },
     });
     this.editorStore.applicationStore.commandCenter.registerCommand({
+      key: LEGEND_PURE_IDE_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE,
+      trigger: () => Boolean(this.textEditorState.editor?.hasTextFocus()),
+      action: () => {
+        const currentPosition = this.textEditorState.editor?.getPosition();
+        if (currentPosition) {
+          this.editorStore
+            .revealConceptInTree(
+              new FileCoordinate(
+                this.filePath,
+                currentPosition.lineNumber,
+                currentPosition.column,
+              ),
+            )
+            .catch(this.editorStore.applicationStore.alertUnhandledError);
+        }
+      },
+    });
+    this.editorStore.applicationStore.commandCenter.registerCommand({
       key: LEGEND_PURE_IDE_COMMAND_KEY.FIND_USAGES,
       trigger: () => Boolean(this.textEditorState.editor?.hasTextFocus()),
       action: () => {
@@ -210,6 +228,7 @@ export class FileEditorState
     [
       LEGEND_PURE_IDE_COMMAND_KEY.GO_TO_DEFINITION,
       LEGEND_PURE_IDE_COMMAND_KEY.GO_BACK,
+      LEGEND_PURE_IDE_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE,
       LEGEND_PURE_IDE_COMMAND_KEY.FIND_USAGES,
     ].forEach((key) =>
       this.editorStore.applicationStore.commandCenter.deregisterCommand(key),

--- a/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
@@ -42,10 +42,29 @@ import type { EditorStore } from './EditorStore.js';
 import { EditorTabState } from './EditorTabManagerState.js';
 import { LEGEND_PURE_IDE_COMMAND_KEY } from './LegendPureIDECommand.js';
 
+const getFileEditorLanguage = (filePath: string): string => {
+  const extension = getNullableLastElement(filePath.split('.'));
+  switch (extension) {
+    case 'pure':
+      return EDITOR_LANGUAGE.PURE;
+    case 'json':
+      return EDITOR_LANGUAGE.JSON;
+    case 'sql':
+      return EDITOR_LANGUAGE.SQL;
+    case 'md':
+      return EDITOR_LANGUAGE.MARKDOWN;
+    case 'java':
+      return EDITOR_LANGUAGE.JAVA;
+    default:
+      return EDITOR_LANGUAGE.TEXT;
+  }
+};
+
 class FileTextEditorState {
   readonly model: monacoEditorAPI.ITextModel;
 
   editor?: monacoEditorAPI.IStandaloneCodeEditor | undefined;
+  language!: string;
   viewState?: monacoEditorAPI.ICodeEditorViewState | undefined;
 
   forcedCursorPosition: TextEditorPosition | undefined;
@@ -63,9 +82,10 @@ class FileTextEditorState {
       setWrapText: action,
     });
 
+    this.language = getFileEditorLanguage(fileEditorState.filePath);
     this.model = monacoEditorAPI.createModel(
       fileEditorState.uuid,
-      EDITOR_LANGUAGE.PURE,
+      this.language,
     );
     this.model.updateOptions({ tabSize: TAB_SIZE });
   }
@@ -100,7 +120,7 @@ export class FileEditorState
 {
   file: File;
   readonly filePath: string;
-  readonly textEditorState = new FileTextEditorState(this);
+  readonly textEditorState!: FileTextEditorState;
 
   constructor(editorStore: EditorStore, file: File, filePath: string) {
     super(editorStore);
@@ -112,6 +132,7 @@ export class FileEditorState
 
     this.file = file;
     this.filePath = filePath;
+    this.textEditorState = new FileTextEditorState(this);
   }
 
   get label(): string {

--- a/packages/legend-application-pure-ide/src/stores/FileEditorUtils.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorUtils.ts
@@ -16,6 +16,7 @@
 
 import type { PureGrammarTextSuggestion } from '@finos/legend-application';
 import { PURE_ELEMENT_NAME, PURE_PARSER } from '@finos/legend-graph';
+import { languages as monacoLanguagesAPI } from 'monaco-editor';
 import {
   BLANK_CLASS_SNIPPET,
   BLANK_FUNCTION_SNIPPET,
@@ -32,6 +33,7 @@ import {
   SIMPLE_FUNCTION_SNIPPET,
   SIMPLE_PROFILE_SNIPPET,
   BLANK_DIAGRAM_SNIPPET,
+  COPYRIGHT_HEADER_SNIPPET,
 } from './LegendPureIDECodeSnippets.js';
 
 // NOTE: these are technically different parsers compared to the ones we have in `Legend Engine` so we will
@@ -190,3 +192,28 @@ export const collectExtraInlineSnippetSuggestions =
       insertText: `println(\${1:})`,
     },
   ];
+
+export const getCopyrightHeaderSuggestions =
+  (): monacoLanguagesAPI.CompletionItem[] => {
+    const results: monacoLanguagesAPI.CompletionItem[] = [];
+
+    results.push({
+      label: {
+        label: `#copyright`,
+        description: `(copyright header)`,
+      },
+      kind: monacoLanguagesAPI.CompletionItemKind.Snippet,
+      insertTextRules:
+        monacoLanguagesAPI.CompletionItemInsertTextRule.InsertAsSnippet,
+      insertText: COPYRIGHT_HEADER_SNIPPET,
+      // NOTE: only show this suggestion when the cursor is on the first line of the file
+      range: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 1000,
+      },
+    } as monacoLanguagesAPI.CompletionItem);
+
+    return results;
+  };

--- a/packages/legend-application-pure-ide/src/stores/LegendPureIDECodeSnippets.ts
+++ b/packages/legend-application-pure-ide/src/stores/LegendPureIDECodeSnippets.ts
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+// ------------------------------------- Copyright header -------------------------------------
+
+export const COPYRIGHT_HEADER_SNIPPET = `// Copyright \${1:2020} Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.\n`;
+
 // ------------------------------------- Class -------------------------------------
 
 export const BLANK_CLASS_SNIPPET = `Class \${1:model::NewClass}

--- a/packages/legend-application-pure-ide/src/stores/LegendPureIDECommand.ts
+++ b/packages/legend-application-pure-ide/src/stores/LegendPureIDECommand.ts
@@ -26,6 +26,7 @@ export enum LEGEND_PURE_IDE_COMMAND_KEY {
   FULL_RECOMPILE_WITH_FULL_INIT = 'editor.full-compile.with-init',
   RUN_ALL_TESTS = 'editor.run-all-tests',
   RUN_RELAVANT_TESTS = 'editor.run-relavant-tests',
+  REVEAL_CONCEPT_IN_TREE = 'editor.file-editor.reveal-concept-in-tree',
   GO_TO_DEFINITION = 'editor.file-editor.go-to-definition',
   GO_BACK = 'editor.file-editor.go-back',
   FIND_USAGES = 'editor.file-editor.find-usage',
@@ -67,6 +68,10 @@ export const LEGEND_PURE_IDE_COMMAND_CONFIG: CommandConfigData = {
   [LEGEND_PURE_IDE_COMMAND_KEY.RUN_RELAVANT_TESTS]: {
     title: 'Run relavant tests',
     defaultKeyboardShortcut: 'Shift+F10',
+  },
+  [LEGEND_PURE_IDE_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE]: {
+    title: 'Reveal concept in tree (File)',
+    defaultKeyboardShortcut: 'Control+Shift+KeyB',
   },
   [LEGEND_PURE_IDE_COMMAND_KEY.GO_TO_DEFINITION]: {
     title: 'Go to definition (File)',

--- a/packages/legend-application-pure-ide/src/stores/LegendPureIDECommand.ts
+++ b/packages/legend-application-pure-ide/src/stores/LegendPureIDECommand.ts
@@ -26,10 +26,6 @@ export enum LEGEND_PURE_IDE_COMMAND_KEY {
   FULL_RECOMPILE_WITH_FULL_INIT = 'editor.full-compile.with-init',
   RUN_ALL_TESTS = 'editor.run-all-tests',
   RUN_RELAVANT_TESTS = 'editor.run-relavant-tests',
-  REVEAL_CONCEPT_IN_TREE = 'editor.file-editor.reveal-concept-in-tree',
-  GO_TO_DEFINITION = 'editor.file-editor.go-to-definition',
-  GO_BACK = 'editor.file-editor.go-back',
-  FIND_USAGES = 'editor.file-editor.find-usage',
 }
 
 export const LEGEND_PURE_IDE_COMMAND_CONFIG: CommandConfigData = {
@@ -69,23 +65,6 @@ export const LEGEND_PURE_IDE_COMMAND_CONFIG: CommandConfigData = {
     title: 'Run relavant tests',
     defaultKeyboardShortcut: 'Shift+F10',
   },
-  [LEGEND_PURE_IDE_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE]: {
-    title: 'Reveal concept in tree (File)',
-    defaultKeyboardShortcut: 'Control+Shift+KeyB',
-  },
-  [LEGEND_PURE_IDE_COMMAND_KEY.GO_TO_DEFINITION]: {
-    title: 'Go to definition (File)',
-    defaultKeyboardShortcut: 'Control+KeyB',
-  },
-  [LEGEND_PURE_IDE_COMMAND_KEY.GO_BACK]: {
-    title: 'Go back (File)',
-    // defaultKeyboardShortcut: 'Control+Alt+b',
-    defaultKeyboardShortcut: 'Control+Alt+KeyB',
-  },
-  [LEGEND_PURE_IDE_COMMAND_KEY.FIND_USAGES]: {
-    title: 'Find Usages (File)',
-    defaultKeyboardShortcut: 'Alt+F7',
-  },
 };
 
 export enum LEGEND_PURE_IDE_DIAGRAM_EDITOR_COMMAND_KEY {
@@ -112,5 +91,37 @@ export const LEGEND_PURE_IDE_DIAGRAM_EDITOR_COMMAND_CONFIG: CommandConfigData =
     [LEGEND_PURE_IDE_DIAGRAM_EDITOR_COMMAND_KEY.USE_PAN_TOOL]: {
       title: 'Diagram Editor: Use pan tool',
       defaultKeyboardShortcut: 'KeyM',
+    },
+  };
+
+export enum LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY {
+  REVEAL_CONCEPT_IN_TREE = 'editor.file-editor.reveal-concept-in-tree',
+  GO_TO_DEFINITION = 'editor.file-editor.go-to-definition',
+  GO_BACK = 'editor.file-editor.go-back',
+  FIND_USAGES = 'editor.file-editor.find-usage',
+  RENAME_CONCEPT = 'editor.file-editor.rename-concept',
+}
+
+export const LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_CONFIG: CommandConfigData =
+  {
+    [LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.REVEAL_CONCEPT_IN_TREE]: {
+      title: 'Reveal concept in tree (File)',
+      defaultKeyboardShortcut: 'Control+Shift+KeyB',
+    },
+    [LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.GO_TO_DEFINITION]: {
+      title: 'Go to definition (File)',
+      defaultKeyboardShortcut: 'Control+KeyB',
+    },
+    [LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.GO_BACK]: {
+      title: 'Go back (File)',
+      defaultKeyboardShortcut: 'Control+Alt+KeyB',
+    },
+    [LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.FIND_USAGES]: {
+      title: 'Find Usages (File)',
+      defaultKeyboardShortcut: 'Alt+F7',
+    },
+    [LEGEND_PURE_IDE_PURE_FILE_EDITOR_COMMAND_KEY.RENAME_CONCEPT]: {
+      title: 'Rename Concept (File)',
+      defaultKeyboardShortcut: 'F2',
     },
   };

--- a/packages/legend-application-pure-ide/src/stores/SearchResultState.ts
+++ b/packages/legend-application-pure-ide/src/stores/SearchResultState.ts
@@ -75,9 +75,10 @@ export class UsageResultState extends SearchResultState {
     editorStore: EditorStore,
     usageConcept: UsageConcept,
     references: Usage[],
+    searchResultCoordinates: SearchResultCoordinate[],
   ) {
     const fileMap = new Map<string, SearchResultEntry>();
-    references.forEach((ref) => {
+    references.forEach((ref, idx) => {
       let entry: SearchResultEntry;
       if (fileMap.has(ref.source)) {
         entry = guaranteeNonNullable(fileMap.get(ref.source));
@@ -86,14 +87,22 @@ export class UsageResultState extends SearchResultState {
         entry.sourceId = ref.source;
         fileMap.set(ref.source, entry);
       }
-      entry.coordinates.push(
-        new SearchResultCoordinate(
-          ref.startLine,
-          ref.startColumn,
-          ref.endLine,
-          ref.endColumn,
-        ),
+      const coordinates = new SearchResultCoordinate(
+        ref.source,
+        ref.startLine,
+        ref.startColumn,
+        ref.endLine,
+        ref.endColumn,
       );
+      coordinates.preview = searchResultCoordinates.find(
+        (result) =>
+          result.sourceId === ref.source &&
+          result.startLine === ref.startLine &&
+          result.startColumn === ref.startColumn &&
+          result.endLine === ref.endLine &&
+          result.endColumn === ref.endColumn,
+      )?.preview;
+      entry.coordinates.push(coordinates);
     });
     super(
       editorStore,

--- a/packages/legend-application-pure-ide/src/stores/SearchResultState.ts
+++ b/packages/legend-application-pure-ide/src/stores/SearchResultState.ts
@@ -24,7 +24,7 @@ import {
   SearchResultCoordinate,
   SearchResultEntry,
 } from '../server/models/SearchEntry.js';
-import type { Usage, UsageConcept } from '../server/models/Usage.js';
+import type { Usage, ConceptInfo } from '../server/models/Usage.js';
 import type { EditorStore } from './EditorStore.js';
 import { deleteEntry, guaranteeNonNullable } from '@finos/legend-shared';
 
@@ -69,11 +69,11 @@ export abstract class SearchResultState extends SearchState {
 export class TextSearchResultState extends SearchResultState {}
 
 export class UsageResultState extends SearchResultState {
-  usageConcept: UsageConcept;
+  usageConcept: ConceptInfo;
 
   constructor(
     editorStore: EditorStore,
-    usageConcept: UsageConcept,
+    usageConcept: ConceptInfo,
     references: Usage[],
     searchResultCoordinates: SearchResultCoordinate[],
   ) {

--- a/packages/legend-application-pure-ide/src/stores/TestRunnerState.ts
+++ b/packages/legend-application-pure-ide/src/stores/TestRunnerState.ts
@@ -96,10 +96,12 @@ export const getTestTreeNodeStatus = (
     return getTestResultById(id, testResultInfo);
   }
   // order matters here, also if one test fail/error the whole sub-tree (package) will be marked as failed
-  return testResultInfo.failedTestIds.some((i) => i.startsWith(id)) ||
-    testResultInfo.testWithErrorIds.some((i) => i.startsWith(id))
+  // NOTE: here, we have to check `startsWith(`${id}_`)` to guarantee we grab the right package, if we just use `startsWith(id)`
+  // we might mark `meta::test` and `meta::test2` both as failed when `meta::test::someTest` fails
+  return testResultInfo.failedTestIds.some((i) => i.startsWith(`${id}_`)) ||
+    testResultInfo.testWithErrorIds.some((i) => i.startsWith(`${id}_`))
     ? TestResultType.FAILED
-    : testResultInfo.notRunTestIds.some((i) => i.startsWith(id))
+    : testResultInfo.notRunTestIds.some((i) => i.startsWith(`${id}_`))
     ? TestResultType.RUNNING
     : TestResultType.PASSED;
 };

--- a/packages/legend-application-pure-ide/style/components/editor/_auxiliary-panel.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/_auxiliary-panel.scss
@@ -75,6 +75,7 @@
   &__header__tab__title {
     font-size: 1.2rem;
     font-weight: 500;
+    user-select: none;
   }
 
   &__content__tab {

--- a/packages/legend-application-pure-ide/style/components/editor/_command.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/_command.scss
@@ -40,6 +40,7 @@
 
 .command-modal__content {
   display: flex;
+  margin-top: 0.5rem;
 
   &__form {
     display: flex;

--- a/packages/legend-application-pure-ide/style/components/editor/_file-editor.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/_file-editor.scss
@@ -69,4 +69,29 @@
     height: calc(100% - 2.8rem);
     width: 100%;
   }
+
+  .monaco-menu-container {
+    .monaco-scrollable-element {
+      border-radius: 0.2rem !important;
+    }
+
+    .monaco-menu {
+      background: var(--color-dark-grey-100);
+      border-radius: 0.2rem;
+
+      .monaco-action-bar.vertical {
+        padding: 0.5rem 0;
+
+        .action-label.separator {
+          border-bottom: 1px solid var(--color-dark-grey-250) !important;
+          border-bottom-color: var(--color-dark-grey-250) !important;
+        }
+      }
+
+      .action-item.focused:hover > a,
+      .action-item.focused > a {
+        background: var(--color-light-blue-450) !important;
+      }
+    }
+  }
 }

--- a/packages/legend-application-pure-ide/style/components/editor/aux-panel/_search-panel.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/aux-panel/_search-panel.scss
@@ -33,6 +33,7 @@
     line-height: 2rem;
     background: var(--color-dark-grey-85);
     margin-bottom: 1rem;
+    user-select: none;
   }
 
   &__entry {

--- a/packages/legend-application-pure-ide/style/components/editor/aux-panel/_search-panel.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/aux-panel/_search-panel.scss
@@ -179,7 +179,7 @@
     }
 
     &__label__preview__text--found {
-      font-weight: 500;
+      font-weight: 700;
       color: var(--color-blue-150);
     }
 

--- a/packages/legend-application-pure-ide/style/components/editor/aux-panel/_search-panel.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/aux-panel/_search-panel.scss
@@ -150,6 +150,38 @@
       width: calc(100% - 2.8rem);
     }
 
+    &__label__content {
+      @include flexVCenter;
+    }
+
+    &__label__coordinates {
+      line-height: 2rem;
+      font-size: 1.2rem;
+      font-family: 'Roboto Mono', monospace;
+      color: var(--color-dark-grey-300);
+      margin-right: 0.5rem;
+    }
+
+    &__label__preview {
+      display: inline-block;
+      line-height: 2rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: pre;
+    }
+
+    &__label__preview__text {
+      line-height: 2rem;
+      font-size: 1.2rem;
+      font-family: 'Roboto Mono', monospace;
+      white-space: pre;
+    }
+
+    &__label__preview__text--found {
+      font-weight: 500;
+      color: var(--color-blue-150);
+    }
+
     &__label__candidate {
       @include flexHSpaceBetween;
 

--- a/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
@@ -129,6 +129,12 @@
     @include flexHCenter;
   }
 
+  &__package-tree__node__icon__type--property-from-association {
+    svg {
+      color: var(--color-pure-association) !important;
+    }
+  }
+
   &__package-tree__node__icon__expand svg {
     font-size: 1rem;
   }
@@ -148,6 +154,18 @@
   &__package-tree__node__label {
     color: inherit;
     user-select: none;
+
+    &__property-from-association-tag {
+      color: var(--color-dark-grey-250);
+      background: var(--color-dark-grey-400);
+      margin-left: 0.5rem;
+      border-radius: 0.2rem;
+      font-size: 1rem;
+      padding: 0 0.5rem;
+      height: 1.6rem;
+      line-height: 1.6rem;
+      font-weight: 500;
+    }
   }
 
   &__new-element-modal__name-input {

--- a/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
@@ -214,7 +214,13 @@
     font-size: 1.8rem;
   }
 
-  &__icon--file {
-    color: var(--color-file);
+  &__icon {
+    &--file {
+      color: var(--color-file);
+    }
+
+    &--platform {
+      color: var(--color-lime-75);
+    }
   }
 }

--- a/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
@@ -155,37 +155,6 @@
     margin-bottom: 1rem;
   }
 
-  &__context-menu {
-    background: var(--color-dark-grey-100);
-    border: 0.1rem solid var(--color-dark-grey-50);
-    padding: 0.5rem 0;
-  }
-
-  &__context-menu__item {
-    @include flexVCenter;
-
-    cursor: default;
-    color: var(--color-light-grey-400);
-    height: 2.8rem;
-    padding: 0 1rem;
-    min-width: 12rem;
-  }
-
-  &__context-menu__item__icon {
-    @include flexCenter;
-
-    width: 2rem;
-    min-width: 2rem;
-  }
-
-  &__context-menu__item__label {
-    padding-left: 1rem;
-  }
-
-  &__context-menu__item:hover {
-    background: var(--color-light-blue-450);
-  }
-
   &__content--empty {
     padding: 2rem;
 
@@ -204,10 +173,6 @@
       color: var(--color-light-grey-50);
       cursor: pointer;
     }
-  }
-
-  &__floating-item {
-    padding-left: 1rem;
   }
 
   &__btn__refresh svg {

--- a/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
+++ b/packages/legend-application-pure-ide/style/components/editor/side-bar/_explorer.scss
@@ -155,16 +155,16 @@
     color: inherit;
     user-select: none;
 
-    &__property-from-association-tag {
-      color: var(--color-dark-grey-250);
-      background: var(--color-dark-grey-400);
+    &__tag {
+      background: var(--color-dark-grey-280);
       margin-left: 0.5rem;
       border-radius: 0.2rem;
       font-size: 1rem;
-      padding: 0 0.5rem;
-      height: 1.6rem;
-      line-height: 1.6rem;
+      padding: 0.2rem 0.3rem;
+      height: 2rem;
+      line-height: 2rem;
       font-weight: 500;
+      vertical-align: middle;
     }
   }
 

--- a/packages/legend-application-pure-ide/style/index.scss
+++ b/packages/legend-application-pure-ide/style/index.scss
@@ -21,6 +21,7 @@
 @forward 'components/editor';
 
 :root {
+  --color-pure-association: var(--color-magenta-100);
   --color-native-function: var(--color-lime-75);
   --color-diagram: var(--color-magenta-100);
   --color-file: var(--color-blue-150);
@@ -29,6 +30,10 @@
 .color {
   &--native-function {
     color: var(--color-native-function);
+  }
+
+  &--pure-association {
+    color: var(--color-pure-association);
   }
 
   &--diagram {

--- a/packages/legend-application-query/package.json
+++ b/packages/legend-application-query/package.json
@@ -57,7 +57,7 @@
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-application-studio/package.json
+++ b/packages/legend-application-studio/package.json
@@ -63,7 +63,7 @@
     "react": "18.2.0",
     "react-dnd": "16.0.1",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-application-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/GrammarTextEditor.tsx
@@ -37,6 +37,8 @@ import {
   clearMarkers,
   setErrorMarkers,
   moveCursorToPosition,
+  MenuContent,
+  MenuContentItem,
 } from '@finos/legend-art';
 import {
   TAB_SIZE,
@@ -117,14 +119,11 @@ export const GrammarTextEditorHeaderTabContextMenu = observer(
       );
 
       return (
-        <div ref={ref} className="edit-panel__header__tab__context-menu">
-          <button
-            className="edit-panel__header__tab__context-menu__item"
-            onClick={leaveTextMode}
-          >
+        <MenuContent ref={ref}>
+          <MenuContentItem onClick={leaveTextMode}>
             Leave Text Mode
-          </button>
-        </div>
+          </MenuContentItem>
+        </MenuContent>
       );
     },
   ),

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/MappingEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/MappingEditor.tsx
@@ -34,6 +34,8 @@ import {
   PURE_AssociationIcon,
   Panel,
   useResizeDetector,
+  MenuContentItem,
+  MenuContent,
 } from '@finos/legend-art';
 import { ClassMappingEditor } from './ClassMappingEditor.js';
 import { EnumerationMappingEditor } from './EnumerationMappingEditor.js';
@@ -113,27 +115,16 @@ const MappingEditorHeaderTabContextMenu = observer(
     const closeAll = (): void => mappingEditorState.closeAllTabs();
 
     return (
-      <div ref={ref} className="mapping-editor__header__tab__context-menu">
-        <button
-          className="mapping-editor__header__tab__context-menu__item"
-          onClick={close}
-        >
-          Close
-        </button>
-        <button
-          className="mapping-editor__header__tab__context-menu__item"
+      <MenuContent ref={ref}>
+        <MenuContentItem onClick={close}>Close</MenuContentItem>
+        <MenuContentItem
           disabled={mappingEditorState.openedTabStates.length < 2}
           onClick={closeOthers}
         >
           Close Others
-        </button>
-        <button
-          className="mapping-editor__header__tab__context-menu__item"
-          onClick={closeAll}
-        >
-          Close All
-        </button>
-      </div>
+        </MenuContentItem>
+        <MenuContentItem onClick={closeAll}>Close All</MenuContentItem>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/MappingExplorer.tsx
@@ -36,6 +36,8 @@ import {
   FilterIcon,
   PanelDropZone,
   BlankPanelPlaceholder,
+  MenuContent,
+  MenuContentItem,
 } from '@finos/legend-art';
 import { MappingElementState } from '../../../../stores/editor-state/element-editor-state/mapping/MappingElementState.js';
 import { useDrop, useDrag } from 'react-dnd';
@@ -169,56 +171,36 @@ export const MappingExplorerContextMenu = observer(
       !!mappingElement.filter;
 
     return (
-      <div ref={ref} className="mapping-explorer__context-menu">
+      <MenuContent ref={ref}>
         {mappingElement instanceof SetImplementation && (
-          <div
-            className="mapping-explorer__context-menu__item"
-            onClick={queryMappingElement}
-          >
-            Query
-          </div>
+          <MenuContentItem onClick={queryMappingElement}>Query</MenuContentItem>
         )}
         {mappingElement instanceof SetImplementation && (
-          <div
-            className="mapping-explorer__context-menu__item"
-            onClick={createTestForMappingElement}
-          >
+          <MenuContentItem onClick={createTestForMappingElement}>
             Test
-          </div>
+          </MenuContentItem>
         )}
         {allowAddFilter && (
-          <div
-            className="mapping-explorer__context-menu__item"
-            onClick={addMappingFilter}
-          >
+          <MenuContentItem onClick={addMappingFilter}>
             Add Filter
-          </div>
+          </MenuContentItem>
         )}
         {allowRemoveFilter && (
-          <div
-            className="mapping-explorer__context-menu__item"
-            onClick={removeMappingFilter}
-          >
+          <MenuContentItem onClick={removeMappingFilter}>
             Remove Filter
-          </div>
+          </MenuContentItem>
         )}
         {mappingElement && (
-          <div
-            className="mapping-explorer__context-menu__item"
-            onClick={removeMappingElement}
-          >
+          <MenuContentItem onClick={removeMappingElement}>
             Delete
-          </div>
+          </MenuContentItem>
         )}
         {!mappingElement && openNewMapingModal && (
-          <div
-            className="mapping-explorer__context-menu__item"
-            onClick={openNewMapingModal}
-          >
+          <MenuContentItem onClick={openNewMapingModal}>
             Create new mapping element
-          </div>
+          </MenuContentItem>
         )}
-      </div>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/mapping-editor/MappingTestsExplorer.tsx
@@ -37,6 +37,8 @@ import {
   PauseCircleIcon,
   PanelDropZone,
   BlankPanelPlaceholder,
+  MenuContent,
+  MenuContentItem,
 } from '@finos/legend-art';
 import {
   type MappingElementDragSource,
@@ -99,56 +101,32 @@ export const MappingTestExplorerContextMenu = observer(
     };
 
     return (
-      <div ref={ref} className="mapping-test-explorer__context-menu">
+      <MenuContent ref={ref}>
         {mappingTestState && (
-          <div
-            className="mapping-test-explorer__context-menu__item"
-            onClick={runMappingTest}
-          >
-            Run
-          </div>
+          <MenuContentItem onClick={runMappingTest}>Run</MenuContentItem>
         )}
         {mappingTestState && mappingTestState.result !== TEST_RESULT.NONE && (
-          <div
-            className="mapping-test-explorer__context-menu__item"
-            onClick={viewTestResult}
-          >
+          <MenuContentItem onClick={viewTestResult}>
             View Result
-          </div>
+          </MenuContentItem>
         )}
         {mappingTestState && (
-          <div
-            className="mapping-test-explorer__context-menu__item"
-            onClick={editTest}
-          >
-            Edit
-          </div>
+          <MenuContentItem onClick={editTest}>Edit</MenuContentItem>
         )}
         {mappingTestState && (
-          <div
-            className="mapping-test-explorer__context-menu__item"
-            onClick={toggleSkipTest}
-          >
+          <MenuContentItem onClick={toggleSkipTest}>
             {mappingTestState.isSkipped ? 'Unskip' : 'Skip'}
-          </div>
+          </MenuContentItem>
         )}
         {!isReadOnly && mappingTestState && (
-          <div
-            className="mapping-test-explorer__context-menu__item"
-            onClick={removeMappingTest}
-          >
-            Delete
-          </div>
+          <MenuContentItem onClick={removeMappingTest}>Delete</MenuContentItem>
         )}
-        {!isReadOnly && !mappingTestState && (
-          <div
-            className="mapping-test-explorer__context-menu__item"
-            onClick={showCreateNewTestModal}
-          >
+        {!isReadOnly && !mappingTestState && showCreateNewTestModal && (
+          <MenuContentItem onClick={showCreateNewTestModal}>
             Create new test
-          </div>
+          </MenuContentItem>
         )}
-      </div>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/edit-panel/service-editor/testable/ServiceTestableEditor.tsx
@@ -27,6 +27,8 @@ import {
   Panel,
   LockIcon,
   ModalTitle,
+  MenuContent,
+  MenuContentItem,
 } from '@finos/legend-art';
 import { observer } from 'mobx-react-lite';
 import {
@@ -83,20 +85,10 @@ const ServiceSuiteHeaderTabContextMenu = observer(
     const rename = (): void => testableState.setSuiteToRename(testSuite);
 
     return (
-      <div ref={ref} className="mapping-editor__header__tab__context-menu">
-        <button
-          className="mapping-editor__header__tab__context-menu__item"
-          onClick={rename}
-        >
-          Rename
-        </button>
-        <button
-          className="mapping-editor__header__tab__context-menu__item"
-          onClick={deleteSuite}
-        >
-          Delete
-        </button>
-      </div>
+      <MenuContent ref={ref}>
+        <MenuContentItem onClick={rename}>Rename</MenuContentItem>
+        <MenuContentItem onClick={deleteSuite}>Delete</MenuContentItem>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-studio/src/components/editor/side-bar/ProjectOverview.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/ProjectOverview.tsx
@@ -35,6 +35,8 @@ import {
   Modal,
   ModalBody,
   ModalFooter,
+  MenuContentItem,
+  MenuContent,
 } from '@finos/legend-art';
 import { PROJECT_OVERVIEW_ACTIVITY_MODE } from '../../../stores/sidebar-state/ProjectOverviewState.js';
 import {
@@ -167,14 +169,9 @@ const WorkspaceViewerContextMenu = observer(
     );
 
     return (
-      <div ref={ref} className="project-overview__context-menu">
-        <div
-          className="project-overview__context-menu__item"
-          onClick={deleteWorkspace}
-        >
-          Delete
-        </div>
-      </div>
+      <MenuContent ref={ref}>
+        <MenuContentItem onClick={deleteWorkspace}>Delete</MenuContentItem>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-studio/src/components/workspace-review/WorkspaceReviewPanel.tsx
+++ b/packages/legend-application-studio/src/components/workspace-review/WorkspaceReviewPanel.tsx
@@ -15,7 +15,14 @@
  */
 
 import { observer } from 'mobx-react-lite';
-import { clsx, DropdownMenu, ContextMenu, TimesIcon } from '@finos/legend-art';
+import {
+  clsx,
+  DropdownMenu,
+  ContextMenu,
+  TimesIcon,
+  MenuContentItem,
+  MenuContent,
+} from '@finos/legend-art';
 import { filterByType } from '@finos/legend-shared';
 import {
   EntityDiffViewState,
@@ -44,30 +51,16 @@ const WorkspaceReviewPanelHeaderTabContextMenu = observer(
     const closeAll = (): void => editorStore.tabManagerState.closeAllTabs();
 
     return (
-      <div
-        ref={ref}
-        className="workspace-review-panel__header__tab__context-menu"
-      >
-        <button
-          className="workspace-review-panel__header__tab__context-menu__item"
-          onClick={close}
-        >
-          Close
-        </button>
-        <button
-          className="workspace-review-panel__header__tab__context-menu__item"
+      <MenuContent ref={ref}>
+        <MenuContentItem onClick={close}>Close</MenuContentItem>
+        <MenuContentItem
           disabled={editorStore.tabManagerState.tabs.length < 2}
           onClick={closeOthers}
         >
           Close Others
-        </button>
-        <button
-          className="workspace-review-panel__header__tab__context-menu__item"
-          onClick={closeAll}
-        >
-          Close All
-        </button>
-      </div>
+        </MenuContentItem>
+        <MenuContentItem onClick={closeAll}>Close All</MenuContentItem>
+      </MenuContent>
     );
   }),
 );

--- a/packages/legend-application-studio/style/components/_review.scss
+++ b/packages/legend-application-studio/style/components/_review.scss
@@ -91,30 +91,6 @@
     width: 100%;
   }
 
-  &__header__tab__context-menu {
-    background: var(--color-dark-grey-100);
-    border: 0.1rem solid var(--color-dark-grey-50);
-    padding: 0.5rem 0;
-  }
-
-  &__header__tab__context-menu__item {
-    @include flexVCenter;
-
-    width: 100%;
-    cursor: default;
-    color: var(--color-light-grey-400);
-    height: 2.8rem;
-    padding: 0 1rem;
-  }
-
-  &__header__tab__context-menu__item[disabled] {
-    color: var(--color-dark-grey-400);
-  }
-
-  &__header__tab__context-menu__item:not([disabled]):hover {
-    background: var(--color-light-blue-450);
-  }
-
   &__header__tab__element__type {
     font-weight: bold;
   }

--- a/packages/legend-application-studio/style/components/editor/_mapping-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_mapping-editor.scss
@@ -73,30 +73,6 @@
     width: 100%;
   }
 
-  &__header__tab__context-menu {
-    background: var(--color-dark-grey-100);
-    border: 0.1rem solid var(--color-dark-grey-50);
-    padding: 0.5rem 0;
-  }
-
-  &__header__tab__context-menu__item {
-    @include flexVCenter;
-
-    width: 100%;
-    cursor: default;
-    color: var(--color-light-grey-400);
-    height: 2.8rem;
-    padding: 0 1rem;
-  }
-
-  &__header__tab__context-menu__item[disabled] {
-    color: var(--color-dark-grey-400);
-  }
-
-  &__header__tab__context-menu__item:not([disabled]):hover {
-    background: var(--color-light-blue-450);
-  }
-
   &__header__tab__icon--test {
     font-size: 1.3rem;
     color: var(--color-test);

--- a/packages/legend-application-studio/style/components/editor/mapping-editor/_mapping-explorer.scss
+++ b/packages/legend-application-studio/style/components/editor/mapping-editor/_mapping-explorer.scss
@@ -161,30 +161,6 @@
     background: var(--color-light-grey-300);
   }
 
-  &__context-menu {
-    background: var(--color-light-grey-100);
-    padding: 0.5rem 0;
-    min-width: 15rem;
-  }
-
-  &__context-menu__item {
-    @include flexVCenter;
-
-    cursor: default;
-    color: var(--color-dark-grey-300);
-    height: 2.8rem;
-    padding: 0 1rem;
-  }
-
-  &__context-menu__item__label {
-    padding-left: 1rem;
-  }
-
-  &__context-menu__item:hover {
-    background: var(--color-light-blue-200);
-    color: var(--color-light-grey-0);
-  }
-
   &__content {
     height: 100%;
     padding-top: 0.5rem;

--- a/packages/legend-application-studio/style/components/editor/mapping-editor/_mapping-test-explorer.scss
+++ b/packages/legend-application-studio/style/components/editor/mapping-editor/_mapping-test-explorer.scss
@@ -239,30 +239,6 @@
     background: var(--color-light-grey-300);
   }
 
-  &__context-menu {
-    background: var(--color-light-grey-100);
-    padding: 0.5rem 0;
-    min-width: 15rem;
-  }
-
-  &__context-menu__item {
-    @include flexVCenter;
-
-    cursor: default;
-    color: var(--color-dark-grey-300);
-    height: 2.8rem;
-    padding: 0 1rem;
-  }
-
-  &__context-menu__item__label {
-    padding-left: 1rem;
-  }
-
-  &__context-menu__item:hover {
-    background: var(--color-light-blue-200);
-    color: var(--color-light-grey-0);
-  }
-
   &__content {
     height: 100%;
     padding-top: 0.5rem;

--- a/packages/legend-application-studio/style/components/editor/side-bar/_project-overview.scss
+++ b/packages/legend-application-studio/style/components/editor/side-bar/_project-overview.scss
@@ -219,29 +219,6 @@
     }
   }
 
-  &__context-menu {
-    background: var(--color-dark-grey-100);
-    border: 0.1rem solid var(--color-dark-grey-50);
-    padding: 0.5rem 0;
-  }
-
-  &__context-menu__item {
-    @include flexVCenter;
-
-    cursor: default;
-    color: var(--color-light-grey-400);
-    height: 2.8rem;
-    padding: 0 1rem;
-  }
-
-  &__context-menu__item__label {
-    padding-left: 1rem;
-  }
-
-  &__context-menu__item:hover {
-    background: var(--color-light-blue-450);
-  }
-
   &__share-project {
     &__btn svg {
       font-size: 1.8rem;

--- a/packages/legend-application-taxonomy/package.json
+++ b/packages/legend-application-taxonomy/package.json
@@ -58,7 +58,7 @@
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-application/package.json
+++ b/packages/legend-application/package.json
@@ -61,7 +61,7 @@
     "react-draggable": "4.4.5",
     "react-router": "5.3.4",
     "react-router-dom": "5.3.4",
-    "serializr": "3.0.1",
+    "serializr": "3.0.2",
     "sql-formatter": "12.0.3"
   },
   "devDependencies": {

--- a/packages/legend-application/src/components/LegendApplicationComponentFrameworkProvider.tsx
+++ b/packages/legend-application/src/components/LegendApplicationComponentFrameworkProvider.tsx
@@ -46,6 +46,7 @@ const PLATFORM_NATIVE_KEYBOARD_SHORTCUTS = [
   'Control+KeyB',
   'F7', // Firefox: Caret browsing
   'Alt+F7', // Firefox: Caret browsing (Mac)
+  'Control+Shift+KeyB',
 ];
 
 const buildReactHotkeysConfiguration = (

--- a/packages/legend-application/src/stores/PureLanguageSupport.ts
+++ b/packages/legend-application/src/stores/PureLanguageSupport.ts
@@ -501,8 +501,18 @@ export const setupPureLanguageService = (
       command: null,
     },
     {
+      // disable change all instances
+      keybinding: KeyMod.CtrlCmd | KeyCode.F2,
+      command: null,
+    },
+    {
       // disable toggle debugger breakpoint
       keybinding: KeyMod.Shift | KeyCode.F10,
+      command: null,
+    },
+    {
+      // disable go-to definition
+      keybinding: KeyMod.CtrlCmd | KeyCode.F12,
       command: null,
     },
   ]);

--- a/packages/legend-dev-utils/package.json
+++ b/packages/legend-dev-utils/package.json
@@ -81,7 +81,7 @@
     "mini-css-extract-plugin": "2.7.2",
     "monaco-editor": "0.34.1",
     "monaco-editor-webpack-plugin": "7.0.1",
-    "postcss": "8.4.19",
+    "postcss": "8.4.20",
     "postcss-loader": "7.0.2",
     "react-refresh": "0.14.0",
     "resolve": "1.22.1",

--- a/packages/legend-extension-dsl-data-space/package.json
+++ b/packages/legend-extension-dsl-data-space/package.json
@@ -58,7 +58,7 @@
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-dsl-diagram/package.json
+++ b/packages/legend-extension-dsl-diagram/package.json
@@ -55,7 +55,7 @@
     "react": "18.2.0",
     "react-dnd": "16.0.1",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-dsl-mastery/package.json
+++ b/packages/legend-extension-dsl-mastery/package.json
@@ -52,7 +52,7 @@
     "@types/react": "18.0.26",
     "mobx": "6.7.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-dsl-persistence-cloud/package.json
+++ b/packages/legend-extension-dsl-persistence-cloud/package.json
@@ -50,7 +50,7 @@
     "@types/react": "18.0.26",
     "mobx": "6.7.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-dsl-persistence/package.json
+++ b/packages/legend-extension-dsl-persistence/package.json
@@ -52,7 +52,7 @@
     "@types/react": "18.0.26",
     "mobx": "6.7.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-dsl-service/package.json
+++ b/packages/legend-extension-dsl-service/package.json
@@ -58,7 +58,7 @@
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-dsl-text/package.json
+++ b/packages/legend-extension-dsl-text/package.json
@@ -53,7 +53,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-store-flat-data/package.json
+++ b/packages/legend-extension-store-flat-data/package.json
@@ -53,7 +53,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-store-relational/package.json
+++ b/packages/legend-extension-store-relational/package.json
@@ -53,7 +53,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-extension-store-service-store/package.json
+++ b/packages/legend-extension-store-service-store/package.json
@@ -53,7 +53,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-graph/package.json
+++ b/packages/legend-graph/package.json
@@ -44,7 +44,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-graph/src/graph/MetaModelUtils.ts
+++ b/packages/legend-graph/src/graph/MetaModelUtils.ts
@@ -38,6 +38,13 @@ import {
 export const extractElementNameFromPath = (fullPath: string): string =>
   guaranteeNonNullable(findLast(fullPath.split(ELEMENT_PATH_DELIMITER)));
 
+export const extractPackagePathFromPath = (
+  fullPath: string,
+): string | undefined => {
+  const idx = fullPath.lastIndexOf(ELEMENT_PATH_DELIMITER);
+  return idx === -1 ? undefined : fullPath.substring(0, idx);
+};
+
 export const matchFunctionName = (
   functionName: string,
   functionFullPaths: string | string[],

--- a/packages/legend-query-builder/package.json
+++ b/packages/legend-query-builder/package.json
@@ -61,7 +61,7 @@
     "react": "18.2.0",
     "react-dnd": "16.0.1",
     "react-dom": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-server-depot/package.json
+++ b/packages/legend-server-depot/package.json
@@ -44,7 +44,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-server-sdlc/package.json
+++ b/packages/legend-server-sdlc/package.json
@@ -44,7 +44,7 @@
     "mobx": "6.7.0",
     "mobx-react-lite": "3.4.0",
     "react": "18.2.0",
-    "serializr": "3.0.1"
+    "serializr": "3.0.2"
   },
   "devDependencies": {
     "@finos/legend-dev-utils": "workspace:*",

--- a/packages/legend-shared/package.json
+++ b/packages/legend-shared/package.json
@@ -56,7 +56,7 @@
     "pretty-format": "29.3.1",
     "query-string": "7.1.3",
     "seedrandom": "3.0.5",
-    "serializr": "3.0.1",
+    "serializr": "3.0.2",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -30,7 +30,7 @@
     "publish:snapshot": "node ../../scripts/release/publishDevSnapshot.js"
   },
   "dependencies": {
-    "postcss": "8.4.19",
+    "postcss": "8.4.20",
     "postcss-scss": "4.0.6",
     "stylelint-config-prettier": "9.0.4",
     "stylelint-config-standard": "29.0.0",

--- a/scripts/typedoc-theme/package.json
+++ b/scripts/typedoc-theme/package.json
@@ -27,7 +27,7 @@
     "eslint": "8.29.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.2",
-    "typedoc": "0.23.21",
+    "typedoc": "0.23.22",
     "typescript": "4.9.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,7 +2049,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2131,7 +2131,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2219,7 +2219,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2293,7 +2293,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2330,7 +2330,7 @@ __metadata:
     react-router-dom: 5.3.4
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     sql-formatter: 12.0.3
     typescript: 4.9.4
   peerDependencies:
@@ -2421,7 +2421,7 @@ __metadata:
     mini-css-extract-plugin: 2.7.2
     monaco-editor: 0.34.1
     monaco-editor-webpack-plugin: 7.0.1
-    postcss: 8.4.19
+    postcss: 8.4.20
     postcss-loader: 7.0.2
     react-refresh: 0.14.0
     resolve: 1.22.1
@@ -2460,7 +2460,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2493,7 +2493,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2521,7 +2521,7 @@ __metadata:
     react: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2548,7 +2548,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 18.2.0
     rimraf: 3.0.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2576,7 +2576,7 @@ __metadata:
     react: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2610,7 +2610,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2639,7 +2639,7 @@ __metadata:
     react: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2704,7 +2704,7 @@ __metadata:
     react: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2733,7 +2733,7 @@ __metadata:
     react: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2762,7 +2762,7 @@ __metadata:
     react: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2822,7 +2822,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 18.2.0
     rimraf: 3.0.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   languageName: unknown
   linkType: soft
@@ -2848,7 +2848,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 18.2.0
     rimraf: 3.0.2
-    typedoc: 0.23.21
+    typedoc: 0.23.22
     typescript: 4.9.4
   languageName: unknown
   linkType: soft
@@ -2911,7 +2911,7 @@ __metadata:
     react-dom: 18.2.0
     rimraf: 3.0.2
     sass: 1.56.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   peerDependencies:
     react: ^18.0.0
@@ -2934,7 +2934,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 18.2.0
     rimraf: 3.0.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   languageName: unknown
   linkType: soft
@@ -2955,7 +2955,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 18.2.0
     rimraf: 3.0.2
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
   languageName: unknown
   linkType: soft
@@ -2989,7 +2989,7 @@ __metadata:
     query-string: 7.1.3
     rimraf: 3.0.2
     seedrandom: 3.0.5
-    serializr: 3.0.1
+    serializr: 3.0.2
     typescript: 4.9.4
     uuid: 9.0.0
   languageName: unknown
@@ -3018,7 +3018,7 @@ __metadata:
   dependencies:
     cross-env: 7.0.3
     eslint: 8.29.0
-    postcss: 8.4.19
+    postcss: 8.4.20
     postcss-scss: 4.0.6
     rimraf: 3.0.2
     stylelint-config-prettier: 9.0.4
@@ -4235,10 +4235,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.11.12":
-  version: 18.11.12
-  resolution: "@types/node@npm:18.11.12"
-  checksum: 6c67f0998a9ad8ef0f357fcc0d72841c579576c746cfbac67c9d0229e1cd219d3b96297c2caaeaa4084ba7e9ad112b412e64af4066e522faa0be4ef9ad0a613a
+"@types/node@npm:18.11.13":
+  version: 18.11.13
+  resolution: "@types/node@npm:18.11.13"
+  checksum: b0c1aa3bd2f5df8240e61096a49d6d4be600109b824d23408ec4ba1ec057dc0c60588e09f73b8a60455ad26d367e9c5562fad8403099f885cbc7b4cace83ec4c
   languageName: node
   linkType: hard
 
@@ -10155,7 +10155,7 @@ __metadata:
     "@finos/eslint-plugin-legend-studio": "workspace:*"
     "@finos/legend-dev-utils": "workspace:*"
     "@finos/stylelint-config-legend-studio": "workspace:*"
-    "@types/node": 18.11.12
+    "@types/node": 18.11.13
     chalk: 5.2.0
     cross-env: 7.0.3
     envinfo: 7.8.1
@@ -10173,7 +10173,7 @@ __metadata:
     semver: 7.3.8
     sort-package-json: 2.1.0
     stylelint: 14.16.0
-    typedoc: 0.23.21
+    typedoc: 0.23.22
     typescript: 4.9.4
     yargs: 17.6.2
   languageName: unknown
@@ -12791,7 +12791,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.19, postcss@npm:^8.4.18, postcss@npm:^8.4.19":
+"postcss@npm:8.4.20":
+  version: 8.4.20
+  resolution: "postcss@npm:8.4.20"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 1a5609ea1c1b204f9c2974a0019ae9eef2d99bf645c2c9aac675166c4cb1005be7b5e2ba196160bc771f5d9ac896ed883f236f888c891e835e59d28fff6651aa
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.18, postcss@npm:^8.4.19":
   version: 8.4.19
   resolution: "postcss@npm:8.4.19"
   dependencies:
@@ -14089,10 +14100,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serializr@npm:3.0.1":
-  version: 3.0.1
-  resolution: "serializr@npm:3.0.1"
-  checksum: edfa984ad392be1571ff12f528c9fdda7789bb0f95982610accdc7f76f6ba18a148a8f12befaab4245068b83d6bdf19bde9a2451cd4260f9f5a77cf106cd6f1e
+"serializr@npm:3.0.2":
+  version: 3.0.2
+  resolution: "serializr@npm:3.0.2"
+  checksum: 4276e0418eef9e30aab9557d299f028396e448a2ec8f4838bffb04e757f7d03bc012d85ff5a60e9260fb9cce6f52b6fba80266f5634eece8f48dc3b9f948dfb9
   languageName: node
   linkType: hard
 
@@ -15389,9 +15400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.23.21":
-  version: 0.23.21
-  resolution: "typedoc@npm:0.23.21"
+"typedoc@npm:0.23.22":
+  version: 0.23.22
+  resolution: "typedoc@npm:0.23.22"
   dependencies:
     lunr: ^2.3.9
     marked: ^4.0.19
@@ -15401,7 +15412,7 @@ __metadata:
     typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
   bin:
     typedoc: bin/typedoc
-  checksum: 931520b21ae25ba8ea86111ea7c66f474468bb83cbe1d04c0ea19490f130ea44ba58b7ee4d12f7f02368cfe053ed1fa291c8843c466c8af383ef956de177360d
+  checksum: ac3a015e72d5e2dc6a3a2cca64572932a6d9d0ea26ee08e87c05e2244795087371a12b103f5f4c4f72d006f8893cd4dccd9addfbbce18577e2fb36c9c1d71be4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This contains features that depend on https://github.com/finos/legend-pure/pull/629 - but due to the setup of `Pure IDE`, we have to release these changes first

- [x] `BUG` test-runner display error: sibling packages `meta::abc`, `meta::abcXYZ`, if there's a failure with `meta::abcXYZ::test1`, `meta::abc` will be marked as failure even if all of its child tests pass
- [x] `FANCY` Fix Ctrl + B on enum value
- [x] `FANCY` Search preview (for text-search and alt + f7)
- [x] `FANCY` Add suggestion for copyright header when cursor is on the first line
- [x] `FANCY` Expand concept in tree `Ctrl + Shift + B`
- [x] `BUG` Import suggestion does not work (also fix it so that suggestion is put in the correct line now, previously it was `suggestedLine + 1`)
- [x] Support context menu
- [x] Disallow deleting non-empty folder
- [x] Differentiation for the display of `platform` folder
- [x] Support renaming files
- [x] File editor support more file types, have a generic `FileEditor` and `PureFileEditor`
- [x] `FANCY` Support renaming concept while in text file
- [x] `BUG` Properly display property owner in concept tree (properties from association, properties from inheritance, vs. own properties, vs. qualified properties, consider recoloring association so we can align the coloring?)
- [x] `FANCY` Support find usage from concept explorer tree (non-package nodes only)
- [x] `FANCY` Rename concept / rename property
- [x] `FANCY` Rename package
- [x] `FANCY` Move concepts
- [x] bump dependencies

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

