### PR TITLE
Wrap text by default when users go to text mode

### DIFF
--- a/.changeset/unlucky-scissors-switch.md
+++ b/.changeset/unlucky-scissors-switch.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application-studio': patch
+---

--- a/packages/legend-application-studio/src/stores/editor-state/GrammarTextEditorState.ts
+++ b/packages/legend-application-studio/src/stores/editor-state/GrammarTextEditorState.ts
@@ -63,7 +63,7 @@ export class GrammarTextEditorState {
 
   graphGrammarText = '';
   currentElementLabelRegexString?: string | undefined;
-  wrapText = false;
+  wrapText = true;
   forcedCursorPosition?: TextEditorPosition | undefined;
 
   constructor(editorStore: EditorStore) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

https://user-images.githubusercontent.com/87973126/214066559-8c135052-3ec6-4c4b-88e2-6a51af24de5c.mp4



<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
