### PR TITLE
Use model pointer for check entitlement APIs in Query Builder

### DIFF
--- a/.changeset/fluffy-books-repair.md
+++ b/.changeset/fluffy-books-repair.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Use model pointer for check entitlement APIs in Query Builder

--- a/.changeset/tricky-avocados-pretend.md
+++ b/.changeset/tricky-avocados-pretend.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-data-space': patch
+---

--- a/packages/legend-extension-dsl-data-space/src/stores/query-builder/DataSpaceQueryBuilderState.ts
+++ b/packages/legend-extension-dsl-data-space/src/stores/query-builder/DataSpaceQueryBuilderState.ts
@@ -30,15 +30,20 @@ import {
   type Runtime,
   type Mapping,
   type FunctionAnalysisInfo,
+  type GraphData,
   getMappingCompatibleClasses,
   Package,
   QueryDataSpaceExecutionContext,
   elementBelongsToPackage,
+  GraphDataWithOrigin,
+  LegendSDLC,
+  InMemoryGraphData,
 } from '@finos/legend-graph';
 import {
   type DepotServerClient,
   type StoredEntity,
   DepotScope,
+  resolveVersion,
   SNAPSHOT_VERSION_ALIAS,
 } from '@finos/legend-server-depot';
 import {
@@ -479,6 +484,18 @@ export class DataSpaceQueryBuilderState extends QueryBuilderState {
       functionInfoMap,
       dependencyFunctionInfoMap,
     };
+  }
+
+  override getGraphData(): GraphData {
+    if (this.dataSpaceRepo instanceof DataSpacesDepotRepository) {
+      const option = new LegendSDLC(
+        this.dataSpaceRepo.project.groupId,
+        this.dataSpaceRepo.project.artifactId,
+        resolveVersion(this.dataSpaceRepo.project.versionId),
+      );
+      return new GraphDataWithOrigin(option);
+    }
+    return new InMemoryGraphData(this.graphManagerState.graph);
   }
 
   *intialize(): GeneratorFn<void> {

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -73,6 +73,8 @@ import {
   QueryExplicitExecutionContext,
   attachFromQuery,
   PackageableElementExplicitReference,
+  GraphData,
+  InMemoryGraphData,
 } from '@finos/legend-graph';
 import { buildLambdaFunction } from './QueryBuilderValueSpecificationBuilder.js';
 import type {
@@ -884,6 +886,10 @@ export abstract class QueryBuilderState implements CommandRegistrar {
     | QueryBuilderExtraFunctionAnalysisInfo
     | undefined {
     return undefined;
+  }
+
+  getGraphData(): GraphData {
+    return new InMemoryGraphData(this.graphManagerState.graph);
   }
 
   /**

--- a/packages/legend-query-builder/src/stores/QueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilderState.ts
@@ -57,6 +57,7 @@ import {
   type QueryGridConfig,
   type QueryExecutionContext,
   type FunctionAnalysisInfo,
+  type GraphData,
   GRAPH_MANAGER_EVENT,
   CompilationError,
   extractSourceInformationCoordinates,
@@ -73,7 +74,6 @@ import {
   QueryExplicitExecutionContext,
   attachFromQuery,
   PackageableElementExplicitReference,
-  GraphData,
   InMemoryGraphData,
 } from '@finos/legend-graph';
 import { buildLambdaFunction } from './QueryBuilderValueSpecificationBuilder.js';

--- a/packages/legend-query-builder/src/stores/entitlements/QueryBuilderCheckEntitlementsState.ts
+++ b/packages/legend-query-builder/src/stores/entitlements/QueryBuilderCheckEntitlementsState.ts
@@ -23,7 +23,6 @@ import {
   type GraphManagerState,
   type RawLambda,
   RuntimePointer,
-  InMemoryGraphData,
   buildRawLambdaFromLambdaFunction,
 } from '@finos/legend-graph';
 import {
@@ -71,9 +70,7 @@ export class QueryBuilderCheckEntitlementsState implements Hashable {
               this.queryBuilderState.parametersState.parameterStates,
               this.queryBuilderState.graphManagerState,
             ),
-          graphData: new InMemoryGraphData(
-            this.queryBuilderState.graphManagerState.graph,
-          ),
+          graphData: this.queryBuilderState.getGraphData(),
         },
       );
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Use model pointer for check entitlement APIs in Query Builder

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
