### PR TITLE
Default to last dataspace

### DIFF
--- a/.changeset/thirty-deers-swim.md
+++ b/.changeset/thirty-deers-swim.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application': patch
+---

--- a/.changeset/thirty-deers-swim.md
+++ b/.changeset/thirty-deers-swim.md
@@ -1,3 +1,5 @@
 ---
 '@finos/legend-application': patch
 ---
+
+Add save last queried dataspace functionality to the LegendQueryUserDataHelper class

--- a/.changeset/wild-cheetahs-cheer.md
+++ b/.changeset/wild-cheetahs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Default to last dataspace/class used when opening up a new query from dataspace

--- a/packages/legend-application-query/src/__lib__/LegendQueryUserDataHelper.ts
+++ b/packages/legend-application-query/src/__lib__/LegendQueryUserDataHelper.ts
@@ -20,7 +20,7 @@ import { createSimpleSchema, deserialize, list, primitive } from 'serializr';
 
 export enum LEGEND_QUERY_USER_DATA_KEY {
   RECENTLY_VIEWED_QUERIES = 'query-editor.recent-queries',
-  LAST_QUERY_DATASPACE_KEY = 'last_query_dataspace',
+  LAST_QUERY_DATASPACE = 'last_query_dataspace',
 }
 
 export const USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT = 10;
@@ -64,12 +64,10 @@ export class LegendQueryUserDataHelper {
   ): void {
     const idx = persistedData.findIndex((data) => data === value);
     if (idx === -1) {
-      if (persistedData.length < opts.limit) {
-        persistedData.unshift(value);
-      } else {
+      if (persistedData.length >= opts.limit) {
         persistedData.pop();
-        persistedData.unshift(value);
       }
+      persistedData.unshift(value);
     } else {
       persistedData.splice(idx, 1);
       persistedData.unshift(value);
@@ -124,14 +122,14 @@ export class LegendQueryUserDataHelper {
   static getRecentlyQueriedDataspaceList(service: UserDataService): SavedData {
     return LegendQueryUserDataHelper.getPersistedData(
       service,
-      LEGEND_QUERY_USER_DATA_KEY.LAST_QUERY_DATASPACE_KEY,
+      LEGEND_QUERY_USER_DATA_KEY.LAST_QUERY_DATASPACE,
     );
   }
 
   static getRecentlyQueriedDataspace(service: UserDataService): string {
     const dataspaceList =
       LegendQueryUserDataHelper.getRecentlyQueriedDataspaceList(service);
-    return dataspaceList?.[0] || '';
+    return dataspaceList?.[0] ?? '';
   }
 
   static saveRecentlyQueriedDataspace(
@@ -142,7 +140,7 @@ export class LegendQueryUserDataHelper {
       LegendQueryUserDataHelper.getRecentlyQueriedDataspaceList(service);
     LegendQueryUserDataHelper.persistValue(service, dataspace, dataspaceList, {
       limit: USER_DATA_QUERY_DATASPACE_LIMIT,
-      key: LEGEND_QUERY_USER_DATA_KEY.LAST_QUERY_DATASPACE_KEY,
+      key: LEGEND_QUERY_USER_DATA_KEY.LAST_QUERY_DATASPACE,
     });
   }
 }

--- a/packages/legend-application-query/src/__lib__/LegendQueryUserDataHelper.ts
+++ b/packages/legend-application-query/src/__lib__/LegendQueryUserDataHelper.ts
@@ -20,7 +20,7 @@ import { createSimpleSchema, deserialize, list, primitive } from 'serializr';
 
 export enum LEGEND_QUERY_USER_DATA_KEY {
   RECENTLY_VIEWED_QUERIES = 'query-editor.recent-queries',
-  LAST_QUERY_DATASPACE = 'last_query_dataspace',
+  LAST_QUERY_DATASPACE = 'query-editor.last_query_dataspace',
 }
 
 export const USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT = 10;

--- a/packages/legend-application-query/src/__lib__/LegendQueryUserDataHelper.ts
+++ b/packages/legend-application-query/src/__lib__/LegendQueryUserDataHelper.ts
@@ -23,8 +23,8 @@ export enum LEGEND_QUERY_USER_DATA_KEY {
   LAST_QUERY_DATASPACE_KEY = 'last_query_dataspace',
 }
 
-const USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT = 10;
-const USER_DATA_QUERY_DATASPACE_LIMIT = 10;
+export const USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT = 10;
+export const USER_DATA_QUERY_DATASPACE_LIMIT = 10;
 
 type SavedData = string[];
 
@@ -97,9 +97,12 @@ export class LegendQueryUserDataHelper {
   ): void {
     const queries = LegendQueryUserDataHelper.getRecentlyViewedQueries(service);
     const idx = queries.findIndex((query) => query === queryId);
-    if (idx === -1) {
+    const notFound = idx === -1;
+
+    if (notFound) {
       return;
     }
+
     queries.splice(idx, 1);
     service.persistValue(
       LEGEND_QUERY_USER_DATA_KEY.RECENTLY_VIEWED_QUERIES,

--- a/packages/legend-application-query/src/__lib__/__tests__/LegendQueryUserDataHelper.test.ts
+++ b/packages/legend-application-query/src/__lib__/__tests__/LegendQueryUserDataHelper.test.ts
@@ -52,9 +52,9 @@ describe('LegendQueryUserDataHelper', () => {
 
       const expected = [queryId];
 
-      expect(expected).toEqual(
+      expect(
         LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
-      );
+      ).toEqual(expected);
     });
 
     it('should delete a saved query', () => {
@@ -71,9 +71,9 @@ describe('LegendQueryUserDataHelper', () => {
         queryId2,
       );
 
-      expect([queryId2, queryId]).toEqual(
+      expect(
         LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
-      );
+      ).toEqual([queryId2, queryId]);
 
       LegendQueryUserDataHelper.removeRecentlyViewedQuery(
         userDataService,
@@ -82,9 +82,9 @@ describe('LegendQueryUserDataHelper', () => {
 
       const expected = [queryId2];
 
-      expect(expected).toEqual(
+      expect(
         LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
-      );
+      ).toEqual(expected);
     });
 
     it('should delete all saved queries', () => {
@@ -103,9 +103,9 @@ describe('LegendQueryUserDataHelper', () => {
 
       LegendQueryUserDataHelper.removeRecentlyViewedQueries(userDataService);
 
-      expect([]).toEqual(
+      expect(
         LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
-      );
+      ).toEqual([]);
     });
 
     it(`should maintain a list of ${USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT} saved queries`, () => {
@@ -151,11 +151,11 @@ describe('LegendQueryUserDataHelper', () => {
 
       const expected = [dataspace3, dataspace2, dataspace];
 
-      expect(expected).toEqual(
+      expect(
         LegendQueryUserDataHelper.getRecentlyQueriedDataspaceList(
           userDataService,
         ),
-      );
+      ).toEqual(expected);
     });
 
     it('should retrieve the most recent queried dataspace', () => {
@@ -181,9 +181,9 @@ describe('LegendQueryUserDataHelper', () => {
 
       const expected = dataspace3;
 
-      expect(expected).toEqual(
+      expect(
         LegendQueryUserDataHelper.getRecentlyQueriedDataspace(userDataService),
-      );
+      ).toEqual(expected);
     });
 
     it(`should maintain a list of ${USER_DATA_QUERY_DATASPACE_LIMIT} saved dataspace`, () => {

--- a/packages/legend-application-query/src/__lib__/__tests__/LegendQueryUserDataHelper.test.ts
+++ b/packages/legend-application-query/src/__lib__/__tests__/LegendQueryUserDataHelper.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { it, expect, describe } from '@jest/globals';
+import type { UserDataService } from '@finos/legend-application';
+import {
+  LegendQueryUserDataHelper,
+  USER_DATA_QUERY_DATASPACE_LIMIT,
+  USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT,
+} from '../LegendQueryUserDataHelper.js';
+
+type MockUserDataStoreValue = object | undefined;
+
+class MockUserDataService {
+  private store: Record<string, MockUserDataStoreValue> = {};
+
+  getObjectValue(key: string): MockUserDataStoreValue {
+    return this.store[key];
+  }
+
+  persistValue(key: string, data: MockUserDataStoreValue): void {
+    this.store[key] = data;
+  }
+}
+
+const getService = (): UserDataService =>
+  new MockUserDataService() as unknown as UserDataService;
+
+describe('LegendQueryUserDataHelper', () => {
+  describe('Recently used query functionality', () => {
+    it('should save and retrieve a recently viewed query', () => {
+      const queryId = 'some-query-id-1234';
+
+      const userDataService = getService();
+      LegendQueryUserDataHelper.addRecentlyViewedQuery(
+        userDataService,
+        queryId,
+      );
+
+      const expected = [queryId];
+
+      expect(expected).toEqual(
+        LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
+      );
+    });
+
+    it('should delete a saved query', () => {
+      const queryId = 'some-query-id-1234';
+      const queryId2 = 'some-query-id2-5678';
+
+      const userDataService = getService();
+      LegendQueryUserDataHelper.addRecentlyViewedQuery(
+        userDataService,
+        queryId,
+      );
+      LegendQueryUserDataHelper.addRecentlyViewedQuery(
+        userDataService,
+        queryId2,
+      );
+
+      expect([queryId2, queryId]).toEqual(
+        LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
+      );
+
+      LegendQueryUserDataHelper.removeRecentlyViewedQuery(
+        userDataService,
+        queryId,
+      );
+
+      const expected = [queryId2];
+
+      expect(expected).toEqual(
+        LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
+      );
+    });
+
+    it('should delete all saved queries', () => {
+      const queryId = 'some-query-id-1234';
+      const queryId2 = 'some-query-id2-5678';
+
+      const userDataService = getService();
+      LegendQueryUserDataHelper.addRecentlyViewedQuery(
+        userDataService,
+        queryId,
+      );
+      LegendQueryUserDataHelper.addRecentlyViewedQuery(
+        userDataService,
+        queryId2,
+      );
+
+      LegendQueryUserDataHelper.removeRecentlyViewedQueries(userDataService);
+
+      expect([]).toEqual(
+        LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService),
+      );
+    });
+
+    it(`should maintain a list of ${USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT} saved queries`, () => {
+      const userDataService = getService();
+
+      for (let i = 0; i < USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT + 2; i++) {
+        const queryId = `some-query-id-${i}`;
+
+        LegendQueryUserDataHelper.addRecentlyViewedQuery(
+          userDataService,
+          queryId,
+        );
+      }
+
+      expect(
+        LegendQueryUserDataHelper.getRecentlyViewedQueries(userDataService)
+          .length,
+      ).toBe(USER_DATA_RECENTLY_VIEWED_QUERIES_LIMIT);
+    });
+  });
+
+  describe('Recently queried dataspaces', () => {
+    it('should save and retrieve a recently queried dataspace', () => {
+      const dataspace = 'extensions/dataspace/some-dataspace:test-demo:latest';
+      const dataspace2 =
+        'extensions/dataspace/some-dataspace:test-demo-2:latest';
+      const dataspace3 =
+        'extensions/dataspace/some-dataspace:test-demo-3:latest';
+
+      const userDataService = getService();
+      LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+        userDataService,
+        dataspace,
+      );
+      LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+        userDataService,
+        dataspace2,
+      );
+      LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+        userDataService,
+        dataspace3,
+      );
+
+      const expected = [dataspace3, dataspace2, dataspace];
+
+      expect(expected).toEqual(
+        LegendQueryUserDataHelper.getRecentlyQueriedDataspaceList(
+          userDataService,
+        ),
+      );
+    });
+
+    it('should retrieve the most recent queried dataspace', () => {
+      const dataspace = 'extensions/dataspace/some-dataspace:test-demo:latest';
+      const dataspace2 =
+        'extensions/dataspace/some-dataspace:test-demo-2:latest';
+      const dataspace3 =
+        'extensions/dataspace/some-dataspace:test-demo-3:latest';
+
+      const userDataService = getService();
+      LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+        userDataService,
+        dataspace,
+      );
+      LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+        userDataService,
+        dataspace2,
+      );
+      LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+        userDataService,
+        dataspace3,
+      );
+
+      const expected = dataspace3;
+
+      expect(expected).toEqual(
+        LegendQueryUserDataHelper.getRecentlyQueriedDataspace(userDataService),
+      );
+    });
+
+    it(`should maintain a list of ${USER_DATA_QUERY_DATASPACE_LIMIT} saved dataspace`, () => {
+      const userDataService = getService();
+
+      for (let i = 0; i < USER_DATA_QUERY_DATASPACE_LIMIT + 2; i++) {
+        const dataspace = `extensions/dataspace/some-dataspace-${i}:test-demo:latest`;
+
+        LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+          userDataService,
+          dataspace,
+        );
+      }
+
+      expect(
+        LegendQueryUserDataHelper.getRecentlyQueriedDataspaceList(
+          userDataService,
+        ).length,
+      ).toBe(USER_DATA_QUERY_DATASPACE_LIMIT);
+    });
+  });
+});

--- a/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
+++ b/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
@@ -34,6 +34,11 @@ import { LegendQueryUserDataHelper } from '../../__lib__/LegendQueryUserDataHelp
 
 import { QueryEditor } from '../QueryEditor.js';
 
+type LocationData = {
+  pathname: string;
+  search: string;
+}
+
 const DataSpaceQueryCreatorStoreProvider: React.FC<{
   children: React.ReactNode;
   gav: string;
@@ -87,10 +92,7 @@ export const DataSpaceQueryCreator = observer(() => {
     applicationStore.navigationService.navigator.getCurrentLocationParameterValue(
       DATA_SPACE_QUERY_CREATOR_QUERY_PARAM_TOKEN.CLASS_PATH,
     );
-  const { pathname, search } = useLocation<{
-    pathname: string;
-    search: string;
-  }>();
+  const { pathname, search } = useLocation() as LocationData;
 
   useEffect(() => {
     LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(

--- a/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
+++ b/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
@@ -30,6 +30,8 @@ import {
   DATA_SPACE_QUERY_CREATOR_ROUTE_PATTERN_TOKEN,
   type DataSpaceQueryCreatorPathParams,
 } from '../../__lib__/DSL_DataSpace_LegendQueryNavigation.js';
+import { LegendQueryUserDataHelper } from '../../__lib__/LegendQueryUserDataHelper.js';
+
 import { QueryEditor } from '../QueryEditor.js';
 
 const DataSpaceQueryCreatorStoreProvider: React.FC<{
@@ -71,8 +73,6 @@ const DataSpaceQueryCreatorStoreProvider: React.FC<{
   );
 };
 
-export const LAST_QUERY_DATASPACE_KEY = 'last_query_dataspace';
-
 export const DataSpaceQueryCreator = observer(() => {
   const applicationStore = useApplicationStore();
   const parameters = useParams<DataSpaceQueryCreatorPathParams>();
@@ -93,8 +93,8 @@ export const DataSpaceQueryCreator = observer(() => {
   }>();
 
   useEffect(() => {
-    applicationStore.userDataService.persistValue(
-      LAST_QUERY_DATASPACE_KEY,
+    LegendQueryUserDataHelper.saveRecentlyQueriedDataspace(
+      applicationStore.userDataService,
       `${pathname}${search}`,
     );
   }, [pathname, search, applicationStore.userDataService]);

--- a/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
+++ b/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
@@ -16,8 +16,9 @@
 
 import { observer, useLocalObservable } from 'mobx-react-lite';
 import { useApplicationStore } from '@finos/legend-application';
-import { useParams } from '@finos/legend-application/browser';
+import { useParams, useLocation } from '@finos/legend-application/browser';
 import { parseGAVCoordinates } from '@finos/legend-storage';
+import { useEffect } from 'react';
 import {
   useLegendQueryApplicationStore,
   useLegendQueryBaseStore,
@@ -70,6 +71,8 @@ const DataSpaceQueryCreatorStoreProvider: React.FC<{
   );
 };
 
+export const LAST_QUERY_DATASPACE_KEY = 'last_query_dataspace';
+
 export const DataSpaceQueryCreator = observer(() => {
   const applicationStore = useApplicationStore();
   const parameters = useParams<DataSpaceQueryCreatorPathParams>();
@@ -84,6 +87,17 @@ export const DataSpaceQueryCreator = observer(() => {
     applicationStore.navigationService.navigator.getCurrentLocationParameterValue(
       DATA_SPACE_QUERY_CREATOR_QUERY_PARAM_TOKEN.CLASS_PATH,
     );
+  const { pathname, search } = useLocation<{
+    pathname: string;
+    search: string;
+  }>();
+
+  useEffect(() => {
+    applicationStore.userDataService.persistValue(
+      LAST_QUERY_DATASPACE_KEY,
+      `${pathname}${search}`,
+    );
+  }, [pathname, search, applicationStore.userDataService]);
 
   return (
     <DataSpaceQueryCreatorStoreProvider

--- a/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
+++ b/packages/legend-application-query/src/components/data-space/DataSpaceQueryCreator.tsx
@@ -37,7 +37,7 @@ import { QueryEditor } from '../QueryEditor.js';
 type LocationData = {
   pathname: string;
   search: string;
-}
+};
 
 const DataSpaceQueryCreatorStoreProvider: React.FC<{
   children: React.ReactNode;

--- a/packages/legend-application-query/src/components/data-space/DataSpaceQuerySetup.tsx
+++ b/packages/legend-application-query/src/components/data-space/DataSpaceQuerySetup.tsx
@@ -42,7 +42,7 @@ import {
   formatDataSpaceOptionLabel,
   type DataSpaceOption,
 } from '@finos/legend-extension-dsl-data-space/application-query';
-import { LAST_QUERY_DATASPACE_KEY } from './DataSpaceQueryCreator.js';
+import { LegendQueryUserDataHelper } from '../../__lib__/LegendQueryUserDataHelper.js';
 
 const DataSpaceQuerySetupStoreProvider: React.FC<{
   children: React.ReactNode;
@@ -67,7 +67,9 @@ export const DataSpaceQuerySetup = observer(() => {
   const applicationStore = useLegendQueryApplicationStore();
 
   const lastSavedQueryDataspace =
-    applicationStore.userDataService.getStringValue(LAST_QUERY_DATASPACE_KEY);
+    LegendQueryUserDataHelper.getRecentlyQueriedDataspace(
+      applicationStore.userDataService,
+    );
 
   if (lastSavedQueryDataspace) {
     applicationStore.navigationService.navigator.goToLocation(

--- a/packages/legend-application-query/src/components/data-space/DataSpaceQuerySetup.tsx
+++ b/packages/legend-application-query/src/components/data-space/DataSpaceQuerySetup.tsx
@@ -42,6 +42,7 @@ import {
   formatDataSpaceOptionLabel,
   type DataSpaceOption,
 } from '@finos/legend-extension-dsl-data-space/application-query';
+import { LAST_QUERY_DATASPACE_KEY } from './DataSpaceQueryCreator.js';
 
 const DataSpaceQuerySetupStoreProvider: React.FC<{
   children: React.ReactNode;
@@ -62,11 +63,26 @@ const DataSpaceQuerySetupStoreProvider: React.FC<{
   );
 };
 
-export const DataSpaceQuerySetup = observer(() => (
-  <DataSpaceQuerySetupStoreProvider>
-    <QueryEditor />
-  </DataSpaceQuerySetupStoreProvider>
-));
+export const DataSpaceQuerySetup = observer(() => {
+  const applicationStore = useLegendQueryApplicationStore();
+
+  const lastSavedQueryDataspace =
+    applicationStore.userDataService.getStringValue(LAST_QUERY_DATASPACE_KEY);
+
+  if (lastSavedQueryDataspace) {
+    applicationStore.navigationService.navigator.goToLocation(
+      lastSavedQueryDataspace,
+    );
+
+    return null;
+  }
+
+  return (
+    <DataSpaceQuerySetupStoreProvider>
+      <QueryEditor />
+    </DataSpaceQuerySetupStoreProvider>
+  );
+});
 
 /**
  * This setup panel supports cascading in order: Data-space -> Execution context (-> Runtime) -> Class

--- a/packages/legend-application/src/stores/navigation/BrowserNavigator.ts
+++ b/packages/legend-application/src/stores/navigation/BrowserNavigator.ts
@@ -43,7 +43,15 @@ import {
 } from 'react-router';
 
 export { BrowserRouter } from 'react-router-dom';
-export { Route, Switch, Redirect, useParams, matchPath, generatePath };
+export {
+  Route,
+  Switch,
+  Redirect,
+  useParams,
+  matchPath,
+  generatePath,
+  useLocation,
+};
 export const useNavigationZone = (): NavigationZone => {
   const location = useLocation() as { hash: string }; // TODO: this is a temporary hack until we upgrade react-router
   return location.hash.substring(NAVIGATION_ZONE_PREFIX.length);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
This PR adds a feature that allows legend query to default to last dataspace/class used when opening up new query from dataspace

## How did you test this change?

- [X] Test(s) added
- [X] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
