### PR TITLE
add test for new render of tag value section in query builder tooltip

### DIFF
--- a/.changeset/silly-buttons-rest.md
+++ b/.changeset/silly-buttons-rest.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-query-builder': patch
+---

--- a/packages/legend-query-builder/src/__lib__/QueryBuilderTesting.ts
+++ b/packages/legend-query-builder/src/__lib__/QueryBuilderTesting.ts
@@ -38,6 +38,7 @@ export enum QUERY_BUILDER_TEST_ID {
   QUERY_BUILDER_PROPERTY_SEARCH_PANEL = 'query__builder__property__search__panel',
   QUERY_BUILDER_PARAMETERS = 'query-builder__parameters',
   QUERY_BUILDER_CONSTANTS = 'query-builder__constants',
+  QUERY_BUILDER_TOOLTIP_ICON = 'query-builder__tooltip__icon',
   // result panel
   QUERY_BUILDER_RESULT_VALUES = 'QUERY_BUILDER_RESULT_VALUES',
   QUERY_BUILDER_RESULT_VALUES_TDS = 'QUERY_BUILDER_RESULT_VALUES_TDS',

--- a/packages/legend-query-builder/src/components/__tests__/TEST_DATA__QueryBuilder_Model_HiglightProperties.json
+++ b/packages/legend-query-builder/src/components/__tests__/TEST_DATA__QueryBuilder_Model_HiglightProperties.json
@@ -1,30 +1,14 @@
 [
   {
-    "path": "my::Firm",
+    "path": "my::TestProfile",
     "content": {
-      "_type": "class",
-      "name": "Firm",
+      "_type": "profile",
+      "name": "TestProfile",
       "package": "my",
-      "properties": [
-        {
-          "multiplicity": {
-            "lowerBound": 1,
-            "upperBound": 1
-          },
-          "name": "legalName",
-          "type": "String"
-        },
-        {
-          "multiplicity": {
-            "lowerBound": 1,
-            "upperBound": 1
-          },
-          "name": "id",
-          "type": "Integer"
-        }
-      ]
+      "stereotypes": [],
+      "tags": ["ID", "Verified", "Test"]
     },
-    "classifierPath": "meta::pure::metamodel::type::Class"
+    "classifierPath": "meta::pure::metamodel::extension::Profile"
   },
   {
     "path": "my::Person",
@@ -48,6 +32,63 @@
           },
           "name": "firmID",
           "type": "Integer"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "my::Firm",
+    "content": {
+      "_type": "class",
+      "name": "Firm",
+      "package": "my",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "legalName",
+          "type": "String"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "id",
+          "type": "Integer"
+        }
+      ],
+      "taggedValues": [
+        {
+          "tag": {
+            "profile": "meta::pure::profiles::doc",
+            "value": "doc"
+          },
+          "value": "this is firm"
+        },
+        {
+          "tag": {
+            "profile": "my::TestProfile",
+            "value": "Verified"
+          },
+          "value": "true"
+        },
+        {
+          "tag": {
+            "profile": "my::TestProfile",
+            "value": "ID"
+          },
+          "value": "4"
+        },
+        {
+          "tag": {
+            "profile": "my::TestProfile",
+            "value": "Test"
+          },
+          "value": "true"
         }
       ]
     },
@@ -313,6 +354,7 @@
       "package": "my",
       "runtimeValue": {
         "_type": "engineRuntime",
+        "connectionStores": [],
         "connections": [
           {
             "store": {

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
@@ -552,7 +552,12 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                 <QueryBuilderRootClassInfoTooltip
                   _class={guaranteeNonNullable(queryBuilderState.class)}
                 >
-                  <div className="query-builder-explorer-tree__node__action query-builder-explorer-tree__node__info">
+                  <div
+                    className="query-builder-explorer-tree__node__action query-builder-explorer-tree__node__info"
+                    data-testid={
+                      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TOOLTIP_ICON
+                    }
+                  >
                     <InfoCircleIcon />
                   </div>
                 </QueryBuilderRootClassInfoTooltip>
@@ -639,7 +644,12 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                     isMapped={node.mappingData.mapped}
                     type={node.type}
                   >
-                    <div className="query-builder-explorer-tree__node__action query-builder-explorer-tree__node__info">
+                    <div
+                      className="query-builder-explorer-tree__node__action query-builder-explorer-tree__node__info"
+                      data-testid={
+                        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TOOLTIP_ICON
+                      }
+                    >
                       <InfoCircleIcon />
                     </div>
                   </QueryBuilderPropertyInfoTooltip>
@@ -651,7 +661,12 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                     isMapped={node.mappingData.mapped}
                     multiplicity={node.multiplicity}
                   >
-                    <div className="query-builder-explorer-tree__node__action query-builder-explorer-tree__node__info">
+                    <div
+                      className="query-builder-explorer-tree__node__action query-builder-explorer-tree__node__info"
+                      data-testid={
+                        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TOOLTIP_ICON
+                      }
+                    >
                       <InfoCircleIcon />
                     </div>
                   </QueryBuilderSubclassInfoTooltip>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

add test for new render of tag value section in query builder tooltip

## How did you test this change?

- [x] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
