### PR TITLE
Add testing for building graph from mapping analytics result

### DIFF
--- a/.changeset/slow-rats-smoke.md
+++ b/.changeset/slow-rats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Add testing for bulding graph from mapping analytics result

--- a/packages/legend-graph/src/graph-manager/__test-utils__/EngineTestSupport.ts
+++ b/packages/legend-graph/src/graph-manager/__test-utils__/EngineTestSupport.ts
@@ -29,6 +29,10 @@ import type { V1_ExecutionResult } from '../protocol/pure/v1/engine/execution/V1
 import { V1_ExecuteInput } from '../protocol/pure/v1/engine/execution/V1_ExecuteInput.js';
 import type { V1_PureModelContext } from '../protocol/pure/v1/model/context/V1_PureModelContext.js';
 import type { V1_ValueSpecification } from '../protocol/pure/v1/model/valueSpecification/V1_ValueSpecification.js';
+import {
+  V1_MappingModelCoverageAnalysisInput,
+  type V1_MappingModelCoverageAnalysisResult,
+} from '../protocol/pure/v1/engine/analytics/V1_MappingModelCoverageAnalysis.js';
 
 export const ENGINE_TEST_SUPPORT_API_URL = 'http://localhost:6300/api';
 
@@ -150,4 +154,24 @@ export async function ENGINE_TEST_SUPPORT__compile(
     `${ENGINE_TEST_SUPPORT_API_URL}/pure/v1/compilation/compile`,
     modelDataContext,
   );
+}
+
+export async function ENGINE_TEST_SUPPORT__mappingCoverage(
+  input: V1_MappingModelCoverageAnalysisInput,
+): Promise<PlainObject<V1_MappingModelCoverageAnalysisResult>> {
+  return (
+    await axios.post<unknown, AxiosResponse<{ elements: object[] }>>(
+      `${ENGINE_TEST_SUPPORT_API_URL}/analytics/mapping/modelCoverage`,
+      V1_MappingModelCoverageAnalysisInput.serialization.toJson(input),
+      {
+        headers: {
+          [HttpHeader.CONTENT_TYPE]: ContentType.APPLICATION_JSON,
+        },
+        params: {
+          returnMappedEntityInfo: true,
+          returnMappedPropertyInfo: true,
+        },
+      },
+    )
+  ).data;
 }

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
@@ -3274,6 +3274,14 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
     );
   }
 
+  async buildEntityFromMappingAnalyticsResult(
+    analyticsResult: V1_MappingModelCoverageAnalysisResult,
+    graph: PureModel,
+    buildActionState: ActionState,
+  ): Promise<Entity[]> {
+    return [];
+  }
+
   buildMappingModelCoverageAnalysisResult(
     input: RawMappingModelCoverageAnalysisResult,
     mapping: Mapping,

--- a/packages/legend-manual-tests/src/__tests__/model-coverage/ModelCoverage.engine-roundtrip-test.ts
+++ b/packages/legend-manual-tests/src/__tests__/model-coverage/ModelCoverage.engine-roundtrip-test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, test } from '@jest/globals';
+import { resolve } from 'path';
+import {
+  integrationTest,
+  type TEMPORARY__JestMatcher,
+} from '@finos/legend-shared/test';
+import {
+  V1_MappingModelCoverageAnalysisInput,
+  V1_MappingModelCoverageAnalysisResult,
+  V1_PureGraphManager,
+} from '@finos/legend-graph';
+import { ActionState } from '@finos/legend-shared';
+import {
+  createGraphManagerStateFromGrammar,
+  generateModelEntitesFromModelGrammar,
+} from '../utils/testUtils.js';
+import {
+  ENGINE_TEST_SUPPORT__mappingCoverage,
+  TEST__excludeSectionIndex,
+} from '@finos/legend-graph/test';
+
+type ModelCoverageTestCase = [
+  string,
+  {
+    mappingPath: string;
+    inputFileDir: string;
+    inputFilePath: string;
+    expectedFileDir: string;
+    expectedFilePath: string;
+  },
+];
+
+const MODEL_COVERAGE_CASES: ModelCoverageTestCase[] = [
+  [
+    'simple relational model',
+    {
+      mappingPath: 'my::map',
+      inputFileDir: 'model',
+      inputFilePath: 'TEST_DATA_Model-coverage',
+      expectedFileDir: 'model',
+      expectedFilePath: 'TEST_DATA_Model-coverage',
+    },
+  ],
+];
+
+describe(
+  integrationTest('Build Graph From Mapping Analytics Coverage and round trip'),
+  () => {
+    test.each(MODEL_COVERAGE_CASES)(
+      '%s',
+      async (
+        testName: ModelCoverageTestCase[0],
+        testCase: ModelCoverageTestCase[1],
+      ) => {
+        const {
+          mappingPath,
+          inputFileDir,
+          inputFilePath,
+          expectedFileDir,
+          expectedFilePath,
+        } = testCase;
+        const graphManagerState = await createGraphManagerStateFromGrammar(
+          resolve(__dirname, inputFileDir),
+          inputFilePath,
+        );
+        const pureGraphManager =
+          graphManagerState.graphManager as V1_PureGraphManager;
+        const mappingModelCoverageInput =
+          new V1_MappingModelCoverageAnalysisInput();
+        mappingModelCoverageInput.clientVersion =
+          V1_PureGraphManager.DEV_PROTOCOL_VERSION;
+        mappingModelCoverageInput.mapping = mappingPath;
+        mappingModelCoverageInput.model =
+          pureGraphManager.getFullGraphModelData(graphManagerState.graph);
+        const mappingModelCoverageAnalysisResult =
+          (await ENGINE_TEST_SUPPORT__mappingCoverage(
+            mappingModelCoverageInput,
+          )) as unknown as V1_MappingModelCoverageAnalysisResult;
+
+        const minalGraphEntities =
+          await pureGraphManager.buildEntityFromMappingAnalyticsResult(
+            mappingModelCoverageAnalysisResult,
+            graphManagerState.graph,
+            ActionState.create(),
+          );
+        const expectedEntities = await generateModelEntitesFromModelGrammar(
+          resolve(__dirname, expectedFileDir),
+          expectedFilePath,
+          undefined,
+        );
+        (
+          expect(expectedEntities) as TEMPORARY__JestMatcher
+        ).toIncludeSameMembers(TEST__excludeSectionIndex(expectedEntities));
+      },
+    );
+  },
+);

--- a/packages/legend-manual-tests/src/__tests__/model-coverage/model/TEST_DATA_Model-coverage.pure
+++ b/packages/legend-manual-tests/src/__tests__/model-coverage/model/TEST_DATA_Model-coverage.pure
@@ -1,0 +1,122 @@
+###Relational
+Database meta::analytics::mapping::modelCoverage::test::sampleDB
+(
+  Table FirmTable
+  (
+    id INTEGER PRIMARY KEY,
+    legalName VARCHAR(200)
+  )
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firmID INTEGER,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200)
+  )
+  Table AddressTable
+  (
+    id INTEGER PRIMARY KEY,
+    firmID INTEGER,
+    name VARCHAR(200)
+  )
+
+  Join firm_person(PersonTable.firmID = FirmTable.id)
+  Join firm_address(AddressTable.firmID = FirmTable.id)
+)
+
+
+###Pure
+Enum meta::analytics::mapping::modelCoverage::test::IncType
+{
+  Corp,
+  LLC
+}
+
+Class meta::analytics::mapping::modelCoverage::test::LegalEntity
+{
+  legalName: String[1];
+  address: meta::analytics::mapping::modelCoverage::test::Address[1];
+}
+
+Class meta::analytics::mapping::modelCoverage::test::Firm extends meta::analytics::mapping::modelCoverage::test::LegalEntity
+{
+  id: Decimal[1];
+  employees: meta::analytics::mapping::modelCoverage::test::Person[1..*];
+  incType: meta::analytics::mapping::modelCoverage::test::IncType[1];
+  employeeSize() {$this.employees->count()}: Number[1];
+}
+
+Class meta::analytics::mapping::modelCoverage::test::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+}
+
+Class meta::analytics::mapping::modelCoverage::test::Address
+{
+  zipcode: Integer[1];
+}
+
+Class meta::analytics::mapping::modelCoverage::test::Street extends meta::analytics::mapping::modelCoverage::test::Address
+{
+  streetName: String[1];
+}
+
+###Mapping
+Mapping meta::analytics::mapping::modelCoverage::test::sampleRelationalMapping
+(
+  *meta::analytics::mapping::modelCoverage::test::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [meta::analytics::mapping::modelCoverage::test::sampleDB]FirmTable.id
+    )
+    ~mainTable [meta::analytics::mapping::modelCoverage::test::sampleDB]FirmTable
+    id: [meta::analytics::mapping::modelCoverage::test::sampleDB]FirmTable.id,
+    employees
+    (
+      firstName: [meta::analytics::mapping::modelCoverage::test::sampleDB]PersonTable.firstName
+    ),
+    address: [meta::analytics::mapping::modelCoverage::test::sampleDB]@firm_address
+  }
+  *meta::analytics::mapping::modelCoverage::test::Person: Relational
+  {
+    ~primaryKey
+    (
+      [meta::analytics::mapping::modelCoverage::test::sampleDB]PersonTable.id
+    )
+    ~mainTable [meta::analytics::mapping::modelCoverage::test::sampleDB]PersonTable
+    firstName: [meta::analytics::mapping::modelCoverage::test::sampleDB]PersonTable.firstName,
+    lastName: [meta::analytics::mapping::modelCoverage::test::sampleDB]PersonTable.lastName
+  }
+  *meta::analytics::mapping::modelCoverage::test::LegalEntity: Operation
+  {
+    meta::pure::router::operations::inheritance_OperationSetImplementation_1__SetImplementation_MANY_()
+  }
+  *meta::analytics::mapping::modelCoverage::test::Address: Operation
+  {
+    meta::pure::router::operations::inheritance_OperationSetImplementation_1__SetImplementation_MANY_()
+  }
+  *meta::analytics::mapping::modelCoverage::test::Street: Operation
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(s1,s2)
+  }
+  meta::analytics::mapping::modelCoverage::test::Street[s2]: Relational
+  {
+    ~primaryKey
+    (
+      [meta::analytics::mapping::modelCoverage::test::sampleDB]AddressTable.id
+    )
+    ~mainTable [meta::analytics::mapping::modelCoverage::test::sampleDB]AddressTable
+    zipcode: [meta::analytics::mapping::modelCoverage::test::sampleDB]AddressTable.id
+  }
+  meta::analytics::mapping::modelCoverage::test::Street[s1]: Relational
+  {
+    ~primaryKey
+    (
+      [meta::analytics::mapping::modelCoverage::test::sampleDB]AddressTable.id
+    )
+    ~mainTable [meta::analytics::mapping::modelCoverage::test::sampleDB]AddressTable
+    zipcode: [meta::analytics::mapping::modelCoverage::test::sampleDB]AddressTable.id
+  }
+)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Add testing for building graph from mapping analytics result

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
