### PR TITLE
Update dev console with feature to set dev protocol version

### DIFF
--- a/.changeset/yellow-parents-wash.md
+++ b/.changeset/yellow-parents-wash.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---
+
+Add developer option to set dev protocol version

--- a/packages/legend-application-studio/src/components/editor/panel-group/DevToolPanel.tsx
+++ b/packages/legend-application-studio/src/components/editor/panel-group/DevToolPanel.tsx
@@ -51,6 +51,10 @@ export const DevToolPanel = observer(() => {
     engineConfig.setUseBase64ForAdhocConnectionDataUrls(
       !engineConfig.useBase64ForAdhocConnectionDataUrls,
     );
+
+  const toggleSetUseDevClientProtocol = (): void =>
+    engineConfig.setUseDevClientProtocol(!engineConfig.useDevClientProtocol);
+
   // Graph Manager
   const toggleStrictMode = (): void => {
     editorStore.graphState.setEnableStrictMode(
@@ -140,6 +144,13 @@ export const DevToolPanel = observer(() => {
           errorMessage={
             !isValidUrl(engineConfig.baseUrl ?? '') ? 'Invalid URL' : ''
           }
+        />
+        <PanelFormBooleanField
+          name="Use Dev client protocol version"
+          prompt="Specifies if development client porotocl (v_X_X_X) version should be used for execution"
+          value={engineConfig.useDevClientProtocol}
+          isReadOnly={false}
+          update={toggleSetUseDevClientProtocol}
         />
         {Boolean(
           editorStore.applicationStore.config.options

--- a/packages/legend-graph/src/graph-manager/action/TEMPORARY__AbstractEngineConfig.ts
+++ b/packages/legend-graph/src/graph-manager/action/TEMPORARY__AbstractEngineConfig.ts
@@ -31,6 +31,7 @@ export class TEMPORARY__AbstractEngineConfig {
   useClientRequestPayloadCompression = false;
   useBase64ForAdhocConnectionDataUrls = false;
   enableDebuggingPayload = false;
+  useDevClientProtocol = false;
 
   constructor() {
     makeObservable(this, {
@@ -41,6 +42,7 @@ export class TEMPORARY__AbstractEngineConfig {
       useClientRequestPayloadCompression: observable,
       useBase64ForAdhocConnectionDataUrls: observable,
       enableDebuggingPayload: observable,
+      useDevClientProtocol: observable,
       setEnv: action,
       setCurrentUserId: action,
       setBaseUrl: action,
@@ -48,6 +50,7 @@ export class TEMPORARY__AbstractEngineConfig {
       setUseClientRequestPayloadCompression: action,
       setUseBase64ForAdhocConnectionDataUrls: action,
       setEnableDebuggingPayload: action,
+      setUseDevClientProtocol: action,
     });
   }
 
@@ -81,5 +84,9 @@ export class TEMPORARY__AbstractEngineConfig {
 
   setEnableDebuggingPayload(val: boolean): void {
     this.enableDebuggingPayload = val;
+  }
+
+  setUseDevClientProtocol(val: boolean): void {
+    this.useDevClientProtocol = val;
   }
 }

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
@@ -2549,7 +2549,9 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       mapping,
       lambda,
       runtime,
-      V1_PureGraphManager.PROD_PROTOCOL_VERSION,
+      this.engine.config.useDevClientProtocol
+        ? V1_PureGraphManager.DEV_PROTOCOL_VERSION
+        : V1_PureGraphManager.PROD_PROTOCOL_VERSION,
       options?.parameterValues,
     );
     stopWatch.record(GRAPH_MANAGER_EVENT.V1_ENGINE_OPERATION_INPUT__SUCCESS);


### PR DESCRIPTION
## Summary

<!--
Add feature to use the dev protocol version. This is necessary so that new engine features can be tested from studio before they are released
-->

## How did you test this change?
Verified that the new toggle sets and clears the dev protocol on client version property in execute input
![image](https://github.com/finos/legend-studio/assets/69924417/19a69f29-329a-4d1b-9c59-5debdb6c3649)

<!--
-->
