### PR TITLE
Add get project entities by classifier APIs in depot server client

### DIFF
--- a/.changeset/honest-lemons-look.md
+++ b/.changeset/honest-lemons-look.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-server-depot': patch
+---
+
+Add get project entities by classifier APIs in depot server client

--- a/packages/legend-server-depot/src/DepotServerClient.ts
+++ b/packages/legend-server-depot/src/DepotServerClient.ts
@@ -75,8 +75,9 @@ export class DepotServerClient extends AbstractServerClient {
     groupId: string,
     artifactId: string,
     version: string,
+    classifier?: string,
   ): string =>
-    `${this._versions(groupId, artifactId)}/${encodeURIComponent(version)}`;
+    `${this._versions(groupId, artifactId)}/${encodeURIComponent(version)}${classifier ? `/classifiers/${classifier}` : ``}`;
 
   getAllVersions = (groupId: string, artifactId: string): Promise<string[]> =>
     this.get(this._versions(groupId, artifactId));
@@ -85,17 +86,20 @@ export class DepotServerClient extends AbstractServerClient {
     groupId: string,
     artifactId: string,
     version: string,
+    classifier?: string,
   ): Promise<PlainObject<Entity>[]> =>
-    this.get(this._version(groupId, artifactId, version));
+    this.get(this._version(groupId, artifactId, version, classifier));
 
   getEntities(
     project: StoreProjectData,
     versionId: string,
+    classifier?: string,
   ): Promise<PlainObject<Entity>[]> {
     return this.getVersionEntities(
       project.groupId,
       project.artifactId,
       resolveVersion(versionId),
+      classifier,
     );
   }
 
@@ -213,9 +217,10 @@ export class DepotServerClient extends AbstractServerClient {
      * Flag indicating whether to return the root of the dependency tree.
      */
     includeOrigin: boolean,
+    classifier?: string,
   ): Promise<PlainObject<ProjectVersionEntities>[]> =>
     this.get(
-      `${this._version(groupId, artifactId, version)}/dependencies`,
+      `${this._version(groupId, artifactId, version)}${classifier ? `/classifiers/${classifier}` : ''}/dependencies`,
       undefined,
       undefined,
       {
@@ -228,6 +233,7 @@ export class DepotServerClient extends AbstractServerClient {
   async getIndexedDependencyEntities(
     project: StoreProjectData,
     versionId: string,
+    classifier?: string,
   ): Promise<Map<string, EntitiesWithOrigin>> {
     const dependencyEntitiesIndex = new Map<string, EntitiesWithOrigin>();
     const dependencies = await this.getDependencyEntities(
@@ -236,6 +242,7 @@ export class DepotServerClient extends AbstractServerClient {
       resolveVersion(versionId),
       true,
       false,
+      classifier,
     );
     dependencies
       .map((v) => ProjectVersionEntities.serialization.fromJson(v))


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Add get project entities by classifier APIs in depot server client

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
