### PR TITLE
loading indicator for query and css fixes for query

### DIFF
--- a/.changeset/gullible-gulls-goad.md
+++ b/.changeset/gullible-gulls-goad.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Add loading indicator for when user closes text-mode query and fixes flickering blank panels [#1853](https://github.com/finos/legend-studio/issues/1853)

--- a/.changeset/tyrannical-terns-threaten.md
+++ b/.changeset/tyrannical-terns-threaten.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-art': patch
+---
+
+Add loading icon.

--- a/packages/legend-art/src/components/LoadingIcon.tsx
+++ b/packages/legend-art/src/components/LoadingIcon.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { clsx } from 'clsx';
+import { RefreshIcon } from './CJS__Icon.cjs';
+
+export const LoadingIcon: React.FC<{
+  isLoading: boolean;
+}> = (props) => {
+  const { isLoading } = props;
+  return (
+    <div className={clsx({ 'loading-icon__container--spinning': isLoading })}>
+      <RefreshIcon />
+    </div>
+  );
+};

--- a/packages/legend-art/src/components/panel/BlankPanelPlaceholder.tsx
+++ b/packages/legend-art/src/components/panel/BlankPanelPlaceholder.tsx
@@ -135,8 +135,8 @@ export const BlankPanelPlaceholder: React.FC<{
   useEffect(() => {
     const _containerWidth = containerWidth ?? 0;
     const _containerHeight = containerHeight ?? 0;
-    const _textWidth = textWidth ?? 0;
-    const _textHeight = textHeight ?? 0;
+    const _textWidth = textWidth ? textWidth : DEFAULT_CONTENT_PADDING;
+    const _textHeight = textHeight ? textHeight : DEFAULT_CONTENT_PADDING;
     const _graphicWidth = graphicWidth ?? 0;
     const _graphicHeight = graphicHeight ?? 0;
     setShowText(

--- a/packages/legend-art/src/components/panel/Panel.tsx
+++ b/packages/legend-art/src/components/panel/Panel.tsx
@@ -150,6 +150,7 @@ export const PanelFormTextField = forwardRef<
     errorMessage?: string | undefined;
     isReadOnly?: boolean;
     className?: string | undefined;
+    inputType?: string | undefined;
     darkMode?: boolean;
     fullWidth?: boolean;
   }
@@ -165,6 +166,7 @@ export const PanelFormTextField = forwardRef<
     className,
     darkMode,
     fullWidth,
+    inputType,
   } = props;
   const displayValue = value ?? '';
   const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -190,6 +192,7 @@ export const PanelFormTextField = forwardRef<
             { 'input--small': !fullWidth },
           )}
           ref={ref}
+          type={inputType ? inputType : 'text'}
           spellCheck={false}
           disabled={isReadOnly}
           placeholder={placeholder}

--- a/packages/legend-art/src/index.ts
+++ b/packages/legend-art/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/CJS__Fuse.cjs';
 
 export * from './components/CJS__Icon.cjs';
 export * from './components/TypeIcon.js';
+export * from './components/LoadingIcon.js';
 export * from './components/Input.js';
 export * from './components/LegendLogo.js';
 export * from './components/TreeView.js';

--- a/packages/legend-art/style/components/_icon.scss
+++ b/packages/legend-art/style/components/_icon.scss
@@ -49,3 +49,8 @@
   font-family: 'Roboto Monospaced', sans-serif;
   font-size: 1.6rem;
 }
+
+.loading-icon__container--spinning svg {
+  animation: spin 1s infinite ease;
+  margin-right: 0.5rem;
+}

--- a/packages/legend-query-builder/src/components/QueryBuilderConstantExpressionPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderConstantExpressionPanel.tsx
@@ -271,7 +271,7 @@ export const QueryBuilderConstantExpressionPanel = observer(
               ))}
             {!constantState.constants.length && (
               <BlankPanelPlaceholder
-                text="Add a Constants"
+                text="Add a Constant"
                 disabled={isReadOnly}
                 onClick={addConstant}
                 clickActionType="add"

--- a/packages/legend-query-builder/src/components/QueryBuilderTextEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderTextEditor.tsx
@@ -19,10 +19,12 @@ import { observer } from 'mobx-react-lite';
 import {
   clsx,
   Dialog,
+  LoadingIcon,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
+  PanelLoadingIndicator,
 } from '@finos/legend-art';
 import type { QueryBuilderState } from '../stores/QueryBuilderState.js';
 import { QueryBuilderTextEditorMode } from '../stores/QueryBuilderTextEditorState.js';
@@ -80,6 +82,11 @@ export const QueryBuilderTextEditor = observer(
               </div>
             )}
           </ModalHeader>
+          <PanelLoadingIndicator
+            isLoading={
+              queryBuilderState.textEditorState.closingQueryState.isInProgress
+            }
+          />
           <ModalBody>
             <div
               className={clsx('query-builder-text-mode__modal__content', {
@@ -119,9 +126,19 @@ export const QueryBuilderTextEditor = observer(
             <button
               className="btn btn--dark"
               onClick={close}
-              disabled={Boolean(queryTextEditorState.parserError)}
+              disabled={
+                Boolean(queryTextEditorState.parserError) ||
+                queryBuilderState.textEditorState.closingQueryState.isInProgress
+              }
             >
-              Close
+              {queryBuilderState.textEditorState.closingQueryState
+                .isInProgress ? (
+                <>
+                  <LoadingIcon isLoading={true} /> Closing
+                </>
+              ) : (
+                <> Close </>
+              )}
             </button>
           </ModalFooter>
         </Modal>

--- a/packages/legend-query-builder/src/stores/QueryBuilderTextEditorState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderTextEditorState.ts
@@ -26,6 +26,7 @@ import {
   type GeneratorFn,
   assertErrorThrown,
   LogEvent,
+  ActionState,
 } from '@finos/legend-shared';
 import { observable, action, flow, makeObservable, flowResult } from 'mobx';
 import type { QueryBuilderState } from './QueryBuilderState.js';
@@ -59,6 +60,8 @@ export class QueryBuilderTextEditorState extends LambdaEditorState {
   rawLambdaState: QueryBuilderRawLambdaState;
   isConvertingLambdaToString = false;
   mode: QueryBuilderTextEditorMode | undefined;
+  closingQueryState = ActionState.create();
+
   /**
    * This is used to store the JSON string when viewing the query in JSON mode
    * TODO: consider moving this to another state if we need to simplify the logic of text-mode
@@ -187,6 +190,7 @@ export class QueryBuilderTextEditorState extends LambdaEditorState {
   }
 
   *closeModal(): GeneratorFn<void> {
+    this.closingQueryState.inProgress();
     if (this.mode === QueryBuilderTextEditorMode.TEXT) {
       yield flowResult(this.convertLambdaGrammarStringToObject());
       if (this.parserError) {
@@ -199,6 +203,8 @@ export class QueryBuilderTextEditorState extends LambdaEditorState {
       }
       return;
     }
+    this.closingQueryState.complete();
+
     this.setMode(undefined);
   }
 }

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -172,7 +172,7 @@
     }
 
     &__info {
-      @include flexVCenter;
+      @include flexCenter;
 
       cursor: help;
       height: 2rem;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

fixes #1853 
## Summary

- [x] Upon leaving text mode in query and clicking close, user gets no feedback from the screen so there should be a loading indicator of some sort so user does not repeatedly click.
             (Adds spinning icon/disabled button when user presses close as well as a panel loading indicator sign. )
![Kapture 2023-01-29 at 14 01 52](https://user-images.githubusercontent.com/41248956/215350955-ce512a0c-db07-4469-be80-30b77638d7cf.gif)
- [x] Fixes flickering of blank panels
- [x] Aligns value indicator info icons to center for consistent margins
<img width="609" alt="image" src="https://user-images.githubusercontent.com/41248956/215351023-542a813f-3f7c-4cc2-b16d-9747b3d4c520.png">

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
       _No testing because these are stylistic css changes/fixes_
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
