### PR TITLE
Fix bug with unwrapping executionResult from ExecutionResultWithMetadata

### DIFF
--- a/.changeset/rich-swans-prove.md
+++ b/.changeset/rich-swans-prove.md
@@ -1,0 +1,7 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-query-builder': patch
+---
+
+Fix bug with unwrapping executionResult from ExecutionResultWithMetadata

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/connection/DatabaseBuilderState.ts
@@ -46,7 +46,7 @@ import {
   type RawLambda,
   type PureModel,
   type Runtime,
-  type ExecutionResult,
+  type ExecutionResultWithMetadata,
   TDSExecutionResult,
   getColumn,
   PrimitiveType,
@@ -715,13 +715,14 @@ export class DatabaseSchemaExplorerState {
         this.connection,
         generatedDb,
       );
-      const execPlan =
+      const execPlan = (
         (yield this.editorStore.graphManagerState.graphManager.runQuery(
           rawLambda,
           mapping,
           runtime,
           emptyGraph,
-        )) as ExecutionResult;
+        )) as ExecutionResultWithMetadata
+      ).executionResult;
       let tdsResult = guaranteeType(
         execPlan,
         TDSExecutionResult,

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/legacy/DEPRECATED__MappingTestState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/legacy/DEPRECATED__MappingTestState.ts
@@ -669,7 +669,7 @@ export class DEPRECATED__MappingTestState extends MappingEditorTabState {
       const query = this.queryState.query;
       const runtime = this.inputDataState.runtime;
       this.isExecutingTest = true;
-      const result =
+      const result = (
         (yield this.editorStore.graphManagerState.graphManager.runQuery(
           query,
           this.mappingEditorState.mapping,
@@ -678,7 +678,8 @@ export class DEPRECATED__MappingTestState extends MappingEditorTabState {
           {
             useLosslessParse: true,
           },
-        )) as ExecutionResult;
+        )) as ExecutionResultWithMetadata
+      ).executionResult;
       if (
         this.assertionState instanceof MappingTestExpectedOutputAssertionState
       ) {

--- a/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityResultState.ts
+++ b/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityResultState.ts
@@ -31,6 +31,7 @@ import {
 import {
   type RawExecutionPlan,
   type ExecutionResult,
+  type ExecutionResultWithMetadata,
   GRAPH_MANAGER_EVENT,
 } from '@finos/legend-graph';
 import { getDataQualityPureGraphManagerExtension } from '../../graph-manager/protocol/pure/DSL_DataQuality_PureGraphManagerExtension.js';
@@ -119,7 +120,8 @@ export class DataQualityResultState {
       ).execute(model, packagePath, this.previewLimit);
 
       this.setQueryRunPromise(promise);
-      const result = (yield promise) as ExecutionResult;
+      const result = ((yield promise) as ExecutionResultWithMetadata)
+        .executionResult;
 
       if (this.queryRunPromise === promise) {
         this.setExecutionResult(result);

--- a/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
+++ b/packages/legend-query-builder/src/stores/explorer/QueryBuilderExplorerState.ts
@@ -31,6 +31,7 @@ import {
   type MappingModelCoverageAnalysisResult,
   type EnumMappedProperty,
   type MappedEntity,
+  type ExecutionResultWithMetadata,
   AbstractPropertyExpression,
   Class,
   VariableExpression,
@@ -55,7 +56,6 @@ import {
   Association,
   PRIMITIVE_TYPE,
   TDSExecutionResult,
-  type ExecutionResult,
   getAllSubclasses,
   PropertyExplicitReference,
   reportGraphAnalytics,
@@ -1008,7 +1008,7 @@ export class QueryBuilderExplorerState {
         case PRIMITIVE_TYPE.INTEGER:
         case PRIMITIVE_TYPE.DECIMAL:
         case PRIMITIVE_TYPE.FLOAT: {
-          const previewResult =
+          const previewResult = (
             (yield this.queryBuilderState.graphManagerState.graphManager.runQuery(
               buildNumericPreviewDataQuery(
                 this.queryBuilderState,
@@ -1021,7 +1021,8 @@ export class QueryBuilderExplorerState {
                 abortController:
                   this.previewDataState.previewDataAbortController,
               },
-            )) as ExecutionResult;
+            )) as ExecutionResultWithMetadata
+          ).executionResult;
           assertType(
             previewResult,
             TDSExecutionResult,
@@ -1049,7 +1050,7 @@ export class QueryBuilderExplorerState {
         case PRIMITIVE_TYPE.DATE:
         case PRIMITIVE_TYPE.STRICTDATE:
         case PRIMITIVE_TYPE.DATETIME: {
-          const previewResult =
+          const previewResult = (
             (yield this.queryBuilderState.graphManagerState.graphManager.runQuery(
               buildNonNumericPreviewDataQuery(
                 this.queryBuilderState,
@@ -1062,7 +1063,8 @@ export class QueryBuilderExplorerState {
                 abortController:
                   this.previewDataState.previewDataAbortController,
               },
-            )) as ExecutionResult;
+            )) as ExecutionResultWithMetadata
+          ).executionResult;
           assertType(
             previewResult,
             TDSExecutionResult,

--- a/packages/legend-query-builder/src/stores/fetch-structure/tds/post-filter/QueryBuilderPostFilterState.ts
+++ b/packages/legend-query-builder/src/stores/fetch-structure/tds/post-filter/QueryBuilderPostFilterState.ts
@@ -19,8 +19,8 @@ import {
   type PureModel,
   type Type,
   type ValueSpecification,
-  type ExecutionResult,
   type SimpleFunctionExpression,
+  type ExecutionResultWithMetadata,
   observe_ValueSpecification,
   PrimitiveType,
   CollectionInstanceValue,
@@ -490,7 +490,7 @@ export class PostFilterConditionState implements Hashable {
       );
       const value = searchValue ?? rightConditionValue.value;
       if (performTypeahead(value)) {
-        const result =
+        const result = (
           (yield this.postFilterState.tdsState.queryBuilderState.graphManagerState.graphManager.runQuery(
             buildProjectionColumnTypeaheadQuery(
               this.postFilterState.tdsState.queryBuilderState,
@@ -507,7 +507,8 @@ export class PostFilterConditionState implements Hashable {
             ),
             this.postFilterState.tdsState.queryBuilderState.graphManagerState
               .graph,
-          )) as ExecutionResult;
+          )) as ExecutionResultWithMetadata
+        ).executionResult;
         this.typeaheadSearchResults = buildTypeaheadOptions(result);
       }
       this.typeaheadSearchState.pass();

--- a/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterState.ts
+++ b/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterState.ts
@@ -37,10 +37,10 @@ import type { QueryBuilderExplorerTreeDragSource } from '../explorer/QueryBuilde
 import { QueryBuilderPropertyExpressionState } from '../QueryBuilderPropertyEditorState.js';
 import type { QueryBuilderState } from '../QueryBuilderState.js';
 import {
-  type ExecutionResult,
-  AbstractPropertyExpression,
   type ValueSpecification,
   type Type,
+  type ExecutionResultWithMetadata,
+  AbstractPropertyExpression,
   observe_ValueSpecification,
   CollectionInstanceValue,
   InstanceValue,
@@ -300,7 +300,7 @@ export class FilterConditionState implements Hashable {
       );
       const value = searchValue ?? rightConditionValue.value;
       if (performTypeahead(value)) {
-        const result =
+        const result = (
           (yield this.filterState.queryBuilderState.graphManagerState.graphManager.runQuery(
             buildPropertyTypeaheadQuery(
               this.filterState.queryBuilderState,
@@ -315,7 +315,8 @@ export class FilterConditionState implements Hashable {
                 .runtimeValue,
             ),
             this.filterState.queryBuilderState.graphManagerState.graph,
-          )) as ExecutionResult;
+          )) as ExecutionResultWithMetadata
+        ).executionResult;
         this.typeaheadSearchResults = buildTypeaheadOptions(result);
       }
       this.typeaheadSearchState.pass();


### PR DESCRIPTION
…Metadata response

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This PR fixes a few bugs that were occurring because we weren't unwrapping the `executionResult` property from the `runQuery` responses, which are now of type `ExecutionResultWithMetadata`, including:
- Preview data button not working
- Filter/post-filter input autocomplete not working

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Preview data working:
![PreviewData](https://github.com/user-attachments/assets/9834e6f8-6012-41e1-9410-dd06205089e9)

Filter/post-filter autocomplete working:
![FilterPostFilterAutocomplete](https://github.com/user-attachments/assets/412c0334-2cce-4445-8ec0-01cc1722f101)