### PR TITLE
Disable "View Query Usage..." button if extra query usage not configured

### DIFF
--- a/.changeset/dirty-insects-know.md
+++ b/.changeset/dirty-insects-know.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Disable "View Query Usage..." button if extra query usage not configured

--- a/packages/legend-query-builder/src/components/result/QueryBuilderResultPanel.tsx
+++ b/packages/legend-query-builder/src/components/result/QueryBuilderResultPanel.tsx
@@ -69,6 +69,7 @@ import { QUERY_BUILDER_DOCUMENTATION_KEY } from '../../__lib__/QueryBuilderDocum
 import { QueryBuilderTDSSimpleGridResult } from './tds/QueryBuilderTDSSimpleGridResult.js';
 import { getExecutedSqlFromExecutionResult } from './tds/QueryBuilderTDSResultShared.js';
 import { QueryBuilderTDSGridResult } from './tds/QueryBuilderTDSGridResult.js';
+import type { QueryBuilder_LegendApplicationPlugin_Extension } from '../../stores/QueryBuilder_LegendApplicationPlugin_Extension.js';
 
 const QueryBuilderResultValues = observer(
   (props: {
@@ -182,6 +183,16 @@ export const QueryBuilderResultPanel = observer(
       isQueryValid &&
       queryBuilderState.fetchStructureState.implementation instanceof
         QueryBuilderTDSState;
+
+    const isExtraQueryUsageOptionsConfigured =
+      applicationStore.pluginManager
+        .getApplicationPlugins()
+        .flatMap(
+          (plugin) =>
+            (
+              plugin as QueryBuilder_LegendApplicationPlugin_Extension
+            ).getExtraQueryUsageConfigurations?.() ?? [],
+        ).length > 0;
 
     const runQuery = (): void => {
       resultState.setSelectedCells([]);
@@ -511,7 +522,10 @@ export const QueryBuilderResultPanel = observer(
                     onClick={(): void =>
                       resultState.setIsQueryUsageViewerOpened(true)
                     }
-                    disabled={queryBuilderState.changeDetectionState.hasChanged}
+                    disabled={
+                      queryBuilderState.changeDetectionState.hasChanged ||
+                      !isExtraQueryUsageOptionsConfigured
+                    }
                   >
                     View Query Usage...
                   </MenuContentItem>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Disable "View Query Usage..." button if extra query usage not configured to improve UX so users don't click the button just to see an empty window saying no query usages available.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

GIF of button disabled when no extra query usage configured:
![disable_view_query_usage](https://github.com/finos/legend-studio/assets/9127428/11dc1d80-b4f6-4c26-9889-9b97c96bd50c)