### PR TITLE
Create pre-filter when right clicking simple projection column in grid output

### DIFF
--- a/.changeset/tender-dots-prove.md
+++ b/.changeset/tender-dots-prove.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Create pre-filter when right clicking simple projection column in grid output

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultPanel.test.ts
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultPanel.test.ts
@@ -393,24 +393,3 @@ test(
     ).not.toBeNull();
   },
 );
-
-describe(
-  integrationTest('Query builder result panel filter by/filter out'),
-  () => {
-    test('Check that filter by pre-filters simple projection columns', async () => {
-      const { renderResult, queryBuilderState } =
-        await testQueryBuilderStateSetup();
-      const executionResult = V1_buildExecutionResult(
-        V1_serializeExecutionResult(TEST_DATA__result),
-      );
-      await act(async () => {
-        queryBuilderState.resultState.setExecutionResult(executionResult);
-      });
-
-      expect(renderResult.getByText('Employees/First Name')).not.toBeNull();
-      expect(renderResult.getByText('Doe')).not.toBeNull();
-      fireEvent.contextMenu(renderResult.getByText('Doe'));
-      expect(await renderResult.findByText('Filter By')).not.toBeNull();
-    });
-  },
-);

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultPanel.test.ts
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderResultPanel.test.ts
@@ -393,3 +393,24 @@ test(
     ).not.toBeNull();
   },
 );
+
+describe(
+  integrationTest('Query builder result panel filter by/filter out'),
+  () => {
+    test('Check that filter by pre-filters simple projection columns', async () => {
+      const { renderResult, queryBuilderState } =
+        await testQueryBuilderStateSetup();
+      const executionResult = V1_buildExecutionResult(
+        V1_serializeExecutionResult(TEST_DATA__result),
+      );
+      await act(async () => {
+        queryBuilderState.resultState.setExecutionResult(executionResult);
+      });
+
+      expect(renderResult.getByText('Employees/First Name')).not.toBeNull();
+      expect(renderResult.getByText('Doe')).not.toBeNull();
+      fireEvent.contextMenu(renderResult.getByText('Doe'));
+      expect(await renderResult.findByText('Filter By')).not.toBeNull();
+    });
+  },
+);

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -49,8 +49,30 @@ import { QueryBuilderTDSState } from '../../stores/fetch-structure/tds/QueryBuil
 import { filterByOrOutValues } from '../result/tds/QueryBuilderTDSResultShared.js';
 import { MockedMonacoEditorInstance } from '@finos/legend-lego/code-editor/test';
 
-const mocked =
-  '{"builder":{"_type":"tdsBuilder","columns":[{"name":"Age","type":"Integer","relationalType":"INTEGER"},{"name":"Edited First Name","type":"String","relationalType":"VARCHAR(200)"},{"name":"Last Reported Flag","type":"Boolean","relationalType":"BIT"}]},"activities":[{"_type":"relational","comment":"","sql":"select"}],"result":{"columns":["Age","Edited First Name","Last Reported Flag"],"rows":[{"values":[22,"John",true]},{"values":[129305879132475986,"Olivia",false]},{"values":[1450,"Henry",true]},{"values":[55,"https://www.google.com/",null]}]}}';
+const mockedResult = {
+  builder: {
+    _type: 'tdsBuilder',
+    columns: [
+      { name: 'Age', type: 'Integer', relationalType: 'INTEGER' },
+      {
+        name: 'Edited First Name',
+        type: 'String',
+        relationalType: 'VARCHAR(200)',
+      },
+      { name: 'Last Reported Flag', type: 'Boolean', relationalType: 'BIT' },
+    ],
+  },
+  activities: [{ _type: 'relational', comment: '', sql: 'select' }],
+  result: {
+    columns: ['Age', 'Edited First Name', 'Last Reported Flag'],
+    rows: [
+      { values: [22, 'John', true] },
+      { values: ['129305879132475986', 'Olivia', false] },
+      { values: [1450, 'Henry', true] },
+      { values: [55, 'https://www.google.com/', null] },
+    ],
+  },
+};
 // TODO make more generic. maybe pass string execution result and what we expect to render for each test case
 test(
   integrationTest('Query Builder run query and render execution result'),
@@ -81,7 +103,7 @@ test(
     const graphManager = queryBuilderState.graphManagerState.graphManager;
     const pureManager = guaranteeType(graphManager, V1_PureGraphManager);
     const executionResultMap = new Map<string, string>();
-    executionResultMap.set(V1_EXECUTION_RESULT, mocked);
+    executionResultMap.set(V1_EXECUTION_RESULT, JSON.stringify(mockedResult));
     createSpy(pureManager.engine, 'runQueryAndReturnMap').mockResolvedValue(
       executionResultMap,
     );
@@ -168,7 +190,7 @@ test(
   },
 );
 
-const mocked2 = {
+const mockedResultForFilterTest = {
   builder: {
     _type: 'tdsBuilder',
     columns: [
@@ -229,7 +251,10 @@ test(
     const graphManager = queryBuilderState.graphManagerState.graphManager;
     const pureManager = guaranteeType(graphManager, V1_PureGraphManager);
     const executionResultMap = new Map<string, string>();
-    executionResultMap.set(V1_EXECUTION_RESULT, JSON.stringify(mocked2));
+    executionResultMap.set(
+      V1_EXECUTION_RESULT,
+      JSON.stringify(mockedResultForFilterTest),
+    );
     createSpy(pureManager.engine, 'runQueryAndReturnMap').mockResolvedValue(
       executionResultMap,
     );

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -68,7 +68,7 @@ const mockedResult = {
     columns: ['Age', 'Edited First Name', 'Last Reported Flag'],
     rows: [
       { values: [22, 'John', true] },
-      { values: ['129305879132475986', 'Olivia', false] },
+      { values: [129305879132475986n.toString(), 'Olivia', false] },
       { values: [1450, 'Henry', true] },
       { values: [55, GOOGLE_LINK, null] },
     ],

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -49,6 +49,7 @@ import { QueryBuilderTDSState } from '../../stores/fetch-structure/tds/QueryBuil
 import { filterByOrOutValues } from '../result/tds/QueryBuilderTDSResultShared.js';
 import { MockedMonacoEditorInstance } from '@finos/legend-lego/code-editor/test';
 
+const GOOGLE_LINK = 'https://www.google.com/';
 const mockedResult = {
   builder: {
     _type: 'tdsBuilder',
@@ -69,7 +70,7 @@ const mockedResult = {
       { values: [22, 'John', true] },
       { values: ['129305879132475986', 'Olivia', false] },
       { values: [1450, 'Henry', true] },
-      { values: [55, 'https://www.google.com/', null] },
+      { values: [55, GOOGLE_LINK, null] },
     ],
   },
 };
@@ -119,7 +120,6 @@ test(
     const tdsResult = renderResult.getByTestId(
       QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_VALUES_TDS,
     );
-    const GOOGLE_LINK = 'https://www.google.com/';
     const knownValues = [
       'Edited First Name',
       'John',

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -124,7 +124,7 @@ test(
     );
 
     await act(async () => {
-      filterByOrOutValues(
+      await filterByOrOutValues(
         queryBuilderState.applicationStore,
         queryBuilderState.resultState.mousedOverCell,
         true,
@@ -149,7 +149,7 @@ test(
 
     // re-add post-filter
     await act(async () => {
-      filterByOrOutValues(
+      await filterByOrOutValues(
         queryBuilderState.applicationStore,
         queryBuilderState.resultState.mousedOverCell,
         true,

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -131,21 +131,19 @@ test(
         state,
       );
     });
-    const postFilterPanel = renderResult.getByTestId(
-      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_POST_FILTER_PANEL,
+    const filterPanel = renderResult.getByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_FILTER_PANEL,
     );
 
-    expect(
-      await findByText(postFilterPanel, 'Edited First Name'),
-    ).not.toBeNull();
-    expect(await findByText(postFilterPanel, 'is')).not.toBeNull();
-    expect(await findByText(postFilterPanel, '"Henry"')).not.toBeNull();
+    expect(await findByText(filterPanel, 'First Name')).not.toBeNull();
+    expect(await findByText(filterPanel, 'is')).not.toBeNull();
+    expect(await findByText(filterPanel, '"Henry"')).not.toBeNull();
 
     // remove post-filter
-    fireEvent.click(getByTitle(postFilterPanel, 'Remove'));
-    expect(queryByText(postFilterPanel, 'Edited First Name')).toBeNull();
-    expect(queryByText(postFilterPanel, 'is')).toBeNull();
-    expect(queryByText(postFilterPanel, '"Henry"')).toBeNull();
+    fireEvent.click(getByTitle(filterPanel, 'Remove'));
+    expect(queryByText(filterPanel, 'First Name')).toBeNull();
+    expect(queryByText(filterPanel, 'is')).toBeNull();
+    expect(queryByText(filterPanel, '"Henry"')).toBeNull();
 
     // re-add post-filter
     await act(async () => {
@@ -156,10 +154,8 @@ test(
         state,
       );
     });
-    expect(
-      await findByText(postFilterPanel, 'Edited First Name'),
-    ).not.toBeNull();
-    expect(await findByText(postFilterPanel, 'is')).not.toBeNull();
-    expect(await findByText(postFilterPanel, '"Henry"')).not.toBeNull();
+    expect(await findByText(filterPanel, 'First Name')).not.toBeNull();
+    expect(await findByText(filterPanel, 'is')).not.toBeNull();
+    expect(await findByText(filterPanel, '"Henry"')).not.toBeNull();
   },
 );

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderRunQuery.test.tsx
@@ -169,13 +169,13 @@ test(
     expect(await findByText(filterPanel, 'is')).not.toBeNull();
     expect(await findByText(filterPanel, '"Henry"')).not.toBeNull();
 
-    // remove post-filter
+    // remove filter
     fireEvent.click(getByTitle(filterPanel, 'Remove'));
     expect(queryByText(filterPanel, 'First Name')).toBeNull();
     expect(queryByText(filterPanel, 'is')).toBeNull();
     expect(queryByText(filterPanel, '"Henry"')).toBeNull();
 
-    // re-add post-filter
+    // re-add filter
     await act(async () => {
       await filterByOrOutValues(
         queryBuilderState.applicationStore,

--- a/packages/legend-query-builder/src/components/filter/QueryBuilderFilterPanel.tsx
+++ b/packages/legend-query-builder/src/components/filter/QueryBuilderFilterPanel.tsx
@@ -1110,7 +1110,7 @@ const QueryBuilderFilterConditionEditor = observer(
                       className="query-builder-filter-tree__condition-node__operator__dropdown__option"
                       onClick={changeOperator(op)}
                     >
-                      {op.getLabel(node.condition)}
+                      {op.getLabel()}
                     </MenuContentItem>
                   ))}
                 </MenuContent>
@@ -1122,7 +1122,7 @@ const QueryBuilderFilterConditionEditor = observer(
               }}
             >
               <div className="query-builder-filter-tree__condition-node__operator__label">
-                {node.condition.operator.getLabel(node.condition)}
+                {node.condition.operator.getLabel()}
               </div>
               <div className="query-builder-filter-tree__condition-node__operator__dropdown__trigger">
                 <CaretDownIcon />

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSGridResult.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSGridResult.tsx
@@ -346,7 +346,7 @@ export const QueryBuilderTDSGridResult = observer(
                   resultState.mousedOverCell,
                   true,
                   fetchStructureImplementation,
-                );
+                ).catch(queryBuilderState.applicationStore.alertUnhandledError);
               },
             },
             {
@@ -357,7 +357,7 @@ export const QueryBuilderTDSGridResult = observer(
                   resultState.mousedOverCell,
                   false,
                   fetchStructureImplementation,
-                );
+                ).catch(queryBuilderState.applicationStore.alertUnhandledError);
               },
             },
             'copy',
@@ -376,6 +376,7 @@ export const QueryBuilderTDSGridResult = observer(
         applicationStore,
         resultState.mousedOverCell,
         resultState.queryBuilderState.fetchStructureState.implementation,
+        queryBuilderState.applicationStore.alertUnhandledError,
       ],
     );
 

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
@@ -247,6 +247,7 @@ const generateNewPreFilterConditionNodeData = (
     LegendApplicationConfig,
     LegendApplicationPluginManager<LegendApplicationPlugin>
   >,
+  operator: QueryBuilderFilterOperator,
   _cellData: QueryBuilderTDSResultCellData,
   filterState: QueryBuilderFilterState,
   propertyExpression: AbstractPropertyExpression | undefined,
@@ -257,6 +258,7 @@ const generateNewPreFilterConditionNodeData = (
       filterConditionState = new FilterConditionState(
         filterState,
         propertyExpression,
+        operator,
       );
 
       const defaultFilterConditionValue =
@@ -592,6 +594,7 @@ const preFilterByOrOutValue = (
     try {
       generateNewPreFilterConditionNodeData(
         applicationStore,
+        operator,
         _cellData,
         queryBuilderState.filterState,
         propertyExpressionState.propertyExpression,

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
@@ -742,7 +742,9 @@ export const QueryBuilderGridResultContextMenu = observer(
         <MenuContentItem
           disabled={!tdsColState}
           onClick={(): void => {
-            filterByOrOutValues(applicationStore, data, true, tdsState);
+            filterByOrOutValues(applicationStore, data, true, tdsState).catch(
+              tdsState.queryBuilderState.applicationStore.alertUnhandledError,
+            );
           }}
         >
           Filter By
@@ -750,7 +752,9 @@ export const QueryBuilderGridResultContextMenu = observer(
         <MenuContentItem
           disabled={!tdsColState}
           onClick={(): void => {
-            filterByOrOutValues(applicationStore, data, false, tdsState);
+            filterByOrOutValues(applicationStore, data, false, tdsState).catch(
+              tdsState.queryBuilderState.applicationStore.alertUnhandledError,
+            );
           }}
         >
           Filter Out

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
@@ -181,7 +181,7 @@ const postFilterNotEqualOperator =
   new QueryBuilderPostFilterOperator_NotEqual();
 const postFilterNotInOperator = new QueryBuilderPostFilterOperator_NotIn();
 
-const getExistingPreFilterNode = (
+const getExistingFilterNode = (
   operators: QueryBuilderFilterOperator[],
   propertyExpressionState: QueryBuilderPropertyExpressionState | undefined,
   filterState: QueryBuilderFilterState,
@@ -242,7 +242,7 @@ const updateFilterConditionValue = (
   }
 };
 
-const generateNewPreFilterConditionNodeData = (
+const generateNewFilterConditionNodeData = (
   applicationStore: ApplicationStore<
     LegendApplicationConfig,
     LegendApplicationPluginManager<LegendApplicationPlugin>
@@ -348,7 +348,7 @@ const generateNewPostFilterConditionNodeData = async (
   }
 };
 
-const updateExistingPreFilterConditionNodeData = (
+const updateExistingFilterConditionNodeData = (
   existingPreFilterNode: QueryBuilderFilterTreeNodeData,
   isFilterBy: boolean,
   _cellData: QueryBuilderTDSResultCellData,
@@ -572,7 +572,7 @@ const preFilterByOrOutValue = (
 ): void => {
   queryBuilderState.filterState.setShowPanel(true);
   const operator = getFilterOperator(isFilterBy, _cellData);
-  const existingPreFilterNode = getExistingPreFilterNode(
+  const existingPreFilterNode = getExistingFilterNode(
     _cellData.value === null
       ? [filterEmptyOperator, filterNotEmptyOperator]
       : isFilterBy
@@ -582,7 +582,7 @@ const preFilterByOrOutValue = (
     queryBuilderState.filterState,
   );
   if (existingPreFilterNode) {
-    updateExistingPreFilterConditionNodeData(
+    updateExistingFilterConditionNodeData(
       existingPreFilterNode,
       isFilterBy,
       _cellData,
@@ -592,7 +592,7 @@ const preFilterByOrOutValue = (
     );
   } else {
     try {
-      generateNewPreFilterConditionNodeData(
+      generateNewFilterConditionNodeData(
         applicationStore,
         operator,
         _cellData,

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSResultShared.tsx
@@ -22,12 +22,13 @@ import {
 import { observer } from 'mobx-react-lite';
 import { flowResult } from 'mobx';
 import {
-  type TDSExecutionResult,
+  type AbstractPropertyExpression,
   type Enumeration,
-  InstanceValue,
-  EnumValueInstanceValue,
-  EnumValueExplicitReference,
   type ExecutionResult,
+  type TDSExecutionResult,
+  EnumValueExplicitReference,
+  EnumValueInstanceValue,
+  InstanceValue,
   RelationalExecutionActivities,
 } from '@finos/legend-graph';
 import { format as formatSQL } from 'sql-formatter';
@@ -47,6 +48,7 @@ import { forwardRef } from 'react';
 import {
   QueryBuilderDerivationProjectionColumnState,
   QueryBuilderProjectionColumnState,
+  QueryBuilderSimpleProjectionColumnState,
 } from '../../../stores/fetch-structure/tds/projection/QueryBuilderProjectionColumnState.js';
 import {
   type QueryBuilderPostFilterTreeNodeData,
@@ -81,6 +83,30 @@ import {
 } from '../../../stores/fetch-structure/tds/post-filter/operators/QueryBuilderPostFilterOperator_IsEmpty.js';
 import { getTDSColumnState } from '../../../stores/fetch-structure/tds/QueryBuilderTDSHelper.js';
 import type { QueryBuilderTDSColumnState } from '../../../stores/fetch-structure/tds/QueryBuilderTDSColumnState.js';
+import {
+  type QueryBuilderFilterState,
+  type QueryBuilderFilterTreeNodeData,
+  FilterConditionState,
+  FilterValueSpecConditionValueState,
+  isCollectionProperty,
+  QueryBuilderFilterTreeConditionNodeData,
+} from '../../../stores/filter/QueryBuilderFilterState.js';
+import { QueryBuilderAggregateColumnState } from '../../../stores/fetch-structure/tds/aggregation/QueryBuilderAggregationState.js';
+import type { QueryBuilderFilterOperator } from '../../../stores/filter/QueryBuilderFilterOperator.js';
+import {
+  QueryBuilderFilterOperator_Equal,
+  QueryBuilderFilterOperator_NotEqual,
+} from '../../../stores/filter/operators/QueryBuilderFilterOperator_Equal.js';
+import {
+  QueryBuilderFilterOperator_In,
+  QueryBuilderFilterOperator_NotIn,
+} from '../../../stores/filter/operators/QueryBuilderFilterOperator_In.js';
+import {
+  QueryBuilderFilterOperator_IsEmpty,
+  QueryBuilderFilterOperator_IsNotEmpty,
+} from '../../../stores/filter/operators/QueryBuilderFilterOperator_IsEmpty.js';
+import type { QueryBuilderState } from '../../../stores/QueryBuilderState.js';
+import type { QueryBuilderPropertyExpressionState } from '../../../stores/QueryBuilderPropertyEditorState.js';
 
 export const tryToFormatSql = (sql: string): string => {
   try {
@@ -139,6 +165,13 @@ export type IQueryRendererParamsWithGridType = DataGridCellRendererParams & {
   tdsExecutionResult: TDSExecutionResult;
 };
 
+const filterEqualOperator = new QueryBuilderFilterOperator_Equal();
+const filterNotEqualOperator = new QueryBuilderFilterOperator_NotEqual();
+const filterInOperator = new QueryBuilderFilterOperator_In();
+const filterNotInOperator = new QueryBuilderFilterOperator_NotIn();
+const filterEmptyOperator = new QueryBuilderFilterOperator_IsEmpty();
+const filterNotEmptyOperator = new QueryBuilderFilterOperator_IsNotEmpty();
+
 const postFilterEqualOperator = new QueryBuilderPostFilterOperator_Equal();
 const postFilterInOperator = new QueryBuilderPostFilterOperator_In();
 const postFilterEmptyOperator = new QueryBuilderPostFilterOperator_IsEmpty();
@@ -147,6 +180,22 @@ const postFilterNotEmptyOperator =
 const postFilterNotEqualOperator =
   new QueryBuilderPostFilterOperator_NotEqual();
 const postFilterNotInOperator = new QueryBuilderPostFilterOperator_NotIn();
+
+const getExistingPreFilterNode = (
+  operators: QueryBuilderFilterOperator[],
+  propertyExpressionState: QueryBuilderPropertyExpressionState | undefined,
+  filterState: QueryBuilderFilterState,
+): QueryBuilderFilterTreeNodeData | undefined =>
+  Array.from(filterState.nodes.values())
+    .filter(filterByType(QueryBuilderFilterTreeConditionNodeData))
+    .filter(
+      (node) =>
+        node.condition.propertyExpressionState.path ===
+          propertyExpressionState?.path &&
+        operators
+          .map((op) => op.getLabel())
+          .includes(node.condition.operator.getLabel()),
+    )[0];
 
 const getExistingPostFilterNode = (
   operators: QueryBuilderPostFilterOperator[],
@@ -173,7 +222,7 @@ const getExistingPostFilterNode = (
 const updateFilterConditionValue = (
   conditionValue: InstanceValue,
   _cellData: QueryBuilderTDSResultCellData,
-  tdsState: QueryBuilderTDSState,
+  queryBuilderState: QueryBuilderState,
 ): void => {
   if (_cellData.value) {
     instanceValue_setValue(
@@ -188,8 +237,53 @@ const updateFilterConditionValue = (
           )
         : _cellData.value,
       0,
-      tdsState.queryBuilderState.observerContext,
+      queryBuilderState.observerContext,
     );
+  }
+};
+
+const generateNewPreFilterConditionNodeData = (
+  applicationStore: ApplicationStore<
+    LegendApplicationConfig,
+    LegendApplicationPluginManager<LegendApplicationPlugin>
+  >,
+  _cellData: QueryBuilderTDSResultCellData,
+  filterState: QueryBuilderFilterState,
+  propertyExpression: AbstractPropertyExpression | undefined,
+): void => {
+  let filterConditionState: FilterConditionState;
+  try {
+    if (propertyExpression) {
+      filterConditionState = new FilterConditionState(
+        filterState,
+        propertyExpression,
+      );
+
+      const defaultFilterConditionValue =
+        filterConditionState.operator.getDefaultFilterConditionValue(
+          filterConditionState,
+        );
+
+      filterConditionState.buildRightConditionValueFromValueSpec(
+        defaultFilterConditionValue,
+      );
+      updateFilterConditionValue(
+        defaultFilterConditionValue as InstanceValue,
+        _cellData,
+        filterState.queryBuilderState,
+      );
+      filterState.addNodeFromNode(
+        new QueryBuilderFilterTreeConditionNodeData(
+          undefined,
+          filterConditionState,
+        ),
+        undefined,
+      );
+    }
+  } catch (error) {
+    assertErrorThrown(error);
+    applicationStore.notificationService.notifyWarning(error.message);
+    return;
   }
 };
 
@@ -235,7 +329,7 @@ const generateNewPostFilterConditionNodeData = async (
       updateFilterConditionValue(
         defaultFilterConditionValue as InstanceValue,
         _cellData,
-        tdsState,
+        tdsState.queryBuilderState,
       );
       tdsState.postFilterState.addNodeFromNode(
         new QueryBuilderPostFilterTreeConditionNodeData(
@@ -249,6 +343,91 @@ const generateNewPostFilterConditionNodeData = async (
     assertErrorThrown(error);
     applicationStore.notificationService.notifyWarning(error.message);
     return;
+  }
+};
+
+const updateExistingPreFilterConditionNodeData = (
+  existingPreFilterNode: QueryBuilderFilterTreeNodeData,
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+  operator: QueryBuilderFilterOperator,
+  data: QueryBuilderTDSResultCellData | null,
+  queryBuilderState: QueryBuilderState,
+): void => {
+  if (operator === filterEmptyOperator || operator === filterNotEmptyOperator) {
+    const conditionState = (
+      existingPreFilterNode as QueryBuilderFilterTreeConditionNodeData
+    ).condition;
+    if (conditionState.operator.getLabel() !== operator.getLabel()) {
+      conditionState.changeOperator(
+        isFilterBy ? filterEmptyOperator : filterNotEmptyOperator,
+      );
+    }
+    return;
+  }
+  const conditionState = (
+    existingPreFilterNode as QueryBuilderFilterTreeConditionNodeData
+  ).condition;
+
+  const rightSide = conditionState.rightConditionValue;
+  if (rightSide instanceof FilterValueSpecConditionValueState) {
+    if (conditionState.operator.getLabel() === operator.getLabel()) {
+      const doesValueAlreadyExist =
+        rightSide.value instanceof InstanceValue &&
+        (rightSide.value instanceof EnumValueInstanceValue
+          ? rightSide.value.values.map((ef) => ef.value.name)
+          : rightSide.value.values
+        ).includes(_cellData.value);
+
+      if (!doesValueAlreadyExist) {
+        const currentValueSpecificaton = rightSide.value;
+        const newValueSpecification =
+          conditionState.operator.getDefaultFilterConditionValue(
+            conditionState,
+          );
+        updateFilterConditionValue(
+          newValueSpecification as InstanceValue,
+          _cellData,
+          queryBuilderState,
+        );
+        conditionState.changeOperator(
+          isFilterBy ? filterInOperator : filterNotInOperator,
+        );
+        instanceValue_setValues(
+          rightSide.value as InstanceValue,
+          [currentValueSpecificaton, newValueSpecification],
+          queryBuilderState.observerContext,
+        );
+      }
+    } else {
+      const doesValueAlreadyExist =
+        rightSide.value instanceof InstanceValue &&
+        rightSide.value.values
+          .filter((v) => v instanceof InstanceValue)
+          .map((v) =>
+            v instanceof EnumValueInstanceValue
+              ? v.values.map((ef) => ef.value.name)
+              : v.values,
+          )
+          .flat()
+          .includes(_cellData.value ?? data?.value);
+
+      if (!doesValueAlreadyExist) {
+        const newValueSpecification = (
+          isFilterBy ? filterEqualOperator : filterNotEqualOperator
+        ).getDefaultFilterConditionValue(conditionState);
+        updateFilterConditionValue(
+          newValueSpecification as InstanceValue,
+          _cellData,
+          queryBuilderState,
+        );
+        instanceValue_setValues(
+          rightSide.value as InstanceValue,
+          [...(rightSide.value as InstanceValue).values, newValueSpecification],
+          queryBuilderState.observerContext,
+        );
+      }
+    }
   }
 };
 
@@ -297,7 +476,7 @@ const updateExistingPostFilterConditionNodeData = (
         updateFilterConditionValue(
           newValueSpecification as InstanceValue,
           _cellData,
-          tdsState,
+          tdsState.queryBuilderState,
         );
         conditionState.changeOperator(
           isFilterBy ? postFilterInOperator : postFilterNotInOperator,
@@ -328,7 +507,7 @@ const updateExistingPostFilterConditionNodeData = (
         updateFilterConditionValue(
           newValueSpecification as InstanceValue,
           _cellData,
-          tdsState,
+          tdsState.queryBuilderState,
         );
         instanceValue_setValues(
           rightSide.value as InstanceValue,
@@ -341,6 +520,25 @@ const updateExistingPostFilterConditionNodeData = (
 };
 
 const getFilterOperator = (
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+): QueryBuilderFilterOperator => {
+  if (isFilterBy) {
+    if (_cellData.value === null) {
+      return filterEmptyOperator;
+    } else {
+      return filterEqualOperator;
+    }
+  } else {
+    if (_cellData.value === null) {
+      return filterNotEmptyOperator;
+    } else {
+      return filterNotEqualOperator;
+    }
+  }
+};
+
+const getPostFilterOperator = (
   isFilterBy: boolean,
   _cellData: QueryBuilderTDSResultCellData,
 ): QueryBuilderPostFilterOperator => {
@@ -359,7 +557,7 @@ const getFilterOperator = (
   }
 };
 
-const filterByOrOutValue = (
+const preFilterByOrOutValue = (
   applicationStore: ApplicationStore<
     LegendApplicationConfig,
     LegendApplicationPluginManager<LegendApplicationPlugin>
@@ -367,13 +565,57 @@ const filterByOrOutValue = (
   isFilterBy: boolean,
   _cellData: QueryBuilderTDSResultCellData,
   data: QueryBuilderTDSResultCellData | null,
-  tdsState: QueryBuilderTDSState,
+  propertyExpressionState: QueryBuilderPropertyExpressionState,
+  queryBuilderState: QueryBuilderState,
 ): void => {
-  tdsState.setShowPostFilterPanel(true);
+  queryBuilderState.filterState.setShowPanel(true);
   const operator = getFilterOperator(isFilterBy, _cellData);
-  const tdsColState = data?.columnName
-    ? getTDSColumnState(tdsState, data.columnName)
-    : undefined;
+  const existingPreFilterNode = getExistingPreFilterNode(
+    _cellData.value === null
+      ? [filterEmptyOperator, filterNotEmptyOperator]
+      : isFilterBy
+        ? [filterEqualOperator, filterInOperator]
+        : [filterNotEqualOperator, filterNotInOperator],
+    propertyExpressionState,
+    queryBuilderState.filterState,
+  );
+  if (existingPreFilterNode) {
+    updateExistingPreFilterConditionNodeData(
+      existingPreFilterNode,
+      isFilterBy,
+      _cellData,
+      operator,
+      data,
+      queryBuilderState,
+    );
+  } else {
+    try {
+      generateNewPreFilterConditionNodeData(
+        applicationStore,
+        _cellData,
+        queryBuilderState.filterState,
+        propertyExpressionState.propertyExpression,
+      );
+    } catch (error) {
+      assertErrorThrown(error);
+      applicationStore.alertUnhandledError(error);
+    }
+  }
+};
+
+const postFilterByOrOutValue = async (
+  applicationStore: ApplicationStore<
+    LegendApplicationConfig,
+    LegendApplicationPluginManager<LegendApplicationPlugin>
+  >,
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+  data: QueryBuilderTDSResultCellData | null,
+  tdsColState: QueryBuilderTDSColumnState,
+  tdsState: QueryBuilderTDSState,
+): Promise<void> => {
+  tdsState.setShowPostFilterPanel(true);
+  const operator = getPostFilterOperator(isFilterBy, _cellData);
   const existingPostFilterNode = getExistingPostFilterNode(
     _cellData.value === null
       ? [postFilterEmptyOperator, postFilterNotEmptyOperator]
@@ -394,17 +636,67 @@ const filterByOrOutValue = (
       tdsState,
     );
   } else {
-    generateNewPostFilterConditionNodeData(
-      applicationStore,
-      operator,
-      _cellData,
-      tdsState,
-      tdsColState,
-    ).catch(applicationStore.alertUnhandledError);
+    try {
+      await generateNewPostFilterConditionNodeData(
+        applicationStore,
+        operator,
+        _cellData,
+        tdsState,
+        tdsColState,
+      );
+    } catch (error) {
+      assertErrorThrown(error);
+      applicationStore.alertUnhandledError(error);
+    }
   }
 };
 
-export const filterByOrOutValues = (
+const filterByOrOutValue = async (
+  applicationStore: ApplicationStore<
+    LegendApplicationConfig,
+    LegendApplicationPluginManager<LegendApplicationPlugin>
+  >,
+  isFilterBy: boolean,
+  _cellData: QueryBuilderTDSResultCellData,
+  data: QueryBuilderTDSResultCellData | null,
+  tdsState: QueryBuilderTDSState,
+): Promise<void> => {
+  const tdsColState = data?.columnName
+    ? getTDSColumnState(tdsState, data.columnName)
+    : undefined;
+  if (
+    tdsColState instanceof QueryBuilderDerivationProjectionColumnState ||
+    tdsColState instanceof QueryBuilderAggregateColumnState ||
+    (tdsColState instanceof QueryBuilderSimpleProjectionColumnState &&
+      isCollectionProperty(
+        tdsColState.propertyExpressionState.propertyExpression,
+      ))
+  ) {
+    await postFilterByOrOutValue(
+      applicationStore,
+      isFilterBy,
+      _cellData,
+      data,
+      tdsColState,
+      tdsState,
+    );
+  } else if (tdsColState instanceof QueryBuilderSimpleProjectionColumnState) {
+    preFilterByOrOutValue(
+      applicationStore,
+      isFilterBy,
+      _cellData,
+      data,
+      tdsColState.propertyExpressionState,
+      tdsState.queryBuilderState,
+    );
+  } else {
+    applicationStore.notificationService.notifyError(
+      `Can't filter column '${data?.columnName}'`,
+    );
+  }
+};
+
+export const filterByOrOutValues = async (
   applicationStore: ApplicationStore<
     LegendApplicationConfig,
     LegendApplicationPluginManager<LegendApplicationPlugin>
@@ -412,10 +704,17 @@ export const filterByOrOutValues = (
   data: QueryBuilderTDSResultCellData | null,
   isFilterBy: boolean,
   tdsState: QueryBuilderTDSState,
-): void => {
-  tdsState.queryBuilderState.resultState.selectedCells.forEach((_cellData) => {
-    filterByOrOutValue(applicationStore, isFilterBy, _cellData, data, tdsState);
-  });
+): Promise<void> => {
+  for (const _cellData of tdsState.queryBuilderState.resultState
+    .selectedCells) {
+    await filterByOrOutValue(
+      applicationStore,
+      isFilterBy,
+      _cellData,
+      data,
+      tdsState,
+    );
+  }
 };
 
 export const QueryBuilderGridResultContextMenu = observer(

--- a/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
@@ -7395,3 +7395,180 @@ export const TEST_DATA__simpleLambdaWithFirstDayOfYearDateFunction = {
   ],
   parameters: [],
 };
+
+export const TEST_DATA__projectionWithSimpleDerivationAndAggregation = {
+  _type: 'lambda',
+  body: [
+    {
+      _type: 'func',
+      function: 'groupBy',
+      parameters: [
+        {
+          _type: 'func',
+          function: 'getAll',
+          parameters: [
+            {
+              _type: 'packageableElementPtr',
+              fullPath: 'model::Firm',
+            },
+          ],
+        },
+        {
+          _type: 'collection',
+          multiplicity: {
+            lowerBound: 3,
+            upperBound: 3,
+          },
+          values: [
+            {
+              _type: 'lambda',
+              body: [
+                {
+                  _type: 'property',
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                  property: 'id',
+                },
+              ],
+              parameters: [
+                {
+                  _type: 'var',
+                  name: 'x',
+                },
+              ],
+            },
+            {
+              _type: 'lambda',
+              body: [
+                {
+                  _type: 'string',
+                  value: 'test',
+                },
+              ],
+              parameters: [
+                {
+                  _type: 'var',
+                  name: 'x',
+                },
+              ],
+            },
+            {
+              _type: 'lambda',
+              body: [
+                {
+                  _type: 'property',
+                  parameters: [
+                    {
+                      _type: 'property',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                      property: 'employees',
+                    },
+                  ],
+                  property: 'firstName',
+                },
+              ],
+              parameters: [
+                {
+                  _type: 'var',
+                  name: 'x',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'collection',
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          values: [
+            {
+              _type: 'func',
+              function: 'agg',
+              parameters: [
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'property',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                      property: 'id',
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                },
+                {
+                  _type: 'lambda',
+                  body: [
+                    {
+                      _type: 'func',
+                      function: 'sum',
+                      parameters: [
+                        {
+                          _type: 'var',
+                          name: 'x',
+                        },
+                      ],
+                    },
+                  ],
+                  parameters: [
+                    {
+                      _type: 'var',
+                      name: 'x',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'collection',
+          multiplicity: {
+            lowerBound: 4,
+            upperBound: 4,
+          },
+          values: [
+            {
+              _type: 'string',
+              value: 'Id',
+            },
+            {
+              _type: 'string',
+              value: '(derivation)',
+            },
+            {
+              _type: 'string',
+              value: 'Employees/First Name',
+            },
+            {
+              _type: 'string',
+              value: 'Id (sum)',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  parameters: [],
+};

--- a/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterOperator.ts
+++ b/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterOperator.ts
@@ -27,7 +27,7 @@ import type {
 export abstract class QueryBuilderFilterOperator implements Hashable {
   readonly uuid = uuid();
 
-  abstract getLabel(filterConditionState: FilterConditionState): string;
+  abstract getLabel(): string;
 
   abstract isCompatibleWithFilterConditionProperty(
     filterConditionState: FilterConditionState,

--- a/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterState.ts
+++ b/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterState.ts
@@ -246,6 +246,7 @@ export class FilterConditionState implements Hashable {
   constructor(
     filterState: QueryBuilderFilterState,
     propertyExpression: AbstractPropertyExpression,
+    operator?: QueryBuilderFilterOperator,
   ) {
     makeObservable(this, {
       propertyExpressionState: observable,
@@ -271,11 +272,15 @@ export class FilterConditionState implements Hashable {
     );
 
     // operator
-    assertTrue(
-      this.operators.length !== 0,
-      `Can't find an operator for property '${this.propertyExpressionState.path}': no operators registered`,
-    );
-    this.operator = this.operators[0] as QueryBuilderFilterOperator;
+    if (operator) {
+      this.operator = operator;
+    } else {
+      assertTrue(
+        this.operators.length !== 0,
+        `Can't find an operator for property '${this.propertyExpressionState.path}': no operators registered`,
+      );
+      this.operator = this.operators[0] as QueryBuilderFilterOperator;
+    }
     this.buildRightConditionValueFromValueSpec(
       this.operator.getDefaultFilterConditionValue(this),
     );

--- a/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterStateBuilder.ts
+++ b/packages/legend-query-builder/src/stores/filter/QueryBuilderFilterStateBuilder.ts
@@ -332,7 +332,7 @@ const processFilterTree = (
         assertTrue(
           parentLambdaVariableName === variableName,
           `Can't process ${extractElementNameFromPath(
-            filterConditionState.operator.getLabel(filterConditionState),
+            filterConditionState.operator.getLabel(),
           )}() expression: expects variable used in lambda body '${variableName}' to match lambda parameter '${parentLambdaVariableName}'`,
         );
         filterState.addNodeFromNode(

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_Contain.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_Contain.ts
@@ -46,7 +46,7 @@ export class QueryBuilderFilterOperator_Contain
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return 'contains';
   }
 
@@ -90,9 +90,7 @@ export class QueryBuilderFilterOperator_Contain
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }
@@ -128,7 +126,7 @@ export class QueryBuilderFilterOperator_Contain
 }
 
 export class QueryBuilderFilterOperator_NotContain extends QueryBuilderFilterOperator_Contain {
-  override getLabel(filterConditionState: FilterConditionState): string {
+  override getLabel(): string {
     return `doesn't contain`;
   }
 

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_EndWith.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_EndWith.ts
@@ -46,7 +46,7 @@ export class QueryBuilderFilterOperator_EndWith
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return 'ends with';
   }
 
@@ -90,9 +90,7 @@ export class QueryBuilderFilterOperator_EndWith
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }
@@ -128,7 +126,7 @@ export class QueryBuilderFilterOperator_EndWith
 }
 
 export class QueryBuilderFilterOperator_NotEndWith extends QueryBuilderFilterOperator_EndWith {
-  override getLabel(filterConditionState: FilterConditionState): string {
+  override getLabel(): string {
     return `doesn't end with`;
   }
 

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_Equal.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_Equal.ts
@@ -44,7 +44,7 @@ export class QueryBuilderFilterOperator_Equal
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return 'is';
   }
 
@@ -143,7 +143,7 @@ export class QueryBuilderFilterOperator_Equal
 }
 
 export class QueryBuilderFilterOperator_NotEqual extends QueryBuilderFilterOperator_Equal {
-  override getLabel(filterConditionState: FilterConditionState): string {
+  override getLabel(): string {
     return `is not`;
   }
 

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_GreaterThan.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_GreaterThan.ts
@@ -43,7 +43,7 @@ export class QueryBuilderFilterOperator_GreaterThan
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return '>';
   }
 
@@ -104,9 +104,7 @@ export class QueryBuilderFilterOperator_GreaterThan
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_GreaterThanEqual.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_GreaterThanEqual.ts
@@ -43,7 +43,7 @@ export class QueryBuilderFilterOperator_GreaterThanEqual
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return '>=';
   }
 
@@ -104,9 +104,7 @@ export class QueryBuilderFilterOperator_GreaterThanEqual
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_In.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_In.ts
@@ -48,7 +48,7 @@ export class QueryBuilderFilterOperator_In
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return 'is in list of';
   }
 
@@ -176,7 +176,7 @@ export class QueryBuilderFilterOperator_In
 }
 
 export class QueryBuilderFilterOperator_NotIn extends QueryBuilderFilterOperator_In {
-  override getLabel(filterConditionState: FilterConditionState): string {
+  override getLabel(): string {
     return `is not in list of`;
   }
 

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_IsEmpty.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_IsEmpty.ts
@@ -42,7 +42,7 @@ export class QueryBuilderFilterOperator_IsEmpty
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return 'is empty';
   }
 
@@ -110,7 +110,7 @@ export class QueryBuilderFilterOperator_IsEmpty
 }
 
 export class QueryBuilderFilterOperator_IsNotEmpty extends QueryBuilderFilterOperator_IsEmpty {
-  override getLabel(filterConditionState: FilterConditionState): string {
+  override getLabel(): string {
     return `is not empty`;
   }
 

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_LessThan.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_LessThan.ts
@@ -43,7 +43,7 @@ export class QueryBuilderFilterOperator_LessThan
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return '<';
   }
 
@@ -104,9 +104,7 @@ export class QueryBuilderFilterOperator_LessThan
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_LessThanEqual.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_LessThanEqual.ts
@@ -43,7 +43,7 @@ export class QueryBuilderFilterOperator_LessThanEqual
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return '<=';
   }
 
@@ -104,9 +104,7 @@ export class QueryBuilderFilterOperator_LessThanEqual
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }

--- a/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_StartWith.ts
+++ b/packages/legend-query-builder/src/stores/filter/operators/QueryBuilderFilterOperator_StartWith.ts
@@ -46,7 +46,7 @@ export class QueryBuilderFilterOperator_StartWith
   extends QueryBuilderFilterOperator
   implements Hashable
 {
-  getLabel(filterConditionState: FilterConditionState): string {
+  getLabel(): string {
     return 'starts with';
   }
 
@@ -90,9 +90,7 @@ export class QueryBuilderFilterOperator_StartWith
       }
       default:
         throw new UnsupportedOperationError(
-          `Can't get default value for filter operator '${this.getLabel(
-            filterConditionState,
-          )}' when the LHS property is of type '${propertyType.path}'`,
+          `Can't get default value for filter operator '${this.getLabel()}' when the LHS property is of type '${propertyType.path}'`,
         );
     }
   }
@@ -128,7 +126,7 @@ export class QueryBuilderFilterOperator_StartWith
 }
 
 export class QueryBuilderFilterOperator_NotStartWith extends QueryBuilderFilterOperator_StartWith {
-  override getLabel(filterConditionState: FilterConditionState): string {
+  override getLabel(): string {
     return `doesn't start with`;
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This change updates the behavior of the "Filter By"/"Filter Out" buttons that appear when a user right clicks a cell/cell range in the result panel. If the column is a simple projection column, we will create a regular (pre) filter node instead of a post-filter node like we do currently. Derivations, aggregations, and exploded properties still create post-filter nodes.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Simple projection column:
![SimpleProjection](https://github.com/user-attachments/assets/c9b731bb-1034-4ec8-8908-f8986d5e7c3c)

Derived column:
![DerivedColumn](https://github.com/user-attachments/assets/42d53070-7b5c-4dcd-8473-e90964c86b3d)

Derivation:
![Derivation](https://github.com/user-attachments/assets/4526dc41-2096-4fd5-913b-a38870e84f89)

Exploded column:
![ExplodedColumn](https://github.com/user-attachments/assets/470ee788-359b-48df-964a-7d856a74ee83)

Aggregation column:
![AggregationColumn](https://github.com/user-attachments/assets/fccdd6bb-78fa-4eaf-bb7f-5ddc3bd77e87)