### PR TITLE
Fix duplicate point zero number in "is in list of" editor

### DIFF
--- a/.changeset/eleven-mugs-allow.md
+++ b/.changeset/eleven-mugs-allow.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Don't allow duplicate numbers by entering '.0' at the end of an existing integer in list

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -727,16 +727,26 @@ const PrimitiveCollectionInstanceValueEditor = observer(
     const convertInputValueToValueSpec = (): ValueSpecification | null => {
       const trimmedInputValue = inputValue.trim();
 
-      if (isValueAlreadySelected(trimmedInputValue)) {
-        return null;
-      }
-
       if (trimmedInputValue.length) {
-        return convertTextToPrimitiveInstanceValue(
+        const newValueSpec = convertTextToPrimitiveInstanceValue(
           expectedType,
           trimmedInputValue,
           observerContext,
         );
+
+        if (
+          newValueSpec === null ||
+          getValueSpecificationStringValue(newValueSpec) === undefined ||
+          isValueAlreadySelected(
+            guaranteeNonNullable(
+              getValueSpecificationStringValue(newValueSpec),
+            ),
+          )
+        ) {
+          return null;
+        }
+
+        return newValueSpec;
       }
       return null;
     };

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -840,19 +840,20 @@ const PrimitiveCollectionInstanceValueEditor = observer(
       if (!parsedData) {
         return;
       }
-      const newValues = uniq(parsedData)
-        .map((value) => {
-          const newValueSpec = convertTextToPrimitiveInstanceValue(
-            expectedType,
-            value,
-            observerContext,
-          );
-          return newValueSpec
-            ? getValueSpecificationStringValue(newValueSpec)
-            : null;
-        })
-        .filter(isNonNullable)
-        .filter((value) => !isValueAlreadySelected(value));
+      const newValues = uniq(
+        uniq(parsedData)
+          .map((value) => {
+            const newValueSpec = convertTextToPrimitiveInstanceValue(
+              expectedType,
+              value,
+              observerContext,
+            );
+            return newValueSpec
+              ? getValueSpecificationStringValue(newValueSpec)
+              : null;
+          })
+          .filter(isNonNullable),
+      ).filter((value) => !isValueAlreadySelected(value));
       setSelectedOptions([
         ...selectedOptions,
         ...newValues.map((value) => ({ label: value, value })),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Currently, the user can create an "is in list of" editor for a number type and type "15" and then "15.0" and it will create a list with 2 elements of "15" (i.e., a list with duplicate elements). The user should not be able to have duplicate elements in the list editor, so "15.0" should be treated the same as "15" and not be allowed if the list already has "15".

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Typing duplicate numeric input:
![TypingInput](https://github.com/finos/legend-studio/assets/9127428/b25648c2-164c-4a1c-b4fd-a21392c9d6d4)

Pasting duplicate numeric input:
![PastingInput](https://github.com/finos/legend-studio/assets/9127428/d61889cc-a06e-4e2d-afec-515b2c68a1a1)
