### PR TITLE
Query builder fixes

### DIFF
--- a/.changeset/fluffy-bottles-sort.md
+++ b/.changeset/fluffy-bottles-sort.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Display name of query upon loading query builder.

--- a/.changeset/modern-worms-relax.md
+++ b/.changeset/modern-worms-relax.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Only show parameter types that match derived property types, and show humanized version of date::adjust functions.

--- a/packages/legend-application-query/src/stores/QueryEditorStore.ts
+++ b/packages/legend-application-query/src/stores/QueryEditorStore.ts
@@ -783,6 +783,7 @@ export class ExistingQueryEditorStore extends QueryEditorStore {
       },
     );
 
+    queryBuilderState.setTitleOfQuery(this.query.name);
     return queryBuilderState;
   }
 

--- a/packages/legend-query-builder/src/components/QueryBuilder.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilder.tsx
@@ -370,6 +370,12 @@ export const QueryBuilder = observer(
                 )}
               </div>
               <div className="query-builder__sub-header__content__actions">
+                <div
+                  title="Query title"
+                  className="query-builder__sub-header__query__title"
+                >
+                  {queryBuilderState.titleOfQuery}
+                </div>
                 <div className="query-builder__sub-header__actions">
                   <DropdownMenu
                     className="query-builder__sub-header__custom-action"

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -71,12 +71,16 @@ const VariableExpressionEditor = observer(
     const { queryBuilderState, lambdaParameterState } = props;
     const applicationStore = useApplicationStore();
     const queryParametersState = queryBuilderState.parametersState;
+    const allVariableNames = queryBuilderState.allVariableNames;
     const isCreating =
       !queryParametersState.parameterStates.includes(lambdaParameterState);
     const varState = lambdaParameterState.parameter;
     const multiplity = varState.multiplicity;
     const validationMessage = !varState.name
       ? `Parameter name can't be empty`
+      : allVariableNames.filter((e) => e === varState.name).length >
+        (isCreating ? 0 : 1)
+      ? 'Parameter Name Already Exists'
       : (isCreating &&
           queryParametersState.parameterStates.find(
             (p) => p.parameter.name === varState.name,

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -304,7 +304,25 @@ export const QueryBuilderPropertyExpressionEditor = observer(
     const { propertyExpressionState } = props;
     const handleClose = (): void =>
       propertyExpressionState.setIsEditingDerivedProperty(false);
-
+    const isParameterCompatibleWithDerivedProperty = (
+      variable: VariableExpression,
+      derivedProperties: QueryBuilderDerivedPropertyExpressionState[],
+    ): boolean => {
+      const sameType = derivedProperties.find((dp) => {
+        if (!variable.genericType?.value.rawType) {
+          return false;
+        }
+        return (
+          isSuperType(
+            dp.derivedProperty.genericType.value.rawType,
+            variable.genericType.value.rawType,
+          ) ||
+          dp.derivedProperty.genericType.value.rawType.name ===
+            variable.genericType.value.rawType.name
+        );
+      });
+      return sameType !== undefined;
+    };
     return (
       <Dialog
         open={Boolean(
@@ -334,8 +352,11 @@ export const QueryBuilderPropertyExpressionEditor = observer(
             <ModalBody className="query-builder__variables__modal__body">
               <VariableSelector
                 queryBuilderState={propertyExpressionState.queryBuilderState}
-                derivedProperties={
-                  propertyExpressionState.derivedPropertyExpressionStates
+                filterBy={(v: VariableExpression) =>
+                  isParameterCompatibleWithDerivedProperty(
+                    v,
+                    propertyExpressionState.derivedPropertyExpressionStates,
+                  )
                 }
               />
             </ModalBody>

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -307,22 +307,22 @@ export const QueryBuilderPropertyExpressionEditor = observer(
     const isParameterCompatibleWithDerivedProperty = (
       variable: VariableExpression,
       derivedProperties: QueryBuilderDerivedPropertyExpressionState[],
-    ): boolean => {
-      const sameType = derivedProperties.find((dp) => {
-        if (!variable.genericType?.value.rawType) {
-          return false;
-        }
-        return (
-          isSuperType(
-            dp.derivedProperty.genericType.value.rawType,
-            variable.genericType.value.rawType,
-          ) ||
-          dp.derivedProperty.genericType.value.rawType.name ===
-            variable.genericType.value.rawType.name
-        );
-      });
-      return sameType !== undefined;
-    };
+    ): boolean =>
+      Boolean(
+        derivedProperties.find((dp) => {
+          if (!variable.genericType?.value.rawType) {
+            return false;
+          }
+          return (
+            isSuperType(
+              dp.derivedProperty.genericType.value.rawType,
+              variable.genericType.value.rawType,
+            ) ||
+            dp.derivedProperty.genericType.value.rawType.name ===
+              variable.genericType.value.rawType.name
+          );
+        }),
+      );
     return (
       <Dialog
         open={Boolean(

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -334,6 +334,9 @@ export const QueryBuilderPropertyExpressionEditor = observer(
             <ModalBody className="query-builder__variables__modal__body">
               <VariableSelector
                 queryBuilderState={propertyExpressionState.queryBuilderState}
+                derivedProperties={
+                  propertyExpressionState.derivedPropertyExpressionStates
+                }
               />
             </ModalBody>
           </ModalBody>

--- a/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
+++ b/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
@@ -594,7 +594,7 @@ const buildCustomDateOptionReferenceMomentValue = (
  * Build CustomDateOption based on the pure date adjust() function.
  * Transform CustomDateOption if it matches any preserved custom adjust date functions. e.g. One Month Ago..
  */
-const buildCustomDateOption = (
+export const buildCustomDateOption = (
   valueSpecification: SimpleFunctionExpression | PrimitiveInstanceValue,
 ): CustomDateOption => {
   if (

--- a/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
+++ b/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
@@ -431,7 +431,7 @@ const buildPureDurationEnumValue = (
 };
 
 /**
- * Generate the pure date ajust() function based on the CustomDateOption.
+ * Generate the pure date adjust() function based on the CustomDateOption.
  */
 const buildPureAdjustDateFunction = (
   customDateOption: CustomDateOption,
@@ -594,7 +594,7 @@ const buildCustomDateOptionReferenceMomentValue = (
  * Build CustomDateOption based on the pure date adjust() function.
  * Transform CustomDateOption if it matches any preserved custom adjust date functions. e.g. One Month Ago..
  */
-export const buildCustomDateOption = (
+const buildCustomDateOption = (
   valueSpecification: SimpleFunctionExpression | PrimitiveInstanceValue,
 ): CustomDateOption => {
   if (
@@ -634,7 +634,7 @@ export const buildCustomDateOption = (
 /**
  * Build DatePickerOption from pure date functions or PrimitiveInstanceValue
  */
-const buildDatePickerOption = (
+export const buildDatePickerOption = (
   valueSpecification: SimpleFunctionExpression | PrimitiveInstanceValue,
 ): DatePickerOption => {
   if (valueSpecification instanceof SimpleFunctionExpression) {

--- a/packages/legend-query-builder/src/components/shared/QueryBuilderVariableSelector.tsx
+++ b/packages/legend-query-builder/src/components/shared/QueryBuilderVariableSelector.tsx
@@ -25,13 +25,11 @@ import {
 } from '@finos/legend-art';
 import {
   SimpleFunctionExpression,
-  SUPPORTED_FUNCTIONS,
   type ValueSpecification,
   type VariableExpression,
 } from '@finos/legend-graph';
 import { observer } from 'mobx-react-lite';
 import { useDrag } from 'react-dnd';
-import type { QueryBuilderDerivedPropertyExpressionState } from '../../stores/QueryBuilderPropertyEditorState.js';
 import type { QueryBuilderState } from '../../stores/QueryBuilderState.js';
 import { getValueSpecificationStringValue } from '../../stores/shared/ValueSpecificationEditorHelper.js';
 import {
@@ -39,7 +37,7 @@ import {
   QUERY_BUILDER_VARIABLE_DND_TYPE,
   VariableInfoTooltip,
 } from './BasicValueSpecificationEditor.js';
-import { buildCustomDateOption } from './CustomDatePicker.js';
+import { buildDatePickerOption } from './CustomDatePicker.js';
 
 export const VariableViewer = observer(
   (props: {
@@ -56,11 +54,11 @@ export const VariableViewer = observer(
       props;
 
     const getNameOfValue = (value: ValueSpecification): string | undefined => {
-      if (
-        value instanceof SimpleFunctionExpression &&
-        value.functionName === SUPPORTED_FUNCTIONS.ADJUST
-      ) {
-        return buildCustomDateOption(value).generateDisplayLabel();
+      if (value instanceof SimpleFunctionExpression) {
+        const possibleDateLabel = buildDatePickerOption(value).label;
+        if (possibleDateLabel) {
+          return possibleDateLabel;
+        }
       }
       return getValueSpecificationStringValue(value);
     };
@@ -163,24 +161,13 @@ export const VariableSelector = observer(
   (props: {
     queryBuilderState: QueryBuilderState;
     filterBy?: (variableExpression: VariableExpression) => boolean;
-    derivedProperties?:
-      | QueryBuilderDerivedPropertyExpressionState[]
-      | undefined;
   }) => {
-    const { queryBuilderState, filterBy, derivedProperties } = props;
+    const { queryBuilderState, filterBy } = props;
     const isReadOnly = !queryBuilderState.isQuerySupported;
     const filteredParameterStates =
-      queryBuilderState.parametersState.parameterStates.filter((p) => {
-        if (derivedProperties && p.variableType) {
-          const allowedTypes = derivedProperties.map(
-            (dp) => dp.derivedProperty.genericType.value.rawType,
-          );
-          if (!allowedTypes.includes(p.variableType)) {
-            return false;
-          }
-        }
-        return filterBy ? filterBy(p.parameter) : true;
-      });
+      queryBuilderState.parametersState.parameterStates.filter((p) =>
+        filterBy ? filterBy(p.parameter) : true,
+      );
     const filteredConstantState =
       queryBuilderState.constantState.constants.filter((c) =>
         filterBy ? filterBy(c.variable) : true,

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -99,6 +99,7 @@ export abstract class QueryBuilderState implements CommandRegistrar {
   textEditorState: QueryBuilderTextEditorState;
   unsupportedQueryState: QueryBuilderUnsupportedQueryState;
   observableContext: ObserverContext;
+  titleOfQuery: string | undefined;
 
   queryCompileState = ActionState.create();
   showFunctionsExplorerPanel = false;
@@ -126,6 +127,7 @@ export abstract class QueryBuilderState implements CommandRegistrar {
       fetchStructureState: observable,
       filterState: observable,
       watermarkState: observable,
+      titleOfQuery: observable,
       checkEntitlementsState: observable,
       resultState: observable,
       textEditorState: observable,
@@ -150,6 +152,8 @@ export abstract class QueryBuilderState implements CommandRegistrar {
       setClass: action,
       setMapping: action,
       setRuntimeValue: action,
+
+      setTitleOfQuery: action,
 
       resetQueryResult: action,
       resetQueryContent: action,
@@ -251,6 +255,10 @@ export abstract class QueryBuilderState implements CommandRegistrar {
 
   setRuntimeValue(val: Runtime | undefined): void {
     this.runtimeValue = val;
+  }
+
+  setTitleOfQuery(val: string | undefined): void {
+    this.titleOfQuery = val;
   }
 
   get isQuerySupported(): boolean {

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -61,6 +61,12 @@
     flex: 1;
   }
 
+  &__sub-header__query__title {
+    color: var(--color-light-grey-180);
+    margin: 0 1rem;
+    flex: 1;
+  }
+
   &__sub-header__custom-action {
     @include flexCenter;
 
@@ -508,19 +514,30 @@
     }
   }
 
+  &__export__dropdown[disabled],
+  &__export__dropdown[disabled]:hover {
+    background: var(--color-dark-grey-250);
+    color: var(--color-dark-grey-500);
+  }
+
+  &__export__dropdown:hover {
+    color: var(--color-light-grey-50);
+  }
+
   &__export__dropdown {
     @include flexVCenter;
 
     margin: 0 0.5rem;
     height: 2.2rem;
     border: 0.1rem solid var(--color-dark-grey-250);
+    background: var(--color-dark-grey-300);
+    color: var(--color-light-grey-180);
 
     &__label {
       @include flexCenter;
       @include flexConstantDimension;
 
       height: 100%;
-      color: var(--color-dark-grey-500);
       font-weight: 500;
       font-size: 1.2rem;
       width: 5rem;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
- [x] Displays query title in query builder on top left corner of the window
![Kapture 2023-02-15 at 15 36 12](https://user-images.githubusercontent.com/41248956/219149842-a58f5f10-8e1b-468a-8b29-4c37e1fcd0d2.gif)
<img width="1507" alt="image" src="https://user-images.githubusercontent.com/41248956/219150221-06dc561b-3022-495f-82c6-1e1bd913ae86.png">



- [x] When in the derived property editor, parameters that display should match the type of the derived property otherwise they should be hidden since the user will not be able to drag and drop the parameter to the derived property value. 
![Kapture 2023-02-15 at 12 22 58](https://user-images.githubusercontent.com/41248956/219107903-14fe6fc6-559c-4481-8a27-5e17f20932e0.gif)

- [x] If there is already a created constant with the same variable name, show a validation error for user when they try to name the parameter. 
![doNotAllowParameterDuplicateName](https://user-images.githubusercontent.com/41248956/219108698-1f010de7-865f-4bdc-baa5-df3c010365dc.gif)


- [x] If the constant type is a date, rather than the label showing previously just `meta::pure::functions::date::adjust` a more descriptive title should appear for users. 

Originally: 
![image](https://user-images.githubusercontent.com/41248956/219109792-075ae8e4-6e9d-4a46-ac4c-20d81c451650.png)

Now:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/41248956/219410660-77003598-ca6f-4488-bf02-19ed51e45e95.png">


- [x] Styling fix to show that the 'export' button in query builder is able to be pressed when previously it appeared the same whether disabled or active.

Originally: 
<img width="486" alt="image" src="https://user-images.githubusercontent.com/41248956/219110580-51cde69b-730d-4295-ba1b-e83d8d5cbabb.png">

Now:
<img width="456" alt="image" src="https://user-images.githubusercontent.com/41248956/219110471-0ccb2bca-310c-426a-a0a9-c42f86318214.png">


<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->


## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


 




<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
