### PR TITLE
Query builder/editor require user confirmation when losing changes

### DIFF
--- a/.changeset/early-falcons-change.md
+++ b/.changeset/early-falcons-change.md
@@ -1,0 +1,8 @@
+---
+'@finos/legend-extension-dsl-service': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-application-query': patch
+'@finos/legend-query-builder': patch
+---
+
+Alert on all unsaved changes, not just using change detection state

--- a/packages/legend-application-query/src/components/Core_LegendQueryApplicationPlugin.tsx
+++ b/packages/legend-application-query/src/components/Core_LegendQueryApplicationPlugin.tsx
@@ -537,10 +537,7 @@ export class Core_LegendQueryApplicationPlugin extends LegendQueryApplicationPlu
                   }
                 }
               } else {
-                if (
-                  queryBuilderState.changeHistoryState.canUndo ||
-                  queryBuilderState.changeHistoryState.canRedo
-                ) {
+                if (queryBuilderState.isUnsavedQueryWithChanges) {
                   queryBuilderState.applicationStore.alertService.setActionAlertInfo(
                     {
                       message:

--- a/packages/legend-application-query/src/components/Core_LegendQueryApplicationPlugin.tsx
+++ b/packages/legend-application-query/src/components/Core_LegendQueryApplicationPlugin.tsx
@@ -317,7 +317,7 @@ export class Core_LegendQueryApplicationPlugin extends LegendQueryApplicationPlu
                 }
               };
 
-            queryBuilderState.changeDetectionState.alertUnsavedChanges(() => {
+            queryBuilderState.alertUnsavedChanges(() => {
               proceedCuratedTemplateQueryPromotion().catch(
                 editorStore.applicationStore.alertUnhandledError,
               );

--- a/packages/legend-application-query/src/stores/QueryEditorStore.ts
+++ b/packages/legend-application-query/src/stores/QueryEditorStore.ts
@@ -300,15 +300,13 @@ export abstract class QueryEditorStore {
       this.graphManagerState,
       {
         loadQuery: (query: LightQuery): void => {
-          this.queryBuilderState?.changeDetectionState.alertUnsavedChanges(
-            () => {
-              this.queryLoaderState.setQueryLoaderDialogOpen(false);
-              applicationStore.navigationService.navigator.goToLocation(
-                generateExistingQueryEditorRoute(query.id),
-                { ignoreBlocking: true },
-              );
-            },
-          );
+          this.queryBuilderState?.alertUnsavedChanges(() => {
+            this.queryLoaderState.setQueryLoaderDialogOpen(false);
+            applicationStore.navigationService.navigator.goToLocation(
+              generateExistingQueryEditorRoute(query.id),
+              { ignoreBlocking: true },
+            );
+          });
         },
         fetchDefaultQueries: async (): Promise<LightQuery[]> => {
           const recentReviewedQueries =

--- a/packages/legend-application-query/src/stores/data-space/DataSpaceQueryCreatorStore.ts
+++ b/packages/legend-application-query/src/stores/data-space/DataSpaceQueryCreatorStore.ts
@@ -334,9 +334,11 @@ export class DataSpaceQueryCreatorStore extends QueryEditorStore {
           hasDataSpaceInfoBeenVisited(dataSpaceInfo, visitedDataSpaces),
       ),
       (dataSpaceInfo: DataSpaceInfo) => {
-        flowResult(this.changeDataSpace(dataSpaceInfo)).catch(
-          this.applicationStore.alertUnhandledError,
-        );
+        queryBuilderState.alertUnsavedChanges(() => {
+          flowResult(this.changeDataSpace(dataSpaceInfo)).catch(
+            this.applicationStore.alertUnhandledError,
+          );
+        });
       },
       dataSpaceAnalysisResult,
       (ec: DataSpaceExecutionContext) => {

--- a/packages/legend-application-studio/src/components/editor/EmbeddedQueryBuilder.tsx
+++ b/packages/legend-application-studio/src/components/editor/EmbeddedQueryBuilder.tsx
@@ -53,7 +53,7 @@ const QueryBuilderDialog = observer(
     const toggleMaximize = (): void => setIsMaximized(!isMaximized);
 
     const confirmCloseQueryBuilder = (): void => {
-      queryBuilderState.changeDetectionState.alertUnsavedChanges((): void => {
+      queryBuilderState.alertUnsavedChanges((): void => {
         flowResult(
           embeddedQueryBuilderState.setEmbeddedQueryBuilderConfiguration(
             undefined,

--- a/packages/legend-extension-dsl-service/src/components/query/DSL_Service_LegendQueryApplicationPlugin.tsx
+++ b/packages/legend-extension-dsl-service/src/components/query/DSL_Service_LegendQueryApplicationPlugin.tsx
@@ -81,7 +81,7 @@ export class DSL_Service_LegendQueryApplicationPlugin extends LegendQueryApplica
               }
             };
 
-            queryBuilderState.changeDetectionState.alertUnsavedChanges(() => {
+            queryBuilderState.alertUnsavedChanges(() => {
               openQueryProductionizer().catch(
                 editorStore.applicationStore.alertUnhandledError,
               );

--- a/packages/legend-query-builder/src/components/QueryBuilderNavigationBlocker.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderNavigationBlocker.tsx
@@ -30,7 +30,11 @@ export const QueryBuilderNavigationBlocker = observer(
 
     useEffect(() => {
       applicationStore.navigationService.navigator.blockNavigation(
-        [(): boolean => queryBuilderState.changeDetectionState.hasChanged],
+        [
+          (): boolean =>
+            queryBuilderState.changeDetectionState.hasChanged ||
+            queryBuilderState.isUnsavedQueryWithChanges,
+        ],
         (onProceed: () => void): void => {
           applicationStore.alertService.setActionAlertInfo({
             message:

--- a/packages/legend-query-builder/src/components/QueryBuilderSideBar.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderSideBar.tsx
@@ -125,8 +125,10 @@ export const QueryBuilderClassSelector = observer(
       if (val.value === queryBuilderState.class) {
         return;
       }
-      queryBuilderState.changeClass(val.value);
-      onClassChange?.(val.value);
+      queryBuilderState.alertUnsavedChanges(() => {
+        queryBuilderState.changeClass(val.value);
+        onClassChange?.(val.value);
+      });
     };
 
     return (

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
@@ -71,7 +71,7 @@ import { QueryBuilderGraphFetchTreeState } from '../../stores/fetch-structure/gr
 import {
   TEST__setUpQueryBuilder,
   dragAndDrop,
-  selectFromCustomSelectorInput,
+  selectFirstOptionFromCustomSelectorInput,
 } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
 import { FETCH_STRUCTURE_IMPLEMENTATION } from '../../stores/fetch-structure/QueryBuilderFetchStructureImplementationState.js';
 import { COLUMN_SORT_TYPE } from '../../graph/QueryBuilderMetaModelConst.js';
@@ -1970,7 +1970,7 @@ test(
     const entityContainer = guaranteeNonNullable(
       renderResult.getByText('Entity').parentElement,
     );
-    selectFromCustomSelectorInput(entityContainer, 'Product');
+    selectFirstOptionFromCustomSelectorInput(entityContainer);
 
     // check for modal
     expect(

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderSetupPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderSetupPanel.test.tsx
@@ -28,7 +28,7 @@ import { TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational } from '../../
 import { TEST_DATA__simpleProjectionWithConstantsAndParameters } from '../../stores/__tests__/TEST_DATA__QueryBuilder_Generic.js';
 import {
   TEST__setUpQueryBuilder,
-  selectFromCustomSelectorInput,
+  selectFirstOptionFromCustomSelectorInput,
 } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
 import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
 import { guaranteeNonNullable } from '@finos/legend-shared';
@@ -62,22 +62,13 @@ test(
     const entitySelectorContainer = guaranteeNonNullable(
       await waitFor(() => getByText(queryBuilderSetup, 'Entity').parentElement),
     );
-    // select FirmExtension from dropdown
-    selectFromCustomSelectorInput(
-      entitySelectorContainer,
-      'FirmExtensionmodel::pure::tests::model::simple::FirmExtension',
-    );
-    await waitFor(() => getByText(queryBuilderSetup, 'FirmExtension'));
-    // select synonym from dropdown
-    selectFromCustomSelectorInput(
-      entitySelectorContainer,
-      'Synonymmodel::pure::tests::model::simple::Synonym',
-    );
-    await waitFor(() => getByText(queryBuilderSetup, 'Synonym'));
+    // select entity from dropdown
+    selectFirstOptionFromCustomSelectorInput(entitySelectorContainer);
+    await waitFor(() => getByText(queryBuilderSetup, 'Account'));
     const queryBuilderExplorerTree = await waitFor(() =>
       renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_EXPLORER),
     );
-    await waitFor(() => getByText(queryBuilderExplorerTree, 'Synonym'));
+    await waitFor(() => getByText(queryBuilderExplorerTree, 'Account'));
   },
   50000,
 );

--- a/packages/legend-query-builder/src/index.ts
+++ b/packages/legend-query-builder/src/index.ts
@@ -21,7 +21,10 @@ export * from './__lib__/QueryBuilderEvent.js';
 export { QueryBuilder_GraphManagerPreset } from './graph-manager/QueryBuilder_GraphManagerPreset.js';
 export { QueryBuilderConfig } from './graph-manager/QueryBuilderConfig.js';
 export { QUERY_BUILDER_TEST_ID } from './__lib__/QueryBuilderTesting.js';
-export { dragAndDrop } from './components/__test-utils__/QueryBuilderComponentTestUtils.js';
+export {
+  dragAndDrop,
+  selectFirstOptionFromCustomSelectorInput,
+} from './components/__test-utils__/QueryBuilderComponentTestUtils.js';
 export {
   type CheckEntitlementEditorRender,
   QueryBuilder_LegendApplicationPlugin,

--- a/packages/legend-query-builder/src/stores/QueryBuilderChangeDetectionState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderChangeDetectionState.ts
@@ -146,31 +146,4 @@ export class QueryBuilderChangeDetectionState {
     this.querySnapshot = initialQuery;
     this.initState.complete();
   }
-
-  alertUnsavedChanges(onProceed: () => void): void {
-    if (this.hasChanged) {
-      this.querybuilderState.applicationStore.alertService.setActionAlertInfo({
-        message:
-          'Unsaved changes will be lost if you continue. Do you still want to proceed?',
-        type: ActionAlertType.CAUTION,
-        actions: [
-          {
-            label: 'Proceed',
-            type: ActionAlertActionType.PROCEED_WITH_CAUTION,
-            handler:
-              this.querybuilderState.applicationStore.guardUnhandledError(
-                async () => onProceed(),
-              ),
-          },
-          {
-            label: 'Abort',
-            type: ActionAlertActionType.PROCEED,
-            default: true,
-          },
-        ],
-      });
-    } else {
-      onProceed();
-    }
-  }
 }

--- a/packages/legend-query-builder/src/stores/QueryBuilderChangeDetectionState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderChangeDetectionState.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import {
-  ActionAlertActionType,
-  ActionAlertType,
-} from '@finos/legend-application';
 import type { RawLambda } from '@finos/legend-graph';
 import {
   ActionState,

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -838,7 +838,8 @@ export abstract class QueryBuilderState implements CommandRegistrar {
       (this.changeHistoryState.canRedo ||
         this.changeHistoryState.canUndo ||
         !this.filterState.isEmpty ||
-        !this.fetchStructureState.implementation.isFilterEmpty)
+        !this.fetchStructureState.implementation.isFilterEmpty ||
+        !this.constantState.isEmpty)
     );
   }
 

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -48,6 +48,10 @@ import {
 } from './QueryBuilderStateBuilder.js';
 import { QueryBuilderUnsupportedQueryState } from './QueryBuilderUnsupportedQueryState.js';
 import {
+  ExistingQueryEditorStore,
+  QueryBuilderActionConfig_QueryApplication,
+} from '@finos/legend-application-query';
+import {
   type Class,
   type Mapping,
   type Runtime,
@@ -833,7 +837,10 @@ export abstract class QueryBuilderState implements CommandRegistrar {
 
   get isUnsavedQueryWithChanges(): boolean {
     return (
-      this.changeDetectionState.hashCodeSnapshot === undefined &&
+      this.workflowState.actionConfig instanceof
+        QueryBuilderActionConfig_QueryApplication &&
+      this.workflowState.actionConfig.editorStore instanceof
+        ExistingQueryEditorStore &&
       (this.changeHistoryState.canRedo ||
         this.changeHistoryState.canUndo ||
         !this.filterState.isEmpty ||
@@ -842,7 +849,6 @@ export abstract class QueryBuilderState implements CommandRegistrar {
   }
 
   alertUnsavedChanges(onProceed: () => void): void {
-    console.log('this.hasChanged?', this.changeDetectionState.hasChanged);
     if (
       this.changeDetectionState.hasChanged ||
       this.isUnsavedQueryWithChanges

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -48,10 +48,6 @@ import {
 } from './QueryBuilderStateBuilder.js';
 import { QueryBuilderUnsupportedQueryState } from './QueryBuilderUnsupportedQueryState.js';
 import {
-  ExistingQueryEditorStore,
-  QueryBuilderActionConfig_QueryApplication,
-} from '@finos/legend-application-query';
-import {
   type Class,
   type Mapping,
   type Runtime,
@@ -493,6 +489,7 @@ export abstract class QueryBuilderState implements CommandRegistrar {
     this.filterState = new QueryBuilderFilterState(this, this.filterOperators);
     this.watermarkState = new QueryBuilderWatermarkState(this);
     this.checkEntitlementsState = new QueryBuilderCheckEntitlementsState(this);
+    this.changeHistoryState = new QueryBuilderChangeHistoryState(this);
     this.isCalendarEnabled = false;
 
     const currentFetchStructureImplementationType =
@@ -837,10 +834,7 @@ export abstract class QueryBuilderState implements CommandRegistrar {
 
   get isUnsavedQueryWithChanges(): boolean {
     return (
-      this.workflowState.actionConfig instanceof
-        QueryBuilderActionConfig_QueryApplication &&
-      this.workflowState.actionConfig.editorStore instanceof
-        ExistingQueryEditorStore &&
+      this.changeDetectionState.hashCodeSnapshot === undefined &&
       (this.changeHistoryState.canRedo ||
         this.changeHistoryState.canUndo ||
         !this.filterState.isEmpty ||

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -471,7 +471,9 @@ export abstract class QueryBuilderState implements CommandRegistrar {
     this.resultState = resultState;
   }
 
-  resetQueryContent(): void {
+  resetQueryContent(options?: {
+    preserveChangeHistoryState?: boolean | undefined;
+  }): void {
     this.textEditorState = new QueryBuilderTextEditorState(this);
     this.unsupportedQueryState = new QueryBuilderUnsupportedQueryState(this);
     this.milestoningState = new QueryBuilderMilestoningState(this);
@@ -489,7 +491,9 @@ export abstract class QueryBuilderState implements CommandRegistrar {
     this.filterState = new QueryBuilderFilterState(this, this.filterOperators);
     this.watermarkState = new QueryBuilderWatermarkState(this);
     this.checkEntitlementsState = new QueryBuilderCheckEntitlementsState(this);
-    this.changeHistoryState = new QueryBuilderChangeHistoryState(this);
+    if (!options?.preserveChangeHistoryState) {
+      this.changeHistoryState = new QueryBuilderChangeHistoryState(this);
+    }
     this.isCalendarEnabled = false;
 
     const currentFetchStructureImplementationType =
@@ -676,7 +680,7 @@ export abstract class QueryBuilderState implements CommandRegistrar {
         previousStateParameterValues = paramValues;
       }
       this.resetQueryResult({ preserveResult: options?.preserveResult });
-      this.resetQueryContent();
+      this.resetQueryContent({ preserveChangeHistoryState: true });
 
       if (!isStubbed_RawLambda(query)) {
         const valueSpec = observe_ValueSpecification(
@@ -712,7 +716,7 @@ export abstract class QueryBuilderState implements CommandRegistrar {
         error,
       );
       this.resetQueryResult({ preserveResult: options?.preserveResult });
-      this.resetQueryContent();
+      this.resetQueryContent({ preserveChangeHistoryState: true });
       this.unsupportedQueryState.setLambdaError(error);
       this.unsupportedQueryState.setRawLambda(query);
       this.setClass(undefined);

--- a/packages/legend-query-builder/src/stores/fetch-structure/QueryBuilderFetchStructureImplementationState.ts
+++ b/packages/legend-query-builder/src/stores/fetch-structure/QueryBuilderFetchStructureImplementationState.ts
@@ -77,6 +77,7 @@ export abstract class QueryBuilderFetchStructureImplementationState
   ): void;
   abstract initialize(): void;
   abstract initializeWithQuery(): void;
+  abstract get isFilterEmpty(): boolean;
   abstract get hasInvalidFilterValues(): boolean;
   abstract get hasInvalidDerivedPropertyParameters(): boolean;
   abstract get hashCode(): string;

--- a/packages/legend-query-builder/src/stores/fetch-structure/graph-fetch/QueryBuilderGraphFetchTreeState.ts
+++ b/packages/legend-query-builder/src/stores/fetch-structure/graph-fetch/QueryBuilderGraphFetchTreeState.ts
@@ -529,6 +529,10 @@ export class QueryBuilderGraphFetchTreeState
     );
   }
 
+  get isFilterEmpty(): boolean {
+    return false;
+  }
+
   get hasInvalidFilterValues(): boolean {
     return false;
   }

--- a/packages/legend-query-builder/src/stores/fetch-structure/tds/QueryBuilderTDSState.ts
+++ b/packages/legend-query-builder/src/stores/fetch-structure/tds/QueryBuilderTDSState.ts
@@ -824,6 +824,10 @@ export class QueryBuilderTDSState
     return Boolean(usedInProjection ?? usedInPostFilter);
   }
 
+  get isFilterEmpty(): boolean {
+    return this.postFilterState.isEmpty;
+  }
+
   get hasInvalidFilterValues(): boolean {
     return (
       this.postFilterState.hasInvalidFilterValues ||


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Prompt user for confirmation when they take an action that will cause loss of changes on a query:
- Changing data space
- Changing entity
- Creating new query
- Loading query

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
### Query builder
Warn after fetch structure change:
![QueryBuilder_FetchStructure_Warn](https://github.com/finos/legend-studio/assets/9127428/16bb2b13-4798-4065-b17d-3c39b03aa17f)

Warn after filter panel change:
![QueryBuilder_FilterPanel_Warn](https://github.com/finos/legend-studio/assets/9127428/4c4b3176-e7c9-4b87-9c90-a46701214b5a)

Warn after parameter creation:
![QueryBuilder_Parameter_Warn](https://github.com/finos/legend-studio/assets/9127428/a0549735-2102-4022-bf0e-dc3417b50c76)

Warn after constant creation:
![QueryBuilder_Constant_Warn](https://github.com/finos/legend-studio/assets/9127428/5523533b-fd52-44a5-af6a-4472b4714c71)

### Query editor (unsaved/new query)
Warn after fetch structure change:
![QueryEditor_FetchStructure_Warn](https://github.com/finos/legend-studio/assets/9127428/8758424e-e2be-433a-87f7-c5fdee508034)

Warn after filter panel change:
![QueryEditor_FilterPanel_Warn](https://github.com/finos/legend-studio/assets/9127428/bde10bcd-56b0-45c1-817b-301eab732418)

Warn after parameter creation:
![QueryEditor_Parameter_Warn](https://github.com/finos/legend-studio/assets/9127428/859127ff-d89d-47e1-931c-7a89bc11b129)

Warn after constant creation:
![QueryEditor_Constant_Warn](https://github.com/finos/legend-studio/assets/9127428/316b83a7-3206-4a61-8372-a31eb19675eb)

### Query editor (saved query)
Warn after fetch structure change:
![QueryEditor_SavedQuery_FetchStructure](https://github.com/finos/legend-studio/assets/9127428/17695dc9-822f-4053-bde6-1d232ab95b48)

No warning when no change:
![QueryEditor_SavedQuery_NoWarn](https://github.com/finos/legend-studio/assets/9127428/7faab1a9-94aa-42a9-9700-b499504227e0)