### PR TITLE
Show zipkin trace id for query execution

### DIFF
--- a/.changeset/chilled-kiwis-explode.md
+++ b/.changeset/chilled-kiwis-explode.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Show zipkin trace id for query execution

--- a/.changeset/eleven-olives-float.md
+++ b/.changeset/eleven-olives-float.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/FunctionEditorState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/FunctionEditorState.ts
@@ -38,6 +38,9 @@ import { ElementEditorState } from './ElementEditorState.js';
 import {
   type CompilationError,
   type PackageableElement,
+  type ExecutionResult,
+  type RawExecutionPlan,
+  type ExecutionResultWithMetadata,
   GRAPH_MANAGER_EVENT,
   LAMBDA_PIPE,
   ParserError,
@@ -45,8 +48,6 @@ import {
   RawLambda,
   buildSourceInformationSourceId,
   isStubbed_PackageableElement,
-  type ExecutionResult,
-  type RawExecutionPlan,
   reportGraphAnalytics,
   buildLambdaVariableExpressions,
   VariableExpression,
@@ -255,7 +256,7 @@ export class FunctionEditorState extends ElementEditorState {
   executionResult?: ExecutionResult | undefined; // NOTE: stored as lossless JSON string
   executionPlanState: ExecutionPlanState;
   parametersState: FunctionParametersState;
-  funcRunPromise: Promise<ExecutionResult> | undefined = undefined;
+  funcRunPromise: Promise<ExecutionResultWithMetadata> | undefined = undefined;
 
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
@@ -388,7 +389,9 @@ export class FunctionEditorState extends ElementEditorState {
     this.executionResult = executionResult;
   };
 
-  setFuncRunPromise = (promise: Promise<ExecutionResult> | undefined): void => {
+  setFuncRunPromise = (
+    promise: Promise<ExecutionResultWithMetadata> | undefined,
+  ): void => {
     this.funcRunPromise = promise;
   };
 
@@ -536,9 +539,9 @@ export class FunctionEditorState extends ElementEditorState {
         report,
       );
       this.setFuncRunPromise(promise);
-      const result = (yield promise) as ExecutionResult;
+      const result = (yield promise) as ExecutionResultWithMetadata;
       if (this.funcRunPromise === promise) {
-        this.setExecutionResult(result);
+        this.setExecutionResult(result.executionResult);
         this.parametersState.setParameters([]);
         // report
         report.timings =

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/MappingExecutionState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/MappingExecutionState.ts
@@ -54,7 +54,6 @@ import {
   type DEPRECATED__InputData,
   type Mapping,
   type Connection,
-  type ExecutionResult,
   type SetImplementation,
   type Table,
   type View,
@@ -62,6 +61,7 @@ import {
   type RawExecutionPlan,
   type EmbeddedData,
   type TestAssertion,
+  type ExecutionResultWithMetadata,
   DEFAULT_TEST_ASSERTION_PREFIX,
   DEFAULT_TEST_PREFIX,
   EqualToJson,
@@ -499,7 +499,8 @@ export class MappingExecutionState extends MappingEditorTabState {
   isGeneratingPlan = false;
   executionPlanState: ExecutionPlanState;
   planGenerationDebugText?: string | undefined;
-  executionRunPromise: Promise<ExecutionResult> | undefined = undefined;
+  executionRunPromise: Promise<ExecutionResultWithMetadata> | undefined =
+    undefined;
 
   constructor(
     editorStore: EditorStore,
@@ -556,7 +557,9 @@ export class MappingExecutionState extends MappingEditorTabState {
     return this.name;
   }
 
-  setExecutionRunPromise(promise: Promise<ExecutionResult> | undefined): void {
+  setExecutionRunPromise(
+    promise: Promise<ExecutionResultWithMetadata> | undefined,
+  ): void {
     this.executionRunPromise = promise;
   }
 
@@ -817,10 +820,14 @@ export class MappingExecutionState extends MappingEditorTabState {
           report,
         );
         this.setExecutionRunPromise(promise);
-        const result = (yield promise) as ExecutionResult;
+        const result = (yield promise) as ExecutionResultWithMetadata;
         if (this.executionRunPromise === promise) {
           this.setExecutionResultText(
-            stringifyLosslessJSON(result, undefined, DEFAULT_TAB_SIZE),
+            stringifyLosslessJSON(
+              result.executionResult,
+              undefined,
+              DEFAULT_TAB_SIZE,
+            ),
           );
           // report
           report.timings =

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/legacy/DEPRECATED__MappingTestState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/legacy/DEPRECATED__MappingTestState.ts
@@ -48,7 +48,10 @@ import {
   type DEPRECATED__InputData,
   type DEPRECATED__MappingTestAssert,
   type Mapping,
+  type RawExecutionPlan,
+  type DEPRECATED__MappingTest,
   type ExecutionResult,
+  type ExecutionResultWithMetadata,
   extractExecutionResultValues,
   GRAPH_MANAGER_EVENT,
   LAMBDA_PIPE,
@@ -71,12 +74,10 @@ import {
   DefaultH2AuthenticationStrategy,
   buildSourceInformationSourceId,
   TableAlias,
-  type RawExecutionPlan,
   isStubbed_RawLambda,
   stub_Class,
   generateIdentifiedConnectionId,
   DEPRECATED__validate_MappingTest,
-  type DEPRECATED__MappingTest,
   ModelStore,
   reportGraphAnalytics,
 } from '@finos/legend-graph';
@@ -422,7 +423,7 @@ export class DEPRECATED__MappingTestState extends MappingEditorTabState {
   assertionState: MappingTestAssertionState;
   isGeneratingPlan = false;
   executionPlanState: ExecutionPlanState;
-  testRunPromise: Promise<ExecutionResult> | undefined = undefined;
+  testRunPromise: Promise<ExecutionResultWithMetadata> | undefined = undefined;
 
   constructor(
     editorStore: EditorStore,
@@ -491,7 +492,9 @@ export class DEPRECATED__MappingTestState extends MappingEditorTabState {
     this.selectedTab = val;
   }
 
-  setTestRunPromise(promise: Promise<ExecutionResult> | undefined): void {
+  setTestRunPromise(
+    promise: Promise<ExecutionResultWithMetadata> | undefined,
+  ): void {
     this.testRunPromise = promise;
   }
 
@@ -734,7 +737,7 @@ export class DEPRECATED__MappingTestState extends MappingEditorTabState {
 
   handleError(
     error: Error,
-    promise: Promise<ExecutionResult> | undefined,
+    promise: Promise<ExecutionResultWithMetadata> | undefined,
   ): void {
     assertErrorThrown(error);
     this.editorStore.applicationStore.logService.error(
@@ -808,9 +811,9 @@ export class DEPRECATED__MappingTestState extends MappingEditorTabState {
         },
       );
       this.setTestRunPromise(promise);
-      const result = (yield promise) as ExecutionResult;
+      const result = (yield promise) as ExecutionResultWithMetadata;
       if (this.testRunPromise === promise) {
-        this.handleResult(result);
+        this.handleResult(result.executionResult);
       }
     } catch (error) {
       // When user cancels the query by calling the cancelQuery api, it will throw an execution failure error.

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/service/ServiceExecutionState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/service/ServiceExecutionState.ts
@@ -35,11 +35,12 @@ import {
   type PureExecution,
   type Mapping,
   type Runtime,
-  type ExecutionResult,
   type PackageableRuntime,
   type RawExecutionPlan,
   type PackageableElementReference,
   type QueryInfo,
+  type LightQuery,
+  type ExecutionResultWithMetadata,
   PureSingleExecution,
   PureMultiExecution,
   KeyedExecutionParameter,
@@ -56,7 +57,6 @@ import {
   stub_PackageableRuntime,
   stub_Mapping,
   reportGraphAnalytics,
-  type LightQuery,
   QuerySearchSpecification,
 } from '@finos/legend-graph';
 import { parseGACoordinates } from '@finos/legend-storage';
@@ -439,7 +439,7 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
   executionResultText?: string | undefined; // NOTE: stored as lossless JSON string
   executionPlanState: ExecutionPlanState;
   readonly parametersState: ServiceExecutionParametersState;
-  queryRunPromise: Promise<ExecutionResult> | undefined = undefined;
+  queryRunPromise: Promise<ExecutionResultWithMetadata> | undefined = undefined;
 
   constructor(
     editorStore: EditorStore,
@@ -490,7 +490,7 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
   };
 
   setQueryRunPromise = (
-    promise: Promise<ExecutionResult> | undefined,
+    promise: Promise<ExecutionResultWithMetadata> | undefined,
   ): void => {
     this.queryRunPromise = promise;
   };
@@ -628,10 +628,14 @@ export abstract class ServicePureExecutionState extends ServiceExecutionState {
         report,
       );
       this.setQueryRunPromise(promise);
-      const result = (yield promise) as ExecutionResult;
+      const result = (yield promise) as ExecutionResultWithMetadata;
       if (this.queryRunPromise === promise) {
         this.setExecutionResultText(
-          stringifyLosslessJSON(result, undefined, DEFAULT_TAB_SIZE),
+          stringifyLosslessJSON(
+            result.executionResult,
+            undefined,
+            DEFAULT_TAB_SIZE,
+          ),
         );
         this.parametersState.setParameters([]);
         // report

--- a/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
@@ -17,6 +17,7 @@
 import type {
   ExecutionResult,
   EXECUTION_SERIALIZATION_FORMAT,
+  ExecutionResultWithMetadata,
 } from './action/execution/ExecutionResult.js';
 import type {
   ServiceRegistrationResult,
@@ -156,6 +157,7 @@ export interface ExecutionOptions {
   serializationFormat?: EXECUTION_SERIALIZATION_FORMAT | undefined;
   parameterValues?: ParameterValue[];
   abortController?: AbortController | undefined;
+  preservedResponseHeadersList?: string[];
 }
 
 export interface ServiceRegistrationOptions {
@@ -503,7 +505,7 @@ export abstract class AbstractPureGraphManager {
     graph: PureModel,
     options?: ExecutionOptions,
     report?: GraphManagerOperationReport,
-  ): Promise<ExecutionResult>;
+  ): Promise<ExecutionResultWithMetadata>;
 
   abstract exportData(
     lambda: RawLambda,

--- a/packages/legend-graph/src/graph-manager/action/execution/ExecutionResult.ts
+++ b/packages/legend-graph/src/graph-manager/action/execution/ExecutionResult.ts
@@ -74,6 +74,11 @@ export abstract class ExecutionResult {
   activities: ExecutionActivities[] | undefined;
 }
 
+export type ExecutionResultWithMetadata = {
+  executionResult: ExecutionResult;
+  executionTraceId?: string;
+};
+
 // ------------------------------------------ Model -----------------------------------------------
 export class JsonBuilder {
   _type = BuilderType.JSON_BUILDER;

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/execution/V1_ExecutionResult.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/execution/V1_ExecutionResult.ts
@@ -30,6 +30,9 @@ import {
 } from '@finos/legend-shared';
 import { ExecutionActivityType } from '../../../../../../graph-manager/action/execution/ExecutionResult.js';
 
+export const V1_EXECUTION_RESULT = 'executionResult';
+export const V1_ZIPKIN_TRACE_HEADER = 'x-b3-traceid';
+
 export class V1_ResultBuilder {
   static readonly builderSerialization = new SerializationFactory(
     createModelSchema(V1_ResultBuilder, {

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -276,9 +276,10 @@ export * from './graph-manager/GraphManagerStatistics.js';
 export * from './graph-manager/GraphManagerUtils.js';
 export * from './__lib__/GraphManagerEvent.js';
 export {
+  type ExecutionResultWithMetadata,
   RelationalExecutionActivities,
   ExecutionResult,
-  TDSExecutionResult as TDSExecutionResult,
+  TDSExecutionResult,
   RawExecutionResult,
   EXECUTION_SERIALIZATION_FORMAT,
   TDSRow,

--- a/packages/legend-manual-tests/src/__tests__/query-execution/TEMPORARY__QueryBuilderExecution.engine-roundtrip-test.tsx
+++ b/packages/legend-manual-tests/src/__tests__/query-execution/TEMPORARY__QueryBuilderExecution.engine-roundtrip-test.tsx
@@ -110,9 +110,11 @@ test(integrationTest('test query execution with parameters'), async () => {
   createSpy(
     queryBuilderState.graphManagerState.graphManager,
     'runQuery',
-  ).mockResolvedValue(
-    V1_buildExecutionResult(V1_serializeExecutionResult(executionResult)),
-  );
+  ).mockResolvedValue({
+    executionResult: V1_buildExecutionResult(
+      V1_serializeExecutionResult(executionResult),
+    ),
+  });
   const queryBuilderResultPanel = await waitFor(() =>
     renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_PANEL),
   );
@@ -172,9 +174,11 @@ test(integrationTest('test query execution with parameters'), async () => {
   createSpy(
     queryBuilderState.graphManagerState.graphManager,
     'runQuery',
-  ).mockResolvedValue(
-    V1_buildExecutionResult(V1_serializeExecutionResult(executionResult1)),
-  );
+  ).mockResolvedValue({
+    executionResult: V1_buildExecutionResult(
+      V1_serializeExecutionResult(executionResult1),
+    ),
+  });
   await act(async () => {
     fireEvent.click(getByText(queryBuilderResultPanel1, 'Run Query'));
   });

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -33,6 +33,7 @@ import { createSpy, integrationTest } from '@finos/legend-shared/test';
 import {
   create_RawLambda,
   stub_RawLambda,
+  V1_EXECUTION_RESULT,
   V1_PureGraphManager,
 } from '@finos/legend-graph';
 import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
@@ -71,8 +72,10 @@ test(
     const param = renderResult.getByRole('dialog');
     const graphManager = queryBuilderState.graphManagerState.graphManager;
     const pureManager = guaranteeType(graphManager, V1_PureGraphManager);
-    createSpy(pureManager.engine, 'runQueryAndReturnString').mockResolvedValue(
-      mocked,
+    const executionResultMap = new Map<string, string>();
+    executionResultMap.set(V1_EXECUTION_RESULT, mocked);
+    createSpy(pureManager.engine, 'runQueryAndReturnMap').mockResolvedValue(
+      executionResultMap,
     );
     // await
     await act(async () => {

--- a/packages/legend-query-builder/src/components/result/QueryBuilderResultPanel.tsx
+++ b/packages/legend-query-builder/src/components/result/QueryBuilderResultPanel.tsx
@@ -45,6 +45,7 @@ import {
   CubesLoadingIndicatorIcon,
   CubesLoadingIndicator,
   InfoCircleIcon,
+  ShareBoxIcon,
 } from '@finos/legend-art';
 import { observer } from 'mobx-react-lite';
 import { flowResult } from 'mobx';
@@ -179,6 +180,7 @@ export const QueryBuilderEmptyExecutionResultPanel = observer(
     );
   },
 );
+import { QueryBuilderBaseInfoTooltip } from '../shared/QueryBuilderPropertyInfoTooltip.js';
 
 export const QueryBuilderResultValues = observer(
   (props: {
@@ -530,13 +532,62 @@ export const QueryBuilderResultPanel = observer(
                 Running Query...
               </div>
             )}
-
-            <div
-              data-testid={QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_ANALYTICS}
-              className="query-builder__result__analytics"
-            >
-              {resultDescription ?? ''}
-            </div>
+            {resultDescription && resultState.executionTraceId && (
+              <div
+                data-testid={
+                  QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_ANALYTICS
+                }
+                className="query-builder__result__analytics"
+              >
+                <QueryBuilderBaseInfoTooltip
+                  title="Execution Result Analytics"
+                  data={[
+                    {
+                      label: 'Trace',
+                      value: 'available here',
+                      actionButton: (
+                        <div className="query-builder__tooltip__item__action">
+                          <button
+                            disabled={
+                              !queryBuilderState.config?.zipkinTraceBaseURL
+                            }
+                            title={
+                              queryBuilderState.config?.zipkinTraceBaseURL
+                                ? ''
+                                : 'No zipkin trace URL configured'
+                            }
+                            onClick={() => {
+                              if (
+                                queryBuilderState.config?.zipkinTraceBaseURL
+                              ) {
+                                applicationStore.navigationService.navigator.visitAddress(
+                                  queryBuilderState.config.zipkinTraceBaseURL +
+                                    resultState.executionTraceId,
+                                );
+                              }
+                            }}
+                          >
+                            <ShareBoxIcon />
+                          </button>
+                        </div>
+                      ),
+                    },
+                  ]}
+                >
+                  <div className="editable-value">{resultDescription}</div>
+                </QueryBuilderBaseInfoTooltip>
+              </div>
+            )}
+            {resultDescription && !resultState.executionTraceId && (
+              <div
+                data-testid={
+                  QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_ANALYTICS
+                }
+                className="query-builder__result__analytics"
+              >
+                {resultDescription}
+              </div>
+            )}
             {executionResult && resultState.checkForStaleResults && (
               <div className="query-builder__result__stale-status">
                 <div className="query-builder__result__stale-status__icon">

--- a/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
+++ b/packages/legend-query-builder/src/components/shared/QueryBuilderPropertyInfoTooltip.tsx
@@ -117,7 +117,7 @@ export const QueryBuilderTaggedValueInfoTooltip: React.FC<{
   );
 };
 
-const QueryBuilderBaseInfoTooltip: React.FC<{
+export const QueryBuilderBaseInfoTooltip: React.FC<{
   title: string;
   data: {
     label: string;

--- a/packages/legend-query-builder/src/graph-manager/QueryBuilderConfig.ts
+++ b/packages/legend-query-builder/src/graph-manager/QueryBuilderConfig.ts
@@ -33,11 +33,17 @@ export class QueryBuilderConfig {
    */
   legendAIServiceURL = '';
 
+  /**
+   * This is the URL of the zipkin trace
+   */
+  zipkinTraceBaseURL = '';
+
   static readonly serialization = new SerializationFactory(
     createModelSchema(QueryBuilderConfig, {
       TEMPORARY__disableQueryBuilderChat: optional(primitive()),
       TEMPORARY__enableGridEnterpriseMode: optional(primitive()),
       legendAIServiceURL: optional(primitive()),
+      zipkinTraceBaseURL: optional(primitive()),
     }),
   );
 }

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -527,9 +527,13 @@
 
   &__item__action {
     margin-left: 0.5rem;
+    display: flex;
+    justify-content: center;
 
     svg {
       color: var(--color-light-grey-150);
+      display: flex;
+      justify-content: center;
 
       &:hover {
         color: white;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Show zipkin trace id for query execution

`x-b3-traceid` has been added in the CORS exposed header params (CrossOriginFilter.EXPOSED_HEADERS_PARAM), which means traceId is provided in the API response header. 

In studio, we need to get the value from the response header then store in the ExecutionResult and display it in the Result panel.


<img width="786" alt="Screenshot 2024-08-01 at 10 33 00 AM" src="https://github.com/user-attachments/assets/bf423e7c-d137-4e25-9717-51f47c64c7a3">



## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
