### PR TITLE
support default query url params

### DIFF
--- a/.changeset/bright-horses-wonder.md
+++ b/.changeset/bright-horses-wonder.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Support opening query with default url param values using the url query key `p:{param}`.

--- a/packages/legend-application-query/src/components/QueryEditorStoreProvider.tsx
+++ b/packages/legend-application-query/src/components/QueryEditorStoreProvider.tsx
@@ -36,7 +36,8 @@ export const QueryEditorStoreContext = createContext<
 export const ExistingQueryEditorStoreProvider: React.FC<{
   children: React.ReactNode;
   queryId: string;
-}> = ({ children, queryId }) => {
+  params: Record<string, string> | undefined;
+}> = ({ children, queryId, params }) => {
   const applicationStore = useLegendQueryApplicationStore();
   const baseStore = useLegendQueryBaseStore();
   const store = useLocalObservable(
@@ -45,6 +46,7 @@ export const ExistingQueryEditorStoreProvider: React.FC<{
         applicationStore,
         baseStore.depotServerClient,
         queryId,
+        params,
       ),
   );
   return (

--- a/packages/legend-application-query/src/components/__test-utils__/QueryEditorComponentTestUtils.tsx
+++ b/packages/legend-application-query/src/components/__test-utils__/QueryEditorComponentTestUtils.tsx
@@ -71,6 +71,7 @@ export const TEST__provideMockedQueryEditorStore = (customization?: {
         serverUrl: applicationStore.config.depotServerUrl,
       }),
       TEST_QUERY_ID,
+      undefined,
     );
   const MOCK__QueryEditorStoreProvider = require('../QueryEditorStoreProvider.js'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
   MOCK__QueryEditorStoreProvider.useQueryEditorStore = createMock();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
- support opening saved queries with defaulted param values such as `/edit/{queryID}?p:{savedQueryParam}={savedQueryParamValue}`
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
