### PR TITLE
Give column name editor its own lifecycle and trim column names

### DIFF
--- a/.changeset/nasty-dots-deny.md
+++ b/.changeset/nasty-dots-deny.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Give column name editor its own lifecycle and trim column names

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -401,6 +401,18 @@ export const QueryBuilderEditablePropertyName = observer(
       }
     }, [isEditingColumnName, columnNameInputRef]);
 
+    const handleFinishEditing = (): void => {
+      const trimmedSelectedColumnName = selectedColumnName.trim();
+      if (trimmedSelectedColumnName.length > 0) {
+        setColumnName?.(trimmedSelectedColumnName);
+        setSelectedColumnName(trimmedSelectedColumnName);
+      } else {
+        setColumnName?.(defaultColumnName);
+        setSelectedColumnName(defaultColumnName);
+      }
+      setIsEditingColumnName(false);
+    };
+
     return isEditingColumnName ? (
       <div className="query-builder__property__name__editor">
         <InputWithInlineValidation
@@ -412,28 +424,10 @@ export const QueryBuilderEditablePropertyName = observer(
           }
           onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
             if (event.key === 'Enter') {
-              const trimmedSelectedColumnName = selectedColumnName.trim();
-              if (trimmedSelectedColumnName.length > 0) {
-                setColumnName?.(trimmedSelectedColumnName);
-                setSelectedColumnName(trimmedSelectedColumnName);
-              } else {
-                setColumnName?.(defaultColumnName);
-                setSelectedColumnName(defaultColumnName);
-              }
-              setIsEditingColumnName(false);
+              handleFinishEditing();
             }
           }}
-          onBlur={() => {
-            const trimmedSelectedColumnName = selectedColumnName.trim();
-            if (trimmedSelectedColumnName.length > 0) {
-              setColumnName?.(trimmedSelectedColumnName);
-              setSelectedColumnName(trimmedSelectedColumnName);
-            } else {
-              setColumnName?.(defaultColumnName);
-              setSelectedColumnName(defaultColumnName);
-            }
-            setIsEditingColumnName(false);
-          }}
+          onBlur={handleFinishEditing}
           ref={columnNameInputRef}
           draggable={true}
           onDragStart={(e: React.DragEvent<HTMLInputElement>) => {

--- a/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderPropertyExpressionEditor.tsx
@@ -412,8 +412,10 @@ export const QueryBuilderEditablePropertyName = observer(
           }
           onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
             if (event.key === 'Enter') {
-              if (selectedColumnName.length > 0) {
-                setColumnName?.(selectedColumnName);
+              const trimmedSelectedColumnName = selectedColumnName.trim();
+              if (trimmedSelectedColumnName.length > 0) {
+                setColumnName?.(trimmedSelectedColumnName);
+                setSelectedColumnName(trimmedSelectedColumnName);
               } else {
                 setColumnName?.(defaultColumnName);
                 setSelectedColumnName(defaultColumnName);
@@ -422,8 +424,10 @@ export const QueryBuilderEditablePropertyName = observer(
             }
           }}
           onBlur={() => {
-            if (selectedColumnName.length > 0) {
-              setColumnName?.(selectedColumnName);
+            const trimmedSelectedColumnName = selectedColumnName.trim();
+            if (trimmedSelectedColumnName.length > 0) {
+              setColumnName?.(trimmedSelectedColumnName);
+              setSelectedColumnName(trimmedSelectedColumnName);
             } else {
               setColumnName?.(defaultColumnName);
               setSelectedColumnName(defaultColumnName);

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  useEffect,
-  useRef,
-  useCallback,
-  useState,
-  forwardRef,
-  type ChangeEvent,
-} from 'react';
+import { useEffect, useRef, useCallback, useState, forwardRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   clsx,
@@ -161,10 +154,10 @@ const QueryBuilderProjectionColumnContextMenu = observer(
 const QueryBuilderSimpleProjectionColumnEditor = observer(
   (props: {
     projectionColumnState: QueryBuilderSimpleProjectionColumnState;
-    changeColumnName: (event: ChangeEvent<HTMLInputElement>) => void;
+    setColumnName: (columnName: string) => void;
     error?: string | undefined;
   }) => {
-    const { projectionColumnState, changeColumnName, error } = props;
+    const { projectionColumnState, setColumnName, error } = props;
     const onPropertyExpressionChange = (
       node: QueryBuilderExplorerTreePropertyNodeData,
     ): void =>
@@ -179,7 +172,7 @@ const QueryBuilderSimpleProjectionColumnEditor = observer(
         columnName={projectionColumnState.columnName}
         propertyExpressionState={projectionColumnState.propertyExpressionState}
         onPropertyExpressionChange={onPropertyExpressionChange}
-        changeColumnName={changeColumnName}
+        setColumnName={setColumnName}
         error={error}
       />
     );
@@ -391,9 +384,8 @@ const QueryBuilderProjectionColumnEditor = observer(
       tdsState.removeColumn(projectionColumnState);
 
     // name
-    const changeColumnName: React.ChangeEventHandler<HTMLInputElement> = (
-      event,
-    ) => projectionColumnState.setColumnName(event.target.value);
+    const setColumnName = (columnName: string): void =>
+      projectionColumnState.setColumnName(columnName);
     const isDuplicatedColumnName =
       projectionColumnState.tdsState.isDuplicateColumn(projectionColumnState);
 
@@ -787,7 +779,7 @@ const QueryBuilderProjectionColumnEditor = observer(
                 <div className="query-builder__projection__column__value">
                   <QueryBuilderSimpleProjectionColumnEditor
                     projectionColumnState={projectionColumnState}
-                    changeColumnName={changeColumnName}
+                    setColumnName={setColumnName}
                     error={
                       isDuplicatedColumnName
                         ? 'Duplicated column'
@@ -814,7 +806,7 @@ const QueryBuilderProjectionColumnEditor = observer(
                 <div className="query-builder__projection__column__value">
                   <QueryBuilderEditablePropertyName
                     columnName={projectionColumnState.columnName}
-                    changeColumnName={changeColumnName}
+                    setColumnName={setColumnName}
                     error={
                       isDuplicatedColumnName
                         ? 'Duplicated column'
@@ -823,6 +815,7 @@ const QueryBuilderProjectionColumnEditor = observer(
                         : undefined
                     }
                     title={projectionColumnState.columnName}
+                    defaultColumnName="(derivation)"
                   />
                   <QueryBuilderDerivationProjectionColumnEditor
                     projectionColumnState={projectionColumnState}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

The column name editor should have its own lifecycle, so that changes to the column name don't get saved to the state until the user finishes editing (hits Enter or blurs the input). Thus, duplicate column names won't be detected and an error shown until the user finishes editing.

Additionally, if the user edits a column name and clears the value and then finishes editing, we should reset the column name to its default value.

Additionally, we should trim any leading and trailing whitespace from the column name when the user finishes editing.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Resetting a simple column name when the value is cleared:
![SimpleColumn_Reset](https://github.com/finos/legend-studio/assets/9127428/87bd198f-6ea5-4067-901d-4130577c842a)

Detecting a duplicate column name when the user finishes editing:
![SimpleColumn_Duplicate](https://github.com/finos/legend-studio/assets/9127428/4167e3e1-5686-445f-8843-88f26d815cca)

Trimming leading/trailing whitespace when finishing editing a column name:
![SimpleColumn_TrimName](https://github.com/finos/legend-studio/assets/9127428/c0a5d7e0-d311-4ecc-95c2-d617b0ab94e0)

Resetting a derivation column name when the value is cleared:
![DerivationColumn_Reset](https://github.com/finos/legend-studio/assets/9127428/5d092838-b8f8-4851-a493-d5fd18eb19fd)
