### PR TITLE
fix failing to generate dataspace template query creator route

### DIFF
--- a/.changeset/smooth-onions-flow.md
+++ b/.changeset/smooth-onions-flow.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-data-space': patch
+---

--- a/packages/legend-extension-dsl-data-space/src/__lib__/query/DSL_DataSpace_LegendQueryNavigation.ts
+++ b/packages/legend-extension-dsl-data-space/src/__lib__/query/DSL_DataSpace_LegendQueryNavigation.ts
@@ -115,6 +115,8 @@ export const generateDataSpaceTemplateQueryViewerRoute = (
         generateGAVCoordinates(groupId, artifactId, versionId),
       [DATA_SPACE_TEMPLATE_QUERY_CREATOR_ROUTE_PATTERN_TOKEN.DATA_SPACE_PATH]:
         dataSpacePath,
+      [DATA_SPACE_QUERY_CREATOR_ROUTE_PATTERN_TOKEN.TEMPLATE]:
+        DATA_SPACE_QUERY_CREATOR_ROUTE_PATTERN_TOKEN.TEMPLATE,
       [DATA_SPACE_TEMPLATE_QUERY_CREATOR_ROUTE_PATTERN_TOKEN.TEMPLATE_QUERY_TITLE]:
         templateQueryTitle,
     },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

fix failing to generate dataspace template query creator route

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
