### PR TITLE
Pure IDE: improve contextual auto-complete/suggestion support

### DIFF
--- a/.changeset/calm-tigers-dance.md
+++ b/.changeset/calm-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application': patch
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-art': patch
+---

--- a/.changeset/chilly-eagles-yawn.md
+++ b/.changeset/chilly-eagles-yawn.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-art': patch
+---

--- a/packages/legend-application-pure-ide/src/components/editor/edit-panel/PureFileEditor.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/edit-panel/PureFileEditor.tsx
@@ -52,6 +52,9 @@ import {
   collectParserElementSnippetSuggestions,
   collectParserKeywordSuggestions,
   getArrowFunctionSuggestions,
+  getAttributeSuggestions,
+  getCastingClassSuggestions,
+  getConstructorClassSuggestions,
   getCopyrightHeaderSuggestions,
   getIdentifierSuggestions,
   getIncompletePathSuggestions,
@@ -151,7 +154,7 @@ export const PureFileEditor = observer(
     const pureConstructSuggestionProviderDisposer = useRef<
       IDisposable | undefined
     >(undefined);
-    const pureAnyIdentifierSuggestionProviderDisposer = useRef<
+    const pureIdentifierSuggestionProviderDisposer = useRef<
       IDisposable | undefined
     >(undefined);
     const textInputRef = useRef<HTMLDivElement>(null);
@@ -372,7 +375,7 @@ export const PureFileEditor = observer(
     pureConstructSuggestionProviderDisposer.current?.dispose();
     pureConstructSuggestionProviderDisposer.current =
       monacoLanguagesAPI.registerCompletionItemProvider(EDITOR_LANGUAGE.PURE, {
-        triggerCharacters: ['#', ':', '>'],
+        triggerCharacters: ['#', ':', '>', '.', '@', '^'],
         provideCompletionItems: async (model, position, context) => {
           let suggestions: monacoLanguagesAPI.CompletionItem[] = [];
 
@@ -411,6 +414,32 @@ export const PureFileEditor = observer(
                 );
                 break;
               }
+              case '.': {
+                suggestions = suggestions.concat(
+                  await getAttributeSuggestions(position, model, editorStore),
+                );
+                break;
+              }
+              case '^': {
+                suggestions = suggestions.concat(
+                  await getConstructorClassSuggestions(
+                    position,
+                    model,
+                    editorStore,
+                  ),
+                );
+                break;
+              }
+              case '@': {
+                suggestions = suggestions.concat(
+                  await getCastingClassSuggestions(
+                    position,
+                    model,
+                    editorStore,
+                  ),
+                );
+                break;
+              }
               default:
                 break;
             }
@@ -420,8 +449,8 @@ export const PureFileEditor = observer(
         },
       });
 
-    pureAnyIdentifierSuggestionProviderDisposer.current?.dispose();
-    pureAnyIdentifierSuggestionProviderDisposer.current =
+    pureIdentifierSuggestionProviderDisposer.current?.dispose();
+    pureIdentifierSuggestionProviderDisposer.current =
       monacoLanguagesAPI.registerCompletionItemProvider(EDITOR_LANGUAGE.PURE, {
         triggerCharacters: [],
         provideCompletionItems: async (model, position, context) => {
@@ -530,7 +559,7 @@ export const PureFileEditor = observer(
         definitionProviderDisposer.current?.dispose();
 
         pureConstructSuggestionProviderDisposer.current?.dispose();
-        pureAnyIdentifierSuggestionProviderDisposer.current?.dispose();
+        pureIdentifierSuggestionProviderDisposer.current?.dispose();
       },
       [editorState, editor],
     );

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/ConceptTreeExplorer.tsx
@@ -39,6 +39,7 @@ import {
   CompressIcon,
   MenuContent,
   MenuContentItem,
+  MenuContentDivider,
 } from '@finos/legend-art';
 import { guaranteeType, isNonNullable } from '@finos/legend-shared';
 import { useDrag } from 'react-dnd';
@@ -57,7 +58,8 @@ const ConceptExplorerContextMenu = observer(
     }
   >(function ConceptExplorerContextMenu(props, ref) {
     const { node, viewConceptSource } = props;
-    const nodeType = node.data.li_attr.pureType;
+    const nodeAttribute = node.data.li_attr;
+    const nodeType = nodeAttribute.pureType;
     const editorStore = useEditorStore();
     const applicationStore = useApplicationStore();
     const renameConcept = (): void =>
@@ -70,7 +72,6 @@ const ConceptExplorerContextMenu = observer(
       );
     };
     const findUsages = (): void => {
-      const nodeAttribute = node.data.li_attr;
       if (
         nodeAttribute instanceof ElementConceptAttribute ||
         nodeAttribute instanceof PropertyConceptAttribute
@@ -87,31 +88,41 @@ const ConceptExplorerContextMenu = observer(
     const viewSource = (): void => viewConceptSource(node);
     const serviceJSON = (): void => {
       window.open(
-        `${editorStore.client.baseUrl}/execute?func=${node.data.li_attr.pureId}&mode=${editorStore.client.mode}`,
+        `${editorStore.client.baseUrl}/execute?func=${nodeAttribute.pureId}&mode=${editorStore.client.mode}`,
         '_blank',
       );
+    };
+    const copyPath = (): void => {
+      applicationStore
+        .copyTextToClipboard(nodeAttribute.pureId)
+        .catch(applicationStore.alertUnhandledError);
     };
 
     return (
       <MenuContent ref={ref}>
-        <MenuContentItem onClick={renameConcept}>Rename</MenuContentItem>
-        {node.data.li_attr instanceof ElementConceptAttribute && (
-          <MenuContentItem onClick={moveElement}>Move</MenuContentItem>
-        )}
+        {nodeAttribute.pureType !== ConceptType.PROPERTY &&
+          nodeAttribute.pureType !== ConceptType.QUALIFIED_PROPERTY && (
+            <MenuContentItem onClick={copyPath}>Copy Path</MenuContentItem>
+          )}
         {nodeType === ConceptType.PACKAGE && (
-          <MenuContentItem onClick={runTests}>Run tests</MenuContentItem>
+          <MenuContentItem onClick={runTests}>Run Tests</MenuContentItem>
         )}
         {nodeType === ConceptType.FUNCTION && (
           <MenuContentItem onClick={serviceJSON}>
             Service (JSON)
           </MenuContentItem>
         )}
-        {(node.data.li_attr instanceof PropertyConceptAttribute ||
-          node.data.li_attr instanceof ElementConceptAttribute) && (
+        {(nodeAttribute instanceof PropertyConceptAttribute ||
+          nodeAttribute instanceof ElementConceptAttribute) && (
           <MenuContentItem onClick={findUsages}>Find Usages</MenuContentItem>
         )}
         {nodeType !== ConceptType.PACKAGE && (
           <MenuContentItem onClick={viewSource}>View Source</MenuContentItem>
+        )}
+        <MenuContentDivider />
+        <MenuContentItem onClick={renameConcept}>Rename</MenuContentItem>
+        {nodeAttribute instanceof ElementConceptAttribute && (
+          <MenuContentItem onClick={moveElement}>Move</MenuContentItem>
         )}
       </MenuContent>
     );

--- a/packages/legend-application-pure-ide/src/components/editor/side-bar/DirectoryTreeExplorer.tsx
+++ b/packages/legend-application-pure-ide/src/components/editor/side-bar/DirectoryTreeExplorer.tsx
@@ -40,6 +40,7 @@ import {
   WrenchIcon,
   MenuContent,
   MenuContentItem,
+  MenuContentDivider,
 } from '@finos/legend-art';
 import { isNonNullable } from '@finos/legend-shared';
 import {
@@ -76,9 +77,16 @@ const FileExplorerContextMenu = observer(
     };
     const renameFile = (): void =>
       editorStore.directoryTreeState.setNodeForRenameFile(node);
+    const copyPath = (): void => {
+      applicationStore
+        .copyTextToClipboard(node.data.li_attr.path)
+        .catch(applicationStore.alertUnhandledError);
+    };
 
     return (
       <MenuContent ref={ref}>
+        <MenuContentItem onClick={copyPath}>Copy Path</MenuContentItem>
+        <MenuContentDivider />
         {isDir && (
           <MenuContentItem onClick={createNewFile}>New File</MenuContentItem>
         )}

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -60,6 +60,37 @@ import type {
   MovePackageableElementsInput,
 } from './models/MovePackageableElements.js';
 
+const AUTO_IMPORT_PACKAGES = [
+  'meta::pure::metamodel',
+  'meta::pure::metamodel::type',
+  'meta::pure::metamodel::type::generics',
+  'meta::pure::metamodel::relationship',
+  'meta::pure::metamodel::valuespecification',
+  'meta::pure::metamodel::multiplicity',
+  'meta::pure::metamodel::function',
+  'meta::pure::metamodel::function::property',
+  'meta::pure::metamodel::extension',
+  'meta::pure::metamodel::import',
+  'meta::pure::functions::date',
+  'meta::pure::functions::string',
+  'meta::pure::functions::collection',
+  'meta::pure::functions::meta',
+  'meta::pure::functions::constraints',
+  'meta::pure::functions::lang',
+  'meta::pure::functions::boolean',
+  'meta::pure::functions::tools',
+  'meta::pure::functions::io',
+  'meta::pure::functions::math',
+  'meta::pure::functions::asserts',
+  'meta::pure::functions::test',
+  'meta::pure::functions::multiplicity',
+  'meta::pure::router',
+  'meta::pure::service',
+  'meta::pure::tds',
+  'meta::pure::tools',
+  'meta::pure::profiles',
+];
+
 export class PureClient {
   private networkClient: NetworkClient;
 
@@ -128,6 +159,17 @@ export class PureClient {
     this.networkClient.get(`${this.baseUrl}/execute`, undefined, undefined, {
       func: 'meta::pure::ide::display_ide(String[1]):String[1]',
       param: path ? `'${path}'` : "'::'",
+      format: 'raw',
+      mode: this.mode,
+      sessionId: this.sessionId,
+    });
+
+  getConceptsChildren = (
+    paths: string[],
+  ): Promise<PlainObject<ConceptNode>[]> =>
+    this.networkClient.get(`${this.baseUrl}/execute`, undefined, undefined, {
+      func: 'meta::pure::ide::display_ide_multiple(String[1]):String[1]',
+      param: `'${[...paths, ...AUTO_IMPORT_PACKAGES].join(',')}'`,
       format: 'raw',
       mode: this.mode,
       sessionId: this.sessionId,

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -59,7 +59,11 @@ import type {
   ChildPackageableElementInfo,
   MovePackageableElementsInput,
 } from './models/MovePackageableElements.js';
-import type { ElementSuggestion } from './models/Suggestion.js';
+import type {
+  AttributeSuggestion,
+  ClassSuggestion,
+  ElementSuggestion,
+} from './models/Suggestion.js';
 
 export class PureClient {
   private networkClient: NetworkClient;
@@ -405,10 +409,12 @@ export class PureClient {
   // ------------------------------------------- Suggestion -------------------------------------------
 
   getSuggestionsForIncompletePath = (
-    currentPath: string,
+    currentPackagePath: string,
+    types: string[],
   ): Promise<PlainObject<ElementSuggestion>[]> =>
     this.networkClient.post(`${this.baseUrl}/suggestion/incompletePath`, {
-      path: currentPath,
+      path: currentPackagePath,
+      types,
     });
 
   getSuggestionsForIdentifier = (
@@ -423,9 +429,18 @@ export class PureClient {
   getSuggestionsForAttribute = (
     importPaths: string[],
     path: string,
-  ): Promise<PlainObject<ElementSuggestion>[]> =>
+  ): Promise<PlainObject<AttributeSuggestion>[]> =>
     this.networkClient.post(`${this.baseUrl}/suggestion/attribute`, {
       importPaths,
       path,
+    });
+
+  getSuggestionsForClass = (
+    importPaths: string[],
+    packagePath: string | undefined,
+  ): Promise<PlainObject<ClassSuggestion>[]> =>
+    this.networkClient.post(`${this.baseUrl}/suggestion/attribute`, {
+      importPaths,
+      packagePath,
     });
 }

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -437,10 +437,8 @@ export class PureClient {
 
   getSuggestionsForClass = (
     importPaths: string[],
-    packagePath: string | undefined,
   ): Promise<PlainObject<ClassSuggestion>[]> =>
     this.networkClient.post(`${this.baseUrl}/suggestion/class`, {
       importPaths,
-      packagePath,
     });
 }

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -59,37 +59,7 @@ import type {
   ChildPackageableElementInfo,
   MovePackageableElementsInput,
 } from './models/MovePackageableElements.js';
-
-const AUTO_IMPORT_PACKAGES = [
-  'meta::pure::metamodel',
-  'meta::pure::metamodel::type',
-  'meta::pure::metamodel::type::generics',
-  'meta::pure::metamodel::relationship',
-  'meta::pure::metamodel::valuespecification',
-  'meta::pure::metamodel::multiplicity',
-  'meta::pure::metamodel::function',
-  'meta::pure::metamodel::function::property',
-  'meta::pure::metamodel::extension',
-  'meta::pure::metamodel::import',
-  'meta::pure::functions::date',
-  'meta::pure::functions::string',
-  'meta::pure::functions::collection',
-  'meta::pure::functions::meta',
-  'meta::pure::functions::constraints',
-  'meta::pure::functions::lang',
-  'meta::pure::functions::boolean',
-  'meta::pure::functions::tools',
-  'meta::pure::functions::io',
-  'meta::pure::functions::math',
-  'meta::pure::functions::asserts',
-  'meta::pure::functions::test',
-  'meta::pure::functions::multiplicity',
-  'meta::pure::router',
-  'meta::pure::service',
-  'meta::pure::tds',
-  'meta::pure::tools',
-  'meta::pure::profiles',
-];
+import type { ElementSuggestion } from './models/Suggestion.js';
 
 export class PureClient {
   private networkClient: NetworkClient;
@@ -134,47 +104,6 @@ export class PureClient {
       },
     );
 
-  getFile = (path: string): Promise<PlainObject<File>> =>
-    this.networkClient.get(
-      `${this.baseUrl}/fileAsJson/${path}`,
-      undefined,
-      undefined,
-      {
-        sessionId: this.sessionId,
-        mode: this.mode,
-        fastCompile: this.compilerMode,
-      },
-    );
-
-  getDirectoryChildren = (
-    path?: string,
-  ): Promise<PlainObject<DirectoryNode>[]> =>
-    this.networkClient.get(`${this.baseUrl}/dir`, undefined, undefined, {
-      parameters: path ?? '/',
-      mode: this.mode,
-      sessionId: this.sessionId,
-    });
-
-  getConceptChildren = (path?: string): Promise<PlainObject<ConceptNode>[]> =>
-    this.networkClient.get(`${this.baseUrl}/execute`, undefined, undefined, {
-      func: 'meta::pure::ide::display_ide(String[1]):String[1]',
-      param: path ? `'${path}'` : "'::'",
-      format: 'raw',
-      mode: this.mode,
-      sessionId: this.sessionId,
-    });
-
-  getConceptsChildren = (
-    paths: string[],
-  ): Promise<PlainObject<ConceptNode>[]> =>
-    this.networkClient.get(`${this.baseUrl}/execute`, undefined, undefined, {
-      func: 'meta::pure::ide::display_ide_multiple(String[1]):String[1]',
-      param: `'${[...paths, ...AUTO_IMPORT_PACKAGES].join(',')}'`,
-      format: 'raw',
-      mode: this.mode,
-      sessionId: this.sessionId,
-    });
-
   getConceptActivity = (): Promise<PlainObject<ConceptActivity>> =>
     this.networkClient.get(
       `${this.baseUrl}/conceptsActivity`,
@@ -215,6 +144,8 @@ export class PureClient {
       },
     );
 
+  // ------------------------------------------- Search -------------------------------------------
+
   findFiles = (searchText: string, isRegExp: boolean): Promise<string[]> =>
     this.networkClient.get(
       `${this.baseUrl}/findPureFiles`,
@@ -252,6 +183,8 @@ export class PureClient {
       coordinates,
     );
 
+  // ------------------------------------------- Test -------------------------------------------
+
   checkTestRunner = (
     testRunnerId: number,
   ): Promise<PlainObject<AbstractTestRunnerCheckResult>> =>
@@ -275,6 +208,17 @@ export class PureClient {
         testRunnerId,
       },
     );
+
+  // ------------------------------------------- Concept -------------------------------------------
+
+  getConceptChildren = (path?: string): Promise<PlainObject<ConceptNode>[]> =>
+    this.networkClient.get(`${this.baseUrl}/execute`, undefined, undefined, {
+      func: 'meta::pure::ide::display_ide(String[1]):String[1]',
+      param: path ? `'${path}'` : "'::'",
+      format: 'raw',
+      mode: this.mode,
+      sessionId: this.sessionId,
+    });
 
   getConceptInfo = (
     file: string,
@@ -348,6 +292,29 @@ export class PureClient {
     );
   };
 
+  // ------------------------------------------- IO / File Management -------------------------------------------
+
+  getFile = (path: string): Promise<PlainObject<File>> =>
+    this.networkClient.get(
+      `${this.baseUrl}/fileAsJson/${path}`,
+      undefined,
+      undefined,
+      {
+        sessionId: this.sessionId,
+        mode: this.mode,
+        fastCompile: this.compilerMode,
+      },
+    );
+
+  getDirectoryChildren = (
+    path?: string,
+  ): Promise<PlainObject<DirectoryNode>[]> =>
+    this.networkClient.get(`${this.baseUrl}/dir`, undefined, undefined, {
+      parameters: path ?? '/',
+      mode: this.mode,
+      sessionId: this.sessionId,
+    });
+
   updateSource = (
     updateInputs: UpdateSourceInput[],
   ): Promise<PlainObject<SourceModificationResult>> =>
@@ -403,6 +370,8 @@ export class PureClient {
       },
     );
 
+  // ------------------------------------------- Diagram -------------------------------------------
+
   getDiagramInfo = async (
     diagramPath: string,
   ): Promise<PlainObject<DiagramInfo>> =>
@@ -432,4 +401,31 @@ export class PureClient {
         },
       ),
     );
+
+  // ------------------------------------------- Suggestion -------------------------------------------
+
+  getSuggestionsForIncompletePath = (
+    currentPath: string,
+  ): Promise<PlainObject<ElementSuggestion>[]> =>
+    this.networkClient.post(`${this.baseUrl}/suggestion/incompletePath`, {
+      path: currentPath,
+    });
+
+  getSuggestionsForIdentifier = (
+    importPaths: string[],
+    types: string[],
+  ): Promise<PlainObject<ElementSuggestion>[]> =>
+    this.networkClient.post(`${this.baseUrl}/suggestion/identifier`, {
+      importPaths,
+      types,
+    });
+
+  getSuggestionsForAttribute = (
+    importPaths: string[],
+    path: string,
+  ): Promise<PlainObject<ElementSuggestion>[]> =>
+    this.networkClient.post(`${this.baseUrl}/suggestion/attribute`, {
+      importPaths,
+      path,
+    });
 }

--- a/packages/legend-application-pure-ide/src/server/PureServerClient.ts
+++ b/packages/legend-application-pure-ide/src/server/PureServerClient.ts
@@ -439,7 +439,7 @@ export class PureClient {
     importPaths: string[],
     packagePath: string | undefined,
   ): Promise<PlainObject<ClassSuggestion>[]> =>
-    this.networkClient.post(`${this.baseUrl}/suggestion/attribute`, {
+    this.networkClient.post(`${this.baseUrl}/suggestion/class`, {
       importPaths,
       packagePath,
     });

--- a/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
+++ b/packages/legend-application-pure-ide/src/server/models/ConceptTree.ts
@@ -30,6 +30,8 @@ export enum ConceptType {
   // PRIMITIVE = 'Primitive',
   PACKAGE = 'Package',
   PROFILE = 'Profile',
+  TAG = 'Tag',
+  STEREOTYPE = 'Stereotype',
   CLASS = 'Class',
   ASSOCIATION = 'Association',
   PROPERTY = 'Property',

--- a/packages/legend-application-pure-ide/src/server/models/Suggestion.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Suggestion.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createModelSchema, primitive } from 'serializr';
+
+export class ElementSuggestion {
+  pureType!: string;
+  pureName!: string;
+  text!: string;
+}
+
+createModelSchema(ElementSuggestion, {
+  pureType: primitive(),
+  pureName: primitive(),
+  text: primitive(),
+});

--- a/packages/legend-application-pure-ide/src/server/models/Suggestion.ts
+++ b/packages/legend-application-pure-ide/src/server/models/Suggestion.ts
@@ -14,16 +14,46 @@
  * limitations under the License.
  */
 
-import { createModelSchema, primitive } from 'serializr';
+import { createModelSchema, list, optional, primitive } from 'serializr';
 
 export class ElementSuggestion {
   pureType!: string;
+  pureId!: string;
   pureName!: string;
   text!: string;
+  requiredClassProperties: string[] = [];
 }
 
 createModelSchema(ElementSuggestion, {
   pureType: primitive(),
+  pureId: primitive(),
   pureName: primitive(),
   text: primitive(),
+  requiredClassProperties: optional(list(primitive())),
+});
+
+export class AttributeSuggestion {
+  pureType!: string;
+  pureName!: string;
+  owner!: string;
+  ownerPureType!: string;
+}
+
+createModelSchema(AttributeSuggestion, {
+  pureType: primitive(),
+  pureName: primitive(),
+  owner: primitive(),
+  ownerPureType: primitive(),
+});
+
+export class ClassSuggestion {
+  pureId!: string;
+  pureName!: string;
+  requiredClassProperties: string[] = [];
+}
+
+createModelSchema(ClassSuggestion, {
+  pureId: primitive(),
+  pureName: primitive(),
+  requiredClassProperties: optional(list(primitive())),
 });

--- a/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
@@ -117,6 +117,7 @@ class FileTextEditorState {
       fileEditorState.uuid,
       this.language,
     );
+    this.model.setValue(fileEditorState.file.content);
   }
 
   // trigger for the manual observer of editor cursor
@@ -233,6 +234,7 @@ export class FileEditorState
 
   setFile(val: File): void {
     this.file = val;
+    this.textEditorState.model.setValue(val.content);
   }
 
   setShowGoToLinePrompt(val: boolean): void {

--- a/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
+++ b/packages/legend-application-pure-ide/src/stores/FileEditorState.ts
@@ -17,7 +17,6 @@
 import {
   type CommandRegistrar,
   EDITOR_LANGUAGE,
-  TAB_SIZE,
   type TabState,
 } from '@finos/legend-application';
 import {
@@ -118,7 +117,6 @@ class FileTextEditorState {
       fileEditorState.uuid,
       this.language,
     );
-    this.model.updateOptions({ tabSize: TAB_SIZE });
   }
 
   // trigger for the manual observer of editor cursor

--- a/packages/legend-application-pure-ide/src/stores/PureFileEditorUtils.ts
+++ b/packages/legend-application-pure-ide/src/stores/PureFileEditorUtils.ts
@@ -205,6 +205,11 @@ export const collectExtraInlineSnippetSuggestions =
       description: '(io)',
       insertText: `println(\${1:})`,
     },
+    {
+      text: 'NULL',
+      description: '(nullish value)',
+      insertText: `[]`,
+    },
   ];
 
 export const getCopyrightHeaderSuggestions =

--- a/packages/legend-application/src/stores/PureLanguageSupport.ts
+++ b/packages/legend-application/src/stores/PureLanguageSupport.ts
@@ -252,7 +252,7 @@ const generateLanguageMonarch = (
     octaldigits: /[0-7]+(_+[0-7]+)*/,
     binarydigits: /[0-1]+(_+[0-1]+)*/,
     hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
-    multiplicity: /\[(?:\d+(?:\.\.(?:\d+|\*|))?|\*)\]/,
+    multiplicity: /\[(?:[a-zA-Z0-9]+(?:\.\.(?:[a-zA-Z0-9]+|\*|))?|\*)\]/,
     package: /(?:[\w_]+::)+/,
     generics: /<.+>/,
     date: /%-?\d+(?:-\d+(?:-\d+(?:T(?:\d+(?::\d+(?::\d+(?:.\d+)?)?)?)(?:[+-][0-9]{4})?)))/,

--- a/packages/legend-application/src/stores/PureLanguageSupport.ts
+++ b/packages/legend-application/src/stores/PureLanguageSupport.ts
@@ -351,9 +351,10 @@ const generateLanguageMonarch = (
 
         // special operators that uses type (e.g. constructor, cast)
         [
-          /([@^])(?:\s*)(@package?)(@identifier)(@generics?)(@multiplicity?)/,
+          /([@^])(\s*)(@package?)(@identifier)(@generics?)(@multiplicity?)/,
           [
             `${PURE_GRAMMAR_TOKEN.TYPE}.operator`,
+            PURE_GRAMMAR_TOKEN.WHITESPACE,
             PURE_GRAMMAR_TOKEN.PACKAGE,
             PURE_GRAMMAR_TOKEN.TYPE,
             PURE_GRAMMAR_TOKEN.GENERICS,

--- a/packages/legend-art/src/utils/TextEditorUtils.ts
+++ b/packages/legend-art/src/utils/TextEditorUtils.ts
@@ -57,29 +57,32 @@ export const getEditorValue = (
   editor.getModel()?.getValue(monacoEditorAPI.EndOfLinePreference.LF) ?? '';
 
 export const getBaseTextEditorOptions =
-  (): monacoEditorAPI.IStandaloneEditorConstructionOptions => ({
-    contextmenu: false,
-    copyWithSyntaxHighlighting: false,
-    // NOTE: These following font options are needed (and CSS font-size option `.monaco-editor * { font-size: ... }` as well)
-    // in order to make the editor appear properly on multiple platform, the ligatures option is needed for Mac to display properly
-    // otherwise the cursor position relatively to text would be off
-    // Another potential cause for this misaligment is that the fonts are being lazy-loaded and made available after `monaco-editor`
-    // calculated the font-width, for this, we can use `remeasureFonts`, but our case here, `fontLigatures: true` seems
-    // to do the trick
-    // See https://github.com/microsoft/monaco-editor/issues/392
-    fontSize: 14,
-    // Enforce a fixed font-family to make cross platform display consistent (i.e. Mac defaults to use `Menlo` which is bigger than
-    // `Consolas` on Windows, etc.)
-    fontFamily: 'Roboto Mono',
-    // Enable font ligature: glyphs which combine the shapes of certain sequences of characters into a new form that makes for
-    //  a more harmonious reading experience.
-    fontLigatures: true,
-    // Make sure hover or widget shown near boundary are not truncated by setting their position to `fixed`
-    fixedOverflowWidgets: true,
-    bracketPairColorization: { enabled: false }, // turn off initial bracket pair coloring
-    detectIndentation: false, // i.e. so we can force tab-size
-    tabSize: 2,
-  });
+  (): monacoEditorAPI.IStandaloneEditorConstructionOptions =>
+    ({
+      contextmenu: false,
+      copyWithSyntaxHighlighting: false,
+      // NOTE: These following font options are needed (and CSS font-size option `.monaco-editor * { font-size: ... }` as well)
+      // in order to make the editor appear properly on multiple platform, the ligatures option is needed for Mac to display properly
+      // otherwise the cursor position relatively to text would be off
+      // Another potential cause for this misaligment is that the fonts are being lazy-loaded and made available after `monaco-editor`
+      // calculated the font-width, for this, we can use `remeasureFonts`, but our case here, `fontLigatures: true` seems
+      // to do the trick
+      // See https://github.com/microsoft/monaco-editor/issues/392
+      fontSize: 14,
+      // Enforce a fixed font-family to make cross platform display consistent (i.e. Mac defaults to use `Menlo` which is bigger than
+      // `Consolas` on Windows, etc.)
+      fontFamily: 'Roboto Mono',
+      // Enable font ligature: glyphs which combine the shapes of certain sequences of characters into a new form that makes for
+      //  a more harmonious reading experience.
+      fontLigatures: true,
+      // Make sure hover or widget shown near boundary are not truncated by setting their position to `fixed`
+      fixedOverflowWidgets: true,
+      detectIndentation: false, // i.e. so we can force tab-size
+      tabSize: 2,
+      // The typing is currently not correct for `bracketPairColorization`, until this is fixed, we will remove the cast
+      // See https://github.com/microsoft/monaco-editor/issues/3013
+      'bracketPairColorization.enabled': false,
+    } as monacoEditorAPI.IStandaloneEditorConstructionOptions);
 
 export const moveCursorToPosition = (
   editor: monacoEditorAPI.ICodeEditor,

--- a/packages/legend-art/style/reset/_react-reflex.scss
+++ b/packages/legend-art/style/reset/_react-reflex.scss
@@ -65,7 +65,7 @@
 .reflex-container > .reflex-splitter {
   background: transparent;
   position: relative;
-  z-index: 100;
+  z-index: 1;
 }
 
 .horizontal > .reflex-splitter {


### PR DESCRIPTION
## Summary

- [x] Support auto complete:
  - [x] `->` function: function will account for all parameters - 1 (due to arrow form)
  - [x] identifier: function will account for all parameters
  - [x] attribute `.` form
  - [x] constructor: `^` and `@` casting, for constructor, support laying out the required properties
- [x] Allow copy element node path - particularly useful for function can also allow copy path for package node
- [x] Allow copying file/folder path in explorer tree

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)
