### PR TITLE
Fixed query chat extension for external use

### DIFF
--- a/.changeset/tame-ligers-visit.md
+++ b/.changeset/tame-ligers-visit.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Patch query extension mechanism.

--- a/packages/legend-query-builder/src/components/QueryChat.tsx
+++ b/packages/legend-query-builder/src/components/QueryChat.tsx
@@ -26,7 +26,7 @@ import {
 } from '@finos/legend-art';
 import { useApplicationStore } from '@finos/legend-application';
 import type { QueryBuilder_LegendApplicationPlugin_Extension } from '../stores/QueryBuilder_LegendApplicationPlugin_Extension.js';
-import { QueryBuilderState } from '../stores/QueryBuilderState.js';
+import type { QueryBuilderState } from '../stores/QueryBuilderState.js';
 
 export const QueryChat = observer(
   (props: { queryBuilderState: QueryBuilderState }) => {

--- a/packages/legend-query-builder/src/components/QueryChat.tsx
+++ b/packages/legend-query-builder/src/components/QueryChat.tsx
@@ -26,7 +26,7 @@ import {
 } from '@finos/legend-art';
 import { useApplicationStore } from '@finos/legend-application';
 import type { QueryBuilder_LegendApplicationPlugin_Extension } from '../stores/QueryBuilder_LegendApplicationPlugin_Extension.js';
-import type { QueryBuilderState } from '../stores/QueryBuilderState.js';
+import { QueryBuilderState } from '../stores/QueryBuilderState.js';
 
 export const QueryChat = observer(
   (props: { queryBuilderState: QueryBuilderState }) => {
@@ -56,7 +56,7 @@ export const QueryChat = observer(
                   Chat Mode is not available
                 </BlankPanelContent>
               ) : (
-                extraQueryChatConfigurations[0]
+                extraQueryChatConfigurations[0]?.(queryBuilderState)
               )}
             </>
           </ModalBody>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

https://github.com/finos/legend-studio/assets/112575523/f560eb20-ba4d-4037-ad12-bc292ed2c75f

