### PR TITLE
Add Generate Models button to enable autogeneration of classes, associations, and mappings feature for relational databases

### DIFF
--- a/.changeset/sixty-carpets-cheat.md
+++ b/.changeset/sixty-carpets-cheat.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---
+
+Add Generate Models button to enable autogeneration of classes, associations, and mapping feature for relational databases

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -111,6 +111,7 @@ import {
   guaranteeRelationalDatabaseConnection,
   extractDependencyGACoordinateFromRootPackageName,
   type FunctionActivatorConfiguration,
+  Database,
 } from '@finos/legend-graph';
 import { useApplicationStore } from '@finos/legend-application';
 import {
@@ -452,6 +453,9 @@ const isRelationalDatabaseConnection = (
   val instanceof PackageableConnection &&
   val.connectionValue instanceof RelationalDatabaseConnection;
 
+const isRelationalDatabase = (val: PackageableElement | undefined): boolean =>
+  val instanceof Database;
+
 const ExplorerContextMenu = observer(
   forwardRef<
     HTMLDivElement,
@@ -523,6 +527,15 @@ const ExplorerContextMenu = observer(
         }
       },
     );
+    const generateModelFromDatabase =
+      editorStore.applicationStore.guardUnhandledError(async () => {
+        if (isRelationalDatabase(node?.packageableElement)) {
+          editorStore.explorerTreeState.generateModelFromDatabase(
+            guaranteeNonEmptyString(node?.packageableElement.path),
+            editorStore.graphManagerState.graph,
+          );
+        }
+      });
     const openSQLPlayground = (): void => {
       if (isRelationalDatabaseConnection(node?.packageableElement)) {
         editorStore.panelGroupDisplayState.open();
@@ -808,6 +821,14 @@ const ExplorerContextMenu = observer(
             )}
             <MenuContentItem onClick={buildDatabase}>
               Build Database...
+            </MenuContentItem>
+            <MenuContentDivider />
+          </>
+        )}
+        {isRelationalDatabase(node.packageableElement) && (
+          <>
+            <MenuContentItem onClick={generateModelFromDatabase}>
+              Generate Models
             </MenuContentItem>
             <MenuContentDivider />
           </>

--- a/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
@@ -570,6 +570,13 @@ export abstract class AbstractPureGraphManager {
     graphData: GraphData,
   ): Promise<void>;
 
+  // --------------------------------------------- Relational ---------------------------------------------
+
+  abstract generateModelFromDatabase(
+    databasePath: string,
+    graph: PureModel,
+  ): Promise<Entity[]>;
+
   // ------------------------------------------- Service -------------------------------------------
   /**
    * @modularize

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
@@ -291,6 +291,7 @@ import { FunctionActivatorConfiguration } from '../../../action/functionActivato
 import { V1_FunctionActivatorInput } from './engine/functionActivator/V1_FunctionActivatorInput.js';
 import { V1_FunctionActivator } from './model/packageableElements/function/V1_FunctionActivator.js';
 import { V1_INTERNAL__UnknownFunctionActivator } from './model/packageableElements/function/V1_INTERNAL__UnknownFunctionActivator.js';
+import { V1_DatabaseToModelGenerationInput } from './engine/relational/V1_DatabaseToModelGenerationInput.js';
 import type { RelationalDatabaseConnection } from '../../../../STO_Relational_Exports.js';
 import { V1_RawSQLExecuteInput } from './engine/execution/V1_RawSQLExecuteInput.js';
 import type { SubtypeInfo } from '../../../action/protocol/ProtocolInfo.js';
@@ -2994,6 +2995,20 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     input.functionActivator = functionActivator.path;
     input.model = this.prepareExecutionContextGraphData(graphData);
     await this.engine.publishFunctionActivatorToSandbox(input);
+  }
+
+  // --------------------------------------------- Relational ---------------------------------------------
+
+  async generateModelFromDatabase(
+    databasePath: string,
+    graph: PureModel,
+  ): Promise<Entity[]> {
+    const graphData = this.graphToPureModelContextData(graph);
+    const input = new V1_DatabaseToModelGenerationInput();
+    input.databasePath = databasePath;
+    input.modelData = graphData;
+    const generatedModel = await this.engine.generateModelFromDatabase(input);
+    return this.pureModelContextDataToEntities(generatedModel);
   }
 
   // --------------------------------------------- Service ---------------------------------------------

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
@@ -77,10 +77,13 @@ import type {
   V1_ArtifactGenerationExtensionInput,
   V1_ArtifactGenerationExtensionOutput,
 } from './generation/V1_ArtifactGenerationExtensionApi.js';
+import type { V1_DatabaseToModelGenerationInput } from './relational/V1_DatabaseToModelGenerationInput.js';
 
 enum CORE_ENGINE_ACTIVITY_TRACE {
   GRAMMAR_TO_JSON = 'transform Pure code to protocol',
   JSON_TO_GRAMMAR = 'transform protocol to Pure code',
+
+  DATABASE_TO_MODEL = 'generate model from database',
 
   EXTERNAL_FORMAT_TO_PROTOCOL = 'transform external format code to protocol',
   GENERATE_FILE = 'generate file',
@@ -771,6 +774,20 @@ export class V1_EngineServerClient extends AbstractServerClient {
         input,
         CORE_ENGINE_ACTIVITY_TRACE.PUBLISH_FUNCTION_ACTIVATOR_TO_SANDBOX,
       ),
+    );
+  }
+
+  // ------------------------------------------- Relational ---------------------------------------
+
+  _relationalElement = (): string => `${this._pure()}/relational`;
+
+  generateModelFromDatabase(
+    input: PlainObject<V1_DatabaseToModelGenerationInput>,
+  ): Promise<PlainObject<V1_PureModelContextData>> {
+    return this.postWithTracing(
+      this.getTraceData(CORE_ENGINE_ACTIVITY_TRACE.DATABASE_TO_MODEL),
+      `${this._relationalElement()}/generateModelFromDatabase`,
+      this.debugPayload(input, CORE_ENGINE_ACTIVITY_TRACE.DATABASE_TO_MODEL),
     );
   }
 

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/relational/V1_DatabaseToModelGenerationInput.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/relational/V1_DatabaseToModelGenerationInput.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { primitive, createModelSchema } from 'serializr';
+import { SerializationFactory } from '@finos/legend-shared';
+import type { V1_PureModelContextData } from '../../model/context/V1_PureModelContextData.js';
+import { V1_pureModelContextDataPropSchema } from '../../transformation/pureProtocol/V1_PureProtocolSerialization.js';
+
+export class V1_DatabaseToModelGenerationInput {
+  databasePath!: string;
+  modelData!: V1_PureModelContextData;
+
+  static readonly serialization = new SerializationFactory(
+    createModelSchema(V1_DatabaseToModelGenerationInput, {
+      databasePath: primitive(),
+      modelData: V1_pureModelContextDataPropSchema,
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds a "Generate Models" button when right-clicking on a relational database, which calls the API for autogeneration of classes, and associations, and mappings.
