### PR TITLE
Refactor query options modal to have "Apply" and "Cancel" buttons

### DIFF
--- a/.changeset/brown-clocks-listen.md
+++ b/.changeset/brown-clocks-listen.md
@@ -1,6 +1,5 @@
 ---
 '@finos/legend-query-builder': patch
-'@finos/legend-art': patch
 ---
 
 Refactor query options modal to have Apply and Cancel buttons

--- a/.changeset/brown-clocks-listen.md
+++ b/.changeset/brown-clocks-listen.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-query-builder': patch
+'@finos/legend-art': patch
+---
+
+Refactor query options modal to have Apply and Cancel buttons

--- a/.changeset/chilled-parents-wait.md
+++ b/.changeset/chilled-parents-wait.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-art': patch
+---
+
+Add secondary property to ModalFooterButton

--- a/packages/legend-art/src/dialog/Modal.tsx
+++ b/packages/legend-art/src/dialog/Modal.tsx
@@ -105,7 +105,7 @@ export const ModalFooterButton: React.FC<{
   } = props;
   const isDarkMode = darkMode ?? true;
   const isFormatText = formatText ?? true;
-  const isSecondary = type === 'secondary' ?? false;
+  const isSecondary = type === 'secondary';
 
   return (
     <button

--- a/packages/legend-art/src/dialog/Modal.tsx
+++ b/packages/legend-art/src/dialog/Modal.tsx
@@ -89,6 +89,7 @@ export const ModalFooterButton: React.FC<{
   className?: string;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   formatText?: boolean | undefined;
+  type?: 'primary' | 'secondary';
 }> = (props) => {
   const {
     onClick,
@@ -100,9 +101,11 @@ export const ModalFooterButton: React.FC<{
     className,
     darkMode,
     formatText,
+    type,
   } = props;
   const isDarkMode = darkMode ?? true;
   const isFormatText = formatText ?? true;
+  const isSecondary = type === 'secondary' ?? false;
 
   return (
     <button
@@ -112,6 +115,9 @@ export const ModalFooterButton: React.FC<{
           'btn--dark': isDarkMode,
         },
         { 'btn--light': !isDarkMode },
+        {
+          'modal__footer__btn--secondary': isSecondary,
+        },
         className,
       )}
       title={title}

--- a/packages/legend-art/style/base/_modal.scss
+++ b/packages/legend-art/style/base/_modal.scss
@@ -115,6 +115,14 @@
       margin-right: 0.5rem;
       font-size: 1.7rem;
     }
+
+    &--secondary {
+      background: var(--color-dark-grey-200);
+
+      &:hover {
+        background: var(--color-dark-grey-250);
+      }
+    }
   }
 }
 

--- a/packages/legend-query-builder/src/__lib__/QueryBuilderTesting.ts
+++ b/packages/legend-query-builder/src/__lib__/QueryBuilderTesting.ts
@@ -47,4 +47,5 @@ export enum QUERY_BUILDER_TEST_ID {
   QUERY_BUILDER_RESULT_ANALYTICS = 'query__builder__result__analytics',
   // result modifier panel
   QUERY_BUILDER_RESULT_MODIFIER_PANEL = 'query__builder__result__modifier__panel',
+  QUERY_BUILDER_RESULT_MODIFIER_PANEL_SORT_REMOVE_BTN = 'query__builder__projection__options__sort__remove-btn',
 }

--- a/packages/legend-query-builder/src/__lib__/QueryBuilderTesting.ts
+++ b/packages/legend-query-builder/src/__lib__/QueryBuilderTesting.ts
@@ -45,4 +45,6 @@ export enum QUERY_BUILDER_TEST_ID {
   QUERY_BUILDER_TDS_RESULT_MODIFIER_PROMPT = 'query-builder__tds__result-modifier-prompt',
   QUERY_BUILDER_RESULT_PANEL = 'query__builder__result__panel',
   QUERY_BUILDER_RESULT_ANALYTICS = 'query__builder__result__analytics',
+  // result modifier panel
+  QUERY_BUILDER_RESULT_MODIFIER_PANEL = 'query__builder__result__modifier__panel',
 }

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
@@ -297,7 +297,7 @@ test(
         modal.querySelector(`input[value="${RESULT_LIMIT}"]`),
       ),
     ).not.toBeNull();
-    fireEvent.click(getByText(modal, 'Close'));
+    fireEvent.click(getByText(modal, 'Apply'));
 
     // Test text decriptions are correctly added for result set modifiers
     await waitFor(() => renderResult.getByText('Query Options'));

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -371,7 +371,7 @@ describe('QueryBuilderResultModifierPanel', () => {
 
       // Verify initial state
       expect(queryByText(resultModifierPrompt, 'Slice')).toBeNull();
-      expect(queryByText(resultModifierPrompt, '10,20')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '1234,2000')).toBeNull();
 
       // Set slice
       const sliceStartInput = guaranteeNonNullable(

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2024-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, test, expect } from '@jest/globals';
+import {
+  waitFor,
+  fireEvent,
+  getByText,
+  act,
+  type RenderResult,
+  findByText,
+  findByRole,
+} from '@testing-library/react';
+import { TEST_DATA__simpleProjection } from '../../stores/__tests__/TEST_DATA__QueryBuilder_Generic.js';
+import { TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational } from '../../stores/__tests__/TEST_DATA__ModelCoverageAnalysisResult.js';
+import TEST_DATA__ComplexRelationalModel from '../../stores/__tests__/TEST_DATA__QueryBuilder_Model_ComplexRelational.json' assert { type: 'json' };
+import { guaranteeNonNullable, guaranteeType } from '@finos/legend-shared';
+import { integrationTest } from '@finos/legend-shared/test';
+import { create_RawLambda, stub_RawLambda } from '@finos/legend-graph';
+import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
+import { TEST__setUpQueryBuilder } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
+import { COLUMN_SORT_TYPE } from '../../graph/QueryBuilderMetaModelConst.js';
+import type { QueryBuilderState } from '../../stores/QueryBuilderState.js';
+import { QueryBuilderTDSState } from '../../stores/fetch-structure/tds/QueryBuilderTDSState.js';
+
+describe('QueryBuilderResultModifierPanel', () => {
+  let renderResult: RenderResult, queryBuilderState: QueryBuilderState;
+
+  beforeEach(async () => {
+    ({ renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+      TEST_DATA__ComplexRelationalModel,
+      stub_RawLambda(),
+      'model::relational::tests::simpleRelationalMapping',
+      'model::MyRuntime',
+      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
+    ));
+
+    const _personClass = queryBuilderState.graphManagerState.graph.getClass(
+      'model::pure::tests::model::simple::Person',
+    );
+
+    await act(async () => {
+      queryBuilderState.changeClass(_personClass);
+    });
+    const queryBuilderSetup = await waitFor(() =>
+      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
+    );
+    await waitFor(() => getByText(queryBuilderSetup, 'Person'));
+    await waitFor(() =>
+      getByText(queryBuilderSetup, 'simpleRelationalMapping'),
+    );
+    await waitFor(() => getByText(queryBuilderSetup, 'MyRuntime'));
+
+    // simpleProjection
+    await act(async () => {
+      queryBuilderState.initializeWithQuery(
+        create_RawLambda(
+          TEST_DATA__simpleProjection.parameters,
+          TEST_DATA__simpleProjection.body,
+        ),
+      );
+    });
+  });
+
+  test.skip(
+    integrationTest(
+      'Query builder result modifier panel sets sort state when Apply is clicked',
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Set sort values
+      await findByText(resultModifierPanel, 'Sort and Order');
+      const addValueButton = guaranteeNonNullable(
+        await renderResult.findByText('Add Value'),
+      );
+      fireEvent.click(addValueButton);
+      fireEvent.click(
+        await findByText(resultModifierPanel, 'Edited First Name'),
+      );
+      const dropdownMenu = guaranteeNonNullable(
+        document.querySelector('.selector-input--dark__menu'),
+      ) as HTMLElement;
+      fireEvent.click(await findByText(dropdownMenu, 'Last Name'));
+      fireEvent.click(addValueButton);
+      expect(
+        await findByText(resultModifierPanel, 'Edited First Name'),
+      ).not.toBeNull();
+
+      const applyButton = await findByRole(resultModifierPanel, 'button', {
+        name: 'Apply ',
+      });
+      fireEvent.click(applyButton);
+
+      // Check state
+      const queryBuilderTDSState = guaranteeType(
+        queryBuilderState.fetchStructureState.implementation,
+        QueryBuilderTDSState,
+      );
+      expect(
+        queryBuilderTDSState.resultSetModifierState.sortColumns,
+      ).toHaveLength(2);
+      expect(
+        queryBuilderTDSState.resultSetModifierState.sortColumns[0]?.sortType,
+      ).toBe(COLUMN_SORT_TYPE.ASC);
+      expect(
+        queryBuilderTDSState.resultSetModifierState.sortColumns[0]?.columnState
+          .columnName,
+      ).toBe('Last Name');
+      expect(
+        queryBuilderTDSState.resultSetModifierState.sortColumns[1]?.sortType,
+      ).toBe(COLUMN_SORT_TYPE.ASC);
+      expect(
+        queryBuilderTDSState.resultSetModifierState.sortColumns[1]?.columnState
+          .columnName,
+      ).toBe('Edited First Name');
+    },
+  );
+
+  test(
+    integrationTest(
+      'Query builder result modifier panel sets eliminate duplicate rows when Apply is clicked',
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Verify initial state
+      const queryBuilderTDSState = guaranteeType(
+        queryBuilderState.fetchStructureState.implementation,
+        QueryBuilderTDSState,
+      );
+      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(false);
+
+      // Toggle eliminate duplicate rows
+      const eliminateDuplicateRowsToggle = await findByText(
+        resultModifierPanel,
+        'Remove duplicate rows from the results',
+      );
+      fireEvent.click(eliminateDuplicateRowsToggle);
+      const applyButton = await renderResult.findByRole('button', {
+        name: 'Apply',
+      });
+      fireEvent.click(applyButton);
+
+      // Check new state
+      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(true);
+    },
+  );
+
+  test(
+    integrationTest(
+      "Query builder result modifier panel doesn't set eliminate duplicate rows when Cancel is clicked",
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Verify initial state
+      const queryBuilderTDSState = guaranteeType(
+        queryBuilderState.fetchStructureState.implementation,
+        QueryBuilderTDSState,
+      );
+      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(false);
+
+      // Toggle eliminate duplicate rows
+      const eliminateDuplicateRowsToggleText = await findByText(
+        resultModifierPanel,
+        'Remove duplicate rows from the results',
+      );
+      const eliminateDuplicateRowsToggleButton = guaranteeNonNullable(
+        eliminateDuplicateRowsToggleText?.parentElement?.firstElementChild,
+      );
+      fireEvent.click(eliminateDuplicateRowsToggleButton);
+      expect(
+        eliminateDuplicateRowsToggleButton.classList.contains(
+          'panel__content__form__section__toggler__btn--toggled',
+        ),
+      ).toBe(true);
+
+      // Don't apply changes
+      const cancelButton = await renderResult.findByRole('button', {
+        name: 'Cancel',
+      });
+      fireEvent.click(cancelButton);
+
+      // Check new state
+      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(false);
+
+      // Verify that panel stays synced with state
+      fireEvent.click(queryOptionsButton);
+      expect(
+        eliminateDuplicateRowsToggleButton.classList.contains(
+          'panel__content__form__section__toggler__btn--toggled',
+        ),
+      ).toBe(false);
+    },
+  );
+});

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -119,7 +119,7 @@ describe('QueryBuilderResultModifierPanel', () => {
             resultModifierPanel,
             QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL_SORT_REMOVE_BTN,
           )
-        )?.[0],
+        )[0],
       );
       fireEvent.click(removeButton);
       expect(queryByText(resultModifierPanel, 'Edited First Name')).toBeNull();
@@ -255,7 +255,7 @@ describe('QueryBuilderResultModifierPanel', () => {
         'Remove duplicate rows from the results',
       );
       const eliminateDuplicateRowsToggleButton = guaranteeNonNullable(
-        eliminateDuplicateRowsToggleText?.parentElement?.firstElementChild,
+        eliminateDuplicateRowsToggleText.parentElement?.firstElementChild,
       );
       fireEvent.click(eliminateDuplicateRowsToggleButton);
       expect(

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-present, Goldman Sachs
+ * Copyright (c) 2020-present, Goldman Sachs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -38,12 +38,12 @@ import { integrationTest } from '@finos/legend-shared/test';
 import { create_RawLambda, stub_RawLambda } from '@finos/legend-graph';
 import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
 import { TEST__setUpQueryBuilder } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
-import { COLUMN_SORT_TYPE } from '../../graph/QueryBuilderMetaModelConst.js';
 import type { QueryBuilderState } from '../../stores/QueryBuilderState.js';
-import { QueryBuilderTDSState } from '../../stores/fetch-structure/tds/QueryBuilderTDSState.js';
 
 describe('QueryBuilderResultModifierPanel', () => {
-  let renderResult: RenderResult, queryBuilderState: QueryBuilderState;
+  let renderResult: RenderResult,
+    queryBuilderState: QueryBuilderState,
+    resultModifierPrompt: HTMLElement;
 
   beforeEach(async () => {
     ({ renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
@@ -79,6 +79,10 @@ describe('QueryBuilderResultModifierPanel', () => {
         ),
       );
     });
+
+    resultModifierPrompt = await renderResult.findByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_TDS_RESULT_MODIFIER_PROMPT,
+    );
   });
 
   test(
@@ -94,13 +98,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(
-        queryBuilderTDSState.resultSetModifierState.sortColumns,
-      ).toHaveLength(0);
+      expect(queryByText(resultModifierPrompt, 'Sort')).toBeNull();
+      expect(queryByText(resultModifierPrompt, 'Last Name ASC')).toBeNull();
 
       // Set sort values
       await findByText(resultModifierPanel, 'Sort and Order');
@@ -134,16 +133,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(applyButton);
 
       // Check state
-      expect(
-        queryBuilderTDSState.resultSetModifierState.sortColumns,
-      ).toHaveLength(1);
-      expect(
-        queryBuilderTDSState.resultSetModifierState.sortColumns[0]?.sortType,
-      ).toBe(COLUMN_SORT_TYPE.ASC);
-      expect(
-        queryBuilderTDSState.resultSetModifierState.sortColumns[0]?.columnState
-          .columnName,
-      ).toBe('Last Name');
+      expect(findByText(resultModifierPrompt, 'Sort')).not.toBeNull();
+      expect(findByText(resultModifierPrompt, 'Last Name ASC')).not.toBeNull();
     },
   );
 
@@ -160,13 +151,10 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
+      expect(queryByText(resultModifierPrompt, 'Sort')).toBeNull();
       expect(
-        queryBuilderTDSState.resultSetModifierState.sortColumns,
-      ).toHaveLength(0);
+        queryByText(resultModifierPrompt, 'Edited First Name ASC'),
+      ).toBeNull();
 
       // Set sort values
       await findByText(resultModifierPanel, 'Sort and Order');
@@ -186,9 +174,10 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(cancelButton);
 
       // Check new state
+      expect(queryByText(resultModifierPrompt, 'Sort')).toBeNull();
       expect(
-        queryBuilderTDSState.resultSetModifierState.sortColumns,
-      ).toHaveLength(0);
+        queryByText(resultModifierPrompt, 'Edited First Name ASC'),
+      ).toBeNull();
 
       // Verify that panel stays synced with state
       fireEvent.click(queryOptionsButton);
@@ -211,11 +200,10 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(false);
+      expect(
+        queryByText(resultModifierPrompt, 'Eliminate Duplicate Rows'),
+      ).toBeNull();
+      expect(queryByText(resultModifierPrompt, 'Yes')).toBeNull();
 
       // Toggle eliminate duplicate rows
       const eliminateDuplicateRowsToggle = await findByText(
@@ -229,7 +217,10 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(applyButton);
 
       // Check new state
-      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(true);
+      expect(
+        await findByText(resultModifierPrompt, 'Eliminate Duplicate Rows'),
+      ).not.toBeNull();
+      expect(await findByText(resultModifierPrompt, 'Yes')).not.toBeNull();
     },
   );
 
@@ -246,11 +237,10 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(false);
+      expect(
+        queryByText(resultModifierPrompt, 'Eliminate Duplicate Rows'),
+      ).toBeNull();
+      expect(queryByText(resultModifierPrompt, 'Yes')).toBeNull();
 
       // Toggle eliminate duplicate rows
       const eliminateDuplicateRowsToggleText = await findByText(
@@ -274,7 +264,10 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(cancelButton);
 
       // Check new state
-      expect(queryBuilderTDSState.resultSetModifierState.distinct).toBe(false);
+      expect(
+        queryByText(resultModifierPrompt, 'Eliminate Duplicate Rows'),
+      ).toBeNull();
+      expect(queryByText(resultModifierPrompt, 'Yes')).toBeNull();
 
       // Verify that panel stays synced with state
       fireEvent.click(queryOptionsButton);
@@ -299,11 +292,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(queryBuilderTDSState.resultSetModifierState.limit).toBeUndefined();
+      expect(queryByText(resultModifierPrompt, 'Max Rows')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '12345')).toBeNull();
 
       // Set result limit and verify only numbers are allowed
       const limitResultsInput = guaranteeType(
@@ -320,7 +310,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(applyButton);
 
       // Check new state
-      expect(queryBuilderTDSState.resultSetModifierState.limit).toBe(12345);
+      expect(await findByText(resultModifierPrompt, 'Max Rows')).not.toBeNull();
+      expect(await findByText(resultModifierPrompt, '12345')).not.toBeNull();
     },
   );
 
@@ -337,11 +328,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(queryBuilderTDSState.resultSetModifierState.limit).toBeUndefined();
+      expect(queryByText(resultModifierPrompt, 'Max Rows')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '12345')).toBeNull();
 
       // Set result limit and verify only numbers are allowed
       const limitResultsInput = guaranteeType(
@@ -360,7 +348,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(cancelButton);
 
       // Check new state
-      expect(queryBuilderTDSState.resultSetModifierState.limit).toBeUndefined();
+      expect(queryByText(resultModifierPrompt, 'Max Rows')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '12345')).toBeNull();
 
       // Verify that panel stays synced with state
       fireEvent.click(queryOptionsButton);
@@ -381,11 +370,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(queryBuilderTDSState.resultSetModifierState.slice).toBeUndefined();
+      expect(queryByText(resultModifierPrompt, 'Slice')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '10,20')).toBeNull();
 
       // Set slice
       const sliceStartInput = guaranteeNonNullable(
@@ -408,9 +394,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(applyButton);
 
       // Check new state
-      expect(queryBuilderTDSState.resultSetModifierState.slice).toEqual([
-        10, 20,
-      ]);
+      expect(await findByText(resultModifierPrompt, 'Slice')).not.toBeNull();
+      expect(await findByText(resultModifierPrompt, '10,20')).not.toBeNull();
     },
   );
 
@@ -427,11 +412,8 @@ describe('QueryBuilderResultModifierPanel', () => {
       );
 
       // Verify initial state
-      const queryBuilderTDSState = guaranteeType(
-        queryBuilderState.fetchStructureState.implementation,
-        QueryBuilderTDSState,
-      );
-      expect(queryBuilderTDSState.resultSetModifierState.slice).toBeUndefined();
+      expect(queryByText(resultModifierPrompt, 'Slice')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '10,20')).toBeNull();
 
       // Set result limit and verify only numbers are allowed
       const sliceStartInput = guaranteeNonNullable(
@@ -462,12 +444,62 @@ describe('QueryBuilderResultModifierPanel', () => {
       fireEvent.click(cancelButton);
 
       // Check new state
-      expect(queryBuilderTDSState.resultSetModifierState.slice).toBeUndefined();
+      expect(queryByText(resultModifierPrompt, 'Slice')).toBeNull();
+      expect(queryByText(resultModifierPrompt, '10,20')).toBeNull();
 
       // Verify that panel stays synced with state
       fireEvent.click(queryOptionsButton);
       expect(queryByDisplayValue(resultModifierPanel, '10')).toBeNull();
       expect(queryByDisplayValue(resultModifierPanel, '20')).toBeNull();
+    },
+  );
+
+  test(
+    integrationTest(
+      'Query builder result modifier panel disables Apply button when slice is invalid',
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Set invalid slice (only start value)
+      const sliceStartInput = guaranteeNonNullable(
+        await findByLabelText(resultModifierPanel, 'Slice'),
+      ) as HTMLInputElement;
+      fireEvent.change(sliceStartInput, {
+        target: { value: '10' },
+      });
+
+      // Check apply button is disabled
+      const applyButton = (await renderResult.findByRole('button', {
+        name: 'Apply',
+      })) as HTMLButtonElement;
+      expect(applyButton.disabled).toBe(true);
+
+      // Set valid slice (start and end values)
+      const sliceEndInput = guaranteeNonNullable(
+        sliceStartInput.parentElement?.parentElement?.nextElementSibling?.nextElementSibling?.querySelector(
+          'input',
+        ),
+      );
+      fireEvent.change(sliceEndInput, {
+        target: { value: '20' },
+      });
+
+      // Check apply button is enabled
+      expect(applyButton.disabled).toBe(false);
+
+      // Set invalid slice (only end value)
+      fireEvent.change(sliceStartInput, {
+        target: { value: '' },
+      });
+
+      // Check apply button is disabled
+      expect(applyButton.disabled).toBe(true);
     },
   );
 });

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -383,10 +383,10 @@ describe('QueryBuilderResultModifierPanel', () => {
         ),
       );
       fireEvent.change(sliceStartInput, {
-        target: { value: '10' },
+        target: { value: '1.2+3-4' },
       });
       fireEvent.change(sliceEndInput, {
-        target: { value: '20' },
+        target: { value: '2000' },
       });
       const applyButton = await renderResult.findByRole('button', {
         name: 'Apply',
@@ -395,7 +395,9 @@ describe('QueryBuilderResultModifierPanel', () => {
 
       // Check new state
       expect(await findByText(resultModifierPrompt, 'Slice')).not.toBeNull();
-      expect(await findByText(resultModifierPrompt, '10,20')).not.toBeNull();
+      expect(
+        await findByText(resultModifierPrompt, '1234,2000'),
+      ).not.toBeNull();
     },
   );
 
@@ -492,6 +494,14 @@ describe('QueryBuilderResultModifierPanel', () => {
 
       // Check apply button is enabled
       expect(applyButton.disabled).toBe(false);
+
+      // Set invalid slice (end value same as start value)
+      fireEvent.change(sliceEndInput, {
+        target: { value: '10' },
+      });
+
+      // Check apply button is disabled
+      expect(applyButton.disabled).toBe(true);
 
       // Set invalid slice (only end value)
       fireEvent.change(sliceStartInput, {

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -364,4 +364,104 @@ describe('QueryBuilderResultModifierPanel', () => {
       expect(limitResultsInput.value).toBe('');
     },
   );
+
+  test(
+    integrationTest(
+      'Query builder result modifier panel sets slice when Apply is clicked',
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Verify initial state
+      const queryBuilderTDSState = guaranteeType(
+        queryBuilderState.fetchStructureState.implementation,
+        QueryBuilderTDSState,
+      );
+      expect(queryBuilderTDSState.resultSetModifierState.slice).toBeUndefined();
+
+      // Set slice
+      const addSliceButton = guaranteeNonNullable(
+        await findByRole(resultModifierPanel, 'button', {
+          name: 'Add Slice',
+        }),
+      );
+      fireEvent.click(addSliceButton);
+      const sliceStartInput = guaranteeNonNullable(
+        resultModifierPanel.querySelector('input[value="0"]'),
+      );
+      const sliceEndInput = guaranteeNonNullable(
+        resultModifierPanel.querySelector('input[value="1"]'),
+      );
+      fireEvent.change(sliceStartInput, {
+        target: { value: '10' },
+      });
+      fireEvent.change(sliceEndInput, {
+        target: { value: '20' },
+      });
+      const applyButton = await renderResult.findByRole('button', {
+        name: 'Apply',
+      });
+      fireEvent.click(applyButton);
+
+      // Check new state
+      expect(queryBuilderTDSState.resultSetModifierState.slice).toEqual([
+        10, 20,
+      ]);
+    },
+  );
+
+  test(
+    integrationTest(
+      "Query builder result modifier panel doesn't set slice when Cancel is clicked",
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Verify initial state
+      const queryBuilderTDSState = guaranteeType(
+        queryBuilderState.fetchStructureState.implementation,
+        QueryBuilderTDSState,
+      );
+      expect(queryBuilderTDSState.resultSetModifierState.slice).toBeUndefined();
+
+      // Set result limit and verify only numbers are allowed
+      const addSliceButton = guaranteeNonNullable(
+        await findByRole(resultModifierPanel, 'button', {
+          name: 'Add Slice',
+        }),
+      );
+      fireEvent.click(addSliceButton);
+      expect(
+        resultModifierPanel.querySelector('input[value="0"]'),
+      ).not.toBeNull();
+      expect(
+        resultModifierPanel.querySelector('input[value="1"]'),
+      ).not.toBeNull();
+
+      // Don't apply changes
+      const cancelButton = await renderResult.findByRole('button', {
+        name: 'Cancel',
+      });
+      fireEvent.click(cancelButton);
+
+      // Check new state
+      expect(queryBuilderTDSState.resultSetModifierState.slice).toBeUndefined();
+
+      // Verify that panel stays synced with state
+      fireEvent.click(queryOptionsButton);
+      expect(
+        await findByRole(resultModifierPanel, 'button', { name: 'Add Slice' }),
+      ).not.toBeNull();
+    },
+  );
 });

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -280,7 +280,7 @@ export const QueryResultModifierModal = observer(
     const changeSliceStart: React.ChangeEventHandler<HTMLInputElement> = (
       event,
     ) => {
-      const val = event.target.value;
+      const val = event.target.value.replace(/[^0-9]/g, '');
       if (val === '') {
         handleSliceChange(undefined, slice[1]);
       } else {
@@ -291,7 +291,7 @@ export const QueryResultModifierModal = observer(
     const changeSliceEnd: React.ChangeEventHandler<HTMLInputElement> = (
       event,
     ) => {
-      const val = event.target.value;
+      const val = event.target.value.replace(/[^0-9]/g, '');
       if (val === '') {
         handleSliceChange(slice[0], undefined);
       } else {
@@ -303,7 +303,10 @@ export const QueryResultModifierModal = observer(
     // Error states
     const isInvalidSlice =
       (slice[0] === undefined && slice[1] !== undefined) ||
-      (slice[0] !== undefined && slice[1] === undefined);
+      (slice[0] !== undefined && slice[1] === undefined) ||
+      (slice[0] !== undefined &&
+        slice[1] !== undefined &&
+        slice[0] >= slice[1]);
 
     return (
       <Dialog
@@ -393,7 +396,7 @@ export const QueryResultModifierModal = observer(
                       spellCheck={false}
                       value={slice[0] ?? ''}
                       onChange={changeSliceStart}
-                      type="number"
+                      type="text"
                       error={isInvalidSlice ? 'Invalid slice' : undefined}
                     />
                   </div>
@@ -404,7 +407,7 @@ export const QueryResultModifierModal = observer(
                       spellCheck={false}
                       value={slice[1] ?? ''}
                       onChange={changeSliceEnd}
-                      type="number"
+                      type="text"
                       error={isInvalidSlice ? 'Invalid slice' : undefined}
                     />
                   </div>

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -341,14 +341,18 @@ export const QueryResultModifierModal = observer(
                 </div>
               </div>
               <div className="panel__content__form__section">
-                <div className="panel__content__form__section__header__label">
+                <label
+                  htmlFor="query-builder__projection__modal__limit-results-input"
+                  className="panel__content__form__section__header__label"
+                >
                   Limit Results
-                </div>
+                </label>
                 <div className="panel__content__form__section__header__prompt">
                   Specify the maximum total number of rows the output will
                   produce
                 </div>
                 <input
+                  id="query-builder__projection__modal__limit-results-input"
                   className="panel__content__form__section__input panel__content__form__section__number-input"
                   spellCheck={false}
                   type="text"

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -254,7 +254,7 @@ export const QueryResultModifierModal = observer(
     const handleLimitResultsChange: React.ChangeEventHandler<
       HTMLInputElement
     > = (event) => {
-      const val = event.target.value;
+      const val = event.target.value.replace(/[^0-9]/g, '');
       setLimitResults(val === '' ? undefined : parseInt(val, 10));
     };
 
@@ -346,7 +346,7 @@ export const QueryResultModifierModal = observer(
                 <input
                   className="panel__content__form__section__input panel__content__form__section__number-input"
                   spellCheck={false}
-                  type="number"
+                  type="text"
                   value={limitResults ?? ''}
                   onChange={handleLimitResultsChange}
                 />

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -33,18 +33,28 @@ import {
   ModalFooterButton,
 } from '@finos/legend-art';
 import { SortColumnState } from '../../stores/fetch-structure/tds/QueryResultSetModifierState.js';
-import { guaranteeNonNullable } from '@finos/legend-shared';
+import {
+  addUniqueEntry,
+  deleteEntry,
+  guaranteeNonNullable,
+} from '@finos/legend-shared';
 import { useApplicationStore } from '@finos/legend-application';
 import type { QueryBuilderTDSState } from '../../stores/fetch-structure/tds/QueryBuilderTDSState.js';
 import type { QueryBuilderTDSColumnState } from '../../stores/fetch-structure/tds/QueryBuilderTDSColumnState.js';
 import { COLUMN_SORT_TYPE } from '../../graph/QueryBuilderMetaModelConst.js';
+import { useEffect, useState } from 'react';
+import type { QueryBuilderProjectionColumnState } from '../../stores/fetch-structure/tds/projection/QueryBuilderProjectionColumnState.js';
 
 const ColumnSortEditor = observer(
-  (props: { tdsState: QueryBuilderTDSState; sortState: SortColumnState }) => {
-    const { tdsState, sortState } = props;
+  (props: {
+    sortColumns: SortColumnState[];
+    setSortColumns: (sortColumns: SortColumnState[]) => void;
+    sortState: SortColumnState;
+    tdsColumns: QueryBuilderTDSColumnState[];
+  }) => {
+    const { sortColumns, setSortColumns, sortState, tdsColumns } = props;
     const applicationStore = useApplicationStore();
-    const sortColumns = tdsState.resultSetModifierState.sortColumns;
-    const projectionOptions = tdsState.tdsColumns
+    const projectionOptions = tdsColumns
       .filter(
         (projectionCol) =>
           projectionCol === sortState.columnState ||
@@ -58,6 +68,8 @@ const ColumnSortEditor = observer(
       label: sortState.columnState.columnName,
       value: sortState,
     };
+    const sortType = sortState.sortType;
+
     const onChange = (
       val: { label: string; value: QueryBuilderTDSColumnState } | null,
     ): void => {
@@ -65,13 +77,17 @@ const ColumnSortEditor = observer(
         sortState.setColumnState(val.value);
       }
     };
-    const sortType = sortState.sortType;
 
-    const deleteColumnSort = (): void =>
-      tdsState.resultSetModifierState.deleteSortColumn(sortState);
+    const deleteColumnSort = (): void => {
+      const newSortColumns = [...sortColumns];
+      deleteEntry(newSortColumns, sortState);
+      setSortColumns(newSortColumns);
+    };
+
     const changeSortBy = (sortOp: COLUMN_SORT_TYPE) => (): void => {
       sortState.setSortType(sortOp);
     };
+
     return (
       <div className="panel__content__form__section__list__item query-builder__projection__options__sort">
         <CustomSelectorInput
@@ -129,11 +145,15 @@ const ColumnSortEditor = observer(
 );
 
 const ColumnsSortEditor = observer(
-  (props: { tdsState: QueryBuilderTDSState }) => {
-    const { tdsState } = props;
-    const resultSetModifierState = tdsState.resultSetModifierState;
-    const sortColumns = resultSetModifierState.sortColumns;
-    const projectionOptions = tdsState.projectionColumns
+  (props: {
+    projectionColumns: QueryBuilderProjectionColumnState[];
+    sortColumns: SortColumnState[];
+    setSortColumns: (sortColumns: SortColumnState[]) => void;
+    tdsColumns: QueryBuilderTDSColumnState[];
+  }) => {
+    const { projectionColumns, sortColumns, setSortColumns, tdsColumns } =
+      props;
+    const projectionOptions = projectionColumns
       .filter(
         (projectionCol) =>
           !sortColumns.some((sortCol) => sortCol.columnState === projectionCol),
@@ -147,7 +167,9 @@ const ColumnsSortEditor = observer(
         const sortColumn = new SortColumnState(
           guaranteeNonNullable(projectionOptions[0]).value,
         );
-        resultSetModifierState.addSortColumn(sortColumn);
+        const newSortColumns = [...sortColumns];
+        addUniqueEntry(newSortColumns, sortColumn);
+        setSortColumns(newSortColumns);
       }
     };
 
@@ -166,8 +188,10 @@ const ColumnsSortEditor = observer(
             {sortColumns.map((value) => (
               <ColumnSortEditor
                 key={value.columnState.uuid}
-                tdsState={tdsState}
+                sortColumns={sortColumns}
+                setSortColumns={setSortColumns}
                 sortState={value}
+                tdsColumns={tdsColumns}
               />
             ))}
           </div>
@@ -189,57 +213,87 @@ const ColumnsSortEditor = observer(
 
 export const QueryResultModifierModal = observer(
   (props: { tdsState: QueryBuilderTDSState }) => {
-    const { tdsState: tdsState } = props;
+    // Read current state
+    const { tdsState } = props;
     const resultSetModifierState = tdsState.resultSetModifierState;
-    const limitResults = resultSetModifierState.limit;
-    const distinct = resultSetModifierState.distinct;
-    const close = (): void => resultSetModifierState.setShowModal(false);
-    const toggleDistinct = (): void => resultSetModifierState.toggleDistinct();
-    const changeValue: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-      const val = event.target.value;
-      resultSetModifierState.setLimit(
-        val === '' ? undefined : parseInt(val, 10),
-      );
+    const stateSortColumns = resultSetModifierState.sortColumns;
+    const stateDistinct = resultSetModifierState.distinct;
+    const stateLimitResults = resultSetModifierState.limit;
+    const stateSlice = resultSetModifierState.slice;
+
+    // Set up temp state for modal lifecycle
+    const [sortColumns, setSortColumns] = useState([...stateSortColumns]);
+    const [distinct, setDistinct] = useState(stateDistinct);
+    const [limitResults, setLimitResults] = useState(stateLimitResults);
+    const [slice, setSlice] = useState(stateSlice);
+
+    // Sync temp state with tdsState when modal is opened/closed
+    useEffect(() => {
+      setSortColumns([...stateSortColumns]);
+      setDistinct(stateDistinct);
+      setLimitResults(stateLimitResults);
+      setSlice(stateSlice);
+    }, [
+      resultSetModifierState.showModal,
+      stateSortColumns,
+      stateDistinct,
+      stateLimitResults,
+      stateSlice,
+    ]);
+
+    // Handle user actions
+    const closeModal = (): void => resultSetModifierState.setShowModal(false);
+    const applyChanges = (): void => {
+      resultSetModifierState.setSortColumns(sortColumns);
+      resultSetModifierState.setDistinct(distinct);
+      resultSetModifierState.setLimit(limitResults);
+      resultSetModifierState.setSlice(slice);
+      resultSetModifierState.setShowModal(false);
     };
 
-    const handleSliceStartChange = (start: number, end: number): void => {
-      const slice: [number, number] = [start, end];
-      resultSetModifierState.setSlice(slice);
+    const handleLimitResultsChange: React.ChangeEventHandler<
+      HTMLInputElement
+    > = (event) => {
+      const val = event.target.value;
+      setLimitResults(val === '' ? undefined : parseInt(val, 10));
+    };
+
+    const handleSliceChange = (start: number, end: number): void => {
+      const newSlice: [number, number] = [start, end];
+      setSlice(newSlice);
     };
 
     const clearSlice = (): void => {
-      resultSetModifierState.setSlice(undefined);
+      setSlice(undefined);
     };
 
     const addSlice = (): void => {
-      resultSetModifierState.setSlice([0, 1]);
+      setSlice([0, 1]);
     };
 
     const changeSliceStart: React.ChangeEventHandler<HTMLInputElement> = (
       event,
     ) => {
-      const currentSlice = resultSetModifierState.slice;
       const val = event.target.value;
       const start = typeof val === 'number' ? val : parseInt(val, 10);
-      if (currentSlice) {
-        handleSliceStartChange(start, currentSlice[1]);
+      if (slice) {
+        handleSliceChange(start, slice[1]);
       }
     };
     const changeSliceEnd: React.ChangeEventHandler<HTMLInputElement> = (
       event,
     ) => {
-      const currentSlice = resultSetModifierState.slice;
       const val = event.target.value;
       const end = typeof val === 'number' ? val : parseInt(val, 10);
-      if (currentSlice) {
-        handleSliceStartChange(currentSlice[0], end);
+      if (slice) {
+        handleSliceChange(slice[0], end);
       }
     };
 
     return (
       <Dialog
         open={Boolean(resultSetModifierState.showModal)}
-        onClose={close}
+        onClose={closeModal}
         classes={{
           root: 'editor-modal__root-container',
           container: 'editor-modal__container',
@@ -250,14 +304,19 @@ export const QueryResultModifierModal = observer(
           <ModalHeader title="Result Set Modifier" />
           <ModalBody className="query-builder__projection__modal__body">
             <div className="query-builder__projection__options">
-              <ColumnsSortEditor tdsState={tdsState} />
+              <ColumnsSortEditor
+                projectionColumns={tdsState.projectionColumns}
+                sortColumns={sortColumns}
+                setSortColumns={setSortColumns}
+                tdsColumns={tdsState.tdsColumns}
+              />
               <div className="panel__content__form__section">
                 <div className="panel__content__form__section__header__label">
                   Eliminate Duplicate Rows
                 </div>
                 <div
                   className="panel__content__form__section__toggler"
-                  onClick={toggleDistinct}
+                  onClick={() => setDistinct(!distinct)}
                 >
                   <button
                     className={clsx(
@@ -289,7 +348,7 @@ export const QueryResultModifierModal = observer(
                   spellCheck={false}
                   type="number"
                   value={limitResults ?? ''}
-                  onChange={changeValue}
+                  onChange={handleLimitResultsChange}
                 />
               </div>
               <div className="panel__content__form__section">
@@ -300,13 +359,13 @@ export const QueryResultModifierModal = observer(
                   Reduce the number of rows in the provided TDS, selecting the
                   set of rows in the specified range between start and stop
                 </div>
-                {resultSetModifierState.slice ? (
+                {slice ? (
                   <>
                     <div className="query-builder__result__slice">
                       <input
                         className="input--dark query-builder__result__slice__input"
                         spellCheck={false}
-                        value={resultSetModifierState.slice[0]}
+                        value={slice[0]}
                         onChange={changeSliceStart}
                         type="number"
                       />
@@ -316,7 +375,7 @@ export const QueryResultModifierModal = observer(
                       <input
                         className="input--dark query-builder__result__slice__input"
                         spellCheck={false}
-                        value={resultSetModifierState.slice[1]}
+                        value={slice[1]}
                         onChange={changeSliceEnd}
                         type="number"
                       />
@@ -345,7 +404,8 @@ export const QueryResultModifierModal = observer(
             </div>
           </ModalBody>
           <ModalFooter>
-            <ModalFooterButton onClick={close} text="Close" />
+            <ModalFooterButton onClick={applyChanges} text="Apply" />
+            <ModalFooterButton onClick={closeModal} text="Cancel" />
           </ModalFooter>
         </Modal>
       </Dialog>

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -375,9 +375,12 @@ export const QueryResultModifierModal = observer(
                 />
               </div>
               <div className="panel__content__form__section">
-                <div className="panel__content__form__section__header__label">
+                <label
+                  htmlFor="query-builder__projection__modal__slice-start-input"
+                  className="panel__content__form__section__header__label"
+                >
                   Slice
-                </div>
+                </label>
                 <div className="panel__content__form__section__header__prompt">
                   Reduce the number of rows in the provided TDS, selecting the
                   set of rows in the specified range between start and stop
@@ -385,6 +388,7 @@ export const QueryResultModifierModal = observer(
                 <div className="query-builder__result__slice">
                   <div className="query-builder__result__slice__input__wrapper">
                     <InputWithInlineValidation
+                      id="query-builder__projection__modal__slice-start-input"
                       className="input--dark query-builder__result__slice__input"
                       spellCheck={false}
                       value={slice[0]}

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -137,6 +137,9 @@ const ColumnSortEditor = observer(
           onClick={deleteColumnSort}
           tabIndex={-1}
           title="Remove"
+          data-testid={
+            QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL_SORT_REMOVE_BTN
+          }
         >
           <TimesIcon />
         </button>

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -405,7 +405,11 @@ export const QueryResultModifierModal = observer(
           </ModalBody>
           <ModalFooter>
             <ModalFooterButton onClick={applyChanges} text="Apply" />
-            <ModalFooterButton onClick={closeModal} text="Cancel" />
+            <ModalFooterButton
+              onClick={closeModal}
+              text="Cancel"
+              type="secondary"
+            />
           </ModalFooter>
         </Modal>
       </Dialog>

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -391,7 +391,7 @@ export const QueryResultModifierModal = observer(
                       id="query-builder__projection__modal__slice-start-input"
                       className="input--dark query-builder__result__slice__input"
                       spellCheck={false}
-                      value={slice[0]}
+                      value={slice[0] ?? ''}
                       onChange={changeSliceStart}
                       type="number"
                       error={isInvalidSlice ? 'Invalid slice' : undefined}
@@ -402,7 +402,7 @@ export const QueryResultModifierModal = observer(
                     <InputWithInlineValidation
                       className="input--dark query-builder__result__slice__input"
                       spellCheck={false}
-                      value={slice[1]}
+                      value={slice[1] ?? ''}
                       onChange={changeSliceEnd}
                       type="number"
                       error={isInvalidSlice ? 'Invalid slice' : undefined}

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -305,7 +305,10 @@ export const QueryResultModifierModal = observer(
         }}
         data-testid={QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL}
       >
-        <Modal darkMode={true} className="editor-modal">
+        <Modal
+          darkMode={true}
+          className="editor-modal query-builder__projection__modal"
+        >
           <ModalHeader title="Result Set Modifier" />
           <ModalBody className="query-builder__projection__modal__body">
             <div className="query-builder__projection__options">

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderResultModifierPanel.tsx
@@ -44,6 +44,7 @@ import type { QueryBuilderTDSColumnState } from '../../stores/fetch-structure/td
 import { COLUMN_SORT_TYPE } from '../../graph/QueryBuilderMetaModelConst.js';
 import { useEffect, useState } from 'react';
 import type { QueryBuilderProjectionColumnState } from '../../stores/fetch-structure/tds/projection/QueryBuilderProjectionColumnState.js';
+import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
 
 const ColumnSortEditor = observer(
   (props: {
@@ -299,6 +300,7 @@ export const QueryResultModifierModal = observer(
           container: 'editor-modal__container',
           paper: 'editor-modal__content',
         }}
+        data-testid={QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL}
       >
         <Modal darkMode={true} className="editor-modal">
           <ModalHeader title="Result Set Modifier" />

--- a/packages/legend-query-builder/src/stores/fetch-structure/tds/QueryResultSetModifierState.ts
+++ b/packages/legend-query-builder/src/stores/fetch-structure/tds/QueryResultSetModifierState.ts
@@ -16,12 +16,7 @@
 
 import { action, computed, makeObservable, observable } from 'mobx';
 import type { QueryBuilderTDSState } from './QueryBuilderTDSState.js';
-import {
-  addUniqueEntry,
-  deleteEntry,
-  type Hashable,
-  hashArray,
-} from '@finos/legend-shared';
+import { addUniqueEntry, type Hashable, hashArray } from '@finos/legend-shared';
 import { QUERY_BUILDER_STATE_HASH_STRUCTURE } from '../../QueryBuilderStateHashUtils.js';
 import type { QueryBuilderTDSColumnState } from './QueryBuilderTDSColumnState.js';
 import { COLUMN_SORT_TYPE } from '../../../graph/QueryBuilderMetaModelConst.js';
@@ -76,8 +71,8 @@ export class QueryResultSetModifierState implements Hashable {
       slice: observable.ref,
       setShowModal: action,
       setLimit: action,
-      toggleDistinct: action,
-      deleteSortColumn: action,
+      setDistinct: action,
+      setSortColumns: action,
       addSortColumn: action,
       updateSortColumns: action,
       setSlice: action,
@@ -96,12 +91,12 @@ export class QueryResultSetModifierState implements Hashable {
     this.limit = val === undefined || val <= 0 ? undefined : val;
   }
 
-  toggleDistinct(): void {
-    this.distinct = !this.distinct;
+  setDistinct(val: boolean): void {
+    this.distinct = val;
   }
 
-  deleteSortColumn(val: SortColumnState): void {
-    deleteEntry(this.sortColumns, val);
+  setSortColumns(val: SortColumnState[]): void {
+    this.sortColumns = val;
   }
 
   addSortColumn(val: SortColumnState): void {

--- a/packages/legend-query-builder/style/_query-builder-projection.scss
+++ b/packages/legend-query-builder/style/_query-builder-projection.scss
@@ -363,8 +363,13 @@
     display: flex;
   }
 
-  &__modal__body {
-    overflow: auto;
+  &__modal {
+    height: 60vh;
+    width: 50vw;
+
+    &__body {
+      overflow: auto;
+    }
   }
 
   &__options {

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -1372,6 +1372,7 @@
 
     &__input {
       height: 2.8rem;
+      width: 100%;
 
       &:not(:focus) {
         border: 0.1rem solid var(--color-dark-grey-250);
@@ -1379,6 +1380,10 @@
 
       &[disabled] {
         cursor: not-allowed;
+      }
+
+      &__wrapper {
+        width: 15rem;
       }
     }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Currently, updating values in the "Query Options" modal automatically updates the values in the store. The modal only has a close button to dismiss.

Instead, the Query Options modal should have an "Apply" button and a "Cancel" button. The user can open the modal to see the current state of query options (query builder result modifiers) and make changes as he/she likes. If the user clicks the Apply button, then the changes will be applied to the state; however, if the user clicks the Cancel button, then the user's changes should be discarded and the state should be left unchanged.

This PR also makes the below changes to the fields within the query options modal:

- Only allow numbers into the limit result input (currently, `+`,`.`, and `-` characters can be entered into the input)
- Only allow numbers into the slice inputs (currently, `+`,`.`, and `-` characters can be entered into the input)
- Make slice input always visible instead of enabled with a button.
  - If the user doesn't enter values into the slice inputs, then the slice state is set to undefined.
- Add validation to the slice input (both boxes must contain values or be empty, and the slice start value cannot be >= the slice end value).

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Editing column sort property:
![ColumnSort](https://github.com/finos/legend-studio/assets/9127428/b294c0d5-f482-4a6b-8336-40ec5429eb7c)

Editing eliminate duplicate rows property:
![Distinct](https://github.com/finos/legend-studio/assets/9127428/c0759c06-a87c-479c-8476-10502f85bae0)

Editing limit results property:
![LimitResults](https://github.com/finos/legend-studio/assets/9127428/20623d23-c414-4d4a-85f2-069cce263c83)

Editing slice property:
![Slice](https://github.com/finos/legend-studio/assets/9127428/439ec480-f7d4-489c-8221-35666786a694)