### PR TITLE
Utilize built-in context menu of ag-grid in enterprise mode

### DIFF
--- a/.changeset/spotty-berries-yell.md
+++ b/.changeset/spotty-berries-yell.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Utilize built-in context menu of ag-grid in enterprise mode

--- a/.changeset/tasty-steaks-raise.md
+++ b/.changeset/tasty-steaks-raise.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-lego': patch
+---

--- a/packages/legend-lego/src/data-grid/DataGrid.tsx
+++ b/packages/legend-lego/src/data-grid/DataGrid.tsx
@@ -41,6 +41,8 @@ import {
   type ColumnState,
   type GridApi,
   type IRowNode,
+  type GetContextMenuItemsParams,
+  type MenuItemDef,
   ModuleRegistry,
 } from '@ag-grid-community/core';
 import { LicenseManager } from '@ag-grid-enterprise/core';
@@ -100,4 +102,6 @@ export type {
   ColumnApi as DataGridColumnApi,
   GridApi as DataGridApi,
   IRowNode as DataGridIRowNode,
+  GetContextMenuItemsParams as DataGridGetContextMenuItemsParams,
+  MenuItemDef as DataGridMenuItemDef,
 };

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSGridResult.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSGridResult.tsx
@@ -332,7 +332,7 @@ export const QueryBuilderTDSGridResult = observer(
               }}
               suppressFieldDotNotation={true}
               suppressClipboardPaste={false}
-              suppressContextMenu={true}
+              suppressContextMenu={false}
               columnDefs={colDefs}
               getContextMenuItems={(params): (string | DataGridMenuItemDef)[] =>
                 getContextMenuItems(params)

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
@@ -32,16 +32,20 @@ import {
   RelationalExecutionActivities,
 } from '@finos/legend-graph';
 import { format as formatSQL } from 'sql-formatter';
-import { useApplicationStore } from '@finos/legend-application';
+import {
+  type ApplicationStore,
+  type LegendApplicationConfig,
+  type LegendApplicationPlugin,
+  type LegendApplicationPluginManager,
+  useApplicationStore,
+} from '@finos/legend-application';
 import {
   assertErrorThrown,
   guaranteeNonNullable,
   filterByType,
   isBoolean,
-  type PlainObject,
 } from '@finos/legend-shared';
 import { forwardRef } from 'react';
-
 import {
   QueryBuilderDerivationProjectionColumnState,
   QueryBuilderProjectionColumnState,
@@ -151,9 +155,9 @@ export const getAggregationTDSColumnCustomizations = (
 
 export const getRowDataFromExecutionResult = (
   executionResult: TDSExecutionResult,
-): PlainObject<QueryBuilderTDSRowDataType>[] => {
+): QueryBuilderTDSRowDataType[] => {
   const rowData = executionResult.result.rows.map((_row, rowIdx) => {
-    const row: PlainObject = {};
+    const row: QueryBuilderTDSRowDataType = {};
     const cols = executionResult.result.columns;
     _row.values.forEach((value, colIdx) => {
       // `ag-grid` shows `false` value as empty string so we have
@@ -172,6 +176,15 @@ export type IQueryRendererParamsWithGridType = DataGridCellRendererParams & {
   resultState: QueryBuilderResultState;
   tdsExecutionResult: TDSExecutionResult;
 };
+
+const postFilterEqualOperator = new QueryBuilderPostFilterOperator_Equal();
+const postFilterInOperator = new QueryBuilderPostFilterOperator_In();
+const postFilterEmptyOperator = new QueryBuilderPostFilterOperator_IsEmpty();
+const postFilterNotEmptyOperator =
+  new QueryBuilderPostFilterOperator_IsNotEmpty();
+const postFilterNotEqualOperator =
+  new QueryBuilderPostFilterOperator_NotEqual();
+const postFilterNotInOperator = new QueryBuilderPostFilterOperator_NotIn();
 
 const getExistingPostFilterNode = (
   operators: QueryBuilderPostFilterOperator[],
@@ -195,6 +208,252 @@ const getExistingPostFilterNode = (
           .includes(node.condition.operator.getLabel()),
     )[0];
 
+const updateFilterConditionValue = (
+  conditionValue: InstanceValue,
+  _cellData: QueryBuilderTDSResultCellData,
+  tdsState: QueryBuilderTDSState,
+): void => {
+  if (_cellData.value) {
+    instanceValue_setValue(
+      conditionValue,
+      conditionValue instanceof EnumValueInstanceValue
+        ? EnumValueExplicitReference.create(
+            guaranteeNonNullable(
+              (
+                conditionValue.genericType?.ownerReference.value as Enumeration
+              ).values.filter((v) => v.name === _cellData.value)[0],
+            ),
+          )
+        : _cellData.value,
+      0,
+      tdsState.queryBuilderState.observerContext,
+    );
+  }
+};
+
+const generateNewPostFilterConditionNodeData = async (
+  applicationStore: ApplicationStore<
+    LegendApplicationConfig,
+    LegendApplicationPluginManager<LegendApplicationPlugin>
+  >,
+  operator: QueryBuilderPostFilterOperator,
+  _cellData: QueryBuilderTDSResultCellData,
+  tdsState: QueryBuilderTDSState,
+  tdsColState: QueryBuilderTDSColumnState | undefined,
+): Promise<void> => {
+  let postFilterConditionState: PostFilterConditionState;
+  try {
+    const possibleProjectionColumnState = _cellData.columnName
+      ? tdsState.projectionColumns
+          .filter((c) => c.columnName === _cellData.columnName)
+          .concat(
+            tdsState.aggregationState.columns
+              .filter((c) => c.columnName === _cellData.columnName)
+              .map((ag) => ag.projectionColumnState),
+          )[0]
+      : tdsColState;
+
+    if (possibleProjectionColumnState) {
+      postFilterConditionState = new PostFilterConditionState(
+        tdsState.postFilterState,
+        possibleProjectionColumnState,
+        operator,
+      );
+
+      if (tdsColState instanceof QueryBuilderDerivationProjectionColumnState) {
+        await flowResult(tdsColState.fetchDerivationLambdaReturnType());
+      }
+
+      const defaultFilterConditionValue =
+        postFilterConditionState.operator.getDefaultFilterConditionValue(
+          postFilterConditionState,
+        );
+
+      postFilterConditionState.buildFromValueSpec(defaultFilterConditionValue);
+      updateFilterConditionValue(
+        defaultFilterConditionValue as InstanceValue,
+        _cellData,
+        tdsState,
+      );
+      tdsState.postFilterState.addNodeFromNode(
+        new QueryBuilderPostFilterTreeConditionNodeData(
+          undefined,
+          postFilterConditionState,
+        ),
+        undefined,
+      );
+    }
+  } catch (error) {
+    assertErrorThrown(error);
+    applicationStore.notificationService.notifyWarning(error.message);
+    return;
+  }
+};
+
+const updateExistingPostFilterConditionNodeData = (
+  existingPostFilterNode: QueryBuilderPostFilterTreeNodeData,
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+  operator: QueryBuilderPostFilterOperator,
+  data: QueryBuilderTDSResultCellData | null,
+  tdsState: QueryBuilderTDSState,
+): void => {
+  if (
+    operator === postFilterEmptyOperator ||
+    operator === postFilterNotEmptyOperator
+  ) {
+    const conditionState = (
+      existingPostFilterNode as QueryBuilderPostFilterTreeConditionNodeData
+    ).condition;
+    if (conditionState.operator.getLabel() !== operator.getLabel()) {
+      conditionState.changeOperator(
+        isFilterBy ? postFilterEmptyOperator : postFilterNotEmptyOperator,
+      );
+    }
+    return;
+  }
+  const conditionState = (
+    existingPostFilterNode as QueryBuilderPostFilterTreeConditionNodeData
+  ).condition;
+
+  const rightSide = conditionState.rightConditionValue;
+  if (rightSide instanceof PostFilterValueSpecConditionValueState) {
+    if (conditionState.operator.getLabel() === operator.getLabel()) {
+      const doesValueAlreadyExist =
+        rightSide.value instanceof InstanceValue &&
+        (rightSide.value instanceof EnumValueInstanceValue
+          ? rightSide.value.values.map((ef) => ef.value.name)
+          : rightSide.value.values
+        ).includes(_cellData.value);
+
+      if (!doesValueAlreadyExist) {
+        const currentValueSpecificaton = rightSide.value;
+        const newValueSpecification =
+          conditionState.operator.getDefaultFilterConditionValue(
+            conditionState,
+          );
+        updateFilterConditionValue(
+          newValueSpecification as InstanceValue,
+          _cellData,
+          tdsState,
+        );
+        conditionState.changeOperator(
+          isFilterBy ? postFilterInOperator : postFilterNotInOperator,
+        );
+        instanceValue_setValues(
+          rightSide.value as InstanceValue,
+          [currentValueSpecificaton, newValueSpecification],
+          tdsState.queryBuilderState.observerContext,
+        );
+      }
+    } else {
+      const doesValueAlreadyExist =
+        rightSide.value instanceof InstanceValue &&
+        rightSide.value.values
+          .filter((v) => v instanceof InstanceValue)
+          .map((v) =>
+            v instanceof EnumValueInstanceValue
+              ? v.values.map((ef) => ef.value.name)
+              : (v as InstanceValue).values,
+          )
+          .flat()
+          .includes(_cellData.value ?? data?.value);
+
+      if (!doesValueAlreadyExist) {
+        const newValueSpecification = (
+          isFilterBy ? postFilterEqualOperator : postFilterNotEqualOperator
+        ).getDefaultFilterConditionValue(conditionState);
+        updateFilterConditionValue(
+          newValueSpecification as InstanceValue,
+          _cellData,
+          tdsState,
+        );
+        instanceValue_setValues(
+          rightSide.value as InstanceValue,
+          [...(rightSide.value as InstanceValue).values, newValueSpecification],
+          tdsState.queryBuilderState.observerContext,
+        );
+      }
+    }
+  }
+};
+
+const getFilterOperator = (
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+): QueryBuilderPostFilterOperator => {
+  if (isFilterBy) {
+    if (_cellData.value === null) {
+      return postFilterEmptyOperator;
+    } else {
+      return postFilterEqualOperator;
+    }
+  } else {
+    if (_cellData.value === null) {
+      return postFilterNotEmptyOperator;
+    } else {
+      return postFilterNotEqualOperator;
+    }
+  }
+};
+
+const filterByOrOutValue = (
+  applicationStore: ApplicationStore<
+    LegendApplicationConfig,
+    LegendApplicationPluginManager<LegendApplicationPlugin>
+  >,
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+  data: QueryBuilderTDSResultCellData | null,
+  tdsState: QueryBuilderTDSState,
+): void => {
+  tdsState.setShowPostFilterPanel(true);
+  const operator = getFilterOperator(isFilterBy, _cellData);
+  const tdsColState = data?.columnName
+    ? getTDSColumnState(tdsState, data.columnName)
+    : undefined;
+  const existingPostFilterNode = getExistingPostFilterNode(
+    _cellData.value === null
+      ? [postFilterEmptyOperator, postFilterNotEmptyOperator]
+      : isFilterBy
+      ? [postFilterEqualOperator, postFilterInOperator]
+      : [postFilterNotEqualOperator, postFilterNotInOperator],
+    _cellData.columnName,
+    tdsState.postFilterState,
+    tdsColState,
+  );
+  existingPostFilterNode === undefined
+    ? generateNewPostFilterConditionNodeData(
+        applicationStore,
+        operator,
+        _cellData,
+        tdsState,
+        tdsColState,
+      ).catch(applicationStore.alertUnhandledError)
+    : updateExistingPostFilterConditionNodeData(
+        existingPostFilterNode,
+        isFilterBy,
+        _cellData,
+        operator,
+        data,
+        tdsState,
+      );
+};
+
+export const filterByOrOutValues = (
+  applicationStore: ApplicationStore<
+    LegendApplicationConfig,
+    LegendApplicationPluginManager<LegendApplicationPlugin>
+  >,
+  data: QueryBuilderTDSResultCellData | null,
+  isFilterBy: boolean,
+  tdsState: QueryBuilderTDSState,
+): void => {
+  tdsState.queryBuilderState.resultState.selectedCells.forEach((_cellData) => {
+    filterByOrOutValue(applicationStore, isFilterBy, _cellData, data, tdsState);
+  });
+};
+
 export const QueryBuilderGridResultContextMenu = observer(
   forwardRef<
     HTMLDivElement,
@@ -207,246 +466,17 @@ export const QueryBuilderGridResultContextMenu = observer(
   >(function QueryBuilderResultContextMenu(props, ref) {
     const { data, tdsState, copyCellValueFunc, copyCellRowValueFunc } = props;
     const applicationStore = useApplicationStore();
-    const postFilterEqualOperator = new QueryBuilderPostFilterOperator_Equal();
-    const postFilterInOperator = new QueryBuilderPostFilterOperator_In();
-    const postFilterEmptyOperator =
-      new QueryBuilderPostFilterOperator_IsEmpty();
-    const postFilterNotEmptyOperator =
-      new QueryBuilderPostFilterOperator_IsNotEmpty();
-    const postFilterNotEqualOperator =
-      new QueryBuilderPostFilterOperator_NotEqual();
-    const postFilterNotInOperator = new QueryBuilderPostFilterOperator_NotIn();
-    const postFilterState = tdsState.postFilterState;
+
     const tdsColState = data?.columnName
       ? getTDSColumnState(tdsState, data.columnName)
       : undefined;
 
-    const updateFilterConditionValue = (
-      conditionValue: InstanceValue,
-      _cellData: QueryBuilderTDSResultCellData,
-    ): void => {
-      if (_cellData.value) {
-        instanceValue_setValue(
-          conditionValue,
-          conditionValue instanceof EnumValueInstanceValue
-            ? EnumValueExplicitReference.create(
-                guaranteeNonNullable(
-                  (
-                    conditionValue.genericType?.ownerReference
-                      .value as Enumeration
-                  ).values.filter((v) => v.name === _cellData.value)[0],
-                ),
-              )
-            : _cellData.value,
-          0,
-          tdsState.queryBuilderState.observerContext,
-        );
-      }
-    };
-
-    const generateNewPostFilterConditionNodeData = async (
-      operator: QueryBuilderPostFilterOperator,
-      _cellData: QueryBuilderTDSResultCellData,
-    ): Promise<void> => {
-      let postFilterConditionState: PostFilterConditionState;
-      try {
-        const possibleProjectionColumnState = _cellData.columnName
-          ? tdsState.projectionColumns
-              .filter((c) => c.columnName === _cellData.columnName)
-              .concat(
-                tdsState.aggregationState.columns
-                  .filter((c) => c.columnName === _cellData.columnName)
-                  .map((ag) => ag.projectionColumnState),
-              )[0]
-          : tdsColState;
-
-        if (possibleProjectionColumnState) {
-          postFilterConditionState = new PostFilterConditionState(
-            postFilterState,
-            possibleProjectionColumnState,
-            operator,
-          );
-
-          if (
-            tdsColState instanceof QueryBuilderDerivationProjectionColumnState
-          ) {
-            await flowResult(tdsColState.fetchDerivationLambdaReturnType());
-          }
-
-          const defaultFilterConditionValue =
-            postFilterConditionState.operator.getDefaultFilterConditionValue(
-              postFilterConditionState,
-            );
-
-          postFilterConditionState.buildFromValueSpec(
-            defaultFilterConditionValue,
-          );
-          updateFilterConditionValue(
-            defaultFilterConditionValue as InstanceValue,
-            _cellData,
-          );
-          postFilterState.addNodeFromNode(
-            new QueryBuilderPostFilterTreeConditionNodeData(
-              undefined,
-              postFilterConditionState,
-            ),
-            undefined,
-          );
-        }
-      } catch (error) {
-        assertErrorThrown(error);
-        applicationStore.notificationService.notifyWarning(error.message);
-        return;
-      }
-    };
-
-    const updateExistingPostFilterConditionNodeData = (
-      existingPostFilterNode: QueryBuilderPostFilterTreeNodeData,
-      isFilterBy: boolean,
-      _cellData: QueryBuilderTDSResultCellData,
-      operator: QueryBuilderPostFilterOperator,
-    ): void => {
-      if (
-        operator === postFilterEmptyOperator ||
-        operator === postFilterNotEmptyOperator
-      ) {
-        const conditionState = (
-          existingPostFilterNode as QueryBuilderPostFilterTreeConditionNodeData
-        ).condition;
-        if (conditionState.operator.getLabel() !== operator.getLabel()) {
-          conditionState.changeOperator(
-            isFilterBy ? postFilterEmptyOperator : postFilterNotEmptyOperator,
-          );
-        }
-        return;
-      }
-      const conditionState = (
-        existingPostFilterNode as QueryBuilderPostFilterTreeConditionNodeData
-      ).condition;
-
-      const rightSide = conditionState.rightConditionValue;
-      if (rightSide instanceof PostFilterValueSpecConditionValueState) {
-        if (conditionState.operator.getLabel() === operator.getLabel()) {
-          const doesValueAlreadyExist =
-            rightSide.value instanceof InstanceValue &&
-            (rightSide.value instanceof EnumValueInstanceValue
-              ? rightSide.value.values.map((ef) => ef.value.name)
-              : rightSide.value.values
-            ).includes(_cellData.value);
-
-          if (!doesValueAlreadyExist) {
-            const currentValueSpecificaton = rightSide.value;
-            const newValueSpecification =
-              conditionState.operator.getDefaultFilterConditionValue(
-                conditionState,
-              );
-            updateFilterConditionValue(
-              newValueSpecification as InstanceValue,
-              _cellData,
-            );
-            conditionState.changeOperator(
-              isFilterBy ? postFilterInOperator : postFilterNotInOperator,
-            );
-            instanceValue_setValues(
-              rightSide.value as InstanceValue,
-              [currentValueSpecificaton, newValueSpecification],
-              tdsState.queryBuilderState.observerContext,
-            );
-          }
-        } else {
-          const doesValueAlreadyExist =
-            rightSide.value instanceof InstanceValue &&
-            rightSide.value.values
-              .filter((v) => v instanceof InstanceValue)
-              .map((v) =>
-                v instanceof EnumValueInstanceValue
-                  ? v.values.map((ef) => ef.value.name)
-                  : (v as InstanceValue).values,
-              )
-              .flat()
-              .includes(_cellData.value ?? data?.value);
-
-          if (!doesValueAlreadyExist) {
-            const newValueSpecification = (
-              isFilterBy ? postFilterEqualOperator : postFilterNotEqualOperator
-            ).getDefaultFilterConditionValue(conditionState);
-            updateFilterConditionValue(
-              newValueSpecification as InstanceValue,
-              _cellData,
-            );
-            instanceValue_setValues(
-              rightSide.value as InstanceValue,
-              [
-                ...(rightSide.value as InstanceValue).values,
-                newValueSpecification,
-              ],
-              tdsState.queryBuilderState.observerContext,
-            );
-          }
-        }
-      }
-    };
-
-    const getFilterOperator = (
-      isFilterBy: boolean,
-      _cellData: QueryBuilderTDSResultCellData,
-    ): QueryBuilderPostFilterOperator => {
-      if (isFilterBy) {
-        if (_cellData.value === null) {
-          return postFilterEmptyOperator;
-        } else {
-          return postFilterEqualOperator;
-        }
-      } else {
-        if (_cellData.value === null) {
-          return postFilterNotEmptyOperator;
-        } else {
-          return postFilterNotEqualOperator;
-        }
-      }
-    };
-
-    const filterByOrOutValue = (
-      isFilterBy: boolean,
-      _cellData: QueryBuilderTDSResultCellData,
-    ): void => {
-      tdsState.setShowPostFilterPanel(true);
-      const operator = getFilterOperator(isFilterBy, _cellData);
-      const existingPostFilterNode = getExistingPostFilterNode(
-        _cellData.value === null
-          ? [postFilterEmptyOperator, postFilterNotEmptyOperator]
-          : isFilterBy
-          ? [postFilterEqualOperator, postFilterInOperator]
-          : [postFilterNotEqualOperator, postFilterNotInOperator],
-        _cellData.columnName,
-        postFilterState,
-        tdsColState,
-      );
-      existingPostFilterNode === undefined
-        ? generateNewPostFilterConditionNodeData(operator, _cellData).catch(
-            applicationStore.alertUnhandledError,
-          )
-        : updateExistingPostFilterConditionNodeData(
-            existingPostFilterNode,
-            isFilterBy,
-            _cellData,
-            operator,
-          );
-    };
-
-    const filterByOrOutValues = (isFilterBy: boolean): void => {
-      tdsState.queryBuilderState.resultState.selectedCells.forEach(
-        (_cellData) => {
-          filterByOrOutValue(isFilterBy, _cellData);
-        },
-      );
-    };
     return (
       <MenuContent ref={ref}>
         <MenuContentItem
           disabled={!tdsColState}
           onClick={(): void => {
-            filterByOrOutValues(true);
+            filterByOrOutValues(applicationStore, data, true, tdsState);
           }}
         >
           Filter By
@@ -454,7 +484,7 @@ export const QueryBuilderGridResultContextMenu = observer(
         <MenuContentItem
           disabled={!tdsColState}
           onClick={(): void => {
-            filterByOrOutValues(false);
+            filterByOrOutValues(applicationStore, data, false, tdsState);
           }}
         >
           Filter Out


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Utilize built-in context menu of ag-grid in enterprise mode

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
