### PR TITLE
Allow is-in filter clause in query to read linebreak values

### DIFF
--- a/.changeset/spicy-bags-work.md
+++ b/.changeset/spicy-bags-work.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-query-builder': patch
+---

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -665,7 +665,8 @@ const CollectionValueInstanceValueEditor = observer(
       setValueSpecification,
       obseverContext,
     } = props;
-    const inputRef = useRef<HTMLInputElement>(null);
+    const inputRef = useRef<HTMLTextAreaElement>(null);
+
     const [text, setText] = useState(stringifyValue(valueSpecification.values));
     const [editable, setEditable] = useState(false);
     const [showAdvancedEditorPopover, setShowAdvancedEditorPopover] =
@@ -697,9 +698,7 @@ const CollectionValueInstanceValueEditor = observer(
       setText(stringifyValue(valueSpecification.values));
       setValueSpecification(valueSpecification);
     };
-    const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-      setText(event.target.value);
-    };
+
     const changeValueTextArea: React.ChangeEventHandler<HTMLTextAreaElement> = (
       event,
     ) => {
@@ -742,15 +741,20 @@ const CollectionValueInstanceValueEditor = observer(
             </BasePopover>
           )}
           <div className={clsx('value-spec-editor', className)}>
-            <input
+            <textarea
               ref={inputRef}
               className={clsx(
-                'panel__content__form__section__input value-spec-editor__input',
+                'panel__content__form__section__input value-spec-editor__input value-spec-editor__textarea ',
               )}
               spellCheck={false}
               value={text}
               placeholder={text === '' ? '(empty)' : undefined}
-              onChange={changeValue}
+              onChange={changeValueTextArea}
+              onKeyDown={(event): void => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  saveEdit();
+                }
+              }}
             />
             <button
               className="value-spec-editor__list-editor__expand-button btn--dark"

--- a/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
@@ -1145,6 +1145,77 @@ export const TEST_DATA__getAllWithOneIntegerConditionFilter = {
   parameters: [],
 };
 
+export const TEST_DATA__getAllWithOneIntegerIsInConditionFilter = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'filter',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'packageableElementPtr',
+              fullPath: 'model::pure::tests::model::simple::Person',
+            },
+          ],
+        },
+        {
+          _type: 'lambda',
+          body: [
+            {
+              _type: 'func',
+              function: 'in',
+              parameters: [
+                {
+                  _type: 'property',
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                  property: 'age',
+                },
+                {
+                  _type: 'collection',
+                  multiplicity: {
+                    lowerBound: 1,
+                    upperBound: 1,
+                  },
+                  values: [
+                    {
+                      _type: 'integer',
+                      value: 1,
+                    },
+                    {
+                      _type: 'integer',
+                      value: 2,
+                    },
+                    {
+                      _type: 'integer',
+                      value: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          parameters: [
+            {
+              _type: 'var',
+              name: 'x',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
 export const TEST_DATA_getAllWithOneFloatConditionFilter = {
   _type: 'lambda',
   body: [

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -211,8 +211,7 @@
 
   &__textarea {
     resize: none;
-    height: 4rem;
-    margin-right: 0.5rem;
+    line-height: 2.6rem;
   }
 
   &__number {

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -209,6 +209,12 @@
     margin-bottom: 0;
   }
 
+  &__textarea {
+    resize: none;
+    height: 4rem;
+    margin-right: 0.5rem;
+  }
+
   &__number {
     &__input-container {
       display: flex;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

- [x] Pasting new-line separated values into the text bar directly for 'is-in' filter in Query does not work as expected - new lines are converted to space characters and the list is treated as a single value. Converting `input` to be `textarea` instead so that pasted content works as expected for users. 
- [x] Hitting enter from the text bar will save the filter directly to be consistent with the same action/behavior when in 'expand window' box 

![Kapture 2023-06-15 at 11 43 48](https://github.com/finos/legend-studio/assets/41248956/39471acd-b9ac-4f30-bd73-2a6bcaf7e1bb)


<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
