### PR TITLE
Enhance "is in"/"is not in" enum filter

### DIFF
--- a/.changeset/calm-taxis-hammer.md
+++ b/.changeset/calm-taxis-hammer.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Enhance is in/is not in filter for enums

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -855,6 +855,7 @@ const EnumCollectionInstanceValueEditor = observer(
           }
           placeholder="Select value"
           autoFocus={true}
+          menuIsOpen={true}
         />
         <button
           className="value-spec-editor__list-editor__save-button btn--dark"

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -34,7 +34,6 @@ import {
   PanelFormSection,
   CalculateIcon,
   InputWithInlineValidation,
-  type SelectComponent,
 } from '@finos/legend-art';
 import {
   type Enum,
@@ -784,7 +783,6 @@ const EnumCollectionInstanceValueEditor = observer(
     saveEdit: () => void;
   }) => {
     const { valueSpecification, observerContext, saveEdit } = props;
-    const inputRef = useRef<SelectComponent>(null);
     const applicationStore = useApplicationStore();
     const enumType = guaranteeType(
       valueSpecification.genericType?.value.rawType,
@@ -801,10 +799,6 @@ const EnumCollectionInstanceValueEditor = observer(
           value: valueSpec.values[0]!.value,
         })),
     );
-
-    useEffect(() => {
-      inputRef.current?.focus();
-    }, []);
 
     const availableOptions = enumType.values
       .filter(
@@ -845,7 +839,6 @@ const EnumCollectionInstanceValueEditor = observer(
     return (
       <>
         <CustomSelectorInput
-          ref={inputRef}
           className="value-spec-editor__enum-collection-selector"
           options={availableOptions}
           isMulti={true}
@@ -861,6 +854,7 @@ const EnumCollectionInstanceValueEditor = observer(
             !applicationStore.layoutService.TEMPORARY__isLightColorThemeEnabled
           }
           placeholder="Select value"
+          autoFocus={true}
         />
         <button
           className="value-spec-editor__list-editor__save-button btn--dark"

--- a/packages/legend-query-builder/style/_query-builder-filter.scss
+++ b/packages/legend-query-builder/style/_query-builder-filter.scss
@@ -362,7 +362,8 @@ $group-node-width: 3.5rem;
       @include flexCenter;
 
       flex-grow: 1;
-      height: 2.8rem;
+      height: fit-content;
+      min-height: 2.8rem;
       border-radius: 0.2rem;
       font-size: 1.2rem;
       font-weight: 500;

--- a/packages/legend-query-builder/style/_query-builder-filter.scss
+++ b/packages/legend-query-builder/style/_query-builder-filter.scss
@@ -361,7 +361,7 @@ $group-node-width: 3.5rem;
     &__value {
       @include flexCenter;
 
-      flex-grow: 1;
+      width: 100%;
       height: fit-content;
       min-height: 2.8rem;
       border-radius: 0.2rem;

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -51,6 +51,33 @@
 
   &__enum-collection-selector {
     width: 100%;
+    display: flex;
+
+    .selector-input--dark__control {
+      height: fit-content;
+      width: 100%;
+    }
+
+    .selector-input--dark__value-container--is-multi {
+      overflow: auto;
+      height: fit-content;
+      max-height: 6.6rem;
+    }
+
+    .selector-input--dark__placeholder {
+      width: fit-content;
+      max-width: 100%;
+    }
+
+    .value-spec-editor__list-editor__save-button {
+      align-self: normal;
+      height: unset;
+    }
+
+    .value-spec-editor__reset-btn {
+      align-self: normal;
+      height: unset;
+    }
   }
 
   ::-webkit-calendar-picker-indicator {

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -53,11 +53,13 @@
     width: 100%;
     display: flex;
 
-    .selector-input--dark__control {
+    .selector-input--dark__control,
+    .selector-input__control {
       height: fit-content;
       width: 100%;
 
-      .selector-input--dark__input {
+      .selector-input--dark__input,
+      .selector-input__input {
         height: 2.2rem;
 
         input {
@@ -65,17 +67,19 @@
           line-height: 2.2rem;
         }
       }
-    }
 
-    .selector-input--dark__value-container--is-multi {
-      overflow: auto;
-      height: fit-content;
-      max-height: 6.6rem;
-    }
+      .selector-input--dark__value-container--is-multi,
+      .selector-input__value-container--is-multi {
+        overflow: auto;
+        height: fit-content;
+        max-height: 6.6rem;
+      }
 
-    .selector-input--dark__placeholder {
-      width: fit-content;
-      max-width: 100%;
+      .selector-input--dark__placeholder,
+      .selector-input__placeholder {
+        width: fit-content;
+        max-width: 100%;
+      }
     }
   }
 
@@ -414,12 +418,6 @@
     height: 2.8rem;
   }
 
-  .selector-input__indicators,
-  .selector-input__value-container {
-    height: 2.6rem;
-  }
-
-  .selector-input__indicator-separator,
   .selector-input--dark__loading-indicator,
   .selector-menu--dark .selector-input--dark__loading-indicator,
   .selector-input--dark .selector-input--dark__loading-indicator {

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -49,6 +49,10 @@
     width: 100%;
   }
 
+  &__enum-collection-selector {
+    width: 100%;
+  }
+
   ::-webkit-calendar-picker-indicator {
     filter: invert(0.8);
   }

--- a/packages/legend-query-builder/style/shared/_value-spec-editor.scss
+++ b/packages/legend-query-builder/style/shared/_value-spec-editor.scss
@@ -30,7 +30,7 @@
     @include flexCenter;
     @include flexConstantDimension;
 
-    height: 2.8rem;
+    align-self: normal;
     width: 2.8rem;
     background: var(--color-dark-grey-200);
     border-radius: 0 50% 50% 0;
@@ -56,6 +56,15 @@
     .selector-input--dark__control {
       height: fit-content;
       width: 100%;
+
+      .selector-input--dark__input {
+        height: 2.2rem;
+
+        input {
+          height: 2.2rem;
+          line-height: 2.2rem;
+        }
+      }
     }
 
     .selector-input--dark__value-container--is-multi {
@@ -67,16 +76,6 @@
     .selector-input--dark__placeholder {
       width: fit-content;
       max-width: 100%;
-    }
-
-    .value-spec-editor__list-editor__save-button {
-      align-self: normal;
-      height: unset;
-    }
-
-    .value-spec-editor__reset-btn {
-      align-self: normal;
-      height: unset;
     }
   }
 
@@ -239,7 +238,7 @@
   }
 
   &__input {
-    height: 100%;
+    height: 2.8rem;
     max-width: 100%;
     width: 100%;
     font-size: 1.4rem;
@@ -360,7 +359,7 @@
   &__list-editor__save-button {
     @include flexCenter;
 
-    height: 2.8rem;
+    align-self: normal;
     width: 2.8rem;
     min-width: 2.8rem;
 
@@ -372,7 +371,7 @@
   &__list-editor__expand-button {
     @include flexCenter;
 
-    height: 2.8rem;
+    align-self: normal;
     min-width: 2.8rem;
 
     svg {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Enhance the "is in" and "is not in" filters for enum types. When the user adds one of these filters, we now show a dropdown with all the available enum values for the user to choose from, and when they click on a value to add it to the filter list, the option is removed from the dropdown. This provides a better UX because the user doesn't have to remember the exact text values of the enums they want to add to the list.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
"Is in" enum filter:
![IsInEnumFilter](https://github.com/finos/legend-studio/assets/9127428/d046c4dc-5956-44de-8484-50f8c79f622c)

"Is in" enum filter with smaller window to show how the select box expands and scrolls:
![IsInEnumFilter_WithScrolling](https://github.com/finos/legend-studio/assets/9127428/6bf07c20-2afa-4f90-9302-2a70aa5b9ae9)

Other data types "is in" filters are unchanged:
![OtherDataTypes_IsInFilter](https://github.com/finos/legend-studio/assets/9127428/2a5bf27e-bea4-48e5-8ca0-38d1fbefd923)