### PR TITLE
Close explorer property search modal on blur

### DIFF
--- a/.changeset/purple-cows-film.md
+++ b/.changeset/purple-cows-film.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Close explorer property search modal on blur

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderPropertySearchPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderPropertySearchPanel.tsx
@@ -300,10 +300,6 @@ export const QueryBuilderPropertySearchPanel = observer(
     return (
       <BasePopover
         open={propertySearchState.isSearchPanelOpen}
-        // we need to get rid of the backdrop and the click-away trap
-        // to make this popover behave like a popper
-        // NOTE: we will cancel the effect of click-away trap using CSS
-        hideBackdrop={true}
         PaperProps={{
           classes: {
             root: 'query-builder-property-search-panel__container__root',

--- a/packages/legend-query-builder/style/_query-builder-property-search-panel.scss
+++ b/packages/legend-query-builder/style/_query-builder-property-search-panel.scss
@@ -25,12 +25,6 @@
   pointer-events: all;
 
   &__container {
-    // NOTE: since we use a popover for the panel, we need to
-    // disable click-away trap so we could mimic the behavior of
-    // popper. See the note on the usage of popover for virtual
-    // assistant panel for more details
-    pointer-events: none;
-
     &__root {
       border-radius: 0;
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Allow closing the explorer property search modal by clicking outside the modal, instead of just by clicking the close (X) button.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Closing the modal by clicking outside the modal and by clicking the close (X) button:
![CloseOnBlur](https://github.com/finos/legend-studio/assets/9127428/dfc90e1a-575e-4a7f-aba3-b0a56358701c)