### PR TITLE
fetch entities from master branch when promoting template query

### DIFF
--- a/.changeset/moody-pumpkins-rhyme.md
+++ b/.changeset/moody-pumpkins-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-space-studio': patch
+---
+
+fetch entities from master branch when promoting template query

--- a/packages/legend-extension-dsl-data-space-studio/src/stores/DataSpaceTemplateQueryPromotionReviewerStore.ts
+++ b/packages/legend-extension-dsl-data-space-studio/src/stores/DataSpaceTemplateQueryPromotionReviewerStore.ts
@@ -25,6 +25,7 @@ import {
   StoreProjectData,
   ProjectDependencyCoordinates,
   ProjectVersionEntities,
+  MASTER_SNAPSHOT_ALIAS,
 } from '@finos/legend-server-depot';
 import {
   ActionState,
@@ -245,7 +246,7 @@ export class DataSpaceTemplateQueryPromotionReviewerStore {
           this.depotServerClient.getVersionEntities(
             this.currentQuery.groupId,
             this.currentQuery.artifactId,
-            this.currentQuery.versionId,
+            MASTER_SNAPSHOT_ALIAS,
           ),
           this.sdlcServerClient.getConfiguration(
             this.currentQueryProject.projectId,
@@ -314,7 +315,10 @@ export class DataSpaceTemplateQueryPromotionReviewerStore {
           this.currentQuery.artifactId,
         )) as PlainObject<StoreProjectData>,
       );
-      this.setWorkspaceName(`${DEFAULT_WORKSPACE_NAME_PREFIX}-${query.name}`);
+      const updatedQueryName = query.name.replace(/[^a-zA-Z0-9]/g, '');
+      this.setWorkspaceName(
+        `${DEFAULT_WORKSPACE_NAME_PREFIX}-${updatedQueryName}`,
+      );
       this.applicationStore.navigationService.navigator.updateCurrentLocation(
         generateDataSpaceTemplateQueryPromotionRoute(
           this.currentQuery.groupId,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->


fetch entities from master branch when promoting template query

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
