### PR TITLE
Display 10 default queries when there is no recently reviewed query

### DIFF
--- a/.changeset/calm-llamas-relax.md
+++ b/.changeset/calm-llamas-relax.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Display 10 default queries when there is no recently reivewed query

--- a/.changeset/spicy-scissors-add.md
+++ b/.changeset/spicy-scissors-add.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query-bootstrap': patch
+'@finos/legend-application-query': patch
+'@finos/legend-query-builder': patch
+---

--- a/packages/legend-application-query-bootstrap/style/index.scss
+++ b/packages/legend-application-query-bootstrap/style/index.scss
@@ -520,6 +520,15 @@
     &__dialog__header__close-btn {
       color: var(--color-legacylight-dark-grey-200);
     }
+
+    ::-webkit-scrollbar-thumb {
+      height: 5rem;
+      background: var(--color-legacylight-light-grey-300);
+      outline-offset: -0.2rem;
+      border-radius: 0.4rem;
+      outline-color: var(--color-legacylight-light-grey-100);
+      border-color: var(--color-legacylight-light-grey-100);
+    }
   }
 
   .query-preview__field__label {

--- a/packages/legend-application-query/src/stores/QueryEditorStore.ts
+++ b/packages/legend-application-query/src/stores/QueryEditorStore.ts
@@ -78,7 +78,6 @@ import {
   type Entity,
   type ProjectGAVCoordinates,
   type EntitiesWithOrigin,
-  parseProjectIdentifier,
   parseGACoordinates,
 } from '@finos/legend-storage';
 import {

--- a/packages/legend-application-query/src/stores/data-space/DataSpaceQueryCreatorStore.ts
+++ b/packages/legend-application-query/src/stores/data-space/DataSpaceQueryCreatorStore.ts
@@ -20,6 +20,8 @@ import {
   RuntimePointer,
   PackageableElementExplicitReference,
   type RawLambda,
+  QueryProjectCoordinates,
+  QuerySearchSpecification,
 } from '@finos/legend-graph';
 import {
   type DepotServerClient,
@@ -39,7 +41,11 @@ import {
   QueryBuilderDataBrowserWorkflow,
   type QueryBuilderState,
 } from '@finos/legend-query-builder';
-import type { Entity, ProjectGAVCoordinates } from '@finos/legend-storage';
+import {
+  parseGACoordinates,
+  type Entity,
+  type ProjectGAVCoordinates,
+} from '@finos/legend-storage';
 import {
   type DataSpaceExecutionContext,
   DSL_DataSpace_getGraphManagerExtension,
@@ -55,6 +61,7 @@ import type { LegendQueryApplicationStore } from '../LegendQueryBaseStore.js';
 import {
   DataSpaceQueryBuilderState,
   createQueryClassTaggedValue,
+  createQueryDataSpaceTaggedValue,
   type DataSpaceInfo,
 } from '@finos/legend-extension-dsl-data-space/application';
 import { LegendQueryUserDataHelper } from '../../__lib__/LegendQueryUserDataHelper.js';
@@ -470,5 +477,35 @@ export class DataSpaceQueryCreatorStore extends QueryEditorStore {
         ),
       );
     }
+  }
+
+  override decorateSearchSpecification(
+    val: QuerySearchSpecification,
+  ): QuerySearchSpecification {
+    if (this.queryableDataSpace) {
+      const currentProjectCoordinates = new QueryProjectCoordinates();
+      currentProjectCoordinates.groupId = this.queryableDataSpace.groupId;
+      currentProjectCoordinates.artifactId = this.queryableDataSpace.artifactId;
+      val.projectCoordinates = [
+        // either get queries for the current project
+        currentProjectCoordinates,
+        // or any of its dependencies
+        ...Array.from(
+          this.graphManagerState.graph.dependencyManager.projectDependencyModelsIndex.keys(),
+        ).map((dependencyKey) => {
+          const { groupId, artifactId } = parseGACoordinates(dependencyKey);
+          const coordinates = new QueryProjectCoordinates();
+          coordinates.groupId = groupId;
+          coordinates.artifactId = artifactId;
+          return coordinates;
+        }),
+      ];
+      val.taggedValues = [
+        createQueryDataSpaceTaggedValue(this.queryableDataSpace.dataSpacePath),
+      ];
+      val.combineTaggedValuesCondition = true;
+    }
+
+    return val;
   }
 }

--- a/packages/legend-application-query/src/stores/data-space/DataSpaceQueryCreatorStore.ts
+++ b/packages/legend-application-query/src/stores/data-space/DataSpaceQueryCreatorStore.ts
@@ -16,12 +16,12 @@
 
 import {
   type Query,
+  type QuerySearchSpecification,
+  type RawLambda,
   extractElementNameFromPath,
   RuntimePointer,
   PackageableElementExplicitReference,
-  type RawLambda,
   QueryProjectCoordinates,
-  QuerySearchSpecification,
 } from '@finos/legend-graph';
 import {
   type DepotServerClient,

--- a/packages/legend-query-builder/src/stores/QueryLoaderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryLoaderState.ts
@@ -43,6 +43,7 @@ import type {
 } from './QueryBuilder_LegendApplicationPlugin_Extension.js';
 
 export const QUERY_LOADER_TYPEAHEAD_SEARCH_LIMIT = 50;
+export const QUERY_LOADER_DEFAULT_QUERY_SEARCH_LIMIT = 10;
 
 export class QueryLoaderState {
   readonly applicationStore: GenericLegendApplicationStore;

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -64,7 +64,7 @@
     padding: 0 0.2rem;
     background: var(--color-dark-grey-200);
     border-radius: 0.2rem;
-    max-width: 60%;
+    max-width: 50%;
   }
 
   &__header__status {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Display 10 default queries when there is no recently reviewed query

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
