### PR TITLE
Fix query options modal sort order

### DIFF
--- a/.changeset/flat-wasps-type.md
+++ b/.changeset/flat-wasps-type.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Fix query options modal sort order

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -228,7 +228,6 @@ describe('QueryBuilderResultModifierPanel', () => {
         (await findByText(resultModifierPanel, 'asc')).nextElementSibling,
       );
       fireEvent.click(orderDropdownButton);
-      // const dropdownMenu = await renderResult.findByRole('menu');
       const descOption = await renderResult.findByRole('button', {
         name: 'desc',
       });

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultModifierPanel.test.tsx
@@ -189,6 +189,69 @@ describe('QueryBuilderResultModifierPanel', () => {
 
   test(
     integrationTest(
+      "Query builder result modifier panel doesn't update sort order when Cancel button is clicked",
+    ),
+    async () => {
+      // Open Query Options panel
+      const queryOptionsButton = await renderResult.findByText('Query Options');
+      fireEvent.click(queryOptionsButton);
+      const resultModifierPanel = await renderResult.findByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_MODIFIER_PANEL,
+      );
+
+      // Set sort values
+      await findByText(resultModifierPanel, 'Sort and Order');
+      const addValueButton = guaranteeNonNullable(
+        await renderResult.findByText('Add Value'),
+      );
+      fireEvent.click(addValueButton);
+      expect(
+        await findByText(resultModifierPanel, 'Edited First Name'),
+      ).not.toBeNull();
+      expect(await findByText(resultModifierPanel, 'asc')).not.toBeNull();
+      const applyButton = await findByRole(resultModifierPanel, 'button', {
+        name: 'Apply',
+      });
+      fireEvent.click(applyButton);
+
+      // Check state
+      expect(findByText(resultModifierPrompt, 'Sort')).not.toBeNull();
+      expect(
+        findByText(resultModifierPrompt, 'Edited First Name ASC'),
+      ).not.toBeNull();
+
+      // Open Query Options panel
+      fireEvent.click(queryOptionsButton);
+
+      // Change asc to desc
+      const orderDropdownButton = guaranteeNonNullable(
+        (await findByText(resultModifierPanel, 'asc')).nextElementSibling,
+      );
+      fireEvent.click(orderDropdownButton);
+      // const dropdownMenu = await renderResult.findByRole('menu');
+      const descOption = await renderResult.findByRole('button', {
+        name: 'desc',
+      });
+      fireEvent.click(descOption);
+      expect(findByText(resultModifierPanel, 'desc')).not.toBeNull();
+
+      // Don't apply the changes
+      const cancelButton = await findByRole(resultModifierPanel, 'button', {
+        name: 'Cancel',
+      });
+      fireEvent.click(cancelButton);
+
+      // Check new state
+      expect(await findByText(resultModifierPrompt, 'Sort')).not.toBeNull();
+      expect(
+        await findByText(resultModifierPrompt, 'Edited First Name ASC'),
+      ).not.toBeNull();
+      expect(queryByText(resultModifierPrompt, 'DESC')).toBeNull();
+    },
+  );
+
+  test(
+    integrationTest(
       'Query builder result modifier panel sets eliminate duplicate rows when Apply is clicked',
     ),
     async () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

A bug exists in the query options modal where if the user adds a column sort order value and applies the changes, then opens the query options modal and changes the sort order type (i.e., from 'asc' to 'desc') and clicks Cancel, the sort order type is still changed. This should be fixed so that the sort type doesn't change unless the user clicks the Apply button.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Demonstration of bug fix:
![ChangeSortOrder](https://github.com/finos/legend-studio/assets/9127428/fce3e356-e3ca-4659-8e43-85dc6eac1cfb)
