### PR TITLE
Fetch structure panel is cluttered

### DIFF
--- a/.changeset/warm-doors-agree.md
+++ b/.changeset/warm-doors-agree.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-query-builder': patch
+'@finos/legend-art': patch
+---
+
+Clean up fetch structure panel

--- a/packages/legend-art/src/icon/Icon.ts
+++ b/packages/legend-art/src/icon/Icon.ts
@@ -604,12 +604,14 @@ export const AnchorLinkIcon = FiLink;
 //======================================================= RI =======================================================
 import {
   RiShapeLine,
+  RiShareBoxFill,
   RiTestTubeFill,
   RiRobotFill,
   RiGovernmentFill,
   RiMoneyDollarCircleFill,
 } from 'react-icons/ri/index.js';
 
+export const ShareBoxIcon = RiShareBoxFill;
 export const ShapeLineIcon = RiShapeLine;
 export const TestTubeIcon = RiTestTubeFill;
 export const DroidIcon = RiRobotFill;

--- a/packages/legend-art/src/input/Input.tsx
+++ b/packages/legend-art/src/input/Input.tsx
@@ -20,14 +20,19 @@ import {
   PencilIcon,
   TimesCircleIcon,
 } from '../icon/Icon.js';
+import { forwardRef } from 'react';
 
-export const InputWithInlineValidation: React.FC<
+type InputWithInlineValidationProps =
   React.InputHTMLAttributes<HTMLInputElement> & {
     error?: string | undefined;
     warning?: string | undefined;
     showEditableIcon?: boolean | undefined;
-  }
-> = (props) => {
+  };
+
+export const InputWithInlineValidation = forwardRef<
+  HTMLInputElement,
+  InputWithInlineValidationProps
+>(function InputWithInlineValidation(props, ref) {
   const { error, warning, showEditableIcon, className, ...inputProps } = props;
 
   const showCautionMessage = Boolean(warning) && !error;
@@ -40,6 +45,7 @@ export const InputWithInlineValidation: React.FC<
           'input--with-validation--error': Boolean(error),
         })}
         {...inputProps}
+        ref={ref}
       />
       {showEditableIcon && !error && (
         <div className="input--with-validation__editable" title={error}>
@@ -58,4 +64,4 @@ export const InputWithInlineValidation: React.FC<
       )}
     </div>
   );
-};
+});

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -372,12 +372,21 @@ export const QueryBuilderPropertyExpressionEditor = observer(
 
 export const QueryBuilderPropertyExpressionBadge = observer(
   (props: {
+    columnName?: string;
     propertyExpressionState: QueryBuilderPropertyExpressionState;
     onPropertyExpressionChange: (
       node: QueryBuilderExplorerTreePropertyNodeData,
     ) => void;
+    setIsEditingColumnName?: (isEditing: boolean) => void;
   }) => {
-    const { propertyExpressionState, onPropertyExpressionChange } = props;
+    const {
+      columnName,
+      propertyExpressionState,
+      onPropertyExpressionChange,
+      setIsEditingColumnName,
+    } = props;
+    const explorerState =
+      propertyExpressionState.queryBuilderState.explorerState;
     const type =
       propertyExpressionState.propertyExpression.func.value.genericType.value
         .rawType;
@@ -442,8 +451,11 @@ export const QueryBuilderPropertyExpressionBadge = observer(
             <div
               className="query-builder-property-expression-badge__property"
               title={`${propertyExpressionState.title} - ${propertyExpressionState.path}`}
+              onDoubleClick={() => {
+                setIsEditingColumnName?.(true);
+              }}
             >
-              {propertyExpressionState.title}
+              {columnName ?? propertyExpressionState.title}
             </div>
             {hasDerivedPropertyInExpression && (
               <button
@@ -465,10 +477,12 @@ export const QueryBuilderPropertyExpressionBadge = observer(
               propertyExpressionState={propertyExpressionState}
             />
             <QueryBuilderPropertyInfoTooltip
+              title={propertyExpressionState.title}
               property={propertyExpressionState.propertyExpression.func.value}
               path={getPropertyPath(propertyExpressionState.propertyExpression)}
               isMapped={true}
               placement="bottom-end"
+              explorerState={explorerState}
             >
               <div className="query-builder-property-expression-badge__property__info">
                 <InfoCircleIcon />

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -451,7 +451,7 @@ export const QueryBuilderPropertyExpressionBadge = observer(
             <div
               className="query-builder-property-expression-badge__property"
               title={`${propertyExpressionState.title} - ${propertyExpressionState.path}`}
-              onDoubleClick={() => {
+              onClick={() => {
                 setIsEditingColumnName?.(true);
               }}
             >

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
@@ -56,7 +56,7 @@ import {
   guaranteeType,
   getNullableFirstEntry,
 } from '@finos/legend-shared';
-import { integrationTest } from '@finos/legend-shared/test';
+import { createMock, integrationTest } from '@finos/legend-shared/test';
 import {
   AbstractPropertyExpression,
   PrimitiveInstanceValue,
@@ -636,6 +636,105 @@ test(
         (e) => e.columnName === 'Edited First Name with Age',
       ),
     );
+  },
+);
+
+test(
+  integrationTest(
+    'Query builder property info tooltip highlights property in explorer when path button is clicked',
+  ),
+  async () => {
+    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+      TEST_DATA__ComplexRelationalModel,
+      stub_RawLambda(),
+      'model::relational::tests::simpleRelationalMapping',
+      'model::MyRuntime',
+      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
+    );
+
+    const _personClass = queryBuilderState.graphManagerState.graph.getClass(
+      'model::pure::tests::model::simple::Person',
+    );
+
+    await act(async () => {
+      queryBuilderState.changeClass(_personClass);
+    });
+    const queryBuilderSetup = await waitFor(() =>
+      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
+    );
+    await waitFor(() => getByText(queryBuilderSetup, 'Person'));
+    await waitFor(() =>
+      getByText(queryBuilderSetup, 'simpleRelationalMapping'),
+    );
+    await waitFor(() => getByText(queryBuilderSetup, 'MyRuntime'));
+    const treeData = guaranteeNonNullable(
+      queryBuilderState.explorerState.treeData,
+    );
+    const rootNode = guaranteeType(
+      treeData.nodes.get(treeData.rootIds[0] as string),
+      QueryBuilderExplorerTreeRootNodeData,
+    );
+
+    expect(rootNode.mappingData.mapped).toBe(true);
+
+    // simpleProjection
+    await act(async () => {
+      queryBuilderState.initializeWithQuery(
+        create_RawLambda(
+          TEST_DATA__simpleProjection.parameters,
+          TEST_DATA__simpleProjection.body,
+        ),
+      );
+    });
+
+    // collapse explorer tree
+    const LAST_NAME_ALIAS = 'Last Name';
+    const explorerPanel = await renderResult.findByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_EXPLORER,
+    );
+    expect(
+      await waitFor(() => queryByText(explorerPanel, LAST_NAME_ALIAS)),
+    ).not.toBeNull();
+    const explorerPanelPersonNode = guaranteeNonNullable(
+      await waitFor(() => queryByText(explorerPanel, 'Person')),
+    );
+    fireEvent.click(explorerPanelPersonNode);
+    expect(
+      await waitFor(() => queryByText(explorerPanel, LAST_NAME_ALIAS)),
+    ).toBeNull();
+
+    // show tooltip
+    const MOCK__ScrollIntoView = createMock();
+    window.HTMLElement.prototype.scrollIntoView = MOCK__ScrollIntoView;
+    const projectionCols = await renderResult.findByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TDS,
+    );
+    const lastNameExpressionInfoTooltipIcon = guaranteeNonNullable(
+      await waitFor(
+        () => queryByText(projectionCols, LAST_NAME_ALIAS)?.nextSibling,
+      ),
+    );
+    fireEvent.mouseOver(lastNameExpressionInfoTooltipIcon);
+    const tooltip = await renderResult.findByRole('tooltip');
+    const pathShowInTreeButton = guaranteeNonNullable(
+      await waitFor(
+        () =>
+          queryByText(tooltip, 'Path')?.parentElement?.querySelector('button'),
+      ),
+    );
+    fireEvent.click(pathShowInTreeButton);
+
+    // check that explorer node is highlighted
+    expect(
+      await waitFor(() => queryByText(explorerPanel, LAST_NAME_ALIAS)),
+    ).not.toBeNull();
+    expect(
+      await waitFor(
+        () =>
+          queryByText(explorerPanel, LAST_NAME_ALIAS)?.parentElement?.classList,
+      ),
+    ).toContain('query-builder-explorer-tree__node__label--highlight');
+    expect(MOCK__ScrollIntoView).toHaveBeenCalledTimes(1);
   },
 );
 

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
@@ -138,14 +138,10 @@ test(
     const FIRST_NAME_ALIAS = 'Edited First Name';
     const LAST_NAME_ALIAS = 'Last Name';
     expect(
-      await waitFor(() =>
-        projectionCols.querySelector(`input[value="${FIRST_NAME_ALIAS}"]`),
-      ),
+      await waitFor(() => queryByText(projectionCols, FIRST_NAME_ALIAS)),
     ).not.toBeNull();
     expect(
-      await waitFor(() =>
-        projectionCols.querySelector(`input[value="${LAST_NAME_ALIAS}"]`),
-      ),
+      await waitFor(() => queryByText(projectionCols, LAST_NAME_ALIAS)),
     ).not.toBeNull();
     let tdsState = guaranteeType(
       queryBuilderState.fetchStructureState.implementation,
@@ -189,9 +185,7 @@ test(
     );
     expect(
       await waitFor(() =>
-        projectionWithChainedPropertyCols.querySelector(
-          `input[value="${CHAINED_PROPERTY_ALIAS}"]`,
-        ),
+        queryByText(projectionWithChainedPropertyCols, CHAINED_PROPERTY_ALIAS),
       ),
     ).not.toBeNull();
     expect(tdsState.projectionColumns.length).toBe(1);
@@ -235,21 +229,13 @@ test(
       renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TDS),
     );
     expect(
-      await waitFor(() =>
-        projectionCols.querySelector(`input[value="${FIRST_NAME_ALIAS}"]`),
-      ),
+      await waitFor(() => queryByText(projectionCols, FIRST_NAME_ALIAS)),
     ).not.toBeNull();
     expect(
-      await waitFor(() =>
-        projectionCols.querySelector(`input[value="${LAST_NAME_ALIAS}"]`),
-      ),
+      await waitFor(() => queryByText(projectionCols, LAST_NAME_ALIAS)),
     ).not.toBeNull();
     expect(
-      await waitFor(() =>
-        projectionCols.querySelector(
-          `input[value="${CHAINED_PROPERTY_ALIAS}"]`,
-        ),
-      ),
+      await waitFor(() => queryByText(projectionCols, CHAINED_PROPERTY_ALIAS)),
     ).not.toBeNull();
     expect(tdsState.projectionColumns.length).toBe(3);
     const resultSetModifierState = tdsState.resultSetModifierState;
@@ -423,11 +409,8 @@ test(
       renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TDS),
     );
     expect(
-      await waitFor(() =>
-        projectionCols.querySelector(`input[value="Full Name With Title"]`),
-      ),
+      await waitFor(() => queryByText(projectionCols, 'Full Name With Title')),
     ).not.toBeNull();
-    await waitFor(() => getByText(projectionCols, 'Name With Title'));
     expect(tdsState.projectionColumns.length).toBe(1);
     fireEvent.click(
       getByTitle(projectionCols, 'Set Derived Property Argument(s)...'),
@@ -511,15 +494,20 @@ test(
       renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TDS),
     );
     const lastNameColumnName = guaranteeNonNullable(
+      await waitFor(() => queryByText(projectionCols, LAST_NAME_ALIAS)),
+    );
+    fireEvent.click(lastNameColumnName);
+    const lastNameColumnNameInput = guaranteeNonNullable(
       await waitFor(() =>
         projectionCols.querySelector(`input[value="${LAST_NAME_ALIAS}"]`),
       ),
     );
-    fireEvent.change(lastNameColumnName, {
+    fireEvent.change(lastNameColumnNameInput, {
       target: { value: 'edited last name' },
     });
+    fireEvent.blur(lastNameColumnNameInput);
     const propertyExpressionBadgeDropZone = await waitFor(() =>
-      getByText(projectionPanel, 'Last Name'),
+      getByText(projectionPanel, 'edited last name'),
     );
     const firstNameNode = await waitFor(() =>
       getByText(explorerPanel, 'First Name'),

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
@@ -459,6 +459,13 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
     ) : (
       <div />
     );
+    const propertyName = explorerState.humanizePropertyName
+      ? node instanceof QueryBuilderExplorerTreeSubTypeNodeData
+        ? TYPE_CAST_TOKEN + prettyCONSTName(node.label)
+        : prettyCONSTName(node.label)
+      : node instanceof QueryBuilderExplorerTreeSubTypeNodeData
+      ? TYPE_CAST_TOKEN + node.label
+      : node.label;
     const selectNode = (): void => onNodeSelect?.(node);
     const openNode = (): void => {
       if (!node.isOpen) {
@@ -606,13 +613,7 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                     },
                   )}
                 >
-                  {explorerState.humanizePropertyName
-                    ? node instanceof QueryBuilderExplorerTreeSubTypeNodeData
-                      ? TYPE_CAST_TOKEN + prettyCONSTName(node.label)
-                      : prettyCONSTName(node.label)
-                    : node instanceof QueryBuilderExplorerTreeSubTypeNodeData
-                    ? TYPE_CAST_TOKEN + node.label
-                    : node.label}
+                  {propertyName}
                 </div>
                 {isDerivedProperty && (
                   <div
@@ -647,17 +648,7 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                 )}
                 {node instanceof QueryBuilderExplorerTreePropertyNodeData && (
                   <QueryBuilderPropertyInfoTooltip
-                    title={
-                      explorerState.humanizePropertyName
-                        ? node instanceof
-                          QueryBuilderExplorerTreeSubTypeNodeData
-                          ? TYPE_CAST_TOKEN + prettyCONSTName(node.label)
-                          : prettyCONSTName(node.label)
-                        : node instanceof
-                          QueryBuilderExplorerTreeSubTypeNodeData
-                        ? TYPE_CAST_TOKEN + node.label
-                        : node.label
-                    }
+                    title={propertyName}
                     property={node.property}
                     path={node.id}
                     isMapped={node.mappingData.mapped}

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
@@ -582,7 +582,12 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                     'query-builder-explorer-tree__node__label--with-preview':
                       allowPreview,
                   },
+                  {
+                    'query-builder-explorer-tree__node__label--highlight':
+                      node.isHighlighting,
+                  },
                 )}
+                onAnimationEnd={() => node.setIsHighlighting(false)}
               >
                 <div
                   className={clsx(
@@ -639,6 +644,17 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
                 )}
                 {node instanceof QueryBuilderExplorerTreePropertyNodeData && (
                   <QueryBuilderPropertyInfoTooltip
+                    title={
+                      explorerState.humanizePropertyName
+                        ? node instanceof
+                          QueryBuilderExplorerTreeSubTypeNodeData
+                          ? TYPE_CAST_TOKEN + prettyCONSTName(node.label)
+                          : prettyCONSTName(node.label)
+                        : node instanceof
+                          QueryBuilderExplorerTreeSubTypeNodeData
+                        ? TYPE_CAST_TOKEN + node.label
+                        : node.label
+                    }
                     property={node.property}
                     path={node.id}
                     isMapped={node.mappingData.mapped}

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
@@ -576,7 +576,7 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
             <>
               <div
                 className="tree-view__node__icon query-builder-explorer-tree__node__icon"
-                ref={node.ref}
+                ref={node.elementRef}
               >
                 <div className="query-builder-explorer-tree__expand-icon">
                   {nodeExpandIcon}

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
@@ -567,7 +567,10 @@ const QueryBuilderExplorerTreeNodeContainer = observer(
           {(node instanceof QueryBuilderExplorerTreePropertyNodeData ||
             node instanceof QueryBuilderExplorerTreeSubTypeNodeData) && (
             <>
-              <div className="tree-view__node__icon query-builder-explorer-tree__node__icon">
+              <div
+                className="tree-view__node__icon query-builder-explorer-tree__node__icon"
+                ref={node.ref}
+              >
                 <div className="query-builder-explorer-tree__expand-icon">
                   {nodeExpandIcon}
                 </div>

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderPropertySearchPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderPropertySearchPanel.tsx
@@ -182,6 +182,12 @@ const QueryBuilderTreeNodeViewer = observer(
         node instanceof QueryBuilderExplorerTreePropertyNodeData &&
         node.parentId === pn.id,
     );
+    const propertyName =
+      parentNode instanceof QueryBuilderExplorerTreeSubTypeNodeData
+        ? prettyPropertyNameForSubType(node.id)
+        : node instanceof QueryBuilderExplorerTreeSubTypeNodeData
+        ? prettyPropertyNameForSubTypeClass(node.id)
+        : prettyPropertyNameFromNodeId(node.id);
 
     return (
       <div>
@@ -205,22 +211,12 @@ const QueryBuilderTreeNodeViewer = observer(
             </div>
           </div>
           <div className="tree-view__node__label query-builder-property-search-panel__node__label query-builder-property-search-panel__node__label--with-action">
-            {parentNode instanceof QueryBuilderExplorerTreeSubTypeNodeData
-              ? prettyPropertyNameForSubType(node.id)
-              : node instanceof QueryBuilderExplorerTreeSubTypeNodeData
-              ? prettyPropertyNameForSubTypeClass(node.id)
-              : prettyPropertyNameFromNodeId(node.id)}
+            {propertyName}
           </div>
           <div className="query-builder-property-search-panel__node__actions">
             {node instanceof QueryBuilderExplorerTreePropertyNodeData && (
               <QueryBuilderPropertyInfoTooltip
-                title={
-                  parentNode instanceof QueryBuilderExplorerTreeSubTypeNodeData
-                    ? prettyPropertyNameForSubType(node.id)
-                    : node instanceof QueryBuilderExplorerTreeSubTypeNodeData
-                    ? prettyPropertyNameForSubTypeClass(node.id)
-                    : prettyPropertyNameFromNodeId(node.id)
-                }
+                title={propertyName}
                 property={node.property}
                 path={node.id}
                 isMapped={node.mappingData.mapped}

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderPropertySearchPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderPropertySearchPanel.tsx
@@ -214,6 +214,13 @@ const QueryBuilderTreeNodeViewer = observer(
           <div className="query-builder-property-search-panel__node__actions">
             {node instanceof QueryBuilderExplorerTreePropertyNodeData && (
               <QueryBuilderPropertyInfoTooltip
+                title={
+                  parentNode instanceof QueryBuilderExplorerTreeSubTypeNodeData
+                    ? prettyPropertyNameForSubType(node.id)
+                    : node instanceof QueryBuilderExplorerTreeSubTypeNodeData
+                    ? prettyPropertyNameForSubTypeClass(node.id)
+                    : prettyPropertyNameFromNodeId(node.id)
+                }
                 property={node.property}
                 path={node.id}
                 isMapped={node.mappingData.mapped}

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -144,8 +144,9 @@ const QueryBuilderProjectionColumnContextMenu = observer(
 const QueryBuilderSimpleProjectionColumnEditor = observer(
   (props: {
     projectionColumnState: QueryBuilderSimpleProjectionColumnState;
+    setIsEditingColumnName: (isEditing: boolean) => void;
   }) => {
-    const { projectionColumnState } = props;
+    const { projectionColumnState, setIsEditingColumnName } = props;
     const onPropertyExpressionChange = (
       node: QueryBuilderExplorerTreePropertyNodeData,
     ): void =>
@@ -158,10 +159,12 @@ const QueryBuilderSimpleProjectionColumnEditor = observer(
     return (
       <div className="query-builder__projection__column__value__property">
         <QueryBuilderPropertyExpressionBadge
+          columnName={projectionColumnState.columnName}
           propertyExpressionState={
             projectionColumnState.propertyExpressionState
           }
           onPropertyExpressionChange={onPropertyExpressionChange}
+          setIsEditingColumnName={setIsEditingColumnName}
         />
       </div>
     );
@@ -362,6 +365,7 @@ const QueryBuilderProjectionColumnEditor = observer(
     const ref = useRef<HTMLDivElement>(null);
     const [isSelectedFromContextMenu, setIsSelectedFromContextMenu] =
       useState(false);
+    const [isEditingColumnName, setIsEditingColumnName] = useState(false);
     const onContextMenuOpen = (): void => setIsSelectedFromContextMenu(true);
     const onContextMenuClose = (): void => setIsSelectedFromContextMenu(false);
 
@@ -742,29 +746,43 @@ const QueryBuilderProjectionColumnEditor = observer(
               dragSourceConnector={dragHandleRef}
               className="query-builder__projection__column__drag-handle__container"
             />
-            <div className="query-builder__projection__column__name">
-              <InputWithInlineValidation
-                className="query-builder__projection__column__name__input input-group__input"
-                spellCheck={false}
-                value={projectionColumnState.columnName}
-                onChange={changeColumnName}
-                error={isDuplicatedColumnName ? 'Duplicated column' : undefined}
-              />
-            </div>
-            <div className="query-builder__projection__column__value">
-              {projectionColumnState instanceof
-                QueryBuilderSimpleProjectionColumnState && (
-                <QueryBuilderSimpleProjectionColumnEditor
-                  projectionColumnState={projectionColumnState}
+            {isEditingColumnName ? (
+              <div className="query-builder__projection__column__name">
+                <InputWithInlineValidation
+                  className="query-builder__projection__column__name__input input-group__input"
+                  spellCheck={false}
+                  value={projectionColumnState.columnName}
+                  onChange={changeColumnName}
+                  onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+                    if (event.key === 'Enter') {
+                      setIsEditingColumnName(false);
+                    }
+                  }}
+                  onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
+                    setIsEditingColumnName(false);
+                  }}
+                  error={
+                    isDuplicatedColumnName ? 'Duplicated column' : undefined
+                  }
                 />
-              )}
-              {projectionColumnState instanceof
-                QueryBuilderDerivationProjectionColumnState && (
-                <QueryBuilderDerivationProjectionColumnEditor
-                  projectionColumnState={projectionColumnState}
-                />
-              )}
-            </div>
+              </div>
+            ) : (
+              <div className="query-builder__projection__column__value">
+                {projectionColumnState instanceof
+                  QueryBuilderSimpleProjectionColumnState && (
+                  <QueryBuilderSimpleProjectionColumnEditor
+                    projectionColumnState={projectionColumnState}
+                    setIsEditingColumnName={setIsEditingColumnName}
+                  />
+                )}
+                {projectionColumnState instanceof
+                  QueryBuilderDerivationProjectionColumnState && (
+                  <QueryBuilderDerivationProjectionColumnEditor
+                    projectionColumnState={projectionColumnState}
+                  />
+                )}
+              </div>
+            )}
             <div className="query-builder__projection__column__aggregate">
               <div className="query-builder__projection__column__aggregate__operator">
                 {aggregateColumnState && (

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -746,76 +746,69 @@ const QueryBuilderProjectionColumnEditor = observer(
               dragSourceConnector={dragHandleRef}
               className="query-builder__projection__column__drag-handle__container"
             />
-            <>
-              {projectionColumnState instanceof
-                QueryBuilderSimpleProjectionColumnState && (
-                <>
-                  {isEditingColumnName ? (
-                    <div className="query-builder__projection__column__name">
-                      <InputWithInlineValidation
-                        className="query-builder__projection__column__name__input input-group__input"
-                        spellCheck={false}
-                        value={projectionColumnState.columnName}
-                        onChange={changeColumnName}
-                        onKeyDown={(
-                          event: React.KeyboardEvent<HTMLInputElement>,
-                        ) => {
-                          if (event.key === 'Enter') {
-                            setIsEditingColumnName(false);
-                          }
-                        }}
-                        onBlur={() => {
-                          setIsEditingColumnName(false);
-                        }}
-                        error={
-                          isDuplicatedColumnName
-                            ? 'Duplicated column'
-                            : undefined
-                        }
-                      />
-                    </div>
-                  ) : (
-                    <div className="query-builder__projection__column__value">
-                      <QueryBuilderSimpleProjectionColumnEditor
-                        projectionColumnState={projectionColumnState}
-                        setIsEditingColumnName={setIsEditingColumnName}
-                      />
-                    </div>
-                  )}
-                </>
-              )}
-              {projectionColumnState instanceof
-                QueryBuilderDerivationProjectionColumnState && (
-                <>
-                  <div className="query-builder__projection__column__name">
-                    <InputWithInlineValidation
-                      className="query-builder__projection__column__name__input input-group__input"
-                      spellCheck={false}
-                      value={projectionColumnState.columnName}
-                      onChange={changeColumnName}
-                      onKeyDown={(
-                        event: React.KeyboardEvent<HTMLInputElement>,
-                      ) => {
-                        if (event.key === 'Enter') {
-                          setIsEditingColumnName(false);
-                        }
-                      }}
-                      onBlur={() => {
+            {projectionColumnState instanceof
+              QueryBuilderSimpleProjectionColumnState &&
+              (isEditingColumnName ? (
+                <div className="query-builder__projection__column__name">
+                  <InputWithInlineValidation
+                    className="query-builder__projection__column__name__input input-group__input"
+                    spellCheck={false}
+                    value={projectionColumnState.columnName}
+                    onChange={changeColumnName}
+                    onKeyDown={(
+                      event: React.KeyboardEvent<HTMLInputElement>,
+                    ) => {
+                      if (event.key === 'Enter') {
                         setIsEditingColumnName(false);
-                      }}
-                      error={
-                        isDuplicatedColumnName ? 'Duplicated column' : undefined
                       }
-                    />
-                  </div>
-                  <div className="query-builder__projection__column__value">
-                    <QueryBuilderDerivationProjectionColumnEditor
-                      projectionColumnState={projectionColumnState}
-                    />
-                  </div>
-                </>
-              )}
-            </>
+                    }}
+                    onBlur={() => {
+                      setIsEditingColumnName(false);
+                    }}
+                    error={
+                      isDuplicatedColumnName ? 'Duplicated column' : undefined
+                    }
+                  />
+                </div>
+              ) : (
+                <div className="query-builder__projection__column__value">
+                  <QueryBuilderSimpleProjectionColumnEditor
+                    projectionColumnState={projectionColumnState}
+                    setIsEditingColumnName={setIsEditingColumnName}
+                  />
+                </div>
+              ))}
+            {projectionColumnState instanceof
+              QueryBuilderDerivationProjectionColumnState && (
+              <>
+                <div className="query-builder__projection__column__name">
+                  <InputWithInlineValidation
+                    className="query-builder__projection__column__name__input input-group__input"
+                    spellCheck={false}
+                    value={projectionColumnState.columnName}
+                    onChange={changeColumnName}
+                    onKeyDown={(
+                      event: React.KeyboardEvent<HTMLInputElement>,
+                    ) => {
+                      if (event.key === 'Enter') {
+                        setIsEditingColumnName(false);
+                      }
+                    }}
+                    onBlur={() => {
+                      setIsEditingColumnName(false);
+                    }}
+                    error={
+                      isDuplicatedColumnName ? 'Duplicated column' : undefined
+                    }
+                  />
+                </div>
+                <div className="query-builder__projection__column__value">
+                  <QueryBuilderDerivationProjectionColumnEditor
+                    projectionColumnState={projectionColumnState}
+                  />
+                </div>
+              </>
+            )}
             <div className="query-builder__projection__column__aggregate">
               <div className="query-builder__projection__column__aggregate__operator">
                 {aggregateColumnState && (

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -788,7 +788,7 @@ const QueryBuilderProjectionColumnEditor = observer(
             {projectionColumnState instanceof
               QueryBuilderDerivationProjectionColumnState && (
               <>
-                <div className="query-builder__projection__column__name">
+                <div className="query-builder__projection__column__name query-builder__projection__column__name__derivation">
                   <InputWithInlineValidation
                     className="query-builder__projection__column__name__input input-group__input"
                     spellCheck={false}

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -746,43 +746,76 @@ const QueryBuilderProjectionColumnEditor = observer(
               dragSourceConnector={dragHandleRef}
               className="query-builder__projection__column__drag-handle__container"
             />
-            {isEditingColumnName ? (
-              <div className="query-builder__projection__column__name">
-                <InputWithInlineValidation
-                  className="query-builder__projection__column__name__input input-group__input"
-                  spellCheck={false}
-                  value={projectionColumnState.columnName}
-                  onChange={changeColumnName}
-                  onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-                    if (event.key === 'Enter') {
-                      setIsEditingColumnName(false);
-                    }
-                  }}
-                  onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
-                    setIsEditingColumnName(false);
-                  }}
-                  error={
-                    isDuplicatedColumnName ? 'Duplicated column' : undefined
-                  }
-                />
-              </div>
-            ) : (
-              <div className="query-builder__projection__column__value">
-                {projectionColumnState instanceof
-                  QueryBuilderSimpleProjectionColumnState && (
-                  <QueryBuilderSimpleProjectionColumnEditor
-                    projectionColumnState={projectionColumnState}
-                    setIsEditingColumnName={setIsEditingColumnName}
-                  />
-                )}
-                {projectionColumnState instanceof
-                  QueryBuilderDerivationProjectionColumnState && (
-                  <QueryBuilderDerivationProjectionColumnEditor
-                    projectionColumnState={projectionColumnState}
-                  />
-                )}
-              </div>
-            )}
+            <>
+              {projectionColumnState instanceof
+                QueryBuilderSimpleProjectionColumnState && (
+                <>
+                  {isEditingColumnName ? (
+                    <div className="query-builder__projection__column__name">
+                      <InputWithInlineValidation
+                        className="query-builder__projection__column__name__input input-group__input"
+                        spellCheck={false}
+                        value={projectionColumnState.columnName}
+                        onChange={changeColumnName}
+                        onKeyDown={(
+                          event: React.KeyboardEvent<HTMLInputElement>,
+                        ) => {
+                          if (event.key === 'Enter') {
+                            setIsEditingColumnName(false);
+                          }
+                        }}
+                        onBlur={() => {
+                          setIsEditingColumnName(false);
+                        }}
+                        error={
+                          isDuplicatedColumnName
+                            ? 'Duplicated column'
+                            : undefined
+                        }
+                      />
+                    </div>
+                  ) : (
+                    <div className="query-builder__projection__column__value">
+                      <QueryBuilderSimpleProjectionColumnEditor
+                        projectionColumnState={projectionColumnState}
+                        setIsEditingColumnName={setIsEditingColumnName}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+              {projectionColumnState instanceof
+                QueryBuilderDerivationProjectionColumnState && (
+                <>
+                  <div className="query-builder__projection__column__name">
+                    <InputWithInlineValidation
+                      className="query-builder__projection__column__name__input input-group__input"
+                      spellCheck={false}
+                      value={projectionColumnState.columnName}
+                      onChange={changeColumnName}
+                      onKeyDown={(
+                        event: React.KeyboardEvent<HTMLInputElement>,
+                      ) => {
+                        if (event.key === 'Enter') {
+                          setIsEditingColumnName(false);
+                        }
+                      }}
+                      onBlur={() => {
+                        setIsEditingColumnName(false);
+                      }}
+                      error={
+                        isDuplicatedColumnName ? 'Duplicated column' : undefined
+                      }
+                    />
+                  </div>
+                  <div className="query-builder__projection__column__value">
+                    <QueryBuilderDerivationProjectionColumnEditor
+                      projectionColumnState={projectionColumnState}
+                    />
+                  </div>
+                </>
+              )}
+            </>
             <div className="query-builder__projection__column__aggregate">
               <div className="query-builder__projection__column__aggregate__operator">
                 {aggregateColumnState && (

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -365,7 +365,6 @@ const QueryBuilderProjectionColumnEditor = observer(
     const ref = useRef<HTMLDivElement>(null);
     const [isSelectedFromContextMenu, setIsSelectedFromContextMenu] =
       useState(false);
-    const [isEditingColumnName, setIsEditingColumnName] = useState(false);
     const onContextMenuOpen = (): void => setIsSelectedFromContextMenu(true);
     const onContextMenuClose = (): void => setIsSelectedFromContextMenu(false);
 
@@ -382,6 +381,13 @@ const QueryBuilderProjectionColumnEditor = observer(
     ) => projectionColumnState.setColumnName(event.target.value);
     const isDuplicatedColumnName =
       projectionColumnState.tdsState.isDuplicateColumn(projectionColumnState);
+    const [isEditingColumnName, setIsEditingColumnName] = useState(false);
+    const columnNameInputRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+      if (isEditingColumnName) {
+        columnNameInputRef.current?.focus();
+      }
+    }, [isEditingColumnName, columnNameInputRef]);
 
     // aggregation
     const aggregateColumnState = tdsState.aggregationState.columns.find(
@@ -768,6 +774,7 @@ const QueryBuilderProjectionColumnEditor = observer(
                     error={
                       isDuplicatedColumnName ? 'Duplicated column' : undefined
                     }
+                    ref={columnNameInputRef}
                   />
                 </div>
               ) : (
@@ -787,16 +794,6 @@ const QueryBuilderProjectionColumnEditor = observer(
                     spellCheck={false}
                     value={projectionColumnState.columnName}
                     onChange={changeColumnName}
-                    onKeyDown={(
-                      event: React.KeyboardEvent<HTMLInputElement>,
-                    ) => {
-                      if (event.key === 'Enter') {
-                        setIsEditingColumnName(false);
-                      }
-                    }}
-                    onBlur={() => {
-                      setIsEditingColumnName(false);
-                    }}
                     error={
                       isDuplicatedColumnName ? 'Duplicated column' : undefined
                     }

--- a/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
+++ b/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { type TooltipPlacement, Tooltip } from '@finos/legend-art';
+import {
+  ShareBoxIcon,
+  type TooltipPlacement,
+  Tooltip,
+} from '@finos/legend-art';
 import {
   type AbstractProperty,
   type Type,
@@ -25,6 +29,7 @@ import {
   PURE_DOC_TAG,
 } from '@finos/legend-graph';
 import { useState } from 'react';
+import type { QueryBuilderExplorerState } from '../../stores/explorer/QueryBuilderExplorerState.js';
 
 export const QueryBuilderTaggedValueInfoTooltip: React.FC<{
   taggedValues: TaggedValue[];
@@ -112,14 +117,25 @@ export const QueryBuilderTaggedValueInfoTooltip: React.FC<{
 };
 
 export const QueryBuilderPropertyInfoTooltip: React.FC<{
+  title: string;
   property: AbstractProperty;
   path: string;
   isMapped: boolean;
   children: React.ReactElement;
   placement?: TooltipPlacement | undefined;
   type?: Type | undefined;
+  explorerState?: QueryBuilderExplorerState | undefined;
 }> = (props) => {
-  const { property, path, isMapped, children, placement, type } = props;
+  const {
+    title,
+    property,
+    path,
+    isMapped,
+    children,
+    placement,
+    type,
+    explorerState,
+  } = props;
 
   return (
     <Tooltip
@@ -138,6 +154,7 @@ export const QueryBuilderPropertyInfoTooltip: React.FC<{
       }}
       title={
         <div className="query-builder__tooltip__content">
+          <div className="query-builder__tooltip__header">{title}</div>
           <div className="query-builder__tooltip__item">
             <div className="query-builder__tooltip__item__label">Type</div>
             <div className="query-builder__tooltip__item__value">
@@ -147,6 +164,14 @@ export const QueryBuilderPropertyInfoTooltip: React.FC<{
           <div className="query-builder__tooltip__item">
             <div className="query-builder__tooltip__item__label">Path</div>
             <div className="query-builder__tooltip__item__value">{path}</div>
+            <div className="query-builder__tooltip__item__action">
+              <button
+                onClick={() => explorerState?.highlightTreeNode(path)}
+                title="Show in tree"
+              >
+                <ShareBoxIcon color="white" />
+              </button>
+            </div>
           </div>
           <div className="query-builder__tooltip__item">
             <div className="query-builder__tooltip__item__label">

--- a/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
+++ b/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
@@ -164,14 +164,16 @@ export const QueryBuilderPropertyInfoTooltip: React.FC<{
           <div className="query-builder__tooltip__item">
             <div className="query-builder__tooltip__item__label">Path</div>
             <div className="query-builder__tooltip__item__value">{path}</div>
-            <div className="query-builder__tooltip__item__action">
-              <button
-                onClick={() => explorerState?.highlightTreeNode(path)}
-                title="Show in tree"
-              >
-                <ShareBoxIcon color="white" />
-              </button>
-            </div>
+            {explorerState && (
+              <div className="query-builder__tooltip__item__action">
+                <button
+                  onClick={() => explorerState?.highlightTreeNode(path)}
+                  title="Show in tree"
+                >
+                  <ShareBoxIcon color="white" />
+                </button>
+              </div>
+            )}
           </div>
           <div className="query-builder__tooltip__item">
             <div className="query-builder__tooltip__item__label">

--- a/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
+++ b/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
@@ -167,7 +167,7 @@ export const QueryBuilderPropertyInfoTooltip: React.FC<{
             {explorerState && (
               <div className="query-builder__tooltip__item__action">
                 <button
-                  onClick={() => explorerState?.highlightTreeNode(path)}
+                  onClick={() => explorerState.highlightTreeNode(path)}
                   title="Show in tree"
                 >
                   <ShareBoxIcon color="white" />

--- a/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
@@ -1314,6 +1314,101 @@ export const TEST_DATA__projectionWithChainedProperty = {
   parameters: [],
 };
 
+export const TEST_DATA__projectionWithDerivation = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'project',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'packageableElementPtr',
+              fullPath: 'model::pure::tests::model::simple::Person',
+            },
+          ],
+        },
+        {
+          _type: 'collection',
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          values: [
+            {
+              _type: 'lambda',
+              body: [
+                {
+                  _type: 'func',
+                  function: 'plus',
+                  parameters: [
+                    {
+                      _type: 'collection',
+                      multiplicity: {
+                        lowerBound: 3,
+                        upperBound: 3,
+                      },
+                      values: [
+                        {
+                          _type: 'property',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                          property: 'firstName',
+                        },
+                        {
+                          _type: 'string',
+                          value: ' ',
+                        },
+                        {
+                          _type: 'property',
+                          parameters: [
+                            {
+                              _type: 'var',
+                              name: 'x',
+                            },
+                          ],
+                          property: 'age',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              parameters: [
+                {
+                  _type: 'var',
+                  name: 'x',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'collection',
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          values: [
+            {
+              _type: 'string',
+              value: 'First Name with Age',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};
+
 export const TEST_DATA__projectWithDerivedProperty = {
   _type: 'lambda',
   body: [

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -745,7 +745,11 @@ export class QueryBuilderExplorerState {
       }
       this.refreshTree();
       nodeToHighlight?.setIsHighlighting(true);
-      nodeToHighlight?.ref?.current?.scrollIntoView();
+      // scrollIntoView must be called in a setTimeout because it must happen after
+      // the tree nodes are recursively opened and the tree is refreshed.
+      setTimeout(() => {
+        nodeToHighlight?.ref?.current?.scrollIntoView();
+      }, 0);
     }
   }
 

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -737,11 +737,10 @@ export class QueryBuilderExplorerState {
         if (!nodeToOpen.isOpen) {
           nodeToOpen.isOpen = true;
         }
-        if (nodeToOpen instanceof QueryBuilderExplorerTreePropertyNodeData) {
-          nodeToOpen = this.treeData?.nodes?.get(nodeToOpen.parentId) ?? null;
-        } else {
-          nodeToOpen = null;
-        }
+        nodeToOpen =
+          nodeToOpen instanceof QueryBuilderExplorerTreePropertyNodeData
+            ? this.treeData?.nodes?.get(nodeToOpen.parentId) ?? null
+            : null;
       }
       this.refreshTree();
       nodeToHighlight?.setIsHighlighting(true);

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -72,6 +72,7 @@ import { QueryBuilderPropertySearchState } from './QueryBuilderPropertySearchSta
 import { QUERY_BUILDER_SUPPORTED_FUNCTIONS } from '../../graph/QueryBuilderMetaModelConst.js';
 import { propertyExpression_setFunc } from '../shared/ValueSpecificationModifierHelper.js';
 import { QueryBuilderTelemetryHelper } from '../../__lib__/QueryBuilderTelemetryHelper.js';
+import { createRef } from 'react';
 
 export enum QUERY_BUILDER_EXPLORER_TREE_DND_TYPE {
   ROOT = 'ROOT',
@@ -105,6 +106,7 @@ export abstract class QueryBuilderExplorerTreeNodeData implements TreeNodeData {
   isPartOfDerivedPropertyBranch: boolean;
   type: Type;
   mappingData: QueryBuilderExplorerTreeNodeMappingData;
+  ref: React.RefObject<HTMLDivElement>;
 
   constructor(
     id: string,
@@ -127,6 +129,7 @@ export abstract class QueryBuilderExplorerTreeNodeData implements TreeNodeData {
     this.isPartOfDerivedPropertyBranch = isPartOfDerivedPropertyBranch;
     this.type = type;
     this.mappingData = mappingData;
+    this.ref = createRef();
   }
 
   setIsSelected(val: boolean | undefined): void {
@@ -742,6 +745,7 @@ export class QueryBuilderExplorerState {
       }
       this.refreshTree();
       nodeToHighlight?.setIsHighlighting(true);
+      nodeToHighlight?.ref?.current?.scrollIntoView();
     }
   }
 

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -729,25 +729,25 @@ export class QueryBuilderExplorerState {
   }
 
   highlightTreeNode(key: string): void {
-    const nodeToHighlight = this.treeData?.nodes?.get(key);
+    const nodeToHighlight = this.treeData?.nodes.get(key);
     if (nodeToHighlight instanceof QueryBuilderExplorerTreePropertyNodeData) {
       let nodeToOpen: QueryBuilderExplorerTreeNodeData | null =
-        this.treeData?.nodes?.get(nodeToHighlight.parentId) ?? null;
+        this.treeData?.nodes.get(nodeToHighlight.parentId) ?? null;
       while (nodeToOpen !== null) {
         if (!nodeToOpen.isOpen) {
           nodeToOpen.isOpen = true;
         }
         nodeToOpen =
           nodeToOpen instanceof QueryBuilderExplorerTreePropertyNodeData
-            ? this.treeData?.nodes?.get(nodeToOpen.parentId) ?? null
+            ? this.treeData?.nodes.get(nodeToOpen.parentId) ?? null
             : null;
       }
       this.refreshTree();
-      nodeToHighlight?.setIsHighlighting(true);
+      nodeToHighlight.setIsHighlighting(true);
       // scrollIntoView must be called in a setTimeout because it must happen after
       // the tree nodes are recursively opened and the tree is refreshed.
       setTimeout(() => {
-        nodeToHighlight?.elementRef?.current?.scrollIntoView();
+        nodeToHighlight.elementRef.current?.scrollIntoView();
       }, 0);
     }
   }

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -106,7 +106,7 @@ export abstract class QueryBuilderExplorerTreeNodeData implements TreeNodeData {
   isPartOfDerivedPropertyBranch: boolean;
   type: Type;
   mappingData: QueryBuilderExplorerTreeNodeMappingData;
-  ref: React.RefObject<HTMLDivElement>;
+  elementRef: React.RefObject<HTMLDivElement>;
 
   constructor(
     id: string,
@@ -129,7 +129,7 @@ export abstract class QueryBuilderExplorerTreeNodeData implements TreeNodeData {
     this.isPartOfDerivedPropertyBranch = isPartOfDerivedPropertyBranch;
     this.type = type;
     this.mappingData = mappingData;
-    this.ref = createRef();
+    this.elementRef = createRef();
   }
 
   setIsSelected(val: boolean | undefined): void {
@@ -747,7 +747,7 @@ export class QueryBuilderExplorerState {
       // scrollIntoView must be called in a setTimeout because it must happen after
       // the tree nodes are recursively opened and the tree is refreshed.
       setTimeout(() => {
-        nodeToHighlight?.ref?.current?.scrollIntoView();
+        nodeToHighlight?.elementRef?.current?.scrollIntoView();
       }, 0);
     }
   }

--- a/packages/legend-query-builder/style/_query-builder-explorer.scss
+++ b/packages/legend-query-builder/style/_query-builder-explorer.scss
@@ -317,6 +317,24 @@
     width: calc(100% - 4rem);
   }
 
+  &__node__label--highlight {
+    animation: highlight-keyframes 4s;
+
+    @keyframes highlight-keyframes {
+      0% {
+        background: var(--color-blue-200);
+      }
+
+      25% {
+        background: var(--color-blue-200);
+      }
+
+      100% {
+        background: unset;
+      }
+    }
+  }
+
   &__node__label__derived-property {
     display: inline-flex;
     font-weight: 700;

--- a/packages/legend-query-builder/style/_query-builder-projection.scss
+++ b/packages/legend-query-builder/style/_query-builder-projection.scss
@@ -167,11 +167,13 @@
     @include flexVCenter;
 
     margin-left: 0.5rem;
+    margin-right: 0.5rem;
     height: 3.4rem;
+    width: 100%;
 
     &__input {
       padding: 0.5rem;
-      width: 20rem;
+      width: 100%;
       height: 2.8rem;
       line-height: 2.8rem;
       background: var(--color-dark-grey-100);

--- a/packages/legend-query-builder/style/_query-builder-projection.scss
+++ b/packages/legend-query-builder/style/_query-builder-projection.scss
@@ -171,6 +171,12 @@
     height: 3.4rem;
     flex: 1;
 
+    &__derivation {
+      flex: 2;
+      min-width: 5rem;
+      max-width: 20rem;
+    }
+
     &__input {
       padding: 0.5rem;
       width: 100%;

--- a/packages/legend-query-builder/style/_query-builder-projection.scss
+++ b/packages/legend-query-builder/style/_query-builder-projection.scss
@@ -169,7 +169,7 @@
     margin-left: 0.5rem;
     margin-right: 0.5rem;
     height: 3.4rem;
-    width: 100%;
+    flex: 1;
 
     &__input {
       padding: 0.5rem;
@@ -199,7 +199,8 @@
     @include flexVCenter;
 
     height: 100%;
-    width: 100%;
+    flex: 4;
+    min-width: 5rem;
   }
 
   &__column__value__property {
@@ -208,6 +209,7 @@
     height: 3.4rem;
     width: 100%;
     margin: 0 0.5rem;
+    min-width: 5rem;
   }
 
   &__column__aggregate {

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -415,6 +415,14 @@
     opacity: 0.9 !important;
   }
 
+  &__header {
+    font-size: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--color-dark-grey-500);
+    user-select: none;
+    cursor: none;
+  }
+
   &__content {
     padding: 0.5rem;
   }
@@ -440,6 +448,10 @@
     // as this tooltip can contain long documentation, it's best we limit its dimension
     max-width: 50rem;
     white-space: pre-line; // properly preserve newline characters
+  }
+
+  &__item__action {
+    margin-left: 0.5rem;
   }
 
   &__combo {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Improve UX by cleaning up the fetch structure panel:
1. Ensure that aggregate operator and remove buttons don't get hidden when the fetch structure panel width is reduced
2. For non-derived columns, show the column name in the property expression badge instead of showing the property name in the property expression badge with a separate input element for the column name.
3. For non-derived columns, clicking on the property expression badge will switch the element to an input to allow editing the column name.
4. Add the property name to the property info tooltip, so that if the column name is edited, the user can still see the original property name.
5. Add a button next to the "path" row in the property info tooltip to highlight the property in the explorer panel.

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Clicking on property expression badge allows editing a column name:
![EditColumnName](https://github.com/finos/legend-studio/assets/9127428/5b32a227-4a36-4c70-bfeb-ea64988e530b)

Edited column names and derived column names work correctly when query is executed:
<img width="1593" alt="QueryWithNamedColumns" src="https://github.com/finos/legend-studio/assets/9127428/0903000b-74df-4678-83a4-ac5d6e5ba244">

Aggregation query works correctly when query is executed.
![AggregationQuery](https://github.com/finos/legend-studio/assets/9127428/7c3c2e17-33c4-4525-bf71-78c19bfcf4de)

Aggregate operator and remove buttons don't get hidden when the fetch structure panel is reduced:
![ResizingFetchStructurePanel](https://github.com/finos/legend-studio/assets/9127428/23cce7cf-d8ed-4556-ab0a-127019415c60)

Property info tooltip has property name and button next to "path" row that highlights property in explorer panel:
![PathNodeHighlight](https://github.com/finos/legend-studio/assets/9127428/4fb06b56-8640-4017-8258-e1824937b4d2)

Property info tooltips in the fetch structure panel and filter panel have the "show in tree" button. Property info tooltips in the explorer panel and search panel don't have the "show in tree" button since it is not needed, as those tooltips already exist within the explorer tree.
![TooltipsWithAndWithoutButton](https://github.com/finos/legend-studio/assets/9127428/e64bf075-3e62-4373-ae9f-3b79c9e0d8e8)

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
