### PR TITLE
Fixes re-rendering of query builder results data table

### DIFF
--- a/.changeset/pistachio-pigeons-ponder.md
+++ b/.changeset/pistachio-pigeons-ponder.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Fixes re-rendering of query builder results data table.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->



## Summary

Formerly, due to our `onCellMouseOver` action we were changing a state every time the user hovered on a cell, and this would cause the table to go back to the top of the grid each time which does not allow them to view any results if they attempt to scroll down. To not have this behavior, adding a row id for each row and also making the row data immutable. See: https://www.ag-grid.com/javascript-data-grid/data-update-row-data/ for details. 


![Kapture 2023-02-23 at 14 50 07](https://user-images.githubusercontent.com/41248956/221015048-17610692-56b0-4baf-a886-c3a47d5a69e6.gif)

Previously: 
![Kapture 2023-02-23 at 14 57 29](https://user-images.githubusercontent.com/41248956/221016470-ef84ecef-1040-4f85-980b-cd009f0e054d.gif)

^This shows that despite trying to scroll you will always end up in the first row '405' unless you scroll directly with your cursor hovered on the scrollbar, but it will also immediately return to the top the moment you hover over a cell


<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
