### PR TITLE
Move query loader search sort-by to mongodb

### DIFF
--- a/.changeset/few-llamas-grow.md
+++ b/.changeset/few-llamas-grow.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-graph': patch
+---

--- a/.changeset/mighty-walls-reply.md
+++ b/.changeset/mighty-walls-reply.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Move query loader search sort-by to mongodb

--- a/packages/legend-graph/src/graph-manager/action/query/QuerySearchSpecification.ts
+++ b/packages/legend-graph/src/graph-manager/action/query/QuerySearchSpecification.ts
@@ -31,6 +31,12 @@ export class QuerySearchTermSpecification {
   }
 }
 
+export enum QuerySearchSortBy {
+  SORT_BY_CREATE = 'SORT_BY_CREATE',
+  SORT_BY_VIEW = 'SORT_BY_VIEW',
+  SORT_BY_UPDATE = 'SORT_BY_UPDATE',
+}
+
 export class QuerySearchSpecification {
   searchTermSpecification: QuerySearchTermSpecification | undefined;
   projectCoordinates?: QueryProjectCoordinates[] | undefined;
@@ -39,6 +45,7 @@ export class QuerySearchSpecification {
   limit?: number | undefined;
   showCurrentUserQueriesOnly?: boolean | undefined;
   combineTaggedValuesCondition?: boolean | undefined;
+  sortByOption?: QuerySearchSortBy;
 
   static createDefault(
     searchTerm: string | undefined,

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineHelper.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineHelper.ts
@@ -418,6 +418,9 @@ export const V1_transformQuerySearchSpecification = (
   });
   protocol.combineTaggedValuesCondition =
     metamodel.combineTaggedValuesCondition;
+  if (metamodel.sortByOption) {
+    protocol.sortByOption = metamodel.sortByOption;
+  }
   return protocol;
 };
 

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/query/V1_QuerySearchSpecification.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/query/V1_QuerySearchSpecification.ts
@@ -22,6 +22,7 @@ import {
   V1_stereotypePtrModelSchema,
   V1_taggedValueModelSchema,
 } from '../../transformation/pureProtocol/serializationHelpers/V1_DomainSerializationHelper.js';
+import type { QuerySearchSortBy } from '../../../../../action/query/QuerySearchSpecification.js';
 
 export class V1_QueryProjectCoordinates {
   groupId!: string;
@@ -60,6 +61,7 @@ export class V1_QuerySearchSpecification {
   limit?: number | undefined;
   showCurrentUserQueriesOnly?: boolean | undefined;
   combineTaggedValuesCondition?: boolean | undefined;
+  sortByOption?: QuerySearchSortBy;
 
   static readonly serialization = new SerializationFactory(
     createModelSchema(V1_QuerySearchSpecification, {
@@ -76,6 +78,7 @@ export class V1_QuerySearchSpecification {
         list(usingModelSchema(V1_stereotypePtrModelSchema)),
       ),
       taggedValues: optional(list(usingModelSchema(V1_taggedValueModelSchema))),
+      sortByOption: optional(primitive()),
     }),
     {
       deserializeNullAsUndefined: true,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Move query loader search sort-by to MongoDB

depends on https://github.com/finos/legend-engine/pull/3009

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Before:

Sort-by algorithm will be applied on the query list returned from Engine.

Now: 

We move sort-by to MongoDB then return a list 


1.  fetch default queries is not bound to sort-by 

https://github.com/user-attachments/assets/f1cbfc7d-6264-41da-852b-6db852d7eb94


2. if a filter condition is chosen, a sort-by dropdown will be displayed. By default,  we sort against last-viewed

https://github.com/user-attachments/assets/d064c28d-1cdc-45de-b98f-f0494818cdb6

3. if there is a provided search text, a sort-by dropdown will be displayed. By default,  we sort against last-viewed


https://github.com/user-attachments/assets/c0118e73-09c8-437f-b191-b20c96e3ba84



<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
