### PR TITLE
only reset mapping testable state when required

### DIFF
--- a/.changeset/ninety-dolls-begin.md
+++ b/.changeset/ninety-dolls-begin.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application-studio': patch
+---

--- a/packages/legend-application-studio/src/components/editor/editor-group/mapping-editor/MappingTestsExplorer.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/mapping-editor/MappingTestsExplorer.tsx
@@ -296,20 +296,24 @@ export const MappingTestsExplorer = observer(
       flowResult(mappingEditorState.runTests()),
     );
     // all test run report summary
-    const numberOfTests = mappingEditorState.mappingTestStates.length;
-    const numberOfTestsPassed = mappingEditorState.mappingTestStates.filter(
-      (testState) => testState.result === TEST_RESULT.PASSED,
-    ).length;
-    const numberOfTestsFailed = mappingEditorState.mappingTestStates.filter(
-      (testState) =>
-        testState.result === TEST_RESULT.FAILED ||
-        testState.result === TEST_RESULT.ERROR,
-    ).length;
-    const numberOfTestSkipped = mappingEditorState.mappingTestStates.filter(
-      (testState) => testState.isSkipped,
-    ).length;
+    const numberOfTests =
+      mappingEditorState.DEPRECATED_mappingTestStates.length;
+    const numberOfTestsPassed =
+      mappingEditorState.DEPRECATED_mappingTestStates.filter(
+        (testState) => testState.result === TEST_RESULT.PASSED,
+      ).length;
+    const numberOfTestsFailed =
+      mappingEditorState.DEPRECATED_mappingTestStates.filter(
+        (testState) =>
+          testState.result === TEST_RESULT.FAILED ||
+          testState.result === TEST_RESULT.ERROR,
+      ).length;
+    const numberOfTestSkipped =
+      mappingEditorState.DEPRECATED_mappingTestStates.filter(
+        (testState) => testState.isSkipped,
+      ).length;
     const percentageTestRun = Math.floor(
-      (mappingEditorState.mappingTestStates.filter(
+      (mappingEditorState.DEPRECATED_mappingTestStates.filter(
         (testState) => testState.result !== TEST_RESULT.NONE,
       ).length /
         numberOfTests) *
@@ -425,7 +429,7 @@ export const MappingTestsExplorer = observer(
                 className="panel__header__action"
                 onClick={runAllTests}
                 disabled={
-                  !mappingEditorState.mappingTestStates.length ||
+                  !mappingEditorState.DEPRECATED_mappingTestStates.length ||
                   mappingEditorState.isRunningAllTests
                 }
                 tabIndex={-1}
@@ -462,31 +466,36 @@ export const MappingTestsExplorer = observer(
             dropTargetConnector={dropRef}
           >
             <div className="mapping-test-explorer__content">
-              {Boolean(mappingEditorState.mappingTestStates.length) &&
-                mappingEditorState.mappingTestStates
-                  .slice()
-                  .map((testState) => (
+              {Boolean(
+                mappingEditorState.DEPRECATED_mappingTestStates.length,
+              ) &&
+                mappingEditorState.DEPRECATED_mappingTestStates.slice().map(
+                  (testState) => (
                     <MappingTestExplorer
                       key={testState.test._UUID}
                       testState={testState}
                       isReadOnly={isReadOnly}
                     />
-                  ))}
-              {!isReadOnly && !mappingEditorState.mappingTestStates.length && (
-                <BlankPanelPlaceholder
-                  text={
-                    new Randomizer().getRandomItemInCollection(addTestPromps) ??
-                    addTestPromps[0] ??
-                    'Add a mapping test'
-                  }
-                  onClick={showClassMappingSelectorModal}
-                  clickActionType="add"
-                  tooltipText="Drop a mapping element to start testing"
-                  isDropZoneActive={isDragOver && !isReadOnly}
-                  disabled={isReadOnly}
-                  previewText="No test"
-                />
-              )}
+                  ),
+                )}
+              {!isReadOnly &&
+                !mappingEditorState.DEPRECATED_mappingTestStates.length && (
+                  <BlankPanelPlaceholder
+                    text={
+                      new Randomizer().getRandomItemInCollection(
+                        addTestPromps,
+                      ) ??
+                      addTestPromps[0] ??
+                      'Add a mapping test'
+                    }
+                    onClick={showClassMappingSelectorModal}
+                    clickActionType="add"
+                    tooltipText="Drop a mapping element to start testing"
+                    isDropZoneActive={isDragOver && !isReadOnly}
+                    disabled={isReadOnly}
+                    previewText="No test"
+                  />
+                )}
             </div>
           </PanelDropZone>
         </ContextMenu>

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/MappingEditorState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/MappingEditorState.ts
@@ -622,12 +622,12 @@ export class MappingEditorState extends ElementEditorState {
   mappingExplorerTreeData: TreeData<MappingExplorerTreeNodeData>;
   newMappingElementSpec?: MappingElementSpec | undefined;
 
+  mappingTestableState: MappingTestableState;
+
   // DEPREACTED legacy tests: TO REMOVE once mapping testable dev work is complete
-  mappingTestStates: DEPRECATED__MappingTestState[] = [];
+  DEPRECATED_mappingTestStates: DEPRECATED__MappingTestState[] = [];
   isRunningAllTests = false;
   allTestRunTime = 0;
-  //
-  mappingTestableState: MappingTestableState;
 
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
@@ -635,7 +635,7 @@ export class MappingEditorState extends ElementEditorState {
     makeObservable<MappingEditorState, 'closeMappingElementTabState'>(this, {
       currentTabState: observable,
       openedTabStates: observable,
-      mappingTestStates: observable,
+      DEPRECATED_mappingTestStates: observable,
       newMappingElementSpec: observable,
       isRunningAllTests: observable,
       allTestRunTime: observable,
@@ -666,7 +666,7 @@ export class MappingEditorState extends ElementEditorState {
       deleteMappingElement: flow,
     });
 
-    this.mappingTestStates = this.mapping.test.map(
+    this.DEPRECATED_mappingTestStates = this.mapping.test.map(
       (t) => new DEPRECATED__MappingTestState(editorStore, t, this),
     );
     this.mappingExplorerTreeData = getMappingElementTreeData(
@@ -1238,7 +1238,7 @@ export class MappingEditorState extends ElementEditorState {
           );
           return this.createMappingElementState(mappingElement);
         } else if (tabState instanceof DEPRECATED__MappingTestState) {
-          return mappingEditorState.mappingTestStates.find(
+          return mappingEditorState.DEPRECATED_mappingTestStates.find(
             (testState) => testState.test.name === tabState.test.name,
           );
         } else if (tabState instanceof MappingExecutionState) {
@@ -1264,7 +1264,7 @@ export class MappingEditorState extends ElementEditorState {
       );
     } else if (this.currentTabState instanceof DEPRECATED__MappingTestState) {
       const currentlyOpenedMappingTest =
-        mappingEditorState.mappingTestStates.find(
+        mappingEditorState.DEPRECATED_mappingTestStates.find(
           (testState) =>
             this.currentTabState instanceof DEPRECATED__MappingTestState &&
             testState.test.name === this.currentTabState.test.name,
@@ -1407,7 +1407,7 @@ export class MappingEditorState extends ElementEditorState {
           tabState.test === test,
       ),
     );
-    const testState = this.mappingTestStates.find(
+    const testState = this.DEPRECATED_mappingTestStates.find(
       (mappingTestState) => mappingTestState.test === test,
     );
     assertNonNullable(
@@ -1442,10 +1442,10 @@ export class MappingEditorState extends ElementEditorState {
   }
 
   get testSuiteResult(): TEST_RESULT {
-    const numberOfTestPassed = this.mappingTestStates.filter(
+    const numberOfTestPassed = this.DEPRECATED_mappingTestStates.filter(
       (testState) => testState.result === TEST_RESULT.PASSED,
     ).length;
-    const numberOfTestFailed = this.mappingTestStates.filter(
+    const numberOfTestFailed = this.DEPRECATED_mappingTestStates.filter(
       (testState) =>
         testState.result === TEST_RESULT.FAILED ||
         testState.result === TEST_RESULT.ERROR,
@@ -1461,11 +1461,11 @@ export class MappingEditorState extends ElementEditorState {
     try {
       const startTime = Date.now();
       this.isRunningAllTests = true;
-      this.mappingTestStates.forEach((testState) =>
+      this.DEPRECATED_mappingTestStates.forEach((testState) =>
         testState.resetTestRunStatus(),
       );
-      const input = this.mappingTestStates
-        .map((testState: DEPRECATED__MappingTestState) => {
+      const input = this.DEPRECATED_mappingTestStates.map(
+        (testState: DEPRECATED__MappingTestState) => {
           // run non-skip tests, and reset all skipped tests
           if (!testState.isSkipped) {
             testState.setIsRunningTest(true);
@@ -1480,8 +1480,8 @@ export class MappingEditorState extends ElementEditorState {
           }
           testState.resetTestRunStatus();
           return undefined;
-        })
-        .filter(isNonNullable);
+        },
+      ).filter(isNonNullable);
       yield this.editorStore.graphManagerState.graphManager.DEPRECATED__runLegacyMappingTests(
         input,
         this.mapping,
@@ -1505,7 +1505,7 @@ export class MappingEditorState extends ElementEditorState {
   }
 
   *addTest(test: DEPRECATED__MappingTest): GeneratorFn<void> {
-    this.mappingTestStates.push(
+    this.DEPRECATED_mappingTestStates.push(
       new DEPRECATED__MappingTestState(this.editorStore, test, this),
     );
     mapping_addDEPRECATEDTest(
@@ -1529,9 +1529,10 @@ export class MappingEditorState extends ElementEditorState {
     this.openedTabStates = this.openedTabStates.filter(
       (tabState) => !matchMappingTestState(tabState),
     );
-    this.mappingTestStates = this.mappingTestStates.filter(
-      (tabState) => !matchMappingTestState(tabState),
-    );
+    this.DEPRECATED_mappingTestStates =
+      this.DEPRECATED_mappingTestStates.filter(
+        (tabState) => !matchMappingTestState(tabState),
+      );
   }
 
   *createNewTest(setImplementation: SetImplementation): GeneratorFn<void> {
@@ -1588,7 +1589,7 @@ export class MappingEditorState extends ElementEditorState {
       this.editorStore.changeDetectionState.observerContext,
     );
     // open the test
-    this.mappingTestStates.push(
+    this.DEPRECATED_mappingTestStates.push(
       new DEPRECATED__MappingTestState(this.editorStore, newTest, this),
     );
     yield flowResult(this.openTest(newTest));

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/testable/MappingTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/testable/MappingTestableState.ts
@@ -646,10 +646,12 @@ export class MappingTestableState {
   }
 
   init(): void {
-    const suite = this.mapping.tests[0];
-    this.selectedTestSuite = suite
-      ? this.buildTestSuiteState(suite)
-      : undefined;
+    if (!this.selectedTestSuite) {
+      const suite = this.mapping.tests[0];
+      this.selectedTestSuite = suite
+        ? this.buildTestSuiteState(suite)
+        : undefined;
+    }
   }
 
   openCreateModal(): void {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->





## Summary
- [x] keep testable state alive when switching between mapping class and test tabs



https://github.com/finos/legend-studio/assets/29690824/0227458c-6a9a-4941-a6db-0fa8d04d2bbe