### PR TITLE
Fix a bug with unable to open file generation tree data after hitting F10

### DIFF
--- a/.changeset/cuddly-bobcats-dance.md
+++ b/.changeset/cuddly-bobcats-dance.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Fix a bug with unable to open file generation tree data after hitting F10

--- a/packages/legend-application-studio/src/stores/editor-state/GraphGenerationState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/GraphGenerationState.ts
@@ -41,6 +41,7 @@ import {
   populateDirectoryTreeNodeChildren,
   buildGenerationDirectory,
   reprocessOpenNodes,
+  getGenerationTreeData,
 } from '../shared/FileGenerationTreeUtils.js';
 import type { TreeData } from '@finos/legend-art';
 import type { EditorStore } from '../EditorStore.js';
@@ -65,6 +66,7 @@ import {
   generationSpecification_addFileGeneration,
   generationSpecification_addGenerationElement,
 } from '../shared/modifier/DSL_Generation_GraphModifierHelper.js';
+import { ExplorerTreeRootPackageLabel } from '../ExplorerTreeState.js';
 
 export const DEFAULT_GENERATION_SPECIFICATION_NAME =
   'MyGenerationSpecification';
@@ -443,6 +445,13 @@ export class GraphGenerationState {
       this.rootFileDirectory,
       generationResultIndex,
       this.filesIndex,
+    );
+    // after building root directory set the generation tree data
+    this.editorStore.graphState.editorStore.explorerTreeState.setFileGenerationTreeData(
+      getGenerationTreeData(
+        this.editorStore.graphState.graphGenerationState.rootFileDirectory,
+        ExplorerTreeRootPackageLabel.FILE_GENERATION,
+      ),
     );
     this.editorStore.graphState.editorStore.explorerTreeState.setFileGenerationTreeData(
       this.reprocessNodeTree(


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

When we generate file generation tree by fitting F10 we are unable to expand the tree. The reason being we never set the tree after we generate those files. So setting file generation tree data after we build the root directory for file generation.
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


https://user-images.githubusercontent.com/87973126/208396847-ca4dc252-204c-415d-b5ed-50d380e8d096.mp4


<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
