### PR TITLE
Allow user to close "Preview data" button before request completes

### DIFF
--- a/.changeset/forty-pigs-relax.md
+++ b/.changeset/forty-pigs-relax.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Allow user to close "Preview data" button before request completes

--- a/.changeset/friendly-buses-dance.md
+++ b/.changeset/friendly-buses-dance.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Allow passing abortController to runQuery function

--- a/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
@@ -155,6 +155,7 @@ export interface ExecutionOptions {
   convertUnsafeNumbersToString?: boolean | undefined;
   serializationFormat?: EXECUTION_SERIALIZATION_FORMAT | undefined;
   parameterValues?: ParameterValue[];
+  abortController?: AbortController | undefined;
 }
 
 export interface ServiceRegistrationOptions {

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_Engine.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_Engine.ts
@@ -759,6 +759,7 @@ export class V1_Engine {
         {
           returnAsResponse: true,
           serializationFormat: options?.serializationFormat,
+          abortController: options?.abortController,
         },
       )) as Response
     ).text();

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
@@ -652,13 +652,16 @@ export class V1_EngineServerClient extends AbstractServerClient {
     options?: {
       returnAsResponse?: boolean;
       serializationFormat?: EXECUTION_SERIALIZATION_FORMAT | undefined;
+      abortController?: AbortController | undefined;
     },
   ): Promise<PlainObject<V1_ExecutionResult> | Response> =>
     this.postWithTracing(
       this.getTraceData(CORE_ENGINE_ACTIVITY_TRACE.EXECUTE),
       `${this._execution()}/execute`,
       this.debugPayload(input, CORE_ENGINE_ACTIVITY_TRACE.EXECUTE),
-      {},
+      {
+        signal: options?.abortController?.signal ?? null,
+      },
       undefined,
       {
         serializationFormat: options?.serializationFormat

--- a/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
+++ b/packages/legend-query-builder/src/components/explorer/QueryBuilderExplorerPanel.tsx
@@ -220,7 +220,14 @@ const QueryBuilderExplorerPreviewDataModal = observer(
     const { queryBuilderState } = props;
     const applicationStore = queryBuilderState.applicationStore;
     const previewDataState = queryBuilderState.explorerState.previewDataState;
-    const close = (): void => previewDataState.setPreviewData(undefined);
+    const close = (): void => {
+      if (previewDataState.previewDataAbortController) {
+        previewDataState.previewDataAbortController.abort();
+        previewDataState.setPreviewDataAbortController(undefined);
+      }
+      previewDataState.setIsGeneratingPreviewData(false);
+      previewDataState.setPreviewData(undefined);
+    };
 
     return (
       <Dialog

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -933,7 +933,6 @@ export class QueryBuilderExplorerState {
             TDSExecutionResult,
             `Unexpected preview data format`,
           );
-          this.previewDataState.setPreviewDataAbortController(undefined);
           this.previewDataState.setPreviewData(
             previewResult.result as QueryBuilderPreviewData,
           );
@@ -955,6 +954,7 @@ export class QueryBuilderExplorerState {
       this.previewDataState.setPreviewData(undefined);
     } finally {
       this.previewDataState.setIsGeneratingPreviewData(false);
+      this.previewDataState.setPreviewDataAbortController(undefined);
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Allow user to close "Preview data" button before request completes. This improves UX because if the user accidentally clicks on the "Preview data" button, they can close the modal without having to wait for the network request to complete.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Example of closing "Preview data" modal and cancelling request:
![ClosePreviewDataModal](https://github.com/user-attachments/assets/b9fd7954-afcd-4d46-bae5-1327b0ebd6f5)
