### PR TITLE
Restyle parameter info tooltip and disable click handler if assistant is disabled

### DIFF
--- a/.changeset/spicy-dryers-collect.md
+++ b/.changeset/spicy-dryers-collect.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Restyle parameter info tooltip and disable click handler if assistant is disabled

--- a/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
+++ b/packages/legend-query-builder/src/components/QueryBuilderParametersPanel.tsx
@@ -30,6 +30,7 @@ import {
   PanelFormValidatedTextField,
   QuestionCircleIcon,
   PanelFormSection,
+  clsx,
 } from '@finos/legend-art';
 import {
   type Type,
@@ -348,8 +349,16 @@ export const QueryBuilderParametersPanel = observer(
           <div className="panel__header__title">
             <div className="panel__header__title__label">parameters</div>
             <div
-              onClick={seeDocumentation}
-              className="query-builder__variables__info"
+              onClick={
+                !queryBuilderState.applicationStore.assistantService.isDisabled
+                  ? seeDocumentation
+                  : undefined
+              }
+              className={clsx('query-builder__variables__info', {
+                'query-builder__variables__info--assistant-disabled':
+                  queryBuilderState.applicationStore.assistantService
+                    .isDisabled,
+              })}
               title={`Parameters are variables assigned to your query. They are dynamic in nature and can change for each execution.`}
             >
               <QuestionCircleIcon />

--- a/packages/legend-query-builder/style/_query-builder-explorer.scss
+++ b/packages/legend-query-builder/style/_query-builder-explorer.scss
@@ -200,6 +200,16 @@
     svg {
       font-size: 1.3rem;
     }
+
+    &--assistant-disabled {
+      cursor: default;
+
+      &:hover {
+        svg {
+          color: var(--color-light-grey-50);
+        }
+      }
+    }
   }
 
   &__variable {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

This PR restyles the parameter info tooltip to remove the cursor pointer and disables the tooltip's click handler if assistant is disabled. Since the click handler opens the virtual assistant, it doesn't do anything if the assistant is disabled. Thus, it is a better UX to not use the pointer cursor if clicking the tooltip doesn't do anything.

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Assistant enabled (default):
![VirtualAssistantEnabled](https://github.com/user-attachments/assets/2d98f19f-258f-433b-aeeb-ed14ce5c4463)

Assistant disabled:
![VirtualAssistantDisabled](https://github.com/user-attachments/assets/0ba9e5d0-0423-4f91-ba14-c8535c8e89df)
