### PR TITLE
default parameter dates to now/today

### DIFF
--- a/.changeset/quick-pumas-type.md
+++ b/.changeset/quick-pumas-type.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-query-builder': patch
+---

--- a/.changeset/quick-pumas-type.md
+++ b/.changeset/quick-pumas-type.md
@@ -1,3 +1,5 @@
 ---
 '@finos/legend-query-builder': patch
 ---
+
+default parameter of type `DATE` and `DATETIME` to the function `now()` and `StrictDate` to `today()`

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderVariables.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderVariables.test.tsx
@@ -22,13 +22,17 @@ import {
   act,
   getByText,
 } from '@testing-library/react';
-import { TEST_DATA__simpleProjection } from '../../stores/__tests__/TEST_DATA__QueryBuilder_Generic.js';
+import {
+  TEST_DATA__simpleProjection,
+  TEST_DATA__simpeDateParameters,
+} from '../../stores/__tests__/TEST_DATA__QueryBuilder_Generic.js';
 import { TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational } from '../../stores/__tests__/TEST_DATA__ModelCoverageAnalysisResult.js';
 import TEST_DATA__ComplexRelationalModel from '../../stores/__tests__/TEST_DATA__QueryBuilder_Model_ComplexRelational.json';
 import { integrationTest } from '@finos/legend-shared';
 import {
   create_RawLambda,
   PrimitiveType,
+  PRIMITIVE_TYPE,
   stub_RawLambda,
 } from '@finos/legend-graph';
 import { QUERY_BUILDER_TEST_ID } from '../QueryBuilder_TestID.js';
@@ -205,3 +209,81 @@ test(
     ).not.toBeNull();
   },
 );
+
+test(integrationTest('Query builder parameter default values'), async () => {
+  const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+    TEST_DATA__ComplexRelationalModel,
+    stub_RawLambda(),
+    'model::relational::tests::simpleRelationalMapping',
+    'model::MyRuntime',
+    TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
+  );
+  // Date
+  const param1Lambda = TEST_DATA__simpeDateParameters(PRIMITIVE_TYPE.DATE);
+  await act(async () => {
+    queryBuilderState.initializeWithQuery(
+      create_RawLambda(param1Lambda.parameters, param1Lambda.body),
+    );
+  });
+  await waitFor(() =>
+    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS),
+  );
+  const parameterPanel = renderResult.getByTestId(
+    QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS,
+  );
+  expect(getByText(parameterPanel, 'var_1')).not.toBeNull();
+  fireEvent.click(renderResult.getByText('Run Query'));
+  let executeDialog = await waitFor(() => renderResult.getByRole('dialog'));
+  expect(getByText(executeDialog, 'Set Parameter Values'));
+  expect(getByText(executeDialog, 'var_1')).not.toBeNull();
+  expect(getByText(executeDialog, 'Date')).not.toBeNull();
+  expect(getByText(executeDialog, 'Now')).not.toBeNull();
+
+  // DateTime
+  const param2Lambda = TEST_DATA__simpeDateParameters(PRIMITIVE_TYPE.DATETIME);
+  await act(async () => {
+    queryBuilderState.initializeWithQuery(
+      create_RawLambda(param2Lambda.parameters, param2Lambda.body),
+    );
+  });
+
+  await waitFor(() =>
+    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS),
+  );
+  const parameter2Panel = renderResult.getByTestId(
+    QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS,
+  );
+  expect(getByText(parameter2Panel, 'var_1')).not.toBeNull();
+  expect(getByText(parameter2Panel, 'DateTime')).not.toBeNull();
+  fireEvent.click(renderResult.getByText('Run Query'));
+  executeDialog = await waitFor(() => renderResult.getByRole('dialog'));
+  expect(getByText(executeDialog, 'Set Parameter Values'));
+  expect(getByText(executeDialog, 'var_1')).not.toBeNull();
+  expect(getByText(executeDialog, 'DateTime')).not.toBeNull();
+  expect(getByText(executeDialog, 'Now')).not.toBeNull();
+
+  // StrictDate
+  const param3Lambda = TEST_DATA__simpeDateParameters(
+    PRIMITIVE_TYPE.STRICTDATE,
+  );
+  await act(async () => {
+    queryBuilderState.initializeWithQuery(
+      create_RawLambda(param3Lambda.parameters, param3Lambda.body),
+    );
+  });
+
+  await waitFor(() =>
+    renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS),
+  );
+  const parameter3Panel = renderResult.getByTestId(
+    QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS,
+  );
+  expect(getByText(parameter3Panel, 'var_1')).not.toBeNull();
+  expect(getByText(parameter3Panel, 'StrictDate')).not.toBeNull();
+  fireEvent.click(renderResult.getByText('Run Query'));
+  executeDialog = await waitFor(() => renderResult.getByRole('dialog'));
+  expect(getByText(executeDialog, 'Set Parameter Values'));
+  expect(getByText(executeDialog, 'var_1')).not.toBeNull();
+  expect(getByText(executeDialog, 'StrictDate')).not.toBeNull();
+  expect(getByText(executeDialog, 'Today')).not.toBeNull();
+});

--- a/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
+++ b/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
@@ -48,7 +48,10 @@ import {
   UnsupportedOperationError,
 } from '@finos/legend-shared';
 import { useEffect, useRef, useState } from 'react';
-import { buildPrimitiveInstanceValue } from '../../stores/shared/ValueSpecificationEditorHelper.js';
+import {
+  buildPrimitiveInstanceValue,
+  createSupportedFunctionExpression,
+} from '../../stores/shared/ValueSpecificationEditorHelper.js';
 import {
   functionExpression_addParameterValue,
   instanceValue_setValue,
@@ -329,26 +332,16 @@ const buildPureDateFunctionExpression = (
   } else {
     switch (datePickerOption.value) {
       case CUSTOM_DATE_PICKER_OPTION.TODAY: {
-        const todaySFE = new SimpleFunctionExpression(
+        return createSupportedFunctionExpression(
           SUPPORTED_FUNCTIONS.TODAY,
+          PrimitiveType.STRICTDATE,
         );
-        valueSpecification_setGenericType(
-          todaySFE,
-          GenericTypeExplicitReference.create(
-            new GenericType(PrimitiveType.STRICTDATE),
-          ),
-        );
-        return todaySFE;
       }
       case CUSTOM_DATE_PICKER_OPTION.NOW: {
-        const nowSFE = new SimpleFunctionExpression(SUPPORTED_FUNCTIONS.NOW);
-        valueSpecification_setGenericType(
-          nowSFE,
-          GenericTypeExplicitReference.create(
-            new GenericType(PrimitiveType.DATETIME),
-          ),
+        return createSupportedFunctionExpression(
+          SUPPORTED_FUNCTIONS.NOW,
+          PrimitiveType.DATETIME,
         );
-        return nowSFE;
       }
       case CUSTOM_DATE_OPTION_REFERENCE_MOMENT.FIRST_DAY_OF_YEAR: {
         const firstDayOfYearSFE = new SimpleFunctionExpression(

--- a/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
@@ -1699,3 +1699,91 @@ export const TEST_DATA__simpleProjectionWithSubtypeFromSubtypeModel = {
   ],
   parameters: [],
 };
+
+export const TEST_DATA__simpeDateParameters = (
+  paramType: string,
+): { parameters?: object; body?: object; _type: string } => ({
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'take',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'project',
+          parameters: [
+            {
+              _type: 'func',
+              function: 'getAll',
+              parameters: [
+                {
+                  _type: 'packageableElementPtr',
+                  fullPath: 'model::pure::tests::model::simple::Person',
+                },
+              ],
+            },
+            {
+              _type: 'collection',
+              multiplicity: {
+                lowerBound: 1,
+                upperBound: 1,
+              },
+              values: [
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'property',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                      property: 'age',
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'collection',
+              multiplicity: {
+                lowerBound: 1,
+                upperBound: 1,
+              },
+              values: [
+                {
+                  _type: 'string',
+                  value: 'Age',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'integer',
+          value: 1000,
+        },
+      ],
+    },
+  ],
+  parameters: [
+    {
+      _type: 'var',
+      class: paramType,
+      multiplicity: {
+        lowerBound: 1,
+        upperBound: 1,
+      },
+      name: 'var_1',
+    },
+  ],
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
- [x] default DATE/DATETIME parameter values to `now()` and default `StrictDate` to `today()`

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
