### PR TITLE
Allow providing config to LegendApplication

### DIFF
--- a/.changeset/healthy-geese-deliver.md
+++ b/.changeset/healthy-geese-deliver.md
@@ -1,5 +1,4 @@
 ---
-'@finos/legend-vscode-extension-dependencies': patch
 '@finos/legend-application': patch
 ---
 

--- a/.changeset/healthy-geese-deliver.md
+++ b/.changeset/healthy-geese-deliver.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-vscode-extension-dependencies': patch
+'@finos/legend-application': patch
+---
+
+Allow providing config to LegendApplication

--- a/.changeset/healthy-geese-deliver.md
+++ b/.changeset/healthy-geese-deliver.md
@@ -3,4 +3,4 @@
 '@finos/legend-application': patch
 ---
 
-Allow providing config to LegendApplication
+Allow injecting application configuration.

--- a/.changeset/rich-eggs-beg.md
+++ b/.changeset/rich-eggs-beg.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-vscode-extension-dependencies': patch
+---
+
+Additional exports for legend-vscode-extension-dependencies

--- a/.changeset/sharp-eyes-love.md
+++ b/.changeset/sharp-eyes-love.md
@@ -1,5 +1,6 @@
 ---
 '@finos/legend-graph': patch
+'@finos/legend-extension-dsl-data-space-studio': patch
 ---
 
 Add module and types to legend-graph package.json

--- a/.changeset/sharp-eyes-love.md
+++ b/.changeset/sharp-eyes-love.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Add module and types to legend-graph package.json

--- a/.changeset/sharp-eyes-love.md
+++ b/.changeset/sharp-eyes-love.md
@@ -2,5 +2,3 @@
 '@finos/legend-graph': patch
 '@finos/legend-extension-dsl-data-space-studio': patch
 ---
-
-Add module and types to legend-graph package.json

--- a/packages/legend-extension-dsl-data-space-studio/package.json
+++ b/packages/legend-extension-dsl-data-space-studio/package.json
@@ -47,6 +47,7 @@
     "@finos/legend-art": "workspace:*",
     "@finos/legend-code-editor": "workspace:*",
     "@finos/legend-extension-dsl-data-space": "workspace:*",
+    "@finos/legend-graph": "workspace:*",
     "@finos/legend-query-builder": "workspace:*",
     "@finos/legend-server-depot": "workspace:*",
     "@finos/legend-server-sdlc": "workspace:*",

--- a/packages/legend-extension-dsl-data-space-studio/tsconfig.build.json
+++ b/packages/legend-extension-dsl-data-space-studio/tsconfig.build.json
@@ -7,6 +7,7 @@
   "exclude": ["src/**/__tests__/**/*.*", "src/**/__mocks__/**/*.*"],
   "references": [
     { "path": "./tsconfig.package.json" },
+    { "path": "../legend-graph/tsconfig.build.json" },
     { "path": "../legend-application/tsconfig.build.json" },
     { "path": "../legend-application-studio/tsconfig.build.json" },
     { "path": "../legend-art/tsconfig.build.json" },

--- a/packages/legend-extension-dsl-data-space-studio/tsconfig.json
+++ b/packages/legend-extension-dsl-data-space-studio/tsconfig.json
@@ -9,6 +9,7 @@
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
   "references": [
     { "path": "./tsconfig.package.json" },
+    { "path": "../legend-graph" },
     { "path": "../legend-application" },
     { "path": "../legend-application-studio" },
     { "path": "../legend-art" },

--- a/packages/legend-graph/package.json
+++ b/packages/legend-graph/package.json
@@ -25,6 +25,8 @@
     ".": "./lib/index.js",
     "./test": "./lib/__test__.js"
   },
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --project ./tsconfig.build.json",

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -187,6 +187,7 @@ export { V1_PropertyGraphFetchTree } from './graph-manager/protocol/pure/v1/mode
 export { V1_SubTypeGraphFetchTree } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/classInstance/graph/V1_SubTypeGraphFetchTree.js';
 export { V1_GenericTypeInstance } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_GenericTypeInstance.js';
 export { V1_ParameterValue } from './graph-manager/protocol/pure/v1/model/packageableElements/service/V1_ParameterValue.js';
+export { V1_PureExecution } from './graph-manager/protocol/pure/v1/model/packageableElements/service/V1_ServiceExecution.js';
 export { V1_SourceInformation } from './graph-manager/protocol/pure/v1/model/V1_SourceInformation.js';
 
 // --------------------------------------------- EXECUTION PLAN --------------------------------------------------

--- a/packages/legend-vscode-extension-dependencies/src/index.ts
+++ b/packages/legend-vscode-extension-dependencies/src/index.ts
@@ -89,6 +89,7 @@ export {
   PureExecution,
   RawLambda,
   Service,
+  ServiceExecution,
   ServiceExecutionMode,
   TEMPORARY__AbstractEngineConfig,
   V1_ArtifactGenerationExtensionInput,
@@ -115,6 +116,7 @@ export {
   V1_MappingModelCoverageAnalysisInput,
   V1_MappingModelCoverageAnalysisResult,
   V1_ParserError,
+  V1_PureExecution,
   V1_PureGraphManager,
   V1_PureModelContext,
   V1_PureModelContextData,
@@ -128,6 +130,7 @@ export {
   V1_serializePackageableElement,
   V1_Service,
   V1_ServiceConfigurationInfo,
+  V1_serviceModelSchema,
   V1_ServiceRegistrationResult,
   V1_ServiceStorage,
   V1_SourceInformation,
@@ -192,4 +195,7 @@ export {
   ServiceQueryBuilderState,
 } from '@finos/legend-query-builder';
 
-export { pureExecution_setFunction } from '@finos/legend-application-studio';
+export {
+  pureExecution_setFunction,
+  service_setExecution,
+} from '@finos/legend-application-studio';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,6 +2908,7 @@ __metadata:
     "@finos/legend-code-editor": "workspace:*"
     "@finos/legend-dev-utils": "workspace:*"
     "@finos/legend-extension-dsl-data-space": "workspace:*"
+    "@finos/legend-graph": "workspace:*"
     "@finos/legend-query-builder": "workspace:*"
     "@finos/legend-server-depot": "workspace:*"
     "@finos/legend-server-sdlc": "workspace:*"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Allow providing a config object directly to `LegendApplication` instead of fetching it from an endpoint. This will allow the VS Code extension to create a class that extends LegendApplication and to provide its config directly to the `start` function, since the VS Code extension doesn't serve its config at an endpoint. If no config is provided, then the default behavior of fetching the config from an endpoint is used instead.

This PR also:
- Updates packages/legend-vscode-extension-dependencies/src/index.ts with a few more exports
- Adds a `"module"` and `"types"` property to the legend-graph package.json so types are properly exported for use in the VS Code extension

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Tested to check that query builder still loads properly:
![QueryBuliderLoads](https://github.com/user-attachments/assets/cb061c01-e60c-4aab-bc12-84ab1b378ebd)