### PR TITLE
Fix explorer tree is not showing all properties while scrolling

### DIFF
--- a/.changeset/silver-dryers-play.md
+++ b/.changeset/silver-dryers-play.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-extension-dsl-data-space': patch
+'@finos/legend-query-builder': patch
+---
+
+Fix explorer tree is not showing all properties while scrolling

--- a/packages/legend-extension-dsl-data-space/style/_data-space-query-plugin.scss
+++ b/packages/legend-extension-dsl-data-space/style/_data-space-query-plugin.scss
@@ -42,6 +42,7 @@
 
     .query-builder__side-bar__content {
       height: 100%;
+      overflow: auto;
     }
   }
 

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -671,6 +671,7 @@
 
   &__content {
     height: 100%;
+    overflow: auto;
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Fix explorer tree is not showing all properties while scrolling

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
