### PR TITLE
Prettify const names with acronyms

### DIFF
--- a/.changeset/flippant-finches-fritter.md
+++ b/.changeset/flippant-finches-fritter.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-shared': patch
+---
+
+Prettify const names with acronyms

--- a/.changeset/swayed-starlings-shuffle.md
+++ b/.changeset/swayed-starlings-shuffle.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-query-builder': patch
+---

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderHighlightExplorerTreeUsedProperty.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderHighlightExplorerTreeUsedProperty.test.tsx
@@ -82,7 +82,7 @@ const cases: TestCase[] = [
       rawLambda: TEST_DATA__projectionWithNestedSubtype,
       rawMappingModelCoverageAnalysisResult:
         TEST_DATA__ModelCoverageAnalysisResult_NestedSubtype,
-      nodesToExpand: ['Address', '@Addresstype1', '@Addresstype2'],
+      nodesToExpand: ['Address', '@Address Type 1', '@Address Type 2'],
       expectedNumberOfUsedPropertyNode: 5,
     },
   ],
@@ -110,7 +110,7 @@ const cases: TestCase[] = [
       rawLambda: TEST_DATA__graphFetchWithNestedSubtype,
       rawMappingModelCoverageAnalysisResult:
         TEST_DATA__ModelCoverageAnalysisResult_NestedSubtype,
-      nodesToExpand: ['Address', '@Addresstype1', '@Addresstype2'],
+      nodesToExpand: ['Address', '@Address Type 1', '@Address Type 2'],
       expectedNumberOfUsedPropertyNode: 5,
     },
   ],

--- a/packages/legend-shared/src/format/FormatterUtils.ts
+++ b/packages/legend-shared/src/format/FormatterUtils.ts
@@ -56,8 +56,6 @@ export const TITLE_CASE_EXCEPTION_WORDS = [
   'up',
 ];
 
-export const CONST_EXCEPTION_ID = ['Id', 'ID'];
-
 export const toTitleCase = (value: string | undefined): string =>
   (value ?? '')
     .trim()
@@ -82,19 +80,29 @@ export const prettyCamelCase = (value: string | undefined): string =>
     .replace(/(?:[A-Z])/gu, (val) => ` ${val}`)
     .trim();
 
+export const prettySimpleCONSTName = (value: string | undefined): string =>
+  toSentenceCase((value ?? '').toLowerCase())
+    .replace(/_(?:\w)/gu, (val) => val.toUpperCase())
+    .replace(/_/gu, ' ')
+    .trim();
+
 export const prettyCONSTName = (value: string | undefined): string => {
   if (!value) {
     return '';
   }
-  const valueSuffix = value.slice(-2);
-  const containsId = CONST_EXCEPTION_ID.includes(valueSuffix);
-  let newValue = containsId ? value.slice(0, value.length - 2) : value;
-  const newName = toSentenceCase(newValue.toLowerCase())
-    .replace(/_(?:\w)/gu, (val) => val.toUpperCase())
-    .replace(/_/gu, ' ')
-    .trim();
-  newValue = isCamelCase(newValue) ? prettyCamelCase(newValue) : newName;
-  return containsId ? `${newValue} ID`.trim() : newName;
+  if (
+    value.includes('_') ||
+    (value.toUpperCase() === value && value.length > 2)
+  ) {
+    return prettySimpleCONSTName(value);
+  }
+
+  let newValue = value.trim();
+  newValue = newValue.charAt(0).toUpperCase() + newValue.slice(1);
+  return newValue
+    .split(/(?<id>[A-Z][a-z]+)/)
+    .filter((e) => e)
+    .join(' ');
 };
 
 export const tryToFormatJSONString = (value: string, tabSize = 2): string => {

--- a/packages/legend-shared/src/format/FormatterUtils.ts
+++ b/packages/legend-shared/src/format/FormatterUtils.ts
@@ -100,7 +100,7 @@ export const prettyCONSTName = (value: string | undefined): string => {
   let newValue = value.trim();
   newValue = newValue.charAt(0).toUpperCase() + newValue.slice(1);
   return newValue
-    .split(/(?<id>[A-Z][a-z]+|[0-9])/)
+    .split(/(?<id>[A-Z][a-z]+|[0-9]+)/)
     .filter((e) => e)
     .join(' ');
 };

--- a/packages/legend-shared/src/format/FormatterUtils.ts
+++ b/packages/legend-shared/src/format/FormatterUtils.ts
@@ -100,7 +100,7 @@ export const prettyCONSTName = (value: string | undefined): string => {
   let newValue = value.trim();
   newValue = newValue.charAt(0).toUpperCase() + newValue.slice(1);
   return newValue
-    .split(/(?<id>[A-Z][a-z]+)/)
+    .split(/(?<id>[A-Z][a-z]+|[0-9])/)
     .filter((e) => e)
     .join(' ');
 };

--- a/packages/legend-shared/src/format/__tests__/FormatterUtils.test.ts
+++ b/packages/legend-shared/src/format/__tests__/FormatterUtils.test.ts
@@ -79,9 +79,10 @@ test(unitTest('Camel/Pascal case check'), () => {
   expect(isCamelCase('AAasd')).toBe(false);
 });
 
-test(unitTest('Prettify CONST name with capitaliztions'), () => {
+test(unitTest('Prettify CONST name with capitalizations'), () => {
   expect(prettyCONSTName('fiveTwoEight')).toEqual('Five Two Eight');
   expect(prettyCONSTName('FIVETwoEight')).toEqual('FIVE Two Eight');
+  expect(prettyCONSTName('FIVETwoEIGHT')).toEqual('FIVE Two EIGHT');
   expect(prettyCONSTName('fiveTWOEight')).toEqual('Five TWO Eight');
   expect(prettyCONSTName('fiveTwoEIGHT')).toEqual('Five Two EIGHT');
   expect(prettyCONSTName('   fiveTwoEIGHT   ')).toEqual('Five Two EIGHT');
@@ -91,20 +92,13 @@ test(unitTest('Prettify CONST name with capitaliztions'), () => {
   expect(prettyCONSTName('five5TWOEight9Two')).toEqual(
     'Five 5 TWO Eight 9 Two',
   );
+  expect(prettyCONSTName('five28FOUR91')).toEqual('Five 28 FOUR 91');
   expect(prettyCONSTName('FIVE5TwoEIGHT')).toEqual('FIVE 5 Two EIGHT');
-  expect(prettyCONSTName('a')).toEqual('A');
-});
-
-test(unitTest('Prettify CONST name with ID acronym'), () => {
-  expect(prettyCONSTName('Personid')).toEqual('Personid');
-  expect(prettyCONSTName('PERSONID')).toEqual('Personid');
-  expect(prettyCONSTName('PersonId')).toEqual('Person Id');
-  expect(prettyCONSTName('PersonID')).toEqual('Person ID');
+  expect(prettyCONSTName('I')).toEqual('I');
   expect(prettyCONSTName('ID')).toEqual('ID');
   expect(prettyCONSTName('Id')).toEqual('Id');
-  expect(prettyCONSTName('somethingPersonPartyID')).toEqual(
-    'Something Person Party ID',
-  );
+  expect(prettyCONSTName('Personid')).toEqual('Personid');
+  expect(prettyCONSTName('PERSONID')).toEqual('Personid');
 });
 
 test(unitTest('Minify JSON string'), () => {

--- a/packages/legend-shared/src/format/__tests__/FormatterUtils.test.ts
+++ b/packages/legend-shared/src/format/__tests__/FormatterUtils.test.ts
@@ -66,18 +66,6 @@ test(unitTest('Prettify CONST name'), () => {
   expect(prettyCONSTName('TOM_TOM')).toEqual('Tom Tom');
 });
 
-test(unitTest('Prettify CONST name with ID'), () => {
-  expect(prettyCONSTName('PersonID')).toEqual('Person ID');
-  expect(prettyCONSTName('PERSONID')).toEqual('Person ID');
-  expect(prettyCONSTName('PersonId')).toEqual('Person ID');
-  expect(prettyCONSTName('ID')).toEqual('ID');
-  expect(prettyCONSTName('Id')).toEqual('ID');
-  expect(prettyCONSTName('Personid')).toEqual('Personid');
-  expect(prettyCONSTName('somethingPersonPartyID')).toEqual(
-    'Something Person Party ID',
-  );
-});
-
 test(unitTest('Camel/Pascal case check'), () => {
   expect(isCamelCase('aSomething')).toBe(true);
   expect(isCamelCase('Something')).toBe(true);
@@ -89,6 +77,33 @@ test(unitTest('Camel/Pascal case check'), () => {
   expect(isCamelCase('AAAAA_AAAA')).toBe(false);
   expect(isCamelCase('AABASD')).toBe(false);
   expect(isCamelCase('AAasd')).toBe(false);
+});
+
+test(unitTest('Prettify CONST name with capitaliztions'), () => {
+  expect(prettyCONSTName('fiveTwoEight')).toEqual('Five Two Eight');
+  expect(prettyCONSTName('FIVETwoEight')).toEqual('FIVE Two Eight');
+  expect(prettyCONSTName('fiveTWOEight')).toEqual('Five TWO Eight');
+  expect(prettyCONSTName('fiveTwoEIGHT')).toEqual('Five Two EIGHT');
+  expect(prettyCONSTName('   fiveTwoEIGHT   ')).toEqual('Five Two EIGHT');
+  expect(prettyCONSTName('five_Two_EIGHT')).toEqual('Five Two Eight');
+  expect(prettyCONSTName('five5TWOEight')).toEqual('Five 5TWO Eight');
+  expect(prettyCONSTName('five5TwoEIGHT')).toEqual('Five 5 Two EIGHT');
+  expect(prettyCONSTName('five5TWOEight9Two')).toEqual('Five 5TWO Eight 9 Two');
+
+  expect(prettyCONSTName('FIVE5TwoEIGHT')).toEqual('FIVE5 Two EIGHT');
+  expect(prettyCONSTName('a')).toEqual('A');
+});
+
+test(unitTest('Prettify CONST name with ID acronym'), () => {
+  expect(prettyCONSTName('Personid')).toEqual('Personid');
+  expect(prettyCONSTName('PERSONID')).toEqual('Personid');
+  expect(prettyCONSTName('PersonId')).toEqual('Person Id');
+  expect(prettyCONSTName('PersonID')).toEqual('Person ID');
+  expect(prettyCONSTName('ID')).toEqual('ID');
+  expect(prettyCONSTName('Id')).toEqual('Id');
+  expect(prettyCONSTName('somethingPersonPartyID')).toEqual(
+    'Something Person Party ID',
+  );
 });
 
 test(unitTest('Minify JSON string'), () => {

--- a/packages/legend-shared/src/format/__tests__/FormatterUtils.test.ts
+++ b/packages/legend-shared/src/format/__tests__/FormatterUtils.test.ts
@@ -86,11 +86,12 @@ test(unitTest('Prettify CONST name with capitaliztions'), () => {
   expect(prettyCONSTName('fiveTwoEIGHT')).toEqual('Five Two EIGHT');
   expect(prettyCONSTName('   fiveTwoEIGHT   ')).toEqual('Five Two EIGHT');
   expect(prettyCONSTName('five_Two_EIGHT')).toEqual('Five Two Eight');
-  expect(prettyCONSTName('five5TWOEight')).toEqual('Five 5TWO Eight');
+  expect(prettyCONSTName('five5TWOEight')).toEqual('Five 5 TWO Eight');
   expect(prettyCONSTName('five5TwoEIGHT')).toEqual('Five 5 Two EIGHT');
-  expect(prettyCONSTName('five5TWOEight9Two')).toEqual('Five 5TWO Eight 9 Two');
-
-  expect(prettyCONSTName('FIVE5TwoEIGHT')).toEqual('FIVE5 Two EIGHT');
+  expect(prettyCONSTName('five5TWOEight9Two')).toEqual(
+    'Five 5 TWO Eight 9 Two',
+  );
+  expect(prettyCONSTName('FIVE5TwoEIGHT')).toEqual('FIVE 5 Two EIGHT');
   expect(prettyCONSTName('a')).toEqual('A');
 });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Enhancing`prettyCONSTName` function to give users better humanized view of property names  
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
