### PR TITLE
Add option to getValueSpecificationStringValue to wrap string in double quotes

### DIFF
--- a/.changeset/moody-turtles-chew.md
+++ b/.changeset/moody-turtles-chew.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Add option to getValueSpecificationStringValue to wrap string in double quotes

--- a/packages/legend-query-builder/src/stores/shared/ValueSpecificationEditorHelper.ts
+++ b/packages/legend-query-builder/src/stores/shared/ValueSpecificationEditorHelper.ts
@@ -335,6 +335,7 @@ export const getValueSpecificationStringValue = (
   >,
   options?: {
     omitEnumOwnerName?: boolean;
+    wrapStringInDoubleQuotes?: boolean;
   },
 ): string | undefined => {
   if (valueSpecification instanceof PrimitiveInstanceValue) {
@@ -345,6 +346,13 @@ export const getValueSpecificationStringValue = (
       )
     ) {
       return buildDatePickerOption(valueSpecification, applicationStore).label;
+    }
+    if (
+      valueSpecification.genericType.value.rawType.path ===
+        PRIMITIVE_TYPE.STRING &&
+      options?.wrapStringInDoubleQuotes
+    ) {
+      return `"${valueSpecification.values[0]?.toString()}"`;
     }
     return valueSpecification.values[0]?.toString();
   } else if (valueSpecification instanceof EnumValueInstanceValue) {

--- a/packages/legend-query-builder/src/stores/shared/ValueSpecificationEditorHelper.ts
+++ b/packages/legend-query-builder/src/stores/shared/ValueSpecificationEditorHelper.ts
@@ -348,8 +348,7 @@ export const getValueSpecificationStringValue = (
       return buildDatePickerOption(valueSpecification, applicationStore).label;
     }
     if (
-      valueSpecification.genericType.value.rawType.path ===
-        PRIMITIVE_TYPE.STRING &&
+      valueSpecification.genericType.value.rawType === PrimitiveType.STRING &&
       options?.wrapStringInDoubleQuotes
     ) {
       return `"${valueSpecification.values[0]?.toString()}"`;

--- a/packages/legend-query-builder/src/stores/shared/ValueSpecificationEditorHelper.ts
+++ b/packages/legend-query-builder/src/stores/shared/ValueSpecificationEditorHelper.ts
@@ -366,6 +366,7 @@ export const getValueSpecificationStringValue = (
     return getValueSpecificationStringValue(
       valueSpecification.getValue(),
       applicationStore,
+      options,
     );
   } else if (valueSpecification instanceof SimpleFunctionExpression) {
     if (
@@ -381,7 +382,7 @@ export const getValueSpecificationStringValue = (
   } else if (valueSpecification instanceof CollectionInstanceValue) {
     return valueSpecification.values
       .map((valueSpec) =>
-        getValueSpecificationStringValue(valueSpec, applicationStore),
+        getValueSpecificationStringValue(valueSpec, applicationStore, options),
       )
       .join(',');
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Add an option to wrap string values in double quotes when converting a value spec to string.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [x] No testing (please provide an explanation)

Did a quick manual test to check that the function was returning the expected result.

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Example of turning on the `wrapStringInDoubleQuotes` flag for `BasicValueSpecificationEditor`.
Note: this won't actually be used for that component. It's just to show that the flag works.
![Screenshot 2024-08-02 at 2 58 47 PM](https://github.com/user-attachments/assets/4e18a994-ee3e-4687-a402-f70041f00c75)