### PR TITLE
Refactor data space executable to support use function pointer

### DIFF
--- a/.changeset/lemon-ads-hear.md
+++ b/.changeset/lemon-ads-hear.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-space': patch
+---
+
+Refactor data sapce executable to support use function pointer

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/action/analytics/DataSpaceAnalysis.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/action/analytics/DataSpaceAnalysis.ts
@@ -134,6 +134,12 @@ export class DataSpaceTemplateExecutableInfo extends DataSpaceExecutableInfo {
   executionContextKey!: string;
 }
 
+export class DataSpaceFunctionPointerExecutableInfo extends DataSpaceExecutableInfo {
+  id!: string;
+  executionContextKey!: string;
+  function!: string;
+}
+
 export class DataSpaceServiceExecutableInfo extends DataSpaceExecutableInfo {
   pattern!: string;
   mapping?: string | undefined;

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/V1_DSL_DataSpace_PureGraphManagerExtension.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/V1_DSL_DataSpace_PureGraphManagerExtension.ts
@@ -77,6 +77,7 @@ import {
   DataSpaceMultiExecutionServiceExecutableInfo,
   DataSpaceMultiExecutionServiceKeyedExecutableInfo,
   DataSpaceTemplateExecutableInfo,
+  DataSpaceFunctionPointerExecutableInfo,
 } from '../../../action/analytics/DataSpaceAnalysis.js';
 import { DSL_DataSpace_PureGraphManagerExtension } from '../DSL_DataSpace_PureGraphManagerExtension.js';
 import {
@@ -89,6 +90,7 @@ import {
   V1_deserializeDataSpaceAnalysisResult,
   V1_DataSpaceMultiExecutionServiceExecutableInfo,
   V1_DataSpaceTemplateExecutableInfo,
+  V1_DataSpaceFunctionPointerExecutableInfo,
 } from './engine/analytics/V1_DataSpaceAnalysis.js';
 import { getDiagram } from '@finos/legend-extension-dsl-diagram/graph';
 
@@ -564,6 +566,16 @@ export class V1_DSL_DataSpace_PureGraphManagerExtension extends DSL_DataSpace_Pu
           const templateExecutableInfo = new DataSpaceTemplateExecutableInfo();
           templateExecutableInfo.id = executableProtocol.info.id;
           templateExecutableInfo.query = executableProtocol.info.query;
+          templateExecutableInfo.executionContextKey =
+            executableProtocol.info.executionContextKey;
+        } else if (
+          executableProtocol.info instanceof
+          V1_DataSpaceFunctionPointerExecutableInfo
+        ) {
+          const templateExecutableInfo =
+            new DataSpaceFunctionPointerExecutableInfo();
+          templateExecutableInfo.id = executableProtocol.info.id;
+          templateExecutableInfo.function = executableProtocol.info.function;
           templateExecutableInfo.executionContextKey =
             executableProtocol.info.executionContextKey;
         } else if (

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/engine/analytics/V1_DataSpaceAnalysis.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/engine/analytics/V1_DataSpaceAnalysis.ts
@@ -249,6 +249,8 @@ export abstract class V1_DataSpaceExecutableInfo {
 }
 
 const V1_DATA_SPACE_TEMPLATE_EXECUTABLE_INFO_TYPE = 'templateExecutableInfo';
+const V1_DATA_SPACE_FUNCTION_POINTER_EXECUTABLE_INFO_TYPE =
+  'functionPointerExecutableInfo';
 const V1_DATA_SPACE_SERVICE_EXECUTABLE_INFO_TYPE = 'service';
 const V1_DATA_SPACE_MULTI_EXECUTION_SERVICE_EXECUTABLE_INFO_TYPE =
   'multiExecutionService';
@@ -258,16 +260,32 @@ export class V1_DataSpaceTemplateExecutableInfo extends V1_DataSpaceExecutableIn
   executionContextKey!: string;
 }
 
-const V1_DataSpaceTemplateExecutableInfoModelSchema = (
-  plugins: PureProtocolProcessorPlugin[],
-): ModelSchema<V1_DataSpaceTemplateExecutableInfo> =>
-  createModelSchema(V1_DataSpaceTemplateExecutableInfo, {
-    _type: usingConstantValueSchema(
-      V1_DATA_SPACE_TEMPLATE_EXECUTABLE_INFO_TYPE,
-    ),
-    id: primitive(),
-    executionContextKey: primitive(),
-  });
+export class V1_DataSpaceFunctionPointerExecutableInfo extends V1_DataSpaceExecutableInfo {
+  id!: string;
+  executionContextKey!: string;
+  function!: string;
+}
+
+const V1_DataSpaceTemplateExecutableInfoModelSchema =
+  (): ModelSchema<V1_DataSpaceTemplateExecutableInfo> =>
+    createModelSchema(V1_DataSpaceTemplateExecutableInfo, {
+      _type: usingConstantValueSchema(
+        V1_DATA_SPACE_TEMPLATE_EXECUTABLE_INFO_TYPE,
+      ),
+      id: primitive(),
+      executionContextKey: primitive(),
+    });
+
+const V1_DataSpaceFunctionPointerExecutableInfoModelSchema =
+  (): ModelSchema<V1_DataSpaceFunctionPointerExecutableInfo> =>
+    createModelSchema(V1_DataSpaceFunctionPointerExecutableInfo, {
+      _type: usingConstantValueSchema(
+        V1_DATA_SPACE_FUNCTION_POINTER_EXECUTABLE_INFO_TYPE,
+      ),
+      id: primitive(),
+      executionContextKey: primitive(),
+      function: primitive(),
+    });
 
 export class V1_DataSpaceServiceExecutableInfo extends V1_DataSpaceExecutableInfo {
   pattern!: string;
@@ -346,8 +364,10 @@ const V1_deserializeDataSpaceExecutableInfo = (
 ): V1_DataSpaceExecutableInfo => {
   switch (json._type) {
     case V1_DATA_SPACE_TEMPLATE_EXECUTABLE_INFO_TYPE:
+      return deserialize(V1_DataSpaceTemplateExecutableInfoModelSchema(), json);
+    case V1_DATA_SPACE_FUNCTION_POINTER_EXECUTABLE_INFO_TYPE:
       return deserialize(
-        V1_DataSpaceTemplateExecutableInfoModelSchema(plugins),
+        V1_DataSpaceFunctionPointerExecutableInfoModelSchema(),
         json,
       );
     case V1_DATA_SPACE_SERVICE_EXECUTABLE_INFO_TYPE:

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/model/packageableElements/dataSpace/V1_DSL_DataSpace_DataSpace.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/model/packageableElements/dataSpace/V1_DSL_DataSpace_DataSpace.ts
@@ -61,14 +61,18 @@ export class V1_DataSpaceElementPointer implements Hashable {
 }
 
 export abstract class V1_DataSpaceExecutable implements Hashable {
+  id?: string;
+  executionContextKey?: string | undefined;
   title!: string;
   description?: string | undefined;
 
   get hashCode(): string {
     return hashArray([
       DATA_SPACE_HASH_STRUCTURE.DATA_SPACE_EXECUTABLE,
+      this.id,
       this.title,
       this.description ?? '',
+      this.executionContextKey ?? '',
     ]);
   }
 }
@@ -82,8 +86,10 @@ export class V1_DataSpacePackageableElementExecutable
   override get hashCode(): string {
     return hashArray([
       DATA_SPACE_HASH_STRUCTURE.DATA_SPACE_PACKAGEABLE_ELEMENT_EXECUTABLE,
+      this.id,
       this.title,
       this.description ?? '',
+      this.executionContextKey ?? '',
       this.executable.path,
     ]);
   }
@@ -93,9 +99,7 @@ export class V1_DataSpaceTemplateExecutable
   extends V1_DataSpaceExecutable
   implements Hashable
 {
-  id!: string;
   query!: V1_RawLambda;
-  executionContextKey?: string | undefined;
 
   override get hashCode(): string {
     return hashArray([

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/V1_DSL_DataSpace_ProtocolHelper.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/V1_DSL_DataSpace_ProtocolHelper.ts
@@ -145,6 +145,8 @@ const V1_dataSpacePackageableElementExecutableModelSchema = createModelSchema(
       V1_DATA_SPACE_PACKAGEABLE_ELEMENT_EXECUTABLE,
     ),
     description: optional(primitive()),
+    executionContextKey: optional(primitive()),
+    id: optional(primitive()),
     title: primitive(),
     executable: usingModelSchema(V1_packageableElementPointerModelSchema),
   },

--- a/packages/legend-extension-dsl-data-space/src/graph/metamodel/pure/model/packageableElements/dataSpace/DSL_DataSpace_DataSpace.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph/metamodel/pure/model/packageableElements/dataSpace/DSL_DataSpace_DataSpace.ts
@@ -27,6 +27,8 @@ import {
   type RawLambda,
   type DataElementReference,
   PackageableElement,
+  ConcreteFunctionDefinition,
+  generateFunctionPrettyName,
 } from '@finos/legend-graph';
 import { DATA_SPACE_HASH_STRUCTURE } from '../../../../../DSL_DataSpace_HashUtils.js';
 import type { Diagram } from '@finos/legend-extension-dsl-diagram/graph';
@@ -68,14 +70,18 @@ export class DataSpaceElementPointer implements Hashable {
 }
 
 export abstract class DataSpaceExecutable implements Hashable {
+  id?: string;
+  executionContextKey?: string;
   title!: string;
   description?: string | undefined;
 
   get hashCode(): string {
     return hashArray([
       DATA_SPACE_HASH_STRUCTURE.DATA_SPACE_EXECUTABLE,
+      this.id,
       this.title,
       this.description ?? '',
+      this.executionContextKey ?? '',
     ]);
   }
 }
@@ -89,9 +95,17 @@ export class DataSpacePackageableElementExecutable
   override get hashCode(): string {
     return hashArray([
       DATA_SPACE_HASH_STRUCTURE.DATA_SPACE_PACKAGEABLE_ELEMENT_EXECUTABLE,
+      this.id,
       this.title,
       this.description ?? '',
-      this.executable.valueForSerialization ?? '',
+      this.executionContextKey ?? '',
+      this.executable.value instanceof ConcreteFunctionDefinition
+        ? generateFunctionPrettyName(this.executable.value, {
+            fullPath: true,
+            spacing: false,
+            notIncludeParamName: true,
+          })
+        : (this.executable.valueForSerialization ?? ''),
     ]);
   }
 }
@@ -100,9 +114,7 @@ export class DataSpaceExecutableTemplate
   extends DataSpaceExecutable
   implements Hashable
 {
-  id!: string;
   query!: RawLambda;
-  executionContextKey?: string;
 
   override get hashCode(): string {
     return hashArray([

--- a/packages/legend-extension-dsl-data-space/src/stores/query-builder/DataSpaceQueryBuilderState.ts
+++ b/packages/legend-extension-dsl-data-space/src/stores/query-builder/DataSpaceQueryBuilderState.ts
@@ -228,17 +228,23 @@ export class DataSpacesDepotRepository extends DataSpacesBuilderRepoistory {
     dataSpace: DataSpace,
     template: DataSpaceExecutableTemplate,
   ): void {
-    this.applicationStore.navigationService.navigator.visitAddress(
-      this.applicationStore.navigationService.navigator.generateAddress(
-        generateDataSpaceTemplateQueryCreatorRoute(
-          this.project.groupId,
-          this.project.artifactId,
-          this.project.versionId,
-          dataSpace.path,
-          template.id,
+    if (template.id) {
+      this.applicationStore.navigationService.navigator.visitAddress(
+        this.applicationStore.navigationService.navigator.generateAddress(
+          generateDataSpaceTemplateQueryCreatorRoute(
+            this.project.groupId,
+            this.project.artifactId,
+            this.project.versionId,
+            dataSpace.path,
+            template.id,
+          ),
         ),
-      ),
-    );
+      );
+    } else {
+      this.applicationStore.notificationService.notifyWarning(
+        `Can't visit tempalte query without a Id`,
+      );
+    }
   }
 
   showAdvancedSearchPanel(dataSpace: DataSpace): void {

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_DataSpace-advanced.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_DataSpace-advanced.pure
@@ -99,10 +99,6 @@ DataSpace <<meta::pure::profiles::typemodifiers.abstract>> {doc.doc = 'bla'} mod
       executable: model::MyService;
     },
     {
-      title: 'Exec 2';
-      executable: model::MyService;
-    },
-    {
       id: template_id;
       title: 'this is template';
       query: |'';


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Refactor data space executable to support use function pointer

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
