### PR TITLE
add more metrics for application loading

### DIFF
--- a/.changeset/chilly-donuts-develop.md
+++ b/.changeset/chilly-donuts-develop.md
@@ -1,0 +1,12 @@
+---
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-taxonomy': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-application-query': patch
+'@finos/legend-query-builder': patch
+'@finos/legend-application': patch
+'@finos/legend-dev-utils': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/babel-preset-legend-studio': patch
+'@finos/legend-art': patch
+---

--- a/.changeset/little-worms-hammer.md
+++ b/.changeset/little-worms-hammer.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application': patch
+---
+
+Fix a problem where abort command (`Control+KeyC`) clash with copy command in `Windows`.

--- a/.changeset/two-steaks-refuse.md
+++ b/.changeset/two-steaks-refuse.md
@@ -1,0 +1,12 @@
+---
+'@finos/legend-application-pure-ide': patch
+'@finos/legend-application-taxonomy': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-application-query': patch
+'@finos/legend-query-builder': patch
+'@finos/legend-application': patch
+'@finos/legend-dev-utils': patch
+'@finos/eslint-plugin-legend-studio': patch
+'@finos/babel-preset-legend-studio': patch
+'@finos/legend-art': patch
+---

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -9,6 +9,7 @@ jobs:
   build-documentation-website:
     name: Build Documentation Site
     runs-on: ubuntu-latest
+    if: github.repository == 'finos/legend-studio' # prevent running this action in forks
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.3.0
@@ -41,6 +42,7 @@ jobs:
   deploy-documentation-website:
     name: Deploy Documentation Site
     runs-on: ubuntu-latest
+    if: github.repository == 'finos/legend-studio' # prevent running this action in forks
     needs: build-documentation-website
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@actions/core": "1.10.0",
     "@actions/github": "5.1.1",
-    "@babel/core": "7.20.12",
+    "@babel/core": "7.21.0",
     "@changesets/cli": "2.26.0",
     "@finos/babel-preset-legend-studio": "workspace:*",
     "@finos/eslint-plugin-legend-studio": "workspace:*",
@@ -112,10 +112,10 @@
     "sass": "1.58.3",
     "semver": "7.3.8",
     "sort-package-json": "2.4.1",
-    "stylelint": "15.1.0",
+    "stylelint": "15.2.0",
     "typedoc": "0.23.25",
     "typescript": "4.9.5",
-    "yargs": "17.7.0"
+    "yargs": "17.7.1"
   },
   "packageManager": "yarn@3.4.0",
   "engines": {

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -34,8 +34,8 @@
     "@babel/helper-plugin-utils": "7.20.2",
     "@babel/preset-env": "7.20.2",
     "@babel/preset-react": "7.18.6",
-    "@babel/preset-typescript": "7.18.6",
-    "@babel/runtime": "7.20.13",
+    "@babel/preset-typescript": "7.21.0",
+    "@babel/runtime": "7.21.0",
     "react-refresh": "0.14.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,10 +31,10 @@
     "publish:snapshot": "node ../../scripts/release/publishDevSnapshot.js"
   },
   "dependencies": {
-    "@babel/core": "7.20.12",
+    "@babel/core": "7.21.0",
     "@babel/eslint-parser": "7.19.1",
-    "@typescript-eslint/eslint-plugin": "5.52.0",
-    "@typescript-eslint/parser": "5.52.0",
+    "@typescript-eslint/eslint-plugin": "5.53.0",
+    "@typescript-eslint/parser": "5.53.0",
     "eslint-config-prettier": "8.6.0",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-prettier": "4.2.1",

--- a/packages/legend-application-pure-ide/src/stores/LegendPureIDEBaseStore.ts
+++ b/packages/legend-application-pure-ide/src/stores/LegendPureIDEBaseStore.ts
@@ -24,8 +24,8 @@ export type LegendPureIDEApplicationStore = ApplicationStore<
 >;
 
 export class LegendPureIDEBaseStore {
-  applicationStore: LegendPureIDEApplicationStore;
-  pluginManager: LegendPureIDEPluginManager;
+  readonly applicationStore: LegendPureIDEApplicationStore;
+  readonly pluginManager: LegendPureIDEPluginManager;
 
   constructor(applicationStore: LegendPureIDEApplicationStore) {
     this.applicationStore = applicationStore;

--- a/packages/legend-application-query/src/components/LegendQueryApplication.tsx
+++ b/packages/legend-application-query/src/components/LegendQueryApplication.tsx
@@ -34,16 +34,37 @@ import type { LegendQueryApplicationConfig } from '../application/LegendQueryApp
 import {
   LegendQueryBaseStoreProvider,
   useLegendQueryApplicationStore,
+  useLegendQueryBaseStore,
 } from './LegendQueryBaseStoreProvider.js';
 import { EditExistingQuerySetup } from './EditExistingQuerySetup.js';
 import { CreateMappingQuerySetup } from './CreateMappingQuerySetup.js';
+import { useEffect } from 'react';
+import { flowResult } from 'mobx';
+import { PanelLoadingIndicator } from '@finos/legend-art';
 
 const LegendQueryApplicationRoot = observer(() => {
   const applicationStore = useLegendQueryApplicationStore();
+  const baseStore = useLegendQueryBaseStore();
+
   const extraApplicationPageEntries = applicationStore.pluginManager
     .getApplicationPlugins()
     .flatMap((plugin) => plugin.getExtraApplicationPageEntries?.() ?? []);
 
+  useEffect(() => {
+    flowResult(baseStore.initialize()).catch(
+      applicationStore.alertUnhandledError,
+    );
+  }, [applicationStore, baseStore]);
+
+  if (baseStore.initState.isInProgress) {
+    return (
+      <div className="app">
+        <div className="app__page">
+          <PanelLoadingIndicator isLoading={true} />
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="app">
       <Switch>

--- a/packages/legend-application-query/src/components/QueryEditorComponentTestUtils.tsx
+++ b/packages/legend-application-query/src/components/QueryEditorComponentTestUtils.tsx
@@ -19,6 +19,7 @@ import {
   guaranteeNonNullable,
   createMock,
   createSpy,
+  type Writable,
 } from '@finos/legend-shared';
 import {
   type GraphManagerState,
@@ -40,6 +41,7 @@ import {
   TEST__getTestApplicationStore,
   Router,
   createMemoryHistory,
+  type GenericLegendApplicationStore,
 } from '@finos/legend-application';
 import { TEST__getTestLegendQueryApplicationConfig } from '../stores/QueryEditorStoreTestUtils.js';
 import { LegendQueryPluginManager } from '../application/LegendQueryPluginManager.js';
@@ -172,8 +174,12 @@ export const TEST__setUpQueryEditor = async (
     initialEntries: [generateExistingQueryEditorRoute(lightQuery.id)],
   });
   const navigator = new WebApplicationNavigator(history);
-  MOCK__editorStore.applicationStore.navigator = navigator;
   TEST__provideMockedWebApplicationNavigator({ mock: navigator });
+  // TODO: this is not the proper way to do this, we prefer to mock and inject this when we
+  // create the editor store, let's consider how we clean this up in the future
+  (
+    MOCK__editorStore.applicationStore as Writable<GenericLegendApplicationStore>
+  ).navigator = navigator;
 
   const renderResult = render(
     <Router history={history}>

--- a/packages/legend-application-studio/src/components/EditorComponentTestUtils.tsx
+++ b/packages/legend-application-studio/src/components/EditorComponentTestUtils.tsx
@@ -29,7 +29,12 @@ import {
   generateEditorRoute,
   LEGEND_STUDIO_ROUTE_PATTERN,
 } from '../stores/LegendStudioRouter.js';
-import { createMock, createSpy, type PlainObject } from '@finos/legend-shared';
+import {
+  createMock,
+  createSpy,
+  type Writable,
+  type PlainObject,
+} from '@finos/legend-shared';
 import { LegendStudioPluginManager } from '../application/LegendStudioPluginManager.js';
 import type { Entity } from '@finos/legend-storage';
 import {
@@ -71,6 +76,7 @@ import {
   Router,
   createMemoryHistory,
   Route,
+  type GenericLegendApplicationStore,
 } from '@finos/legend-application';
 import { TEST__getLegendStudioApplicationConfig } from '../stores/EditorStoreTestUtils.js';
 import type { LegendStudioApplicationStore } from '../stores/LegendStudioBaseStore.js';
@@ -340,8 +346,12 @@ export const TEST__setUpEditor = async (
     ],
   });
   const navigator = new WebApplicationNavigator(history);
-  MOCK__editorStore.applicationStore.navigator = navigator;
   TEST__provideMockedWebApplicationNavigator({ mock: navigator });
+  // TODO: this is not the proper way to do this, we prefer to mock and inject this when we
+  // create the editor store, let's consider how we clean this up in the future
+  (
+    MOCK__editorStore.applicationStore as Writable<GenericLegendApplicationStore>
+  ).navigator = navigator;
 
   const renderResult = render(
     <Router history={history}>

--- a/packages/legend-application-studio/src/components/LegendStudioApplication.tsx
+++ b/packages/legend-application-studio/src/components/LegendStudioApplication.tsx
@@ -110,6 +110,7 @@ const LegendStudioNotFoundRouteScreen = observer(() => {
 export const LegendStudioApplicationRoot = observer(() => {
   const baseStore = useLegendStudioBaseStore();
   const applicationStore = useLegendStudioApplicationStore();
+
   const extraApplicationPageEntries = applicationStore.pluginManager
     .getApplicationPlugins()
     .flatMap((plugin) => plugin.getExtraApplicationPageEntries?.() ?? []);
@@ -120,13 +121,17 @@ export const LegendStudioApplicationRoot = observer(() => {
     );
   }, [applicationStore, baseStore]);
 
-  return (
-    <div className="app">
-      {baseStore.isSDLCAuthorized === false && (
+  if (baseStore.initState.isInProgress) {
+    return (
+      <div className="app">
         <div className="app__page">
           <PanelLoadingIndicator isLoading={true} />
         </div>
-      )}
+      </div>
+    );
+  }
+  return (
+    <div className="app">
       {baseStore.isSDLCAuthorized === undefined && (
         <>
           <Switch>

--- a/packages/legend-application-studio/src/components/__tests__/LegendStudioApplication.test.tsx
+++ b/packages/legend-application-studio/src/components/__tests__/LegendStudioApplication.test.tsx
@@ -90,9 +90,13 @@ test(
 );
 
 test(integrationTest('Failed to authorize SDLC will redirect'), async () => {
+  const navigator = new WebApplicationNavigator(createMemoryHistory());
+  TEST__provideMockedWebApplicationNavigator({ mock: navigator });
+
   const applicationStore = TEST__provideMockedApplicationStore(
     TEST__getLegendStudioApplicationConfig(),
     LegendStudioPluginManager.create(),
+    { navigator },
   );
   const sdlcServerClient = TEST__provideMockedSDLCServerClient();
   const stubURL = 'stubUrl';
@@ -102,8 +106,7 @@ test(integrationTest('Failed to authorize SDLC will redirect'), async () => {
     name: 'testUser',
     userId: 'testUserId',
   });
-  const navigator = new WebApplicationNavigator(createMemoryHistory());
-  applicationStore.navigator = navigator;
+
   const navigationActionSpy = createSpy(
     navigator,
     'goToAddress',
@@ -111,8 +114,6 @@ test(integrationTest('Failed to authorize SDLC will redirect'), async () => {
   createSpy(navigator, 'getCurrentAddress').mockImplementationOnce(
     () => stubURL,
   );
-
-  TEST__provideMockedWebApplicationNavigator();
 
   render(
     <MemoryRouter>

--- a/packages/legend-application-taxonomy/src/components/LegendTaxonomyApplication.tsx
+++ b/packages/legend-application-taxonomy/src/components/LegendTaxonomyApplication.tsx
@@ -32,11 +32,31 @@ import { StandaloneDataSpaceViewer } from './StandaloneDataSpaceViewer.js';
 import {
   LegendTaxonomyBaseStoreProvider,
   useLegendTaxonomyApplicationStore,
+  useLegendTaxonomyBaseStore,
 } from './LegendTaxonomyBaseStoreProvider.js';
+import { useEffect } from 'react';
+import { flowResult } from 'mobx';
+import { PanelLoadingIndicator } from '@finos/legend-art';
 
 export const LegendTaxonomyApplicationRoot = observer(() => {
   const applicationStore = useLegendTaxonomyApplicationStore();
+  const baseStore = useLegendTaxonomyBaseStore();
 
+  useEffect(() => {
+    flowResult(baseStore.initialize()).catch(
+      applicationStore.alertUnhandledError,
+    );
+  }, [applicationStore, baseStore]);
+
+  if (baseStore.initState.isInProgress) {
+    return (
+      <div className="app">
+        <div className="app__page">
+          <PanelLoadingIndicator isLoading={true} />
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="app">
       <Switch>

--- a/packages/legend-application/src/components/ActionAlert.tsx
+++ b/packages/legend-application/src/components/ActionAlert.tsx
@@ -19,7 +19,7 @@ import {
   ActionAlertActionType,
   ActionAlertType,
   type ActionAlertInfo,
-} from '../stores/ApplicationStore.js';
+} from '../stores/AlertService.js';
 import { observer } from 'mobx-react-lite';
 import { noop } from '@finos/legend-shared';
 import { useApplicationStore } from './ApplicationStoreProvider.js';

--- a/packages/legend-application/src/components/NotificationManager.tsx
+++ b/packages/legend-application/src/components/NotificationManager.tsx
@@ -15,10 +15,6 @@
  */
 
 import { observer } from 'mobx-react-lite';
-import {
-  DEFAULT_NOTIFICATION_HIDE_TIME,
-  NOTIFCATION_SEVERITY,
-} from '../stores/ApplicationStore.js';
 import { useApplicationStore } from './ApplicationStoreProvider.js';
 import {
   Notification,
@@ -35,6 +31,10 @@ import {
   clsx,
 } from '@finos/legend-art';
 import { useState } from 'react';
+import {
+  DEFAULT_NOTIFICATION_HIDE_TIME,
+  NOTIFCATION_SEVERITY,
+} from '../stores/NotificationService.js';
 
 export const NotificationManager = observer(() => {
   const applicationStore = useApplicationStore();

--- a/packages/legend-application/src/index.ts
+++ b/packages/legend-application/src/index.ts
@@ -34,6 +34,8 @@ export { WebApplicationNavigator } from './stores/WebApplicationNavigator.js';
 export * from './stores/DocumentationService.js';
 export * from './stores/CommandCenter.js';
 export * from './stores/EventService.js';
+export * from './stores/NotificationService.js';
+export * from './stores/AlertService.js';
 export * from './stores/AssistantService.js';
 export * from './stores/ApplicationNavigationContextService.js';
 export * from './stores/LegendApplicationPlugin.js';

--- a/packages/legend-application/src/stores/AlertService.ts
+++ b/packages/legend-application/src/stores/AlertService.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum ActionAlertType {
+  STANDARD = 'STANDARD',
+  CAUTION = 'CAUTION',
+}
+
+export enum ActionAlertActionType {
+  STANDARD = 'STANDARD',
+  PROCEED_WITH_CAUTION = 'PROCEED_WITH_CAUTION',
+  PROCEED = 'PROCEED',
+}
+
+export interface ActionAlertInfo {
+  title?: string;
+  message: string;
+  prompt?: string;
+  type?: ActionAlertType;
+  onClose?: () => void;
+  onEnter?: () => void;
+  actions: {
+    label: string;
+    default?: boolean;
+    handler?: () => void; // default to dismiss
+    type?: ActionAlertActionType;
+  }[];
+}
+
+export interface BlockingAlertInfo {
+  message: string;
+  prompt?: string;
+  showLoading?: boolean;
+}

--- a/packages/legend-application/src/stores/ApplicationEvent.ts
+++ b/packages/legend-application/src/stores/ApplicationEvent.ts
@@ -21,6 +21,8 @@ export enum APPLICATION_EVENT {
   ILLEGAL_APPLICATION_STATE_OCCURRED = 'application.error.illegal-state',
   APPLICATION_CONFIGURATION_FAILURE = 'application.configuration.failure',
 
+  APPLICATION_IDENTITY_AUTO_FETCH_FAILURE = 'application.identity.auto-fetch.failure',
+
   APPLICATION_DOCUMENTATION_FETCH_FAILURE = 'application.fetch.documentation.failure',
   APPLICATION_DOCUMENTATION_LOAD_SKIPPED = 'application.load.documentation.skipped',
   APPLICATION_DOCUMENTATION_REQUIREMENT_CHECK_FAILURE = 'application.load.documentation.requirement-check.failure',

--- a/packages/legend-application/src/stores/ApplicationStore.ts
+++ b/packages/legend-application/src/stores/ApplicationStore.ts
@@ -38,73 +38,14 @@ import type { LegendApplicationPlugin } from './LegendApplicationPlugin.js';
 import { CommandCenter } from './CommandCenter.js';
 import { KeyboardShortcutsService } from './KeyboardShortcutsService.js';
 import { TerminalService } from './TerminalService.js';
-
-export enum ActionAlertType {
-  STANDARD = 'STANDARD',
-  CAUTION = 'CAUTION',
-}
-
-export enum ActionAlertActionType {
-  STANDARD = 'STANDARD',
-  PROCEED_WITH_CAUTION = 'PROCEED_WITH_CAUTION',
-  PROCEED = 'PROCEED',
-}
-
-export interface ActionAlertInfo {
-  title?: string;
-  message: string;
-  prompt?: string;
-  type?: ActionAlertType;
-  onClose?: () => void;
-  onEnter?: () => void;
-  actions: {
-    label: string;
-    default?: boolean;
-    handler?: () => void; // default to dismiss
-    type?: ActionAlertActionType;
-  }[];
-}
-
-export interface BlockingAlertInfo {
-  message: string;
-  prompt?: string;
-  showLoading?: boolean;
-}
-
-export const DEFAULT_NOTIFICATION_HIDE_TIME = 6000; // ms
-export const DEFAULT_ERROR_NOTIFICATION_HIDE_TIME = 10000; // ms
-
-export enum NOTIFCATION_SEVERITY {
-  ILEGAL_STATE = 'ILEGAL_STATE', // highest priority since this implies bugs - we expect user to never see this
-  ERROR = 'ERROR',
-  WARNING = 'WARNING',
-  SUCCESS = 'SUCCESS',
-  INFO = 'INFO',
-}
-
-export interface NotificationAction {
-  icon: React.ReactNode;
-  action: () => void;
-}
-
-export class Notification {
-  severity: NOTIFCATION_SEVERITY;
-  message: string;
-  actions: NotificationAction[];
-  autoHideDuration?: number | undefined;
-
-  constructor(
-    severity: NOTIFCATION_SEVERITY,
-    message: string,
-    actions: NotificationAction[],
-    autoHideDuration: number | undefined,
-  ) {
-    this.severity = severity;
-    this.message = message;
-    this.actions = actions;
-    this.autoHideDuration = autoHideDuration;
-  }
-}
+import type { ActionAlertInfo, BlockingAlertInfo } from './AlertService.js';
+import {
+  Notification,
+  type NotificationAction,
+  DEFAULT_NOTIFICATION_HIDE_TIME,
+  NOTIFCATION_SEVERITY,
+} from './NotificationService.js';
+import { UNKNOWN_USER_ID } from './IdentityService.js';
 
 export type GenericLegendApplicationStore = ApplicationStore<
   LegendApplicationConfig,
@@ -115,12 +56,15 @@ export class ApplicationStore<
   T extends LegendApplicationConfig,
   V extends LegendApplicationPluginManager<LegendApplicationPlugin>,
 > {
-  config: T;
-  pluginManager: V;
+  readonly config: T;
+  readonly pluginManager: V;
+
+  // user
+  currentUser = UNKNOWN_USER_ID;
 
   // navigation
-  navigator: WebApplicationNavigator;
-  navigationContextService: ApplicationNavigationContextService;
+  readonly navigator: WebApplicationNavigator;
+  readonly navigationContextService: ApplicationNavigationContextService;
 
   // TODO: refactor this to `NotificationService` including notifications and alerts
   notification?: Notification | undefined;
@@ -128,21 +72,21 @@ export class ApplicationStore<
   actionAlertInfo?: ActionAlertInfo | undefined;
 
   // TODO: consider renaming this to `LogService`
-  log = new Log();
-  terminalService: TerminalService;
+  readonly log = new Log();
+  readonly terminalService: TerminalService;
 
   // documentation & help
-  documentationService: DocumentationService;
-  assistantService: AssistantService;
+  readonly documentationService: DocumentationService;
+  readonly assistantService: AssistantService;
 
   // communication
-  eventService = new EventService();
-  telemetryService = new TelemetryService();
-  tracerService = new TracerService();
+  readonly eventService = new EventService();
+  readonly telemetryService = new TelemetryService();
+  readonly tracerService = new TracerService();
 
   // control and interactions
-  commandCenter: CommandCenter;
-  keyboardShortcutsService: KeyboardShortcutsService;
+  readonly commandCenter: CommandCenter;
+  readonly keyboardShortcutsService: KeyboardShortcutsService;
 
   // TODO: config
   // See https://github.com/finos/legend-studio/issues/407
@@ -161,6 +105,7 @@ export class ApplicationStore<
 
   constructor(config: T, navigator: WebApplicationNavigator, pluginManager: V) {
     makeObservable(this, {
+      currentUser: observable,
       notification: observable,
       blockingAlertInfo: observable,
       actionAlertInfo: observable,
@@ -171,6 +116,7 @@ export class ApplicationStore<
       setShowBackdrop: action,
       setBlockingAlert: action,
       setActionAlertInfo: action,
+      setCurrentUser: action,
       setNotification: action,
       notify: action,
       notifySuccess: action,
@@ -195,6 +141,7 @@ export class ApplicationStore<
     this.telemetryService.registerPlugins(
       pluginManager.getTelemetryServicePlugins(),
     );
+    this.telemetryService.setUserId(this.currentUser);
     this.commandCenter = new CommandCenter(this);
     this.keyboardShortcutsService = new KeyboardShortcutsService(this);
     this.tracerService.registerPlugins(pluginManager.getTracerServicePlugins());
@@ -241,6 +188,10 @@ export class ApplicationStore<
       this.keyboardShortcutsService.unblockGlobalHotkeys();
     }
     this.actionAlertInfo = alertInfo;
+  }
+
+  setCurrentUser(val: string): void {
+    this.currentUser = val;
   }
 
   setNotification(notification: Notification | undefined): void {

--- a/packages/legend-application/src/stores/IdentityService.ts
+++ b/packages/legend-application/src/stores/IdentityService.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const UNKNOWN_USER_ID = '(unknown)';

--- a/packages/legend-application/src/stores/NotificationService.ts
+++ b/packages/legend-application/src/stores/NotificationService.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DEFAULT_NOTIFICATION_HIDE_TIME = 6000; // ms
+export const DEFAULT_ERROR_NOTIFICATION_HIDE_TIME = 10000; // ms
+
+export enum NOTIFCATION_SEVERITY {
+  ILEGAL_STATE = 'ILEGAL_STATE', // highest priority since this implies bugs - we expect user to never see this
+  ERROR = 'ERROR',
+  WARNING = 'WARNING',
+  SUCCESS = 'SUCCESS',
+  INFO = 'INFO',
+}
+
+export interface NotificationAction {
+  icon: React.ReactNode;
+  action: () => void;
+}
+
+export class Notification {
+  severity: NOTIFCATION_SEVERITY;
+  message: string;
+  actions: NotificationAction[];
+  autoHideDuration?: number | undefined;
+
+  constructor(
+    severity: NOTIFCATION_SEVERITY,
+    message: string,
+    actions: NotificationAction[],
+    autoHideDuration: number | undefined,
+  ) {
+    this.severity = severity;
+    this.message = message;
+    this.actions = actions;
+    this.autoHideDuration = autoHideDuration;
+  }
+}

--- a/packages/legend-application/src/stores/terminal/XTerm.ts
+++ b/packages/legend-application/src/stores/terminal/XTerm.ts
@@ -336,8 +336,11 @@ export class XTerm extends Terminal {
               });
           }
         } else if (
-          isMatchingKeyCombination(domEvent, 'Control+KeyC') ||
-          isMatchingKeyCombination(domEvent, 'Control+KeyD')
+          isMatchingKeyCombination(domEvent, 'Control+KeyD') ||
+          // NOTE: this handling here makes the assumption that the hotkey used for copying is
+          // fixed to `Control+KeyC` (for Windows), it doesn't handling a different assignment
+          (isMatchingKeyCombination(domEvent, 'Control+KeyC') &&
+            !this.instance.hasSelection())
         ) {
           // abort command
           this.abort();

--- a/packages/legend-art/package.json
+++ b/packages/legend-art/package.json
@@ -55,7 +55,7 @@
     "@fontsource/roboto": "4.5.8",
     "@fontsource/roboto-condensed": "4.5.9",
     "@fontsource/roboto-mono": "4.5.10",
-    "@mui/material": "5.11.9",
+    "@mui/material": "5.11.10",
     "@types/react": "18.0.28",
     "@types/react-select": "4.0.18",
     "@types/react-window": "1.8.5",
@@ -71,7 +71,7 @@
     "react-icons": "4.7.1",
     "react-markdown": "8.0.5",
     "react-reflex": "4.0.9",
-    "react-resize-detector": "8.0.3",
+    "react-resize-detector": "8.0.4",
     "react-select": "4.3.1",
     "react-window": "1.8.8",
     "remark-gfm": "3.0.1"

--- a/packages/legend-dev-utils/package.json
+++ b/packages/legend-dev-utils/package.json
@@ -50,7 +50,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@babel/core": "7.20.12",
+    "@babel/core": "7.21.0",
     "@changesets/assemble-release-plan": "5.2.3",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/config": "2.3.0",
@@ -76,7 +76,7 @@
     "jest": "29.4.3",
     "jest-canvas-mock": "2.4.0",
     "jest-environment-jsdom": "29.4.3",
-    "jest-extended": "3.2.3",
+    "jest-extended": "3.2.4",
     "jest-watch-typeahead": "2.2.2",
     "jsonc-parser": "3.2.0",
     "micromatch": "4.0.5",

--- a/packages/legend-query-builder/src/components/QueryBuilderComponentTestUtils.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderComponentTestUtils.tsx
@@ -62,9 +62,15 @@ export const TEST__setUpQueryBuilder = async (
     entities,
     graphManagerState.graphBuildState,
   );
+
+  const history = createMemoryHistory();
+  const navigator = new WebApplicationNavigator(history);
+  TEST__provideMockedWebApplicationNavigator({ mock: navigator });
+
   const applicationStore = TEST__provideMockedApplicationStore(
     TEST__getGenericApplicationConfig(),
     pluginManager,
+    { navigator },
   );
 
   const queryBuilderState = new INTERNAL__BasicQueryBuilderState(
@@ -92,11 +98,6 @@ export const TEST__setUpQueryBuilder = async (
       ),
     );
   }
-
-  const history = createMemoryHistory();
-  const navigator = new WebApplicationNavigator(history);
-  applicationStore.navigator = navigator;
-  TEST__provideMockedWebApplicationNavigator({ mock: navigator });
 
   const renderResult = render(
     <Router history={history}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,7 +72,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampproject/remapping@npm:^2.1.0":
+"@ampproject/remapping@npm:^2.2.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
   dependencies:
@@ -92,32 +92,32 @@ __metadata:
   linkType: hard
 
 "@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.20.1, @babel/compat-data@npm:^7.20.5":
-  version: 7.20.14
-  resolution: "@babel/compat-data@npm:7.20.14"
-  checksum: 6c9efe36232094e4ad0b70d165587f21ca718e5d011f7a52a77a18502a7524e90e2855aa5a2e086395bcfd21bd2c7c99128dcd8d9fdffe94316b72acf5c66f2c
+  version: 7.21.0
+  resolution: "@babel/compat-data@npm:7.21.0"
+  checksum: dbf632c532f9c75ba0be7d1dc9f6cd3582501af52f10a6b90415d634ec5878735bd46064c91673b10317af94d4cc99c4da5bd9d955978cdccb7905fc33291e4d
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.20.12, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3":
-  version: 7.20.12
-  resolution: "@babel/core@npm:7.20.12"
+"@babel/core@npm:7.21.0, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3":
+  version: 7.21.0
+  resolution: "@babel/core@npm:7.21.0"
   dependencies:
-    "@ampproject/remapping": ^2.1.0
+    "@ampproject/remapping": ^2.2.0
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.20.7
+    "@babel/generator": ^7.21.0
     "@babel/helper-compilation-targets": ^7.20.7
-    "@babel/helper-module-transforms": ^7.20.11
-    "@babel/helpers": ^7.20.7
-    "@babel/parser": ^7.20.7
+    "@babel/helper-module-transforms": ^7.21.0
+    "@babel/helpers": ^7.21.0
+    "@babel/parser": ^7.21.0
     "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.20.12
-    "@babel/types": ^7.20.7
+    "@babel/traverse": ^7.21.0
+    "@babel/types": ^7.21.0
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.2.2
     semver: ^6.3.0
-  checksum: 62e6c3e2149a70b5c9729ef5f0d3e2e97e9dcde89fc039c8d8e3463d5d7ba9b29ee84d10faf79b61532ac1645aa62f2bd42338320617e6e3a8a4d8e2a27076e7
+  checksum: 357f4dd3638861ceebf6d95ff49ad8b902065ee8b7b352621deed5666c2a6d702a48ca7254dba23ecae2a0afb67d20f90db7dd645c3b75e35e72ad9776c671aa
   languageName: node
   linkType: hard
 
@@ -135,14 +135,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.20.7, @babel/generator@npm:^7.7.2":
-  version: 7.20.14
-  resolution: "@babel/generator@npm:7.20.14"
+"@babel/generator@npm:^7.21.0, @babel/generator@npm:^7.7.2":
+  version: 7.21.1
+  resolution: "@babel/generator@npm:7.21.1"
   dependencies:
-    "@babel/types": ^7.20.7
+    "@babel/types": ^7.21.0
     "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
     jsesc: ^2.5.1
-  checksum: 5f6aa2d86af26e76d276923a5c34191124a119b16ee9ccc34aef654a7dec84fbd7d2daed2e6458a6a06bf87f3661deb77c9fea59b8f67faff5c90793c96d76d6
+  checksum: 69085a211ff91a7a608ee3f86e6fcb9cf5e724b756d792a713b0c328a671cd3e423e1ef1b12533f366baba0616caffe0a7ba9d328727eab484de5961badbef00
   languageName: node
   linkType: hard
 
@@ -180,33 +181,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.20.12, @babel/helper-create-class-features-plugin@npm:^7.20.5, @babel/helper-create-class-features-plugin@npm:^7.20.7":
-  version: 7.20.12
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.20.12"
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
     "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
-    "@babel/helper-member-expression-to-functions": ^7.20.7
+    "@babel/helper-function-name": ^7.21.0
+    "@babel/helper-member-expression-to-functions": ^7.21.0
     "@babel/helper-optimise-call-expression": ^7.18.6
     "@babel/helper-replace-supers": ^7.20.7
     "@babel/helper-skip-transparent-expression-wrappers": ^7.20.0
     "@babel/helper-split-export-declaration": ^7.18.6
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 1e9ed4243b75278fa24deb40dc62bf537b79307987223a2d2d2ae5abf7ba6dc8435d6e3bb55d52ceb30d3e1eba88e7eb6a1885a8bb519e5cfc3e9dedb97d43e6
+  checksum: 3e781d91d1056ea9b3a0395f3017492594a8b86899119b4a1645227c31727b8bec9bc8f6b72e86b1c5cf2dd6690893d2e8c5baff4974c429e616ead089552a21
   languageName: node
   linkType: hard
 
 "@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.20.5":
-  version: 7.20.5
-  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.20.5"
+  version: 7.21.0
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
-    regexpu-core: ^5.2.1
+    regexpu-core: ^5.3.1
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 7f29c3cb7447cca047b0d394f8ab98e4923d00e86a7afa56e5df9770c48ec107891505d2d1f06b720ecc94ed24bf58d90986cc35fe4a43b549eb7b7a5077b693
+  checksum: 63a6396a4e9444edc7e97617845583ea5cf059573d0b4cc566869f38576d543e37fde0edfcc21d6dfb7962ed241e909561714dc41c5213198bac04e0983b04f2
   languageName: node
   linkType: hard
 
@@ -242,13 +243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.18.9, @babel/helper-function-name@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/helper-function-name@npm:7.19.0"
+"@babel/helper-function-name@npm:^7.18.9, @babel/helper-function-name@npm:^7.19.0, @babel/helper-function-name@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-function-name@npm:7.21.0"
   dependencies:
-    "@babel/template": ^7.18.10
-    "@babel/types": ^7.19.0
-  checksum: eac1f5db428ba546270c2b8d750c24eb528b8fcfe50c81de2e0bdebf0e20f24bec688d4331533b782e4a907fad435244621ca2193cfcf80a86731299840e0f6e
+    "@babel/template": ^7.20.7
+    "@babel/types": ^7.21.0
+  checksum: d63e63c3e0e3e8b3138fa47b0cd321148a300ef12b8ee951196994dcd2a492cc708aeda94c2c53759a5c9177fffaac0fd8778791286746f72a000976968daf4e
   languageName: node
   linkType: hard
 
@@ -261,12 +262,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.20.7":
-  version: 7.20.7
-  resolution: "@babel/helper-member-expression-to-functions@npm:7.20.7"
+"@babel/helper-member-expression-to-functions@npm:^7.20.7, @babel/helper-member-expression-to-functions@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.21.0"
   dependencies:
-    "@babel/types": ^7.20.7
-  checksum: cec17aab7e964830b0146e575bd141127032319f26ed864a65b35abd75ad618d264d3e11449b9b4e29cfd95bb1a7e774afddd4884fdcc29c36ac9cbd2b66359f
+    "@babel/types": ^7.21.0
+  checksum: 49cbb865098195fe82ba22da3a8fe630cde30dcd8ebf8ad5f9a24a2b685150c6711419879cf9d99b94dad24cff9244d8c2a890d3d7ec75502cd01fe58cff5b5d
   languageName: node
   linkType: hard
 
@@ -279,9 +280,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.18.6, @babel/helper-module-transforms@npm:^7.20.11":
-  version: 7.20.11
-  resolution: "@babel/helper-module-transforms@npm:7.20.11"
+"@babel/helper-module-transforms@npm:^7.18.6, @babel/helper-module-transforms@npm:^7.20.11, @babel/helper-module-transforms@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-module-transforms@npm:7.21.0"
   dependencies:
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-module-imports": ^7.18.6
@@ -289,9 +290,9 @@ __metadata:
     "@babel/helper-split-export-declaration": ^7.18.6
     "@babel/helper-validator-identifier": ^7.19.1
     "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.20.10
-    "@babel/types": ^7.20.7
-  checksum: 29319ebafa693d48756c6ba0d871677bb0037e0da084fbe221a17c38d57093fc8aa38543c07d76e788266a937976e37ab4901971ca7f237c5ab45f524b9ecca0
+    "@babel/traverse": ^7.21.0
+    "@babel/types": ^7.21.0
+  checksum: bd92d0b73c12dc2f37be906954c58cc3fbec74ba243731e1aa223063b422eef6b961ca7fe19737a073be18db298e1385d370df2e5781646b8c09ecebd7c847de
   languageName: node
   linkType: hard
 
@@ -380,10 +381,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-validator-option@npm:7.18.6"
-  checksum: f9cc6eb7cc5d759c5abf006402180f8d5e4251e9198197428a97e05d65eb2f8ae5a0ce73b1dfd2d35af41d0eb780627a64edf98a4e71f064eeeacef8de58f2cf
+"@babel/helper-validator-option@npm:^7.18.6, @babel/helper-validator-option@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-validator-option@npm:7.21.0"
+  checksum: 8ece4c78ffa5461fd8ab6b6e57cc51afad59df08192ed5d84b475af4a7193fc1cb794b59e3e7be64f3cdc4df7ac78bf3dbb20c129d7757ae078e6279ff8c2f07
   languageName: node
   linkType: hard
 
@@ -399,14 +400,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.20.7":
-  version: 7.20.13
-  resolution: "@babel/helpers@npm:7.20.13"
+"@babel/helpers@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helpers@npm:7.21.0"
   dependencies:
     "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.20.13
-    "@babel/types": ^7.20.7
-  checksum: d62076fa834f342798f8c3fd7aec0870cc1725d273d99e540cbaa8d6c3ed10258228dd14601c8e66bfeabbb9424c3b31090ecc467fe855f7bd72c4734df7fb09
+    "@babel/traverse": ^7.21.0
+    "@babel/types": ^7.21.0
+  checksum: 9370dad2bb665c551869a08ac87c8bdafad53dbcdce1f5c5d498f51811456a3c005d9857562715151a0f00b2e912ac8d89f56574f837b5689f5f5072221cdf54
   languageName: node
   linkType: hard
 
@@ -421,12 +422,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.13, @babel/parser@npm:^7.20.7":
-  version: 7.20.15
-  resolution: "@babel/parser@npm:7.20.15"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.0":
+  version: 7.21.1
+  resolution: "@babel/parser@npm:7.21.1"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 1d0f47ca67ff2652f1c0ff1570bed8deccbc4b53509e7cd73476af9cc7ed23480c99f1179bd6d0be01612368b92b39e206d330ad6054009d699934848a89298b
+  checksum: a564cff6dec4201a611d1f2ae5af8d7436ce80550e75a77ee72dca6b094df6188b5a4ccfae6a98c85991b56a51e6c48159e466cc5a374c7a37af706fcb5a6bc2
   languageName: node
   linkType: hard
 
@@ -481,15 +482,15 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-class-static-block@npm:^7.18.6":
-  version: 7.20.7
-  resolution: "@babel/plugin-proposal-class-static-block@npm:7.20.7"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-class-static-block@npm:7.21.0"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.20.7
+    "@babel/helper-create-class-features-plugin": ^7.21.0
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-class-static-block": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.12.0
-  checksum: ce1f3e8fd96437d820aa36323b7b3a0cb65b5f2600612665129880d5a4eb7194ce6a298ed2a5a4d3a9ea49bd33089ab95503c4c5b3ba9cea251a07d1706453d9
+  checksum: 236c0ad089e7a7acab776cc1d355330193314bfcd62e94e78f2df35817c6144d7e0e0368976778afd6b7c13e70b5068fa84d7abbf967d4f182e60d03f9ef802b
   languageName: node
   linkType: hard
 
@@ -593,15 +594,15 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-optional-chaining@npm:^7.18.9, @babel/plugin-proposal-optional-chaining@npm:^7.20.7":
-  version: 7.20.7
-  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.20.7"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.21.0"
   dependencies:
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/helper-skip-transparent-expression-wrappers": ^7.20.0
     "@babel/plugin-syntax-optional-chaining": ^7.8.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 274b8932335bd064ca24cf1a4da2b2c20c92726d4bfa8b0cb5023857479b8481feef33505c16650c7b9239334e5c6959babc924816324c4cf223dd91c7ca79bc
+  checksum: 11c5449e01b18bb8881e8e005a577fa7be2fe5688e2382c8822d51f8f7005342a301a46af7b273b1f5645f9a7b894c428eee8526342038a275ef6ba4c8d8d746
   languageName: node
   linkType: hard
 
@@ -618,16 +619,16 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-private-property-in-object@npm:^7.18.6":
-  version: 7.20.5
-  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.20.5"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-create-class-features-plugin": ^7.20.5
+    "@babel/helper-create-class-features-plugin": ^7.21.0
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-private-property-in-object": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 513b5e0e2c1b2846be5336cf680e932ae17924ef885aa1429e1a4f7924724bdd99b15f28d67187d0a006d5f18a0c4b61d96c3ecb4902fed3c8fe2f0abfc9753a
+  checksum: add881a6a836635c41d2710551fdf777e2c07c0b691bf2baacc5d658dd64107479df1038680d6e67c468bfc6f36fb8920025d6bac2a1df0a81b867537d40ae78
   languageName: node
   linkType: hard
 
@@ -888,24 +889,24 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-block-scoping@npm:^7.20.2":
-  version: 7.20.15
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.20.15"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.21.0"
   dependencies:
     "@babel/helper-plugin-utils": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 1dddf7be578306837074cb5059f8408af0b1c0bfcf922ed920d4aa65d08fb7c6e6129ca254e9879c4c6d2a6be4937111551f51922e8b0e071ed16eb6564a4dbb
+  checksum: 15aacaadbecf96b53a750db1be4990b0d89c7f5bc3e1794b63b49fb219638c1fd25d452d15566d7e5ddf5b5f4e1a0a0055c35c1c7aee323c7b114bf49f66f4b0
   languageName: node
   linkType: hard
 
 "@babel/plugin-transform-classes@npm:^7.20.2":
-  version: 7.20.7
-  resolution: "@babel/plugin-transform-classes@npm:7.20.7"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-classes@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
     "@babel/helper-compilation-targets": ^7.20.7
     "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-function-name": ^7.21.0
     "@babel/helper-optimise-call-expression": ^7.18.6
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/helper-replace-supers": ^7.20.7
@@ -913,7 +914,7 @@ __metadata:
     globals: ^11.1.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 4cf55ad88e52c7c66a991add4c8e1c3324384bd52df7085962d396879561456a44352e5ab1725cc80f4e83737a2931e847c4a96c7aa4a549357f23631ff31799
+  checksum: 088ae152074bd0e90f64659169255bfe50393e637ec8765cb2a518848b11b0299e66b91003728fd0a41563a6fdc6b8d548ece698a314fd5447f5489c22e466b7
   languageName: node
   linkType: hard
 
@@ -976,13 +977,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-for-of@npm:^7.18.8":
-  version: 7.18.8
-  resolution: "@babel/plugin-transform-for-of@npm:7.18.8"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-for-of@npm:7.21.0"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: ca64c623cf0c7a80ab6f07ebd3e6e4ade95e2ae806696f70b43eafe6394fa8ce21f2b1ffdd15df2067f7363d2ecfe26472a97c6c774403d2163fa05f50c98f17
+  checksum: 2f3f86ca1fab2929fcda6a87e4303d5c635b5f96dc9a45fd4ca083308a3020c79ac33b9543eb4640ef2b79f3586a00ab2d002a7081adb9e9d7440dce30781034
   languageName: node
   linkType: hard
 
@@ -1152,17 +1153,17 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-jsx@npm:^7.18.6":
-  version: 7.20.13
-  resolution: "@babel/plugin-transform-react-jsx@npm:7.20.13"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
     "@babel/helper-module-imports": ^7.18.6
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-jsx": ^7.18.6
-    "@babel/types": ^7.20.7
+    "@babel/types": ^7.21.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: b1daaa9b093ab59f71572dde7ad05ed3490433a47de103fc866f60347da55fa7fe84cf9b4c9fa22917517d52f70ab5e05ec631bba1c348733c0d8ebbd7de8c68
+  checksum: c77d277d2e55b489a9b9be185c3eed5d8e2c87046778810f8e47ee3c87b47e64cad93c02211c968486c7958fd05ce203c66779446484c98a7b3a69bec687d5dc
   languageName: node
   linkType: hard
 
@@ -1257,16 +1258,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.18.6":
-  version: 7.20.13
-  resolution: "@babel/plugin-transform-typescript@npm:7.20.13"
+"@babel/plugin-transform-typescript@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-typescript@npm:7.21.0"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.20.12
+    "@babel/helper-create-class-features-plugin": ^7.21.0
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-typescript": ^7.20.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 0b0c3a3e53268d4feb35eb17d57873f2488392e404a0b32735d51c49b08462dc738ebd860f0ff3a3dc5cd1b1fa70340bb6c072239c86afca635831b930593b3b
+  checksum: 091931118eb515738a4bc8245875f985fc9759d3f85cdf08ee641779b41520241b369404e2bb86fc81907ad827678fdb704e8e5a995352def5dd3051ea2cd870
   languageName: node
   linkType: hard
 
@@ -1409,16 +1410,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:7.18.6":
-  version: 7.18.6
-  resolution: "@babel/preset-typescript@npm:7.18.6"
+"@babel/preset-typescript@npm:7.21.0":
+  version: 7.21.0
+  resolution: "@babel/preset-typescript@npm:7.21.0"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
-    "@babel/helper-validator-option": ^7.18.6
-    "@babel/plugin-transform-typescript": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/helper-validator-option": ^7.21.0
+    "@babel/plugin-transform-typescript": ^7.21.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 7fe0da5103eb72d3cf39cf3e138a794c8cdd19c0b38e3e101507eef519c46a87a0d6d0e8bc9e28a13ea2364001ebe7430b9d75758aab4c3c3a8db9a487b9dc7c
+  checksum: 6e1f4d7294de2678fbaf36035e98847b2be432f40fe7a1204e5e45b8b05bcbe22902fe0d726e16af14de5bc08987fae28a7899871503fd661050d85f58755af6
   languageName: node
   linkType: hard
 
@@ -1429,12 +1430,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.20.13, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.20.13
-  resolution: "@babel/runtime@npm:7.20.13"
+"@babel/runtime@npm:7.21.0, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.21.0
+  resolution: "@babel/runtime@npm:7.21.0"
   dependencies:
     regenerator-runtime: ^0.13.11
-  checksum: 09b7a97a05c80540db6c9e4ddf8c5d2ebb06cae5caf3a87e33c33f27f8c4d49d9c67a2d72f1570e796045288fad569f98a26ceba0c4f5fad2af84b6ad855c4fb
+  checksum: 7b33e25bfa9e0e1b9e8828bb61b2d32bdd46b41b07ba7cb43319ad08efc6fda8eb89445193e67d6541814627df0ca59122c0ea795e412b99c5183a0540d338ab
   languageName: node
   linkType: hard
 
@@ -1449,32 +1450,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.20.10, @babel/traverse@npm:^7.20.12, @babel/traverse@npm:^7.20.13, @babel/traverse@npm:^7.20.5, @babel/traverse@npm:^7.20.7, @babel/traverse@npm:^7.7.2":
-  version: 7.20.13
-  resolution: "@babel/traverse@npm:7.20.13"
+"@babel/traverse@npm:^7.20.5, @babel/traverse@npm:^7.20.7, @babel/traverse@npm:^7.21.0, @babel/traverse@npm:^7.7.2":
+  version: 7.21.0
+  resolution: "@babel/traverse@npm:7.21.0"
   dependencies:
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.20.7
+    "@babel/generator": ^7.21.0
     "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-function-name": ^7.21.0
     "@babel/helper-hoist-variables": ^7.18.6
     "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.20.13
-    "@babel/types": ^7.20.7
+    "@babel/parser": ^7.21.0
+    "@babel/types": ^7.21.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 30ca6e0bd18233fda48fa09315efd14dfc61dcf5b8fa3712b343bfc61b32bc63b5e85ea1773cc9576c9b293b96f46b4589aaeb0a52e1f3eeac4edc076d049fc7
+  checksum: 99241b22db509d2f01a9af51bfab1d68e73cd3b66bbc2560f0f65e49880f68a05ead913e72a4e464152430a027f0c7822f126d6f1bcc3bc3e01ef8b8558a6dc6
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.20.7, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.20.7
-  resolution: "@babel/types@npm:7.20.7"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+  version: 7.21.0
+  resolution: "@babel/types@npm:7.21.0"
   dependencies:
     "@babel/helper-string-parser": ^7.19.4
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
-  checksum: b39af241f0b72bba67fd6d0d23914f6faec8c0eba8015c181cbd5ea92e59fc91a52a1ab490d3520c7dbd19ddb9ebb76c476308f6388764f16d8201e37fae6811
+  checksum: dbcdda202b3a2bfd59e4de880ce38652f1f8957893a9751be069ac86e47ad751222070fe6cd92220214d77973f1474e4e1111c16dc48199dfca1489c0ee8c0c5
   languageName: node
   linkType: hard
 
@@ -1759,9 +1760,9 @@ __metadata:
   linkType: hard
 
 "@csstools/css-tokenizer@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "@csstools/css-tokenizer@npm:2.0.2"
-  checksum: 49bd0a191954b56e9fa50d4a3e2d04059196f04efe398c0cb3c2cbcc18549313d984cd0b8c3faa161d81768256014461d1b4d0f40a67764c9c7a6c0e14a97fea
+  version: 2.1.0
+  resolution: "@csstools/css-tokenizer@npm:2.1.0"
+  checksum: af3619557e18cd348810cfb41b3b7177b36d216df8dd4cac3979f241c15416baf8cdd55fb764ecc78fab5985b085363cfc8e8b8a18aaa361d00c9b9300b7c0f3
   languageName: node
   linkType: hard
 
@@ -2006,8 +2007,8 @@ __metadata:
     "@babel/helper-plugin-utils": 7.20.2
     "@babel/preset-env": 7.20.2
     "@babel/preset-react": 7.18.6
-    "@babel/preset-typescript": 7.18.6
-    "@babel/runtime": 7.20.13
+    "@babel/preset-typescript": 7.21.0
+    "@babel/runtime": 7.21.0
     cross-env: 7.0.3
     eslint: 8.34.0
     react-refresh: 0.14.0
@@ -2022,10 +2023,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/eslint-plugin-legend-studio@workspace:packages/eslint-plugin"
   dependencies:
-    "@babel/core": 7.20.12
+    "@babel/core": 7.21.0
     "@babel/eslint-parser": 7.19.1
-    "@typescript-eslint/eslint-plugin": 5.52.0
-    "@typescript-eslint/parser": 5.52.0
+    "@typescript-eslint/eslint-plugin": 5.53.0
+    "@typescript-eslint/parser": 5.53.0
     cross-env: 7.0.3
     eslint-config-prettier: 8.6.0
     eslint-plugin-import: 2.27.5
@@ -2393,7 +2394,7 @@ __metadata:
     "@fontsource/roboto-condensed": 4.5.9
     "@fontsource/roboto-mono": 4.5.10
     "@jest/globals": 29.4.3
-    "@mui/material": 5.11.9
+    "@mui/material": 5.11.10
     "@types/react": 18.0.28
     "@types/react-select": 4.0.18
     "@types/react-window": 1.8.5
@@ -2413,7 +2414,7 @@ __metadata:
     react-icons: 4.7.1
     react-markdown: 8.0.5
     react-reflex: 4.0.9
-    react-resize-detector: 8.0.3
+    react-resize-detector: 8.0.4
     react-select: 4.3.1
     react-window: 1.8.8
     remark-gfm: 3.0.1
@@ -2429,7 +2430,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@finos/legend-dev-utils@workspace:packages/legend-dev-utils"
   dependencies:
-    "@babel/core": 7.20.12
+    "@babel/core": 7.21.0
     "@changesets/assemble-release-plan": 5.2.3
     "@changesets/changelog-github": 0.4.8
     "@changesets/config": 2.3.0
@@ -2457,7 +2458,7 @@ __metadata:
     jest: 29.4.3
     jest-canvas-mock: 2.4.0
     jest-environment-jsdom: 29.4.3
-    jest-extended: 3.2.3
+    jest-extended: 3.2.4
     jest-watch-typeahead: 2.2.2
     jsonc-parser: 3.2.0
     micromatch: 4.0.5
@@ -3438,7 +3439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.14, @jridgewell/trace-mapping@npm:^0.3.15, @jridgewell/trace-mapping@npm:^0.3.9":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.14, @jridgewell/trace-mapping@npm:^0.3.15, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.17
   resolution: "@jridgewell/trace-mapping@npm:0.3.17"
   dependencies:
@@ -3518,9 +3519,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:5.11.9":
-  version: 5.11.9
-  resolution: "@mui/material@npm:5.11.9"
+"@mui/material@npm:5.11.10":
+  version: 5.11.10
+  resolution: "@mui/material@npm:5.11.10"
   dependencies:
     "@babel/runtime": ^7.20.13
     "@mui/base": 5.0.0-alpha.118
@@ -3547,7 +3548,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: a9f796549aef16dc7aaae4afc65fb0deaf920004f00c957c21fa1f09fe0a7587c3e1fbeffb239b961ca64d7727beadd434b62e530a9e44d59a909e4c95f0f1ce
+  checksum: 7d0ee8b7bc8a39146464a9a3ccc18766aff55914e7d801590b401f79c36e98b3b17aacd069e2620166024dd1020e67ad3a38da0d72e6aa0283d760a488c79501
   languageName: node
   linkType: hard
 
@@ -4557,13 +4558,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.52.0"
+"@typescript-eslint/eslint-plugin@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.53.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.52.0
-    "@typescript-eslint/type-utils": 5.52.0
-    "@typescript-eslint/utils": 5.52.0
+    "@typescript-eslint/scope-manager": 5.53.0
+    "@typescript-eslint/type-utils": 5.53.0
+    "@typescript-eslint/utils": 5.53.0
     debug: ^4.3.4
     grapheme-splitter: ^1.0.4
     ignore: ^5.2.0
@@ -4577,43 +4578,43 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: cff07ee94d8ab2a1b6c33b5c5bf641eff2bf2bebc0f35a9d8b3f128fd610e27a4aaf620bc2ad23608ad161b1810b7e32e5a2e0f746cc5094c3f506f7a14daa34
+  checksum: 12dffe65969d8e5248c86a700fe46a737e55ecafb276933e747b4731eab6266fe55e2d43a34b8b340179fe248e127d861cd016a7614b1b9804cd0687c99616d1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/parser@npm:5.52.0"
+"@typescript-eslint/parser@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/parser@npm:5.53.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.52.0
-    "@typescript-eslint/types": 5.52.0
-    "@typescript-eslint/typescript-estree": 5.52.0
+    "@typescript-eslint/scope-manager": 5.53.0
+    "@typescript-eslint/types": 5.53.0
+    "@typescript-eslint/typescript-estree": 5.53.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 1d8ff6e932f9c9db8d24b16ce89fd963f0982c38559e500aa1f8dc5cd66abd02f1659dd1a1361ce550def05331803caa69a69a039b54c94fc0f22919a2305c12
+  checksum: 979e5d63793a9e64998b1f956ba0f00f8a2674db3a664fafce7b2433323f5248bd776af8305e2419d73a9d94c55176fee099abc5c153b4cc52e5765c725c1edd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.52.0"
+"@typescript-eslint/scope-manager@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.53.0"
   dependencies:
-    "@typescript-eslint/types": 5.52.0
-    "@typescript-eslint/visitor-keys": 5.52.0
-  checksum: 9a03fe30f8e90a5106c482478f213eefdd09f2f74e24d9dc59b453885466a758fe6d1cd24d706aed6188fb03c84b16ca6491cf20da6b16b8fc53cad8b8c327f2
+    "@typescript-eslint/types": 5.53.0
+    "@typescript-eslint/visitor-keys": 5.53.0
+  checksum: 51f31dc01e95908611f402441f58404da80a338c0237b2b82f4a7b0b2e8868c4bfe8f7cf44b2567dd56533de609156a5d4ac54bb1f9f09c7014b99428aef2543
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/type-utils@npm:5.52.0"
+"@typescript-eslint/type-utils@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/type-utils@npm:5.53.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": 5.52.0
-    "@typescript-eslint/utils": 5.52.0
+    "@typescript-eslint/typescript-estree": 5.53.0
+    "@typescript-eslint/utils": 5.53.0
     debug: ^4.3.4
     tsutils: ^3.21.0
   peerDependencies:
@@ -4621,23 +4622,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ac5422040461febab8a2eeec76d969024ccff76203dec357f7220c9b5e0dde96e3e3a76fd4118d42b50bd5bfb3a194aaceeb63417a2ac4e1ebf5e687558a9a10
+  checksum: 52c40967c5fabd58c2ae8bf519ef89e4feb511e4df630aeaeac8335661a79b6b3a32d30a61a5f1d8acc703f21c4d90751a5d41cda1b35d08867524da11bc2e1d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/types@npm:5.52.0"
-  checksum: 018940d61aebf7cf3f7de1b9957446e2ea01f08fe950bef4788c716a3a88f7c42765fe7d80152b0d0428fcd4bd3ace2dfa8c459ba1c59d9a84e951642180f869
+"@typescript-eslint/types@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/types@npm:5.53.0"
+  checksum: b0eaf23de4ab13697d4d2095838c959a3f410c30f0d19091e5ca08e62320c3cc3c72bcb631823fb6a4fbb31db0a059e386a0801244930d0a88a6a698e5f46548
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.52.0"
+"@typescript-eslint/typescript-estree@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.53.0"
   dependencies:
-    "@typescript-eslint/types": 5.52.0
-    "@typescript-eslint/visitor-keys": 5.52.0
+    "@typescript-eslint/types": 5.53.0
+    "@typescript-eslint/visitor-keys": 5.53.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -4646,35 +4647,35 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 67d396907fee3d6894e26411a5098a37f07e5d50343189e6361ff7db91c74a7ffe2abd630d11f14c2bda1f4af13edf52b80b11cbccb55b44079c7cec14c9e108
+  checksum: 6e119c8e4167c8495d728c5556a834545a9c064918dd5e7b79b0d836726f4f8e2a0297b0ac82bf2b71f1e5427552217d0b59d8fb1406fd79bd3bf91b75dca873
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/utils@npm:5.52.0"
+"@typescript-eslint/utils@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/utils@npm:5.53.0"
   dependencies:
     "@types/json-schema": ^7.0.9
     "@types/semver": ^7.3.12
-    "@typescript-eslint/scope-manager": 5.52.0
-    "@typescript-eslint/types": 5.52.0
-    "@typescript-eslint/typescript-estree": 5.52.0
+    "@typescript-eslint/scope-manager": 5.53.0
+    "@typescript-eslint/types": 5.53.0
+    "@typescript-eslint/typescript-estree": 5.53.0
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
     semver: ^7.3.7
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 01906be5262ece36537e9d586e4d2d4791e05752a9354bcb42b1f5bf965f53daa13309c61c3dff5e201ea28c298e4e01cf0c93738afa0099fea0da3b1d8cb3a5
+  checksum: 18e6bac14ae853385a74123759850bca367904723e170c37416fc014673eb714afb6bb090367bff61494a8387e941b6af65ee5f4f845f7177fabb4df85e01643
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.52.0":
-  version: 5.52.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.52.0"
+"@typescript-eslint/visitor-keys@npm:5.53.0":
+  version: 5.53.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.53.0"
   dependencies:
-    "@typescript-eslint/types": 5.52.0
+    "@typescript-eslint/types": 5.53.0
     eslint-visitor-keys: ^3.3.0
-  checksum: 33b44f0cd35b7b47f34e89d52e47b8d8200f55af306b22db4de104d79f65907458ea022e548f50d966e32fea150432ac9c1ae65b3001b0ad2ac8a17c0211f370
+  checksum: 090695883c15364c6f401e97f56b13db0f31c1114f3bd22562bd41734864d27f6a3c80de33957e9dedab2d5f94b0f4480ba3fde1d4574e74dca4593917b7b54a
   languageName: node
   linkType: hard
 
@@ -5789,9 +5790,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001426, caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001456
-  resolution: "caniuse-lite@npm:1.0.30001456"
-  checksum: c2cc479962149abd09a25b64699ee7484d9c433db2bad0a489f7b51b09a463c991f6efd7b8e201bc1a1ccf3294263f88503a3adf0a57db9046939ee7e58b76a6
+  version: 1.0.30001457
+  resolution: "caniuse-lite@npm:1.0.30001457"
+  checksum: f311a7c5098681962402a86a0a367014ee91c3135395ee68bbfaf45caf0e36d581e42d7c5b1526ce99484a228e6cf5cf0e400678292c65f5a21512a3fc7a5fb6
   languageName: node
   linkType: hard
 
@@ -7052,9 +7053,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.284":
-  version: 1.4.302
-  resolution: "electron-to-chromium@npm:1.4.302"
-  checksum: aa764494f9a5b6916ba9f311c0204b2c73449addba18cc55d43e84e8c4465732af9cd6560a8efeb32f3c5a928299030e41352e5b3a081e9e56b086d5be618f45
+  version: 1.4.304
+  resolution: "electron-to-chromium@npm:1.4.304"
+  checksum: 40c8b9e18155d8f0800d7ff99be57fb0512ecd807300ab678eed5a3dc59f44d47be60142cfb8abff5cdc1557fcba5f35e016860c0198dcc8f7303153bbe0926a
   languageName: node
   linkType: hard
 
@@ -7959,13 +7960,13 @@ __metadata:
   linkType: hard
 
 "find-my-way@npm:^7.3.0":
-  version: 7.4.0
-  resolution: "find-my-way@npm:7.4.0"
+  version: 7.5.0
+  resolution: "find-my-way@npm:7.5.0"
   dependencies:
     fast-deep-equal: ^3.1.3
     fast-querystring: ^1.0.0
     safe-regex2: ^2.0.0
-  checksum: 8f01b63c28d2a95f5bea674ca4c2ea6f444af5a5d87b54e124fe8a656d26617f4be1443f13e5e7cc155ddf40c2c9604dcd2fe9cfd5d06343aa9e32e06af42a16
+  checksum: 25d2ab4af6cc9a22e8f6d41b50d8ee84e8304ceebeb5c0a0951d7d48056cd904cc18d78d0c1675fcea8b56311e7f82e28d19b48715910282fa3cd191d532909e
   languageName: node
   linkType: hard
 
@@ -9694,9 +9695,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-extended@npm:3.2.3":
-  version: 3.2.3
-  resolution: "jest-extended@npm:3.2.3"
+"jest-extended@npm:3.2.4":
+  version: 3.2.4
+  resolution: "jest-extended@npm:3.2.4"
   dependencies:
     jest-diff: ^29.0.0
     jest-get-type: ^29.0.0
@@ -9705,7 +9706,7 @@ __metadata:
   peerDependenciesMeta:
     jest:
       optional: true
-  checksum: af837ca22ed80e9542bb234d137b0d235ef04efb4a071717ec9f41f97533e44e1f1b8de2d47504804bb78e568fafca662a6ccf12b74f66f3b8e8bcb7d460d7aa
+  checksum: 16e4f300d9c5bf110f7f3422e49e06c968a99a44cede2b2821ddd480c33b3d9cd4dc58035b2f022e6018247da8f887295d6c2499647675dedb6e305142604e7d
   languageName: node
   linkType: hard
 
@@ -10261,7 +10262,7 @@ __metadata:
   dependencies:
     "@actions/core": 1.10.0
     "@actions/github": 5.1.1
-    "@babel/core": 7.20.12
+    "@babel/core": 7.21.0
     "@changesets/cli": 2.26.0
     "@finos/babel-preset-legend-studio": "workspace:*"
     "@finos/eslint-plugin-legend-studio": "workspace:*"
@@ -10284,10 +10285,10 @@ __metadata:
     sass: 1.58.3
     semver: 7.3.8
     sort-package-json: 2.4.1
-    stylelint: 15.1.0
+    stylelint: 15.2.0
     typedoc: 0.23.25
     typescript: 4.9.5
-    yargs: 17.7.0
+    yargs: 17.7.1
   languageName: unknown
   linkType: soft
 
@@ -12088,13 +12089,13 @@ __metadata:
   linkType: hard
 
 "open@npm:^8.0.9":
-  version: 8.4.1
-  resolution: "open@npm:8.4.1"
+  version: 8.4.2
+  resolution: "open@npm:8.4.2"
   dependencies:
     define-lazy-prop: ^2.0.0
     is-docker: ^2.1.1
     is-wsl: ^2.2.0
-  checksum: dbe8e1d98889df60b5179eab8b94b9591744d1f0033bce1a9a10738ba140bd9d625d6bcde7ff9f043e379aafb918975c2daa03b87cef13eb046ac18ed807f06d
+  checksum: 6388bfff21b40cb9bd8f913f9130d107f2ed4724ea81a8fd29798ee322b361ca31fa2cdfb491a5c31e43a3996cfe9566741238c7a741ada8d7af1cb78d85cf26
   languageName: node
   linkType: hard
 
@@ -13401,15 +13402,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resize-detector@npm:8.0.3":
-  version: 8.0.3
-  resolution: "react-resize-detector@npm:8.0.3"
+"react-resize-detector@npm:8.0.4":
+  version: 8.0.4
+  resolution: "react-resize-detector@npm:8.0.4"
   dependencies:
     lodash: ^4.17.21
   peerDependencies:
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 21d34004c925ee97708501d4484ee1e81411eaaa84772d58ed6be08665a81725508645223be14347ae6dad321386830c72619f8de7046708f0b3b9d900b225aa
+  checksum: f53a99cc5413844a6fc2a713b0b1094d23947897c14ab64481938632f4e77fadded52d91a6619055abf6240c7cacd6cc7dd492ea866639b302f81df680709d45
   languageName: node
   linkType: hard
 
@@ -13682,7 +13683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpu-core@npm:^5.2.1":
+"regexpu-core@npm:^5.3.1":
   version: 5.3.1
   resolution: "regexpu-core@npm:5.3.1"
   dependencies:
@@ -15021,9 +15022,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint@npm:15.1.0":
-  version: 15.1.0
-  resolution: "stylelint@npm:15.1.0"
+"stylelint@npm:15.2.0":
+  version: 15.2.0
+  resolution: "stylelint@npm:15.2.0"
   dependencies:
     "@csstools/css-parser-algorithms": ^2.0.1
     "@csstools/css-tokenizer": ^2.0.1
@@ -15069,7 +15070,7 @@ __metadata:
     write-file-atomic: ^5.0.0
   bin:
     stylelint: bin/stylelint.js
-  checksum: 65cb90cf52fd6214999affd4463090ad52fa2735471987a79860028ed8b4149670158fd56e2c2c7f0efff3d7070329ba167a0fa1c4bfc0cd79dc841ed113a20e
+  checksum: 2a52d1b36345659e92280317554d82fc621203341d3a6baf1b19f3c28d06a07b8c5f7a25b9be2383f73a4e6a395d69dfbbe4daeca19bd119b88673dd8b6518ac
   languageName: node
   linkType: hard
 
@@ -16536,9 +16537,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.0, yargs@npm:^17.1.1, yargs@npm:^17.3.1":
-  version: 17.7.0
-  resolution: "yargs@npm:17.7.0"
+"yargs@npm:17.7.1, yargs@npm:^17.1.1, yargs@npm:^17.3.1":
+  version: 17.7.1
+  resolution: "yargs@npm:17.7.1"
   dependencies:
     cliui: ^8.0.1
     escalade: ^3.1.1
@@ -16547,7 +16548,7 @@ __metadata:
     string-width: ^4.2.3
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
-  checksum: e7d5f5b60e63b04ded7c27c3d4b194565565cac3ea19fffcdbb183bed973a83106822a04dda28ebba4811ce92949a9d9858d3935186ff8f343548bf98aab2120
+  checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- [x] bump dependencies
- [x] add metrics for application loading (including `Legend Query` and `Legend Taxonomy`)
- [x] terminal: fix a problem with hotkey `Control+KeyC` clash between abort and copy commands in Windows
- [x] refactor: update fields in `ApplicationStore` to be **readonly**

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

