### PR TITLE
Enhance Query Builder property info tooltip

### DIFF
--- a/.changeset/honest-bobcats-cover.md
+++ b/.changeset/honest-bobcats-cover.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Enhance query builder property info tooltip

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
@@ -711,10 +711,11 @@ test(
     );
     const lastNameExpressionInfoTooltipIcon = guaranteeNonNullable(
       await waitFor(
-        () => queryByText(projectionCols, LAST_NAME_ALIAS)?.nextSibling,
+        () =>
+          queryByText(projectionCols, LAST_NAME_ALIAS)?.nextSibling?.firstChild,
       ),
     );
-    fireEvent.mouseOver(lastNameExpressionInfoTooltipIcon);
+    fireEvent.click(lastNameExpressionInfoTooltipIcon);
     const tooltip = await renderResult.findByRole('tooltip');
     const pathShowInTreeButton = guaranteeNonNullable(
       await waitFor(

--- a/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
+++ b/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
@@ -18,6 +18,7 @@ import {
   ShareBoxIcon,
   type TooltipPlacement,
   Tooltip,
+  ClickAwayListener,
 } from '@finos/legend-art';
 import {
   type AbstractProperty,
@@ -137,73 +138,88 @@ export const QueryBuilderPropertyInfoTooltip: React.FC<{
     explorerState,
   } = props;
 
+  const [open, setIsOpen] = useState(false);
+
   return (
-    <Tooltip
-      arrow={true}
-      {...(placement !== undefined ? { placement } : {})}
-      classes={{
-        tooltip: 'query-builder__tooltip',
-        arrow: 'query-builder__tooltip__arrow',
-        tooltipPlacementRight: 'query-builder__tooltip--right',
-      }}
-      TransitionProps={{
-        // disable transition
-        // NOTE: somehow, this is the only workaround we have, if for example
-        // we set `appear = true`, the tooltip will jump out of position
-        timeout: 0,
-      }}
-      title={
-        <div className="query-builder__tooltip__content">
-          <div className="query-builder__tooltip__header">{title}</div>
-          <div className="query-builder__tooltip__item">
-            <div className="query-builder__tooltip__item__label">Type</div>
-            <div className="query-builder__tooltip__item__value">
-              {type?.path ?? property.genericType.value.rawType.path}
-            </div>
-          </div>
-          <div className="query-builder__tooltip__item">
-            <div className="query-builder__tooltip__item__label">Path</div>
-            <div className="query-builder__tooltip__item__value">{path}</div>
-            {explorerState && (
-              <div className="query-builder__tooltip__item__action">
-                <button
-                  onClick={() => explorerState.highlightTreeNode(path)}
-                  title="Show in tree"
-                >
-                  <ShareBoxIcon color="white" />
-                </button>
+    <ClickAwayListener onClickAway={() => setIsOpen(false)}>
+      <div>
+        <Tooltip
+          arrow={true}
+          {...(placement !== undefined ? { placement } : {})}
+          classes={{
+            tooltip: 'query-builder__tooltip',
+            arrow: 'query-builder__tooltip__arrow',
+            tooltipPlacementRight: 'query-builder__tooltip--right',
+          }}
+          open={open}
+          onClose={() => setIsOpen(false)}
+          TransitionProps={{
+            // disable transition
+            // NOTE: somehow, this is the only workaround we have, if for example
+            // we set `appear = true`, the tooltip will jump out of position
+            timeout: 0,
+          }}
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          title={
+            <div className="query-builder__tooltip__content">
+              <div className="query-builder__tooltip__header">{title}</div>
+              <div className="query-builder__tooltip__item">
+                <div className="query-builder__tooltip__item__label">Type</div>
+                <div className="query-builder__tooltip__item__value">
+                  {type?.path ?? property.genericType.value.rawType.path}
+                </div>
               </div>
-            )}
-          </div>
-          <div className="query-builder__tooltip__item">
-            <div className="query-builder__tooltip__item__label">
-              Multiplicity
+              <div className="query-builder__tooltip__item">
+                <div className="query-builder__tooltip__item__label">Path</div>
+                <div className="query-builder__tooltip__item__value">
+                  {path}
+                </div>
+                {explorerState && (
+                  <div className="query-builder__tooltip__item__action">
+                    <button
+                      onClick={() => explorerState.highlightTreeNode(path)}
+                      title="Show in tree"
+                    >
+                      <ShareBoxIcon color="white" />
+                    </button>
+                  </div>
+                )}
+              </div>
+              <div className="query-builder__tooltip__item">
+                <div className="query-builder__tooltip__item__label">
+                  Multiplicity
+                </div>
+                <div className="query-builder__tooltip__item__value">
+                  {getMultiplicityDescription(property.multiplicity)}
+                </div>
+              </div>
+              <div className="query-builder__tooltip__item">
+                <div className="query-builder__tooltip__item__label">
+                  Derived Property
+                </div>
+                <div className="query-builder__tooltip__item__value">
+                  {property instanceof DerivedProperty ? 'Yes' : 'No'}
+                </div>
+              </div>
+              <div className="query-builder__tooltip__item">
+                <div className="query-builder__tooltip__item__label">
+                  Mapped
+                </div>
+                <div className="query-builder__tooltip__item__value">
+                  {isMapped ? 'Yes' : 'No'}
+                </div>
+              </div>
+              <QueryBuilderTaggedValueInfoTooltip
+                taggedValues={property.taggedValues}
+              />
             </div>
-            <div className="query-builder__tooltip__item__value">
-              {getMultiplicityDescription(property.multiplicity)}
-            </div>
-          </div>
-          <div className="query-builder__tooltip__item">
-            <div className="query-builder__tooltip__item__label">
-              Derived Property
-            </div>
-            <div className="query-builder__tooltip__item__value">
-              {property instanceof DerivedProperty ? 'Yes' : 'No'}
-            </div>
-          </div>
-          <div className="query-builder__tooltip__item">
-            <div className="query-builder__tooltip__item__label">Mapped</div>
-            <div className="query-builder__tooltip__item__value">
-              {isMapped ? 'Yes' : 'No'}
-            </div>
-          </div>
-          <QueryBuilderTaggedValueInfoTooltip
-            taggedValues={property.taggedValues}
-          />
-        </div>
-      }
-    >
-      {children}
-    </Tooltip>
+          }
+        >
+          <div onClick={() => setIsOpen(true)}>{children}</div>
+        </Tooltip>
+      </div>
+    </ClickAwayListener>
   );
 };

--- a/packages/legend-query-builder/style/_query-builder-explorer.scss
+++ b/packages/legend-query-builder/style/_query-builder-explorer.scss
@@ -410,6 +410,6 @@
   }
 
   &__node__info {
-    cursor: help;
+    cursor: pointer;
   }
 }

--- a/packages/legend-query-builder/style/_query-builder-property-search-panel.scss
+++ b/packages/legend-query-builder/style/_query-builder-property-search-panel.scss
@@ -125,7 +125,7 @@
   }
 
   &__node__info {
-    cursor: help;
+    cursor: pointer;
   }
 
   &__header {

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -565,6 +565,7 @@
     height: 2.2rem;
     width: 2.2rem;
     margin: 0.3rem;
+    cursor: pointer;
 
     svg {
       font-size: 1.2rem;

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -442,8 +442,6 @@
     font-size: 1.5rem;
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--color-dark-grey-500);
-    user-select: none;
-    cursor: none;
   }
 
   &__content {
@@ -457,15 +455,11 @@
 
   &__item__label {
     font-size: 1.3rem;
-    user-select: none;
-    cursor: default;
     color: var(--color-dark-grey-500);
   }
 
   &__item__value {
     font-size: 1.3rem;
-    user-select: none;
-    cursor: default;
     font-weight: 500;
     margin-left: 0.5rem;
     // as this tooltip can contain long documentation, it's best we limit its dimension


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Make the following changes to the QueryBuilderPropertyInfoTooltip:
- Show tooltip on click instead of mouseover
- Show pointer cursor for property info tooltip
- Don't hide tooltip when mouse leaves tooltip
- Allow copying text in tooltip

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Clicking on the tooltip to display it. Tooltip remains visible after cursor leaves tooltip. User can select text in tooltip.
![TooltipDisplay](https://github.com/finos/legend-studio/assets/9127428/81c9f67b-f756-4789-b89e-9f2eab0ea1ce)