### PR TITLE
Support primitive types as source of Pure mappings

### DIFF
--- a/.changeset/brown-rice-bake.md
+++ b/.changeset/brown-rice-bake.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---
+
+Support primtive types as source of Pure mappings

--- a/packages/legend-application-studio/src/components/editor/editor-group/data-editor/EmbeddedDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/data-editor/EmbeddedDataEditor.tsx
@@ -51,7 +51,7 @@ import {
 } from '../../../../stores/editor/editor-state/element-editor-state/data/EmbeddedDataState.js';
 import {
   PackageableElementExplicitReference,
-  type Class,
+  type Type,
   type DataElement,
 } from '@finos/legend-graph';
 import {
@@ -256,7 +256,7 @@ export const ModelEmbeddedDataEditor = observer(
     const elementFilterOption = createFilter({
       ignoreCase: true,
       ignoreAccents: false,
-      stringify: (option: { data: PackageableElementOption<Class> }): string =>
+      stringify: (option: { data: PackageableElementOption<Type> }): string =>
         option.data.value.path,
     });
     const editorStore = modelStoreDataState.editorStore;
@@ -274,7 +274,7 @@ export const ModelEmbeddedDataEditor = observer(
       label: _class.name,
     };
 
-    const changeClass = (val: PackageableElementOption<Class> | null): void => {
+    const changeClass = (val: PackageableElementOption<Type> | null): void => {
       if (val?.value) {
         modelStoreData_setDataModelModel(
           modelData,

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/testable/MappingTestingHelper.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/mapping/testable/MappingTestingHelper.ts
@@ -17,6 +17,7 @@
 import {
   LambdaFunction,
   type Class,
+  type Type,
   type GraphManagerState,
   type RawLambda,
   type SetImplementation,
@@ -93,7 +94,7 @@ export const createGraphFetchRawLambda = (
 };
 
 export const createStoreBareModelStoreData = (
-  _class: Class,
+  _class: Type,
   editorStore: EditorStore,
 ): StoreTestData => {
   const modelStoreData = createBareModelStoreData(_class, editorStore);

--- a/packages/legend-application-studio/src/stores/editor/utils/TestableUtils.ts
+++ b/packages/legend-application-studio/src/stores/editor/utils/TestableUtils.ts
@@ -27,7 +27,6 @@ import {
   type Runtime,
   type TestAssertion,
   type AtomicTest,
-  type Class,
   type EmbeddedDataVisitor,
   type INTERNAL__UnknownConnection,
   type DataElementReference,
@@ -36,6 +35,7 @@ import {
   type ValueSpecification,
   type Binding,
   type RawLambda,
+  type Type,
   ExternalFormatData,
   RelationalCSVData,
   ConnectionTestData,
@@ -122,7 +122,7 @@ export const createDefaultEqualToJSONTestAssertion = (
 };
 
 export const createEmbeddedDataFromClass = (
-  _class: Class,
+  _class: Type,
   editorStore: EditorStore,
 ): ExternalFormatData => {
   const _json = createMockDataForMappingElementSource(_class, editorStore);
@@ -132,7 +132,7 @@ export const createEmbeddedDataFromClass = (
 };
 
 export const createBareModelStoreData = (
-  _class: Class,
+  _class: Type,
   editorStore: EditorStore,
 ): ModelStoreData => {
   const embeddedData = createEmbeddedDataFromClass(_class, editorStore);

--- a/packages/legend-application-studio/src/stores/graph-modifier/DSL_Data_GraphModifierHelper.ts
+++ b/packages/legend-application-studio/src/stores/graph-modifier/DSL_Data_GraphModifierHelper.ts
@@ -21,6 +21,7 @@ import {
   type ExternalFormatData,
   type ModelStoreData,
   type Class,
+  type Type,
   type DataElementReference,
   type RelationalCSVDataTable,
   type RelationalCSVData,
@@ -117,7 +118,7 @@ export const modelStoreData_addModelData = action(
 );
 
 export const modelStoreData_setDataModelModel = action(
-  (modelData: ModelData, val: PackageableElementReference<Class>): void => {
+  (modelData: ModelData, val: PackageableElementReference<Type>): void => {
     modelData.model = val;
   },
 );

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/to/V1_ClassMappingFirstPassBuilder.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/to/V1_ClassMappingFirstPassBuilder.ts
@@ -183,7 +183,7 @@ export class V1_ClassMappingFirstPassBuilder
     );
     const targetClass = this.context.resolveClass(classMapping.class);
     const srcClassReference = classMapping.srcClass
-      ? this.context.resolveClass(classMapping.srcClass)
+      ? this.context.resolveType(classMapping.srcClass)
       : undefined;
     const pureInstanceSetImplementation = new PureInstanceSetImplementation(
       V1_getInferredClassMappingId(targetClass.value, classMapping),

--- a/packages/legend-graph/src/graph/metamodel/pure/data/EmbeddedData.ts
+++ b/packages/legend-graph/src/graph/metamodel/pure/data/EmbeddedData.ts
@@ -19,7 +19,7 @@ import {
   CORE_HASH_STRUCTURE,
   hashObjectWithoutSourceInformation,
 } from '../../../../graph/Core_HashUtils.js';
-import type { Class } from '../packageableElements/domain/Class.js';
+import type { Type } from '../packageableElements/domain/Type.js';
 import type { PackageableElementReference } from '../packageableElements/PackageableElementReference.js';
 import type { RelationalCSVData } from './RelationalCSVData.js';
 import type { INTERNAL__UnknownEmbeddedData } from './INTERNAL__UnknownEmbeddedData.js';
@@ -72,7 +72,7 @@ export class ExternalFormatData extends EmbeddedData implements Hashable {
 }
 
 export abstract class ModelData implements Hashable {
-  model!: PackageableElementReference<Class>;
+  model!: PackageableElementReference<Type>;
 
   abstract get hashCode(): string;
 }

--- a/packages/legend-graph/src/graph/metamodel/pure/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation.ts
+++ b/packages/legend-graph/src/graph/metamodel/pure/packageableElements/store/modelToModel/mapping/PureInstanceSetImplementation.ts
@@ -17,6 +17,7 @@
 import { hashArray, type Hashable } from '@finos/legend-shared';
 import { CORE_HASH_STRUCTURE } from '../../../../../../../graph/Core_HashUtils.js';
 import type { Class } from '../../../domain/Class.js';
+import type { Type } from '../../../domain/Type.js';
 import { InstanceSetImplementation } from '../../../mapping/InstanceSetImplementation.js';
 import type { PurePropertyMapping } from './PurePropertyMapping.js';
 import type { SetImplementationVisitor } from '../../../mapping/SetImplementation.js';
@@ -31,7 +32,7 @@ export class PureInstanceSetImplementation
   implements Hashable
 {
   declare propertyMappings: PurePropertyMapping[];
-  srcClass?: PackageableElementReference<Class> | undefined;
+  srcClass?: PackageableElementReference<Type> | undefined;
   /**
    * Studio does not process value specification, they are left in raw JSON form
    *
@@ -44,7 +45,7 @@ export class PureInstanceSetImplementation
     parent: Mapping,
     _class: PackageableElementReference<Class>,
     root: InferableMappingElementRoot,
-    srcClass: PackageableElementReference<Class> | undefined,
+    srcClass: PackageableElementReference<Type> | undefined,
   ) {
     super(id, parent, _class, root);
     this.srcClass = srcClass;

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_Mapping-m2m-primitivetype-source.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_Mapping-m2m-primitivetype-source.pure
@@ -21,9 +21,8 @@ Mapping model::ModelToModelMappingFromPrimitiveType
   *model::Dest: Pure
   {
     ~src model::Source
-    w[dateMapping] : $src.d
+    w[dateMapping]: $src.d
   }
-
   model::Wrapper: Pure
   {
     ~src StrictDate

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_Mapping-m2m-primitivetype-source.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_Mapping-m2m-primitivetype-source.pure
@@ -23,7 +23,7 @@ Mapping model::ModelToModelMappingFromPrimitiveType
     ~src model::Source
     w[dateMapping]: $src.d
   }
-  model::Wrapper: Pure
+  model::Wrapper[dateMapping]: Pure
   {
     ~src StrictDate
     d: $src

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_Mapping-m2m-primitivetype-source.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_Mapping-m2m-primitivetype-source.pure
@@ -1,0 +1,32 @@
+###Pure
+Class model::Source
+{
+  d: StrictDate[1];
+}
+
+Class model::Wrapper
+{
+  d: StrictDate[1];
+}
+
+Class model::Dest
+{
+  w: model::Wrapper[1];
+}
+
+
+###Mapping
+Mapping model::ModelToModelMappingFromPrimitiveType
+(
+  *model::Dest: Pure
+  {
+    ~src model::Source
+    w[dateMapping] : $src.d
+  }
+
+  model::Wrapper: Pure
+  {
+    ~src StrictDate
+    d: $src
+  }
+)


### PR DESCRIPTION
Update Pure mapping metamodel to handle primitive types as source of Pure mappings (mirrors change to engine: https://github.com/finos/legend-engine/pull/3246)