### PR TITLE
Enhance update parameter modal

### DIFF
--- a/.changeset/curly-baboons-collect.md
+++ b/.changeset/curly-baboons-collect.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Enhance parameters modal

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -133,15 +133,14 @@ const VariableExpressionEditor = observer(
     };
 
     const handleApply = (): void => {
+      lambdaParameterState.changeVariableType(selectedType.value);
+      lambdaParameterState.changeMultiplicity(
+        varState,
+        selectedMultiplicity.value,
+      );
+      variableExpression_setName(varState, selectedName ?? '');
       if (isCreating) {
         queryParametersState.addParameter(lambdaParameterState);
-      } else {
-        lambdaParameterState.changeVariableType(selectedType.value);
-        lambdaParameterState.changeMultiplicity(
-          varState,
-          selectedMultiplicity.value,
-        );
-        variableExpression_setName(varState, selectedName ?? '');
       }
       handleCancel();
     };

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -78,13 +78,12 @@ const VariableExpressionEditor = observer(
     const isCreating =
       !queryParametersState.parameterStates.includes(lambdaParameterState);
     const varState = lambdaParameterState.parameter;
-    const multiplity = varState.multiplicity;
 
     // type
-    const variableType =
-      lambdaParameterState.variableType ?? PrimitiveType.STRING;
-    const selectedType = buildElementOption(variableType);
-    const selectedMultiplicity = buildMultiplicityOption(multiplity);
+    const stateType = lambdaParameterState.variableType ?? PrimitiveType.STRING;
+    const [selectedType, setSelectedType] = useState(
+      buildElementOption(stateType),
+    );
     const typeOptions: PackageableElementOption<Type>[] =
       queryBuilderState.graphManagerState.graph.primitiveTypes
         .map(buildElementOption)
@@ -94,12 +93,14 @@ const VariableExpressionEditor = observer(
           ),
         );
     const changeType = (val: PackageableElementOption<Type>): void => {
-      if (variableType !== val.value) {
-        lambdaParameterState.changeVariableType(val.value);
-      }
+      setSelectedType(val);
     };
 
     // multiplicity
+    const stateMultiplicity = varState.multiplicity;
+    const [selectedMultiplicity, setSelectedMultiplicity] = useState(
+      buildMultiplicityOption(stateMultiplicity),
+    );
     const validParamMultiplicityList = [
       Multiplicity.ONE,
       Multiplicity.ZERO_ONE,
@@ -108,46 +109,47 @@ const VariableExpressionEditor = observer(
     const multilicityOptions: MultiplicityOption[] =
       validParamMultiplicityList.map(buildMultiplicityOption);
     const changeMultiplicity = (val: MultiplicityOption): void => {
-      lambdaParameterState.changeMultiplicity(varState, val.value);
+      setSelectedMultiplicity(val);
     };
 
-    const parameterNameValue = varState.name;
-
+    // name
+    const stateName = varState.name;
+    const [selectedName, setSelectedName] = useState(stateName);
     const [isNameValid, setIsNameValid] = useState<boolean>(true);
 
     const getValidationMessage = (input: string): string | undefined =>
       !input
         ? `Parameter name can't be empty`
-        : allVariableNames.filter((e) => e === input).length >
-          (isCreating ? 0 : 1)
-        ? 'Parameter name already exists'
-        : (isCreating &&
-            queryParametersState.parameterStates.find(
-              (p) => p.parameter.name === input,
-            )) ||
-          (!isCreating &&
-            queryParametersState.parameterStates.filter(
-              (p) => p.parameter.name === input,
-            ).length > 1)
+        : allVariableNames.filter((e) => e === input).length > 0 &&
+          input !== stateName
         ? 'Parameter name already exists'
         : isValidIdentifier(input, true) === false
         ? 'Parameter name must be text with no spaces and not start with an uppercase letter or number'
         : undefined;
 
-    const close = (): void => {
+    // modal lifecycle actions
+    const handleClose = (): void => {
       queryParametersState.setSelectedParameter(undefined);
     };
-    const onAction = (): void => {
+
+    const handleApply = (): void => {
       if (isCreating) {
         queryParametersState.addParameter(lambdaParameterState);
+      } else {
+        lambdaParameterState.changeVariableType(selectedType.value);
+        lambdaParameterState.changeMultiplicity(
+          varState,
+          selectedMultiplicity.value,
+        );
+        variableExpression_setName(varState, selectedName ?? '');
       }
-      close();
+      handleClose();
     };
 
     return (
       <Dialog
         open={Boolean(lambdaParameterState)}
-        onClose={close}
+        onClose={handleClose}
         classes={{
           root: 'editor-modal__root-container',
           container: 'editor-modal__container',
@@ -165,9 +167,9 @@ const VariableExpressionEditor = observer(
             <PanelFormValidatedTextField
               name="Parameter Name"
               prompt="Name of the parameter. Should be descriptive of its purpose."
-              value={parameterNameValue}
+              value={selectedName}
               update={(value: string | undefined): void => {
-                variableExpression_setName(varState, value ?? '');
+                setSelectedName(value ?? '');
               }}
               validate={getValidationMessage}
               onValidate={(issue: string | undefined) => setIsNameValid(!issue)}
@@ -222,14 +224,16 @@ const VariableExpressionEditor = observer(
             </div>
           </ModalBody>
           <ModalFooter>
-            {isCreating && (
-              <ModalFooterButton
-                text="Create"
-                disabled={!isNameValid}
-                onClick={onAction}
-              />
-            )}
-            <ModalFooterButton onClick={close} text="Close" />
+            <ModalFooterButton
+              text={isCreating ? 'Create' : 'Update'}
+              disabled={!isNameValid}
+              onClick={handleApply}
+            />
+            <ModalFooterButton
+              onClick={handleClose}
+              text="Close"
+              type="secondary"
+            />
           </ModalFooter>
         </Modal>
       </Dialog>

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -128,7 +128,7 @@ const VariableExpressionEditor = observer(
         : undefined;
 
     // modal lifecycle actions
-    const handleClose = (): void => {
+    const handleCancel = (): void => {
       queryParametersState.setSelectedParameter(undefined);
     };
 
@@ -143,13 +143,13 @@ const VariableExpressionEditor = observer(
         );
         variableExpression_setName(varState, selectedName ?? '');
       }
-      handleClose();
+      handleCancel();
     };
 
     return (
       <Dialog
         open={Boolean(lambdaParameterState)}
-        onClose={handleClose}
+        onClose={handleCancel}
         classes={{
           root: 'editor-modal__root-container',
           container: 'editor-modal__container',
@@ -230,8 +230,8 @@ const VariableExpressionEditor = observer(
               onClick={handleApply}
             />
             <ModalFooterButton
-              onClick={handleClose}
-              text="Close"
+              onClick={handleCancel}
+              text="Cancel"
               type="secondary"
             />
           </ModalFooter>

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -138,7 +138,7 @@ const VariableExpressionEditor = observer(
         varState,
         selectedMultiplicity.value,
       );
-      variableExpression_setName(varState, selectedName ?? '');
+      variableExpression_setName(varState, selectedName);
       if (isCreating) {
         queryParametersState.addParameter(lambdaParameterState);
       }

--- a/packages/legend-query-builder/src/components/__test-utils__/QueryBuilderComponentTestUtils.tsx
+++ b/packages/legend-query-builder/src/components/__test-utils__/QueryBuilderComponentTestUtils.tsx
@@ -52,15 +52,19 @@ import {
 import { STYLE_PREFIX, STYLE_PREFIX__DARK } from '@finos/legend-art';
 import { expect } from '@jest/globals';
 
+const getSelectorContainerClassName = (lightMode?: boolean): string =>
+  '.' + `${lightMode ? STYLE_PREFIX : STYLE_PREFIX__DARK}__value-container`;
+
+const getSelectorInputClassName = (lightMode?: boolean): string =>
+  '.' + `${lightMode ? STYLE_PREFIX : STYLE_PREFIX__DARK}__single-value`;
+
 export const selectFromCustomSelectorInput = (
   selectorContainer: HTMLElement,
   optionText: string,
   lightMode?: boolean,
 ): void => {
-  const selectorContainerClassName =
-    '.' + `${lightMode ? STYLE_PREFIX : STYLE_PREFIX__DARK}__value-container`;
-  const selectorInputValue =
-    '.' + `${lightMode ? STYLE_PREFIX : STYLE_PREFIX__DARK}__single-value`;
+  const selectorContainerClassName = getSelectorContainerClassName(lightMode);
+  const selectorInputValue = getSelectorInputClassName(lightMode);
 
   let foundOptionText = false;
   const selector = selectorContainer.querySelector(
@@ -104,6 +108,22 @@ export const selectFromCustomSelectorInput = (
       `The option is unavailable in the selector dropdown. Kindly review the input: ${optionText}`,
     );
   }
+};
+
+export const getCustomSelectorInputValue = (
+  selectorContainer: HTMLElement,
+  lightMode?: boolean,
+): string | null => {
+  const selectorContainerClassName = getSelectorContainerClassName(lightMode);
+  const selectorInputValue = getSelectorInputClassName(lightMode);
+
+  const selector = guaranteeNonNullable(
+    selectorContainer.querySelector(selectorContainerClassName),
+  ) as HTMLSelectElement;
+  const selectorInput = guaranteeNonNullable(
+    selector.querySelector(selectorInputValue),
+  );
+  return selectorInput.textContent;
 };
 
 export const dragAndDrop = async (

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
@@ -346,12 +346,12 @@ test(
     fireEvent.change(parameterNameInput, { target: { value: 'var_2' } });
     // select Number from dropdown
     const typeContainer = guaranteeNonNullable(
-      renderResult.getByText('Type')?.parentElement,
+      renderResult.getByText('Type').parentElement,
     );
     selectFromCustomSelectorInput(typeContainer, 'Number');
     // select Optional from dropdown
     const multiplicityContainer = guaranteeNonNullable(
-      renderResult.getByText('Multiplicity')?.parentElement,
+      renderResult.getByText('Multiplicity').parentElement,
     );
     selectFromCustomSelectorInput(multiplicityContainer, '[0..1] - Optional');
     const createButton = renderResult.getByRole('button', { name: 'Create' });
@@ -417,12 +417,12 @@ test(
     fireEvent.change(parameterNameInput, { target: { value: 'var_2' } });
     // select Number from dropdown
     const typeContainer = guaranteeNonNullable(
-      renderResult.getByText('Type')?.parentElement,
+      renderResult.getByText('Type').parentElement,
     );
     selectFromCustomSelectorInput(typeContainer, 'Number');
     // select Optional from dropdown
     const multiplicityContainer = guaranteeNonNullable(
-      renderResult.getByText('Multiplicity')?.parentElement,
+      renderResult.getByText('Multiplicity').parentElement,
     );
     selectFromCustomSelectorInput(multiplicityContainer, '[0..1] - Optional');
     fireEvent.click(renderResult.getByRole('button', { name: 'Update' }));
@@ -487,12 +487,12 @@ test(
     fireEvent.change(parameterNameInput, { target: { value: 'var_2' } });
     // select Number from dropdown
     let typeContainer = guaranteeNonNullable(
-      renderResult.getByText('Type')?.parentElement,
+      renderResult.getByText('Type').parentElement,
     );
     selectFromCustomSelectorInput(typeContainer, 'Number');
     // select Optional from dropdown
     let multiplicityContainer = guaranteeNonNullable(
-      renderResult.getByText('Multiplicity')?.parentElement,
+      renderResult.getByText('Multiplicity').parentElement,
     );
     selectFromCustomSelectorInput(multiplicityContainer, '[0..1] - Optional');
     fireEvent.click(renderResult.getByRole('button', { name: 'Cancel' }));
@@ -516,11 +516,11 @@ test(
       await waitFor(() => renderResult.getByDisplayValue('var_1')),
     ).not.toBeNull();
     typeContainer = guaranteeNonNullable(
-      renderResult.getByText('Type')?.parentElement,
+      renderResult.getByText('Type').parentElement,
     );
     expect(getCustomSelectorInputValue(typeContainer)).toBe('String');
     multiplicityContainer = guaranteeNonNullable(
-      renderResult.getByText('Multiplicity')?.parentElement,
+      renderResult.getByText('Multiplicity').parentElement,
     );
     expect(getCustomSelectorInputValue(multiplicityContainer)).toBe(
       '[1] - Required',

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
@@ -33,22 +33,19 @@ import TEST_DATA__ComplexRelationalModel from '../../stores/__tests__/TEST_DATA_
 import { createMock, integrationTest } from '@finos/legend-shared/test';
 import {
   create_RawLambda,
-  PrimitiveType,
   PRIMITIVE_TYPE,
   stub_RawLambda,
 } from '@finos/legend-graph';
 import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
 import { TEST__setUpQueryBuilder } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
-import { CUSTOM_DATE_PICKER_OPTION } from '../shared/CustomDatePicker.js';
 import {
   MockedMonacoEditorInstance,
   MockedMonacoEditorAPI,
 } from '@finos/legend-lego/code-editor/test';
-import { QueryBuilderSimpleConstantExpressionState } from '../../stores/QueryBuilderConstantsState.js';
 
 test(
   integrationTest(
-    'Query builder shows validation error for parameter name if existing duplicate constant name',
+    'Query builder shows validation error for creating parameter name if existing duplicate constant name',
   ),
   async () => {
     const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
@@ -102,123 +99,6 @@ test(
     expect(renderResult.getByText('Create').hasAttribute('disabled')).toBe(
       true,
     );
-  },
-);
-
-test(
-  integrationTest(
-    'Query builder shows validation error for constant name if existing duplicate parameter name',
-  ),
-  async () => {
-    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
-      TEST_DATA__ComplexRelationalModel,
-      stub_RawLambda(),
-      'model::relational::tests::simpleRelationalMapping',
-      'model::MyRuntime',
-      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
-    );
-    await act(async () => {
-      queryBuilderState.initializeWithQuery(
-        create_RawLambda(
-          TEST_DATA__simpleProjection.parameters,
-          TEST_DATA__simpleProjection.body,
-        ),
-      );
-      // NOTE: Render result will not currently find the
-      // 'show constant(s)' panel so we will directly force
-      // the panel to show for now
-      queryBuilderState.constantState.setShowConstantPanel(true);
-    });
-
-    await waitFor(() =>
-      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS),
-    );
-    const constantsPanel = renderResult.getByTestId(
-      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS,
-    );
-
-    fireEvent.click(getByTitle(constantsPanel, 'Add Constant'));
-
-    await act(async () => {
-      if (!queryBuilderState.constantState.selectedConstant) {
-        return;
-      }
-    });
-    const constantNameInput = renderResult.getByDisplayValue('c_var_1');
-    fireEvent.change(constantNameInput, { target: { value: 'var_1' } });
-    expect(
-      await waitFor(() =>
-        renderResult.getByText('Constant name already exists'),
-      ),
-    ).not.toBeNull();
-    expect(renderResult.getByText('Create').hasAttribute('disabled')).toBe(
-      true,
-    );
-  },
-);
-
-test(
-  integrationTest(
-    'Query builder shows humanized date label value for constant variable with type Date',
-  ),
-  async () => {
-    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
-      TEST_DATA__ComplexRelationalModel,
-      stub_RawLambda(),
-      'model::relational::tests::simpleRelationalMapping',
-      'model::MyRuntime',
-      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
-    );
-    await act(async () => {
-      queryBuilderState.initializeWithQuery(
-        create_RawLambda(
-          TEST_DATA__simpleProjection.parameters,
-          TEST_DATA__simpleProjection.body,
-        ),
-      );
-      queryBuilderState.constantState.setShowConstantPanel(true);
-    });
-
-    await waitFor(() =>
-      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS),
-    );
-    const constantsPanel = renderResult.getByTestId(
-      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS,
-    );
-    fireEvent.click(getByTitle(constantsPanel, 'Add Constant'));
-
-    await act(async () => {
-      if (!queryBuilderState.constantState.selectedConstant) {
-        return;
-      }
-      const selectedConstant = queryBuilderState.constantState.selectedConstant;
-      if (
-        selectedConstant instanceof QueryBuilderSimpleConstantExpressionState
-      ) {
-        selectedConstant.changeValSpecType(PrimitiveType.STRICTDATE);
-      }
-    });
-
-    await waitFor(() =>
-      renderResult.getByTitle('Click to edit and pick from more date options'),
-    );
-    fireEvent.click(
-      renderResult.getByTitle('Click to edit and pick from more date options'),
-    );
-
-    await waitFor(() =>
-      renderResult.getByText(CUSTOM_DATE_PICKER_OPTION.TODAY),
-    );
-    fireEvent.click(renderResult.getByText(CUSTOM_DATE_PICKER_OPTION.TODAY));
-
-    await waitFor(() => renderResult.getByText('Create'));
-    fireEvent.click(renderResult.getByText('Create'));
-
-    expect(
-      await waitFor(() =>
-        getByText(constantsPanel, CUSTOM_DATE_PICKER_OPTION.TODAY),
-      ),
-    ).not.toBeNull();
   },
 );
 
@@ -394,78 +274,6 @@ test(
     executeDialog = await waitFor(() => renderResult.getByRole('dialog'));
     expect(getByText(executeDialog, 'Set Parameter Values'));
     expect(getByText(executeDialog, 'var_1')).toStrictEqual(parameterValue);
-  },
-);
-
-test(
-  integrationTest(
-    'Query builder disables constant creation and shows validation error if invalid constant name',
-  ),
-  async () => {
-    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
-      TEST_DATA__ComplexRelationalModel,
-      stub_RawLambda(),
-      'model::relational::tests::simpleRelationalMapping',
-      'model::MyRuntime',
-      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
-    );
-    await act(async () => {
-      queryBuilderState.initializeWithQuery(
-        create_RawLambda(
-          TEST_DATA__simpleProjection.parameters,
-          TEST_DATA__simpleProjection.body,
-        ),
-      );
-      queryBuilderState.constantState.setShowConstantPanel(true);
-    });
-
-    await waitFor(() =>
-      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS),
-    );
-    const constantsPanel = renderResult.getByTestId(
-      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS,
-    );
-
-    fireEvent.click(getByTitle(constantsPanel, 'Add Constant'));
-
-    await act(async () => {
-      if (!queryBuilderState.constantState.selectedConstant) {
-        return;
-      }
-    });
-    const constantNameInput = renderResult.getByDisplayValue('c_var_1');
-    fireEvent.change(constantNameInput, {
-      target: { value: '1startsWithNumber' },
-    });
-    expect(
-      await waitFor(() =>
-        renderResult.getByText(
-          'Constant name must be text with no spaces and not start with an uppercase letter or number',
-        ),
-      ),
-    ).not.toBeNull();
-    expect(renderResult.getByText('Create').hasAttribute('disabled')).toBe(
-      true,
-    );
-    fireEvent.change(constantNameInput, {
-      target: { value: 'validInput' },
-    });
-    expect(renderResult.getByText('Create').hasAttribute('disabled')).toBe(
-      false,
-    );
-    fireEvent.change(constantNameInput, {
-      target: { value: 'invalidInput!' },
-    });
-    expect(
-      await waitFor(() =>
-        renderResult.getByText(
-          'Constant name must be text with no spaces and not start with an uppercase letter or number',
-        ),
-      ),
-    ).not.toBeNull();
-    expect(renderResult.getByText('Create').hasAttribute('disabled')).toBe(
-      true,
-    );
   },
 );
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Make the update parameter modal have an Apply and Cancel button so that changes made in the modal only take effect if Apply is clicked. If Cancel is clicked, then the changes made in the modal shouldn't be saved to the state.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Validation of parameter name when creating a new parameter (against existing parameter and constant names):
![CreateParameter_Validation](https://github.com/finos/legend-studio/assets/9127428/c6b6aa97-6f1e-41d2-bfa0-b4c77b2e1fbb)

Validation of parameter name when updating a parameter (against existing parameter and constant names):
![UpdateParameter_Validation](https://github.com/finos/legend-studio/assets/9127428/dd413c51-4e9c-4bf7-8cb8-9932f592bed7)

Showing that changes don't take effect when Cancel button is clicked, but changes do take effect when Apply button is clicked
![UpdateParameter_ApplyCancel](https://github.com/finos/legend-studio/assets/9127428/0022f9bb-7035-46b3-9b67-07f30e2233c4)

Showing that changes made in the create parameter modal take effect when you create a new parameter
![CreateParameter_ChangeValues](https://github.com/finos/legend-studio/assets/9127428/87cf02a5-d1e3-4b65-84b0-4d4b99c70eb0)
