### PR TITLE
Create an executable query for entitlements by resetting parameters

### DIFF
--- a/.changeset/brave-zebras-joke.md
+++ b/.changeset/brave-zebras-joke.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Create an executable query for entitlements by resetting paraneters.

--- a/packages/legend-query-builder/src/stores/entitlements/QueryBuilderCheckEntitlementsState.ts
+++ b/packages/legend-query-builder/src/stores/entitlements/QueryBuilderCheckEntitlementsState.ts
@@ -20,6 +20,7 @@ import { QUERY_BUILDER_STATE_HASH_STRUCTURE } from '../QueryBuilderStateHashUtil
 import type { QueryBuilderState } from '../QueryBuilderState.js';
 import { DataAccessState } from '../data-access/DataAccessState.js';
 import { RuntimePointer, InMemoryGraphData } from '@finos/legend-graph';
+import { getExecutionQueryFromRawLambda } from '../shared/LambdaParameterState.js';
 
 export class QueryBuilderCheckEntitlementsState implements Hashable {
   readonly queryBuilderState: QueryBuilderState;
@@ -53,7 +54,12 @@ export class QueryBuilderCheckEntitlementsState implements Hashable {
           mapping: this.queryBuilderState.mapping.path,
           runtime:
             this.queryBuilderState.runtimeValue.packageableRuntime.value.path,
-          getQuery: async () => this.queryBuilderState.buildQuery(),
+          getQuery: async () =>
+            getExecutionQueryFromRawLambda(
+              this.queryBuilderState.buildQuery(),
+              this.queryBuilderState.parametersState.parameterStates,
+              this.queryBuilderState.graphManagerState,
+            ),
           graphData: new InMemoryGraphData(
             this.queryBuilderState.graphManagerState.graph,
           ),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->
Create an executable query for entitlements by resetting parameters
## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
