### PR TITLE
Fix: allow query ui results to render data for columns with dot notation

### DIFF
--- a/.changeset/debonair-ducks-dwaddle.md
+++ b/.changeset/debonair-ducks-dwaddle.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Fix for allowing column names that include '.' to render data

--- a/packages/legend-query-builder/src/components/QueryBuilderResultPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderResultPanel.tsx
@@ -379,6 +379,7 @@ const QueryBuilderGridResult = observer(
           onCellMouseOver={(event): void => {
             setCellDoubleClickedEvent(event);
           }}
+          suppressFieldDotNotation={true}
           columnDefs={columns.map((colName) => ({
             minWidth: 50,
             sortable: true,


### PR DESCRIPTION
Originally, query results were not returning data in the special case where a column name had contained a '.' 

```

    executionResult.result = {
      columns: ['This Column Has .Dot', 'Normal Column'],
      rows: [
        {
          values: ['valueOne', 'valueTwo'],
        },
      ],
    };
```
would have shown up as 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/41248956/227030283-ed108ec1-1c92-4f07-914b-ee502ca2decb.png">.
This is due to how ag-grid-table options render it, more detail found: https://www.ag-grid.com/javascript-data-grid/column-definitions/#suppress-field-dot-notation.

Fixed so now data will render successfully and not show up as empty cells even though values exist.


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
