### PR TITLE
fix result set modifier text descriptions css in light theme

### DIFF
--- a/.changeset/fresh-squids-lie.md
+++ b/.changeset/fresh-squids-lie.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-application-query-bootstrap': patch
+'@finos/legend-query-builder': patch
+---

--- a/packages/legend-application-query-bootstrap/style/index.scss
+++ b/packages/legend-application-query-bootstrap/style/index.scss
@@ -132,6 +132,7 @@
   .btn--medium:hover {
     background: var(--color-legacylight-light-blue-270);
   }
+
   // ---------------------------- Table -------------------------------
 
   .query-builder__explorer__preview-data-modal__body .table {
@@ -927,6 +928,11 @@
     .query-builder-graph-fetch-tree__actions__action-btn__label {
       background: var(--color-legacylight-light-blue-200);
       color: var(--color-light-grey-100);
+    }
+
+    .query-builder__projection__result-modifier-prompt__group__label {
+      background: var(--color-light-grey-250);
+      color: var(--color-legacylight-light-dark-grey-200);
     }
 
     // ------------------------------------ Projection Panel ---------------------------------------

--- a/packages/legend-query-builder/style/_query-builder-projection.scss
+++ b/packages/legend-query-builder/style/_query-builder-projection.scss
@@ -69,6 +69,7 @@
         padding: 0.7rem;
         height: 2.2rem;
         background: var(--color-dark-grey-280);
+        color: var(--color-light-grey-200);
         white-space: nowrap;
         line-height: 1.8rem;
         border-radius: 0.1rem;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->
fix result set modifier text descriptions css in light theme

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
