### PR TITLE
[Fix] Improve handling of changing const/param/derivation types

### DIFF
--- a/.changeset/cuddly-socks-clap.md
+++ b/.changeset/cuddly-socks-clap.md
@@ -1,6 +1,6 @@
 ---
 '@finos/legend-application-query-bootstrap': patch
-'@finos/legend-query-builder: patch
+'@finos/legend-query-builder': patch
 ---
 
 [Fix] Improve handling of changing const/param/derivation types

--- a/.changeset/cuddly-socks-clap.md
+++ b/.changeset/cuddly-socks-clap.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-query-bootstrap': patch
+'@finos/legend-query-builder: patch
+---
+
+[Fix] Improve handling of changing const/param/derivation types

--- a/packages/legend-application-query-bootstrap/style/index.scss
+++ b/packages/legend-application-query-bootstrap/style/index.scss
@@ -1718,6 +1718,33 @@
       background: var(--color-blue-200);
     }
 
+    .query-builder-post-filter-tree__condition-node__value--error {
+      .query-builder-column-badge__content {
+        background: var(--color-red-200);
+        color: var(--color-light-grey-150);
+
+        .query-builder-column-badge__type {
+          background: var(--color-dark-shade-100);
+
+          .query-builder-column-badge__icon {
+            color: var(--color-light-grey-150);
+          }
+        }
+
+        .query-builder-column-badge__property {
+          color: var(--color-light-grey-150);
+
+          &__info svg {
+            color: var(--color-light-grey-200);
+          }
+        }
+
+        .query-builder-column-badge__action svg {
+          color: var(--color-light-grey-200);
+        }
+      }
+    }
+
     .query-builder-post-filter-tree__node__container--selected
       .query-builder-post-filter-tree__blank-node,
     .query-builder-post-filter-tree__node__container--selected:hover

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderConstantsPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderConstantsPanel.test.tsx
@@ -47,13 +47,17 @@ import { CUSTOM_DATE_PICKER_OPTION } from '../shared/CustomDatePicker.js';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { MockedMonacoEditorInstance } from '@finos/legend-lego/code-editor/test';
 
-const getConstantNameInput = (renderResult: RenderResult): HTMLInputElement =>
+export const getConstantNameInput = (
+  renderResult: RenderResult,
+): HTMLInputElement =>
   getByRole(
     guaranteeNonNullable(renderResult.getByText('Constant Name').parentElement),
     'textbox',
   );
 
-const getConstantValueInput = (renderResult: RenderResult): HTMLInputElement =>
+export const getConstantValueInput = (
+  renderResult: RenderResult,
+): HTMLInputElement =>
   getByRole(
     guaranteeNonNullable(renderResult.getByText('Value').parentElement),
     'textbox',

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
@@ -50,6 +50,10 @@ import {
   MockedMonacoEditorAPI,
 } from '@finos/legend-lego/code-editor/test';
 import { guaranteeNonNullable } from '@finos/legend-shared';
+import {
+  getConstantNameInput,
+  getConstantValueInput,
+} from './QueryBuilderConstantsPanel.test.js';
 
 export const getParameterNameInput = (
   renderResult: RenderResult,
@@ -58,18 +62,6 @@ export const getParameterNameInput = (
     guaranteeNonNullable(
       renderResult.getByText('Parameter Name').parentElement,
     ),
-    'textbox',
-  );
-
-const getConstantNameInput = (renderResult: RenderResult): HTMLInputElement =>
-  getByRole(
-    guaranteeNonNullable(renderResult.getByText('Constant Name').parentElement),
-    'textbox',
-  );
-
-const getConstantValueInput = (renderResult: RenderResult): HTMLInputElement =>
-  getByRole(
-    guaranteeNonNullable(renderResult.getByText('Value').parentElement),
     'textbox',
   );
 

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderPostFilterPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderPostFilterPanel.test.tsx
@@ -69,6 +69,7 @@ import {
   TEST__setUpQueryBuilder,
   dragAndDrop,
   selectFirstOptionFromCustomSelectorInput,
+  selectFromCustomSelectorInput,
 } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
 import TEST_DATA__QueryBuilder_Model_SimpleRelational from '../../stores/__tests__/TEST_DATA__QueryBuilder_Model_SimpleRelational.json' assert { type: 'json' };
 import TEST_DATA__QueryBuilder_Model_SimpleRelationalWithDates from '../../stores/__tests__/TEST_DATA__QueryBuilder_Model_SimpleRelationalWithDates.json' assert { type: 'json' };
@@ -95,6 +96,11 @@ import { INTERNAL__BasicQueryBuilderState } from '../../stores/QueryBuilderState
 import { QueryBuilderAdvancedWorkflowState } from '../../stores/query-workflow/QueryBuilderWorkFlowState.js';
 import { CUSTOM_DATE_PICKER_OPTION } from '../shared/CustomDatePicker.js';
 import type { Entity } from '@finos/legend-storage';
+import {
+  getConstantNameInput,
+  getConstantValueInput,
+} from './QueryBuilderConstantsPanel.test.js';
+import { getParameterNameInput } from './QueryBuilderParametersPanel.test.js';
 
 test(
   integrationTest('Query builder loads simple post-filter with DateTime value'),
@@ -1431,6 +1437,170 @@ test(
         );
       expect(expectedLambda).toEqual(jsonQuery);
     });
+  },
+);
+
+test(
+  integrationTest(
+    'Query builder shows error when constant and parameter types become invalid',
+  ),
+  async () => {
+    // Set up query
+    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+      TEST_DATA__QueryBuilder_Model_SimpleRelational,
+      stub_RawLambda(),
+      'execution::RelationalMapping',
+      'execution::Runtime',
+      TEST_DATA__ModelCoverageAnalysisResult_SimpleRelationalWithExists,
+    );
+
+    const _firmClass =
+      queryBuilderState.graphManagerState.graph.getClass('model::Firm');
+    await act(async () => {
+      queryBuilderState.changeClass(_firmClass);
+      queryBuilderState.setShowParametersPanel(true);
+      queryBuilderState.constantState.setShowConstantPanel(true);
+      const tdsState = guaranteeType(
+        queryBuilderState.fetchStructureState.implementation,
+        QueryBuilderTDSState,
+      );
+      tdsState.setShowPostFilterPanel(true);
+    });
+
+    // DND property from explorer panel to fetch structure panel
+    const explorerPanel = await renderResult.findByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_EXPLORER,
+    );
+    const fetchStructurePanel = await renderResult.findByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_FETCH_STRUCTURE,
+    );
+    const explorerDragSource = await findByText(explorerPanel, 'Legal Name');
+    const fetchStructureDropZone = await findByText(
+      fetchStructurePanel,
+      'Add a projection column',
+    );
+    await dragAndDrop(
+      explorerDragSource,
+      fetchStructureDropZone,
+      fetchStructurePanel,
+      'Add a projection column',
+    );
+    await findByText(fetchStructurePanel, 'Legal Name');
+
+    // DND property from fetch structure panel to post-filter panel
+    const fetchStructureDragSource = await findByText(
+      fetchStructurePanel,
+      'Legal Name',
+    );
+    const postFilterPanel = await renderResult.findByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_POST_FILTER_PANEL,
+    );
+    const postFilterDropZone = await findByText(
+      postFilterPanel,
+      'Add a post-filter condition',
+    );
+    await dragAndDrop(
+      fetchStructureDragSource,
+      postFilterDropZone,
+      postFilterPanel,
+      'Add a post-filter condition',
+    );
+    await findByText(postFilterPanel, 'Legal Name');
+    await findByText(postFilterPanel, 'is');
+
+    // Create constant of type string
+    const constantsPanel = renderResult.getByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_CONSTANTS,
+    );
+    fireEvent.click(getByTitle(constantsPanel, 'Add Constant'));
+    const constantNameInput = getConstantNameInput(renderResult);
+    let constantValueInput = getConstantValueInput(renderResult);
+    fireEvent.change(constantNameInput, { target: { value: 'c_var_1' } });
+    fireEvent.change(constantValueInput, { target: { value: 'test' } });
+    fireEvent.click(renderResult.getByRole('button', { name: 'Create' }));
+
+    // Drag and drop constant to post-filter panel value
+    const constantDragSource = await findByText(constantsPanel, 'c_var_1');
+    await dragAndDrop(
+      constantDragSource,
+      postFilterPanel,
+      postFilterPanel,
+      'Change Filter Value',
+    );
+
+    // Verify no validation error
+    expect(queryByText(postFilterPanel, '1 issue')).toBeNull();
+    expect(
+      renderResult.getByRole('button', { name: 'Run Query' }),
+    ).toHaveProperty('disabled', false);
+
+    // Change constant type
+    fireEvent.click(getByText(constantsPanel, 'c_var_1'));
+    let typeContainer = guaranteeNonNullable(
+      renderResult.getByText('Type').parentElement,
+    );
+    selectFromCustomSelectorInput(typeContainer, 'Number');
+    constantValueInput = getConstantValueInput(renderResult);
+    fireEvent.change(constantValueInput, { target: { value: '5' } });
+    fireEvent.click(renderResult.getByRole('button', { name: 'Apply' }));
+
+    // Verify 1 validation error
+    expect(getByText(postFilterPanel, '1 issue')).not.toBeNull();
+    expect(
+      getByTitle(
+        postFilterPanel,
+        'Filter value for Legal Name is missing or invalid',
+        { exact: false },
+      ),
+    ).not.toBeNull();
+    expect(
+      renderResult.getByRole('button', { name: 'Run Query' }),
+    ).toHaveProperty('disabled', true);
+
+    // Create parameter of type string
+    const parametersPanel = renderResult.getByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS,
+    );
+    fireEvent.click(getByTitle(parametersPanel, 'Add Parameter'));
+    const parameterNameInput = getParameterNameInput(renderResult);
+    fireEvent.change(parameterNameInput, { target: { value: 'p_var_1' } });
+    fireEvent.click(renderResult.getByRole('button', { name: 'Create' }));
+
+    // Drag and drop parameter to post-filter panel value
+    const parameterDragSource = await findByText(parametersPanel, 'p_var_1');
+    await dragAndDrop(
+      parameterDragSource,
+      postFilterPanel,
+      postFilterPanel,
+      'Change Filter Value',
+    );
+
+    // Verify no validation error
+    expect(queryByText(postFilterPanel, '1 issue')).toBeNull();
+    expect(
+      renderResult.getByRole('button', { name: 'Run Query' }),
+    ).toHaveProperty('disabled', false);
+
+    // Change parameter type
+    fireEvent.click(getByText(parametersPanel, 'p_var_1'));
+    typeContainer = guaranteeNonNullable(
+      renderResult.getByText('Type').parentElement,
+    );
+    selectFromCustomSelectorInput(typeContainer, 'Number');
+    fireEvent.click(renderResult.getByRole('button', { name: 'Update' }));
+
+    // Verify 1 validation error
+    expect(getByText(postFilterPanel, '1 issue')).not.toBeNull();
+    expect(
+      getByTitle(
+        postFilterPanel,
+        'Filter value for Legal Name is missing or invalid',
+        { exact: false },
+      ),
+    ).not.toBeNull();
+    expect(
+      renderResult.getByRole('button', { name: 'Run Query' }),
+    ).toHaveProperty('disabled', true);
   },
 );
 

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderPostFilterPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderPostFilterPanel.tsx
@@ -52,6 +52,7 @@ import {
   Class,
   Enumeration,
   PrimitiveType,
+  VariableExpression,
 } from '@finos/legend-graph';
 import {
   assertErrorThrown,
@@ -422,10 +423,21 @@ const QueryBuilderPostFilterConditionEditor = observer(
         rightConditionValue instanceof PostFilterValueSpecConditionValueState &&
         rightConditionValue.value
       ) {
+        const isInvalidVariable =
+          rightConditionValue.value instanceof VariableExpression &&
+          node.condition.postFilterState.isInvalidValueSpecPostFilterValue(
+            node,
+          );
         return (
           <div
             ref={dropConnector}
-            className="query-builder-post-filter-tree__condition-node__value"
+            className={clsx(
+              'query-builder-post-filter-tree__condition-node__value',
+              {
+                'query-builder-post-filter-tree__condition-node__value--error':
+                  isInvalidVariable,
+              },
+            )}
           >
             <PanelEntryDropZonePlaceholder
               isDragOver={isFilterValueDragOver}
@@ -456,10 +468,20 @@ const QueryBuilderPostFilterConditionEditor = observer(
         rightConditionValue instanceof
         PostFilterTDSColumnValueConditionValueState
       ) {
+        const isInvalidTDSColumn =
+          node.condition.postFilterState.isInvalidTDSColumnPostFilterValue(
+            node,
+          );
         return (
           <div
             ref={dropConnector}
-            className="query-builder-post-filter-tree__condition-node__value"
+            className={clsx(
+              'query-builder-post-filter-tree__condition-node__value',
+              {
+                'query-builder-post-filter-tree__condition-node__value--error':
+                  isInvalidTDSColumn,
+              },
+            )}
           >
             <PanelEntryDropZonePlaceholder
               isDragOver={isFilterValueDragOver}

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -214,7 +214,8 @@ const QueryBuilderDerivationProjectionColumnEditor = observer(
   }) => {
     const { projectionColumnState } = props;
     const hasParserError = projectionColumnState.tdsState.hasParserError;
-    const onEditorBlur = (): void => {
+
+    const onEditorBlur = useCallback((): void => {
       flowResult(
         projectionColumnState.fetchDerivationLambdaReturnType({
           forceConversionStringToLambda: true,
@@ -224,7 +225,8 @@ const QueryBuilderDerivationProjectionColumnEditor = observer(
         projectionColumnState.tdsState.queryBuilderState.applicationStore
           .alertUnhandledError,
       );
-    };
+    }, [projectionColumnState]);
+
     const handleDrop = useCallback(
       (
         item: QueryBuilderDerivationProjectionColumnDropTarget,
@@ -256,6 +258,7 @@ const QueryBuilderDerivationProjectionColumnEditor = observer(
       },
       [projectionColumnState],
     );
+
     const [, dropConnector] =
       useDrop<QueryBuilderDerivationProjectionColumnDropTarget>(
         () => ({
@@ -268,6 +271,11 @@ const QueryBuilderDerivationProjectionColumnEditor = observer(
         }),
         [handleDrop],
       );
+
+    // Calculate derivation return type on mount
+    useEffect(() => {
+      onEditorBlur();
+    }, [onEditorBlur]);
 
     return (
       <div

--- a/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
+++ b/packages/legend-query-builder/src/components/fetch-structure/QueryBuilderTDSPanel.tsx
@@ -272,11 +272,6 @@ const QueryBuilderDerivationProjectionColumnEditor = observer(
         [handleDrop],
       );
 
-    // Calculate derivation return type on mount
-    useEffect(() => {
-      onEditorBlur();
-    }, [onEditorBlur]);
-
     return (
       <div
         ref={dropConnector}

--- a/packages/legend-query-builder/src/components/filter/QueryBuilderFilterPanel.tsx
+++ b/packages/legend-query-builder/src/components/filter/QueryBuilderFilterPanel.tsx
@@ -1020,13 +1020,22 @@ const QueryBuilderFilterConditionEditor = observer(
         rightConditionValue instanceof FilterValueSpecConditionValueState &&
         rightConditionValue.value
       ) {
+        const isInvalidVariable =
+          rightConditionValue.value instanceof VariableExpression &&
+          node.condition.filterState.isInvalidValueSpecFilterValue(node);
         return (
           <div
             ref={dropConnector}
             data-testid={
               QUERY_BUILDER_TEST_ID.QUERY_BUILDER_FILTER_TREE_CONDITION_NODE_VALUE
             }
-            className="query-builder-filter-tree__condition-node__value"
+            className={clsx(
+              'query-builder-filter-tree__condition-node__value',
+              {
+                'query-builder-filter-tree__condition-node__value--error':
+                  isInvalidVariable,
+              },
+            )}
           >
             <PanelEntryDropZonePlaceholder
               isDragOver={isFilterValueDragOver}

--- a/packages/legend-query-builder/src/stores/QueryBuilderValueSpecificationHelper.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderValueSpecificationHelper.ts
@@ -213,7 +213,7 @@ export const isPropertyExpressionChainOptional = (
 
 export const isTypeCompatibleForAssignment = (
   type: Type | undefined,
-  assignmentType: Type,
+  assignmentType: Type | undefined,
 ): boolean => {
   const NUMERIC_PRIMITIVE_TYPES = [
     PRIMITIVE_TYPE.NUMBER,
@@ -231,6 +231,7 @@ export const isTypeCompatibleForAssignment = (
   // When changing the return type for LHS, the RHS value should be adjusted accordingly.
   return (
     type !== undefined &&
+    assignmentType !== undefined &&
     // Numeric value is handled loosely because of autoboxing
     // e.g. LHS (integer) = RHS (float) is acceptable
     ((NUMERIC_PRIMITIVE_TYPES.includes(type.path) &&

--- a/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterState.ts
+++ b/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterState.ts
@@ -38,7 +38,6 @@ import { QueryBuilderPropertyExpressionState } from '../QueryBuilderPropertyEdit
 import type { QueryBuilderState } from '../QueryBuilderState.js';
 import {
   type ValueSpecification,
-  type VariableExpression,
   type Type,
   type ExecutionResultWithMetadata,
   AbstractPropertyExpression,
@@ -46,6 +45,7 @@ import {
   CollectionInstanceValue,
   InstanceValue,
   SimpleFunctionExpression,
+  VariableExpression,
   matchFunctionName,
 } from '@finos/legend-graph';
 import { DEFAULT_LAMBDA_VARIABLE_NAME } from '../QueryBuilderConfig.js';
@@ -61,6 +61,7 @@ import { QUERY_BUILDER_STATE_HASH_STRUCTURE } from '../QueryBuilderStateHashUtil
 import {
   getCollectionValueSpecificationType,
   getNonCollectionValueSpecificationType,
+  isTypeCompatibleForAssignment,
   isValidInstanceValue,
   isValueExpressionReferencedInValue,
 } from '../QueryBuilderValueSpecificationHelper.js';
@@ -1186,8 +1187,15 @@ export class QueryBuilderFilterState
       node instanceof QueryBuilderFilterTreeConditionNodeData &&
       node.condition.rightConditionValue instanceof
         FilterValueSpecConditionValueState &&
-      node.condition.rightConditionValue.value instanceof InstanceValue &&
-      !isValidInstanceValue(node.condition.rightConditionValue.value)
+      ((node.condition.rightConditionValue.value instanceof InstanceValue &&
+        !isValidInstanceValue(node.condition.rightConditionValue.value)) ||
+        (node.condition.rightConditionValue.value instanceof
+          VariableExpression &&
+          !isTypeCompatibleForAssignment(
+            node.condition.propertyExpressionState.propertyExpression.func.value
+              .genericType.value.rawType,
+            node.condition.rightConditionValue.value.genericType?.value.rawType,
+          )))
     );
   }
 

--- a/packages/legend-query-builder/style/_query-builder-filter.scss
+++ b/packages/legend-query-builder/style/_query-builder-filter.scss
@@ -378,6 +378,12 @@ $group-node-width: 3.5rem;
       font-size: 1.2rem;
       font-weight: 500;
 
+      &--error {
+        .value-spec-editor__variable {
+          background: var(--color-red-200);
+        }
+      }
+
       .value-spec-editor {
         width: 10rem;
         flex: 1;

--- a/packages/legend-query-builder/style/_query-builder-post-filter.scss
+++ b/packages/legend-query-builder/style/_query-builder-post-filter.scss
@@ -304,6 +304,24 @@
       font-size: 1.2rem;
       font-weight: 500;
 
+      &--error {
+        .value-spec-editor__variable {
+          background: var(--color-red-200);
+        }
+
+        .query-builder-column-badge__content {
+          background: var(--color-red-200);
+
+          .query-builder-column-badge__type {
+            background: var(--color-dark-shade-100);
+
+            .query-builder-column-badge__icon {
+              color: var(--color-light-grey-200);
+            }
+          }
+        }
+      }
+
       .value-spec-editor {
         width: 10rem;
         flex: 1;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This PR re-commits the [changes](https://github.com/finos/legend-studio/pull/3414) to improve the handling of changing constant/parameter/derivation types, but without the [`useEffect`](https://github.com/finos/legend-studio/pull/3414/files#diff-bfcb7c4acbc2f777f024273092e945091e6e7e8837034d4603c5bb0a7aaae5e5R276) hook that was causing a bug.

The below is taken from the original PR:

Improve how we handle when a user changes the type of a constant/parameter/derivation. This PR implements new behavior such that if a user changes the type of a constant/parameter/derivation, if the value is used in the filter or post-filter panels and is no longer compatible, we show it as an error. This ensures users can't change the types of these values and accidentally create an invalid query.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Changing const type:
![ChangingConst](https://github.com/user-attachments/assets/8f704756-3a73-4028-b0cd-b31bc6f3f089)

Changing param type:
![ChangingParam](https://github.com/user-attachments/assets/288f1fc4-bf26-4754-a85f-c4b774cd44e0)

Changing derivation type when used as post-filter condition left value:
![DerivationLeftValue](https://github.com/user-attachments/assets/22c43498-7047-4306-80ca-c01f7aea7100)

Changing derivation type when used as post-filter condition right value:
![DerivationRightValue](https://github.com/user-attachments/assets/6f81bdd5-6c89-4ed3-add5-65c8d37c5909)

Derivation is maintained when "edit pure" modal is opened and closed (bug that was occurring previously with the `useEffect` hook):
![DerivationEditPure](https://github.com/user-attachments/assets/5c048c9b-ba98-4d88-b324-fc4d8e4be503)
