### PR TITLE
fix dataGeneration for milestoned class

### DIFF
--- a/.changeset/twelve-knives-pump.md
+++ b/.changeset/twelve-knives-pump.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+fixed dataGeneration for milestoned class

--- a/packages/legend-application-studio/src/stores/editor/utils/MockDataUtils.ts
+++ b/packages/legend-application-studio/src/stores/editor/utils/MockDataUtils.ts
@@ -56,6 +56,7 @@ import {
   Date as ColumnDate,
   SemiStructured,
   Json,
+  MILESTONING_VERSION_PROPERTY_SUFFIX,
 } from '@finos/legend-graph';
 import {
   CLASS_PROPERTY_TYPE,
@@ -116,10 +117,23 @@ export const createMockClassInstance = (
   depth = 0,
 ): PlainObject => {
   const properties = traverseNonRequiredProperties
-    ? getAllClassProperties(_class)
-    : getAllClassProperties(_class).filter((p) => p.multiplicity.lowerBound);
+    ? getAllClassProperties(_class, true)
+    : getAllClassProperties(_class, true).filter(
+        (p) => p.multiplicity.lowerBound,
+      );
+  const propertyNames = properties.map((property) => property.name);
+  const filteredProperties = properties.filter(
+    (prop) =>
+      prop.name.endsWith(MILESTONING_VERSION_PROPERTY_SUFFIX.ALL_VERSIONS) ||
+      (!propertyNames.includes(
+        prop.name + MILESTONING_VERSION_PROPERTY_SUFFIX.ALL_VERSIONS,
+      ) &&
+        !prop.name.endsWith(
+          MILESTONING_VERSION_PROPERTY_SUFFIX.ALL_VERSIONS_IN_RANGE,
+        )),
+  );
   const mockData: Record<string, object | string | number | boolean> = {};
-  properties.forEach((property) => {
+  filteredProperties.forEach((property) => {
     const propertyType = property.genericType.value.rawType;
     let propertyMockData: PlainObject | string | number | boolean | undefined;
     switch (getClassPropertyType(propertyType)) {

--- a/packages/legend-application-studio/src/stores/editor/utils/__tests__/MockDataUtil.test.ts
+++ b/packages/legend-application-studio/src/stores/editor/utils/__tests__/MockDataUtil.test.ts
@@ -132,3 +132,18 @@ test(unitTest('Test mock data with classes cycle'), () => {
   // should not continue on to next depth
   expect(secondApplicantInstance).not.toContain('previousApplication');
 });
+
+test(unitTest('Class with miestoning'), () => {
+  const VehicleOwner = editorStore.graphManagerState.graph.getClass(
+    'myPackage::test::shared::dest::VehicleOwner',
+  );
+  const VehicleOwner_Instance = createMockClassInstance(VehicleOwner, true, 2);
+  const vehicleOwner_properties = [
+    'name',
+    'businessDate',
+    'vehicleAllVersions',
+  ];
+  (expect(VehicleOwner_Instance) as TEMPORARY__JestMatcher).toContainAllKeys(
+    vehicleOwner_properties,
+  );
+});

--- a/packages/legend-application-studio/src/stores/editor/utils/__tests__/MockDataUtil.test.ts
+++ b/packages/legend-application-studio/src/stores/editor/utils/__tests__/MockDataUtil.test.ts
@@ -135,7 +135,7 @@ test(unitTest('Test mock data with classes cycle'), () => {
 
 test(unitTest('Class with miestoning'), () => {
   const vehicleOwner = editorStore.graphManagerState.graph.getClass(
-    'myPackage::test::shared::dest::vehicleOwner',
+    'myPackage::test::shared::dest::VehicleOwner',
   );
   const vehicleOwner_Instance = createMockClassInstance(vehicleOwner, true, 2);
   const vehicleOwner_properties = [

--- a/packages/legend-application-studio/src/stores/editor/utils/__tests__/MockDataUtil.test.ts
+++ b/packages/legend-application-studio/src/stores/editor/utils/__tests__/MockDataUtil.test.ts
@@ -134,16 +134,16 @@ test(unitTest('Test mock data with classes cycle'), () => {
 });
 
 test(unitTest('Class with miestoning'), () => {
-  const VehicleOwner = editorStore.graphManagerState.graph.getClass(
-    'myPackage::test::shared::dest::VehicleOwner',
+  const vehicleOwner = editorStore.graphManagerState.graph.getClass(
+    'myPackage::test::shared::dest::vehicleOwner',
   );
-  const VehicleOwner_Instance = createMockClassInstance(VehicleOwner, true, 2);
+  const vehicleOwner_Instance = createMockClassInstance(vehicleOwner, true, 2);
   const vehicleOwner_properties = [
     'name',
     'businessDate',
     'vehicleAllVersions',
   ];
-  (expect(VehicleOwner_Instance) as TEMPORARY__JestMatcher).toContainAllKeys(
+  (expect(vehicleOwner_Instance) as TEMPORARY__JestMatcher).toContainAllKeys(
     vehicleOwner_properties,
   );
 });

--- a/packages/legend-application-studio/src/stores/editor/utils/__tests__/TEST_DATA__MockDataGeneration.json
+++ b/packages/legend-application-studio/src/stores/editor/utils/__tests__/TEST_DATA__MockDataGeneration.json
@@ -870,5 +870,79 @@
         }
       ]
     }
+  },
+  {
+    "path": "myPackage::test::shared::dest::MilestonedVehicle",
+    "content": {
+      "_type": "class",
+      "name": "MilestonedVehicle",
+      "package": "myPackage::test::shared::dest",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "id",
+          "type": "Integer"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "description",
+          "type": "String"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "name",
+          "type": "String"
+        }
+      ],
+      "stereotypes": [
+        {
+          "profile": "temporal",
+          "value": "businesstemporal"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "myPackage::test::shared::dest::VehicleOwner",
+    "content": {
+      "_type": "class",
+      "name": "VehicleOwner",
+      "package": "myPackage::test::shared::dest",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "vehicle",
+          "type": "myPackage::test::shared::dest::MilestonedVehicle"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "name",
+          "type": "String"
+        }
+      ],
+      "stereotypes": [
+        {
+          "profile": "temporal",
+          "value": "businesstemporal"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
   }
 ]


### PR DESCRIPTION
## Summary
This PR fixes the testDataGeneration for M2M mapping, for a milestoned class it will generate milestoning dates and allVersion property.

## How did you test this change?

- [X ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)
