### PR TITLE
Add Generate Models button to enable autogeneration of classes, associations, and mapping feature for relational databases

### DIFF
--- a/.changeset/sixty-carpets-cheat.md
+++ b/.changeset/sixty-carpets-cheat.md
@@ -1,6 +1,5 @@
 ---
-'@finos/legend-application-studio': patch
-'@finos/legend-graph': patch
+'@finos/legend-application-studio': minor
+'@finos/legend-graph': minor
 ---
-
-Add Generate Models button to enable autogeneration of classes, associations, and mapping feature for relational databases
+Support generating models from relational database. 

--- a/.changeset/sixty-carpets-cheat.md
+++ b/.changeset/sixty-carpets-cheat.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---
+
+Add Generate Models button to enable autogeneration of classes, associations, and mapping feature for relational databases

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -111,7 +111,7 @@ import {
   guaranteeRelationalDatabaseConnection,
   extractDependencyGACoordinateFromRootPackageName,
   type FunctionActivatorConfiguration,
- Database,
+  Database,
 } from '@finos/legend-graph';
 import {
   ActionAlertActionType,

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -111,8 +111,14 @@ import {
   guaranteeRelationalDatabaseConnection,
   extractDependencyGACoordinateFromRootPackageName,
   type FunctionActivatorConfiguration,
+  Database,
+  type PureModel,
 } from '@finos/legend-graph';
-import { useApplicationStore } from '@finos/legend-application';
+import {
+  ActionAlertActionType,
+  ActionAlertType,
+  useApplicationStore,
+} from '@finos/legend-application';
 import {
   getPackageableElementOptionFormatter,
   type PackageableElementOption,
@@ -452,6 +458,9 @@ const isRelationalDatabaseConnection = (
   val instanceof PackageableConnection &&
   val.connectionValue instanceof RelationalDatabaseConnection;
 
+const isRelationalDatabase = (val: PackageableElement | undefined): boolean =>
+  val instanceof Database;
+
 const ExplorerContextMenu = observer(
   forwardRef<
     HTMLDivElement,
@@ -523,6 +532,46 @@ const ExplorerContextMenu = observer(
         }
       },
     );
+    const generateModelsFromDatabaseSpecification =
+      editorStore.applicationStore.guardUnhandledError(async () => {
+        if (isRelationalDatabase(node?.packageableElement)) {
+          const databasePath: string = guaranteeNonEmptyString(
+            node?.packageableElement.path,
+          );
+          const graph: PureModel = editorStore.graphManagerState.graph;
+          if (graph.getDatabase(databasePath).joins.length === 0) {
+            applicationStore.alertService.setActionAlertInfo({
+              message:
+                'You are attempting to generate models but have defined no joins. Are you sure you wish to proceed?',
+              type: ActionAlertType.CAUTION,
+              actions: [
+                {
+                  label: 'Proceed',
+                  type: ActionAlertActionType.PROCEED_WITH_CAUTION,
+                  handler: () => {
+                    flowResult(
+                      editorStore.explorerTreeState.generateModelsFromDatabaseSpecification(
+                        databasePath,
+                        graph,
+                      ),
+                    ).catch(applicationStore.alertUnhandledError);
+                  },
+                },
+                {
+                  label: 'Abort',
+                  type: ActionAlertActionType.PROCEED,
+                  default: true,
+                },
+              ],
+            });
+          } else {
+            editorStore.explorerTreeState.generateModelsFromDatabaseSpecification(
+              databasePath,
+              graph,
+            );
+          }
+        }
+      });
     const openSQLPlayground = (): void => {
       if (isRelationalDatabaseConnection(node?.packageableElement)) {
         editorStore.panelGroupDisplayState.open();
@@ -808,6 +857,14 @@ const ExplorerContextMenu = observer(
             )}
             <MenuContentItem onClick={buildDatabase}>
               Build Database...
+            </MenuContentItem>
+            <MenuContentDivider />
+          </>
+        )}
+        {isRelationalDatabase(node.packageableElement) && (
+          <>
+            <MenuContentItem onClick={generateModelsFromDatabaseSpecification}>
+              Generate Models
             </MenuContentItem>
             <MenuContentDivider />
           </>

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -111,8 +111,7 @@ import {
   guaranteeRelationalDatabaseConnection,
   extractDependencyGACoordinateFromRootPackageName,
   type FunctionActivatorConfiguration,
-  Database,
-  type PureModel,
+ Database,
 } from '@finos/legend-graph';
 import {
   ActionAlertActionType,

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -535,7 +535,7 @@ const ExplorerContextMenu = observer(
     const generateModelsFromDatabaseSpecification =
       editorStore.applicationStore.guardUnhandledError(async () => {
         if (isRelationalDatabase(node?.packageableElement)) {
-          const databasePath: string = guaranteeNonEmptyString(
+          const databasePath = guaranteeNonEmptyString(
             node?.packageableElement.path,
           );
           const graph = editorStore.graphManagerState.graph;

--- a/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/side-bar/Explorer.tsx
@@ -538,7 +538,7 @@ const ExplorerContextMenu = observer(
           const databasePath: string = guaranteeNonEmptyString(
             node?.packageableElement.path,
           );
-          const graph: PureModel = editorStore.graphManagerState.graph;
+          const graph = editorStore.graphManagerState.graph;
           if (graph.getDatabase(databasePath).joins.length === 0) {
             applicationStore.alertService.setActionAlertInfo({
               message:

--- a/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
@@ -570,6 +570,13 @@ export abstract class AbstractPureGraphManager {
     graphData: GraphData,
   ): Promise<void>;
 
+  // --------------------------------------------- Relational ---------------------------------------------
+
+  abstract generateModelsFromDatabaseSpecification(
+    databasePath: string,
+    graph: PureModel,
+  ): Promise<Entity[]>;
+
   // ------------------------------------------- Service -------------------------------------------
   /**
    * @modularize

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
@@ -291,6 +291,7 @@ import { FunctionActivatorConfiguration } from '../../../action/functionActivato
 import { V1_FunctionActivatorInput } from './engine/functionActivator/V1_FunctionActivatorInput.js';
 import { V1_FunctionActivator } from './model/packageableElements/function/V1_FunctionActivator.js';
 import { V1_INTERNAL__UnknownFunctionActivator } from './model/packageableElements/function/V1_INTERNAL__UnknownFunctionActivator.js';
+import { V1_DatabaseToModelGenerationInput } from './engine/relational/V1_DatabaseToModelGenerationInput.js';
 import type { RelationalDatabaseConnection } from '../../../../STO_Relational_Exports.js';
 import { V1_RawSQLExecuteInput } from './engine/execution/V1_RawSQLExecuteInput.js';
 import type { SubtypeInfo } from '../../../action/protocol/ProtocolInfo.js';
@@ -2994,6 +2995,21 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     input.functionActivator = functionActivator.path;
     input.model = this.prepareExecutionContextGraphData(graphData);
     await this.engine.publishFunctionActivatorToSandbox(input);
+  }
+
+  // --------------------------------------------- Relational ---------------------------------------------
+
+  async generateModelsFromDatabaseSpecification(
+    databasePath: string,
+    graph: PureModel,
+  ): Promise<Entity[]> {
+    const graphData = this.graphToPureModelContextData(graph);
+    const input = new V1_DatabaseToModelGenerationInput();
+    input.databasePath = databasePath;
+    input.modelData = graphData;
+    const generatedModel =
+      await this.engine.generateModelsFromDatabaseSpecification(input);
+    return this.pureModelContextDataToEntities(generatedModel);
   }
 
   // --------------------------------------------- Service ---------------------------------------------

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_Engine.ts
@@ -135,6 +135,7 @@ import {
   V1_ArtifactGenerationExtensionOutput,
   V1_ArtifactGenerationExtensionInput,
 } from './generation/V1_ArtifactGenerationExtensionApi.js';
+import { V1_DatabaseToModelGenerationInput } from './relational/V1_DatabaseToModelGenerationInput.js';
 
 class V1_EngineConfig extends TEMPORARY__AbstractEngineConfig {
   private engine: V1_Engine;
@@ -1011,6 +1012,33 @@ export class V1_Engine {
           .map((error) => `- ${error.message}`)
           .join('\n')}`,
       );
+    }
+  }
+
+  // ------------------------------------------- Relational -------------------------------------------
+
+  async generateModelsFromDatabaseSpecification(
+    input: V1_DatabaseToModelGenerationInput,
+  ): Promise<V1_PureModelContextData> {
+    try {
+      const json =
+        await this.engineServerClient.generateModelsFromDatabaseSpecification(
+          V1_DatabaseToModelGenerationInput.serialization.toJson(input),
+        );
+      return V1_deserializePureModelContextData(json);
+    } catch (error) {
+      assertErrorThrown(error);
+      if (
+        error instanceof NetworkClientError &&
+        error.response.status === HttpStatus.BAD_REQUEST
+      ) {
+        throw V1_buildParserError(
+          V1_ParserError.serialization.fromJson(
+            error.payload as PlainObject<V1_ParserError>,
+          ),
+        );
+      }
+      throw error;
     }
   }
 }

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
@@ -77,10 +77,13 @@ import type {
   V1_ArtifactGenerationExtensionInput,
   V1_ArtifactGenerationExtensionOutput,
 } from './generation/V1_ArtifactGenerationExtensionApi.js';
+import type { V1_DatabaseToModelGenerationInput } from './relational/V1_DatabaseToModelGenerationInput.js';
 
 enum CORE_ENGINE_ACTIVITY_TRACE {
   GRAMMAR_TO_JSON = 'transform Pure code to protocol',
   JSON_TO_GRAMMAR = 'transform protocol to Pure code',
+
+  DATABASE_TO_MODELS = 'generate models from database',
 
   EXTERNAL_FORMAT_TO_PROTOCOL = 'transform external format code to protocol',
   GENERATE_FILE = 'generate file',
@@ -771,6 +774,20 @@ export class V1_EngineServerClient extends AbstractServerClient {
         input,
         CORE_ENGINE_ACTIVITY_TRACE.PUBLISH_FUNCTION_ACTIVATOR_TO_SANDBOX,
       ),
+    );
+  }
+
+  // ------------------------------------------- Relational ---------------------------------------
+
+  _relationalElement = (): string => `${this._pure()}/relational`;
+
+  generateModelsFromDatabaseSpecification(
+    input: PlainObject<V1_DatabaseToModelGenerationInput>,
+  ): Promise<PlainObject<V1_PureModelContextData>> {
+    return this.postWithTracing(
+      this.getTraceData(CORE_ENGINE_ACTIVITY_TRACE.DATABASE_TO_MODELS),
+      `${this._relationalElement()}/generateModelsFromDatabaseSpecification`,
+      this.debugPayload(input, CORE_ENGINE_ACTIVITY_TRACE.DATABASE_TO_MODELS),
     );
   }
 

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/relational/V1_DatabaseToModelGenerationInput.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/relational/V1_DatabaseToModelGenerationInput.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { primitive, createModelSchema } from 'serializr';
+import { SerializationFactory } from '@finos/legend-shared';
+import type { V1_PureModelContextData } from '../../model/context/V1_PureModelContextData.js';
+import { V1_pureModelContextDataPropSchema } from '../../transformation/pureProtocol/V1_PureProtocolSerialization.js';
+
+export class V1_DatabaseToModelGenerationInput {
+  databasePath!: string;
+  modelData!: V1_PureModelContextData;
+
+  static readonly serialization = new SerializationFactory(
+    createModelSchema(V1_DatabaseToModelGenerationInput, {
+      databasePath: primitive(),
+      modelData: V1_pureModelContextDataPropSchema,
+    }),
+  );
+}


### PR DESCRIPTION
**Summary**

This PR adds a "Generate Models" button when right-clicking on a relational database, which calls the API for autogeneration of classes, and associations, and mapping. Additionally, when the user does not define any joins in the relational database, a pop-up appears with an option to either proceed or abort.

Note:
This PR depends on https://github.com/finos/legend-engine/pull/2070 which has been merged in Legend Engine
