### PR TITLE
update and skip executionEnvironment test til engine is updated

### DIFF
--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/RoundtripGrammar.test.ts
@@ -77,6 +77,11 @@ const EXCLUSIONS: { [key: string]: ROUNTRIP_TEST_PHASES[] | typeof SKIP } = {
     ROUNTRIP_TEST_PHASES.PROTOCOL_ROUNDTRIP,
     ROUNTRIP_TEST_PHASES.CHECK_HASH,
   ],
+  // TODO: remove these once latest engine changes are merged
+  'DSL_ExecutionEnvironment-plus-service-models.pure': [
+    ROUNTRIP_TEST_PHASES.PROTOCOL_ROUNDTRIP,
+    ROUNTRIP_TEST_PHASES.GRAMMAR_ROUNDTRIP,
+  ],
 };
 
 type GrammarRoundtripOptions = {

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_ExecutionEnvironment-plus-service-models.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_ExecutionEnvironment-plus-service-models.pure
@@ -1,0 +1,65 @@
+###Service
+Service test::testService
+{
+  pattern: '/093bd56b-5945-44da-8de5-4f710d3b2b48';
+  owners:
+  [
+    'anonymous'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |'';
+    mapping: test::mapping;
+    runtime: test::runtime;
+  }
+}
+
+ExecutionEnvironment test::executionEnvironment
+{
+  executions:
+  [
+    QA:
+    {
+      mapping: test::mapping;
+      runtime: test::runtime;
+    },
+    PROD:
+    {
+      mapping: test::mapping;
+      runtime: test::runtime;
+    }
+  ];
+}
+
+
+###Pure
+Class test::class
+{
+  prop1: Integer[0..1];
+}
+
+
+###Mapping
+Mapping test::mapping
+(
+)
+
+
+###Connection
+JsonModelConnection test::connection
+{
+  class: test::class;
+  url: 'asd';
+}
+
+
+###Runtime
+Runtime test::runtime
+{
+  mappings:
+  [
+    test::mapping
+  ];
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->
update and skip executionEnvironment test til engine is updated

## How did you test this change?

- [x] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
