### PR TITLE
use northWind proc as default relational connection

### DIFF
--- a/.changeset/rude-seals-joke.md
+++ b/.changeset/rude-seals-joke.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Use northWind proc as default relational connection to provide sample data for users.

--- a/packages/legend-application-studio/src/stores/editor/NewElementState.ts
+++ b/packages/legend-application-studio/src/stores/editor/NewElementState.ts
@@ -66,7 +66,6 @@ import {
   PackageableElementExplicitReference,
   RelationalDatabaseConnection,
   DatabaseType,
-  StaticDatasourceSpecification,
   DefaultH2AuthenticationStrategy,
   ModelGenerationSpecification,
   DataElement,
@@ -74,6 +73,7 @@ import {
   Measure,
   Multiplicity,
   PrimitiveType,
+  LocalH2DatasourceSpecification,
 } from '@finos/legend-graph';
 import type { DSL_Mapping_LegendStudioApplicationPlugin_Extension } from '../extensions/DSL_Mapping_LegendStudioApplicationPlugin_Extension.js';
 import {
@@ -302,6 +302,8 @@ export class NewFlatDataConnectionDriver extends NewConnectionValueDriver<FlatDa
   }
 }
 
+const DEFAULT_H2_SQL =
+  '-- loads sample data for getting started. See https://github.com/pthom/northwind_psql for more info\n call loadNorthwindData()';
 export class NewRelationalDatabaseConnectionDriver extends NewConnectionValueDriver<RelationalDatabaseConnection> {
   constructor(editorStore: EditorStore) {
     super(editorStore);
@@ -327,10 +329,12 @@ export class NewRelationalDatabaseConnectionDriver extends NewConnectionValueDri
       const dbs = this.editorStore.graphManagerState.usableDatabases;
       selectedStore = dbs.length ? (dbs[0] as Database) : stub_Database();
     }
+    const spec = new LocalH2DatasourceSpecification();
+    spec.testDataSetupSqls = [DEFAULT_H2_SQL];
     return new RelationalDatabaseConnection(
       PackageableElementExplicitReference.create(selectedStore),
       DatabaseType.H2,
-      new StaticDatasourceSpecification('dummyHost', 80, 'myDb'),
+      spec,
       new DefaultH2AuthenticationStrategy(),
     );
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

- [x] when creating realtional db connection, we will default to create a local h2 with the northwind proc. See: https://github.com/finos/legend-engine/pull/1869


<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


https://github.com/finos/legend-studio/assets/29690824/c93ccee6-757f-4d9a-a178-56b0bd47b1b5

<!--




  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

