### PR TITLE
Created an extension mechanism to auto-fold Text/Diagram

### DIFF
--- a/.changeset/cool-chefs-teach.md
+++ b/.changeset/cool-chefs-teach.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-art': patch
+---

--- a/.changeset/gentle-turkeys-wave.md
+++ b/.changeset/gentle-turkeys-wave.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-text': patch
+---

--- a/.changeset/itchy-humans-divide.md
+++ b/.changeset/itchy-humans-divide.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-diagram': patch
+---

--- a/.changeset/sour-ghosts-sell.md
+++ b/.changeset/sour-ghosts-sell.md
@@ -1,0 +1,5 @@
+---
+'@finos/packages/legend-application-studio': patch
+---
+
+Added the code to auto-fold components upon the form mode to text switch, and added an extension mechanism to get Auto-Folding candidates.

--- a/.changeset/sour-ghosts-sell.md
+++ b/.changeset/sour-ghosts-sell.md
@@ -1,5 +1,5 @@
 ---
-'@finos/packages/legend-application-studio': patch
+'@finos/legend-application-studio': patch
 ---
 
 Added the code to auto-fold components upon the form mode to text switch, and added an extension mechanism to get Auto-Folding candidates.

--- a/packages/legend-application-studio/src/stores/LegendStudioApplicationPlugin.ts
+++ b/packages/legend-application-studio/src/stores/LegendStudioApplicationPlugin.ts
@@ -321,4 +321,10 @@ export interface DSL_LegendStudioApplicationPlugin_Extension
    * (e.g. Class, Enum in ###Pure)
    */
   getExtraPureGrammarParserElementSnippetSuggestionsGetters?(): PureGrammarParserElementSnippetSuggestionsGetter[];
+
+  /**
+   * Get a string of the Pure grammar element name for auto-folding the element
+   * (e.g. Diagram, or Text)
+   */
+  getAutoFoldingCandidateToken?(): string[];
 }

--- a/packages/legend-art/src/icon/Icon.ts
+++ b/packages/legend-art/src/icon/Icon.ts
@@ -195,6 +195,8 @@ export const QueryIcon = MD.MdQueryStats;
 export const CenterFocusIcon = MD.MdFilterCenterFocus;
 export const DescriptionIcon = MD.MdOutlineDescription;
 export const QuestionAnswerIcon = MD.MdQuestionAnswer;
+export const FoldIcon = MD.MdUnfoldLess;
+export const UnfoldIcon = MD.MdUnfoldMore;
 
 const VSC = ReactIcons.VSC;
 export const ErrorIcon = VSC.VscError;

--- a/packages/legend-extension-dsl-diagram/src/components/studio/DSL_Diagram_LegendStudioApplicationPlugin.tsx
+++ b/packages/legend-extension-dsl-diagram/src/components/studio/DSL_Diagram_LegendStudioApplicationPlugin.tsx
@@ -296,4 +296,8 @@ export class DSL_Diagram_LegendStudioApplicationPlugin
           : undefined,
     ];
   }
+
+  getAutoFoldingCandidateToken(): string[] {
+    return [PURE_GRAMMAR_DIAGRAM_PARSER_NAME];
+  }
 }

--- a/packages/legend-extension-dsl-text/src/components/studio/DSL_Text_LegendStudioApplicationPlugin.tsx
+++ b/packages/legend-extension-dsl-text/src/components/studio/DSL_Text_LegendStudioApplicationPlugin.tsx
@@ -236,4 +236,8 @@ export class DSL_Text_LegendStudioApplicationPlugin
           : undefined,
     ];
   }
+
+  getAutoFoldingCandidateToken(): string[] {
+    return [PURE_GRAMMAR_TEXT_PARSER_NAME];
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Users have to scroll a lot of lines of code for Text and Diagram that are often irrelevant to what users are trying to work on. Thus, Text and Diagram lines tend to clutter developers screens, and are often too long (spanning hundreds or thousands of lines of code.) We tackle that by automatically folding Text/Diagram elements as soon as users enter Text mode. Moreover, this PR creates an extension mechanism to allow for other elements to be auto-folded in the future, if needed. Finally, this PR adds a button to the top right of the screen to allow users to fold/unfold those auto-folding elements easily. 
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?
- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


I manually tested:
1 - Having a single Diagram, or a single Text element
2 - Having multiple Diagram and Text elements
3 - Typing in the editor in different places, or right before or after some of the folded elements
  * Also, tried manually unfolding and then typing somewhere, and then folding again using the button or manually

4 - Switching back and forth between Text mode and form mode
  * Also tried adding new Text and/or Diagram elements and switching back and forth as I did so

5 - Tested having empty Text and Diagram elements
6 - Tested folding/unfolding elements other than Text and Diagram, and making sure they don't affect the behavior of the button, or the auto-folding action
7 - Manually unfolding Text/Diagram elements and switching back to Form mode and back to Text mode again

[Demo Video](https://github.com/finos/legend-studio/assets/73408381/1f066684-15a2-4fbf-af51-e1190d09e71c)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
