### PR TITLE
Support open data cube query with parameters that use function

### DIFF
--- a/.changeset/fifty-apricots-jam.md
+++ b/.changeset/fifty-apricots-jam.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-data-cube': patch
+---
+
+Support open data cube query with parameters that use function

--- a/.changeset/many-mails-dream.md
+++ b/.changeset/many-mails-dream.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-graph': patch
+---

--- a/packages/legend-application-data-cube/src/stores/model/LegendQueryDataCubeSource.ts
+++ b/packages/legend-application-data-cube/src/stores/model/LegendQueryDataCubeSource.ts
@@ -19,6 +19,7 @@ import type {
   QueryInfo,
   V1_Lambda,
   V1_ParameterValue,
+  V1_ValueSpecification,
 } from '@finos/legend-graph';
 import {
   SerializationFactory,
@@ -36,6 +37,7 @@ export class LegendQueryDataCubeSource extends DataCubeSource {
   runtime!: string;
   model!: PlainObject;
   parameterValues: V1_ParameterValue[] = [];
+  letParameterValueSpec: V1_ValueSpecification[] = [];
 }
 
 export class RawLegendQueryDataCubeSource {

--- a/packages/legend-graph/src/graph/MetaModelConst.ts
+++ b/packages/legend-graph/src/graph/MetaModelConst.ts
@@ -31,6 +31,8 @@ export const PARSER_SECTION_MARKER = '###';
 export const FUNCTION_SIGNATURE_MULTIPLICITY_INFINITE_TOKEN = 'MANY';
 export const DIRECTORY_PATH_DELIMITER = '/';
 export const SOURCE_INFORMATION_PROPERTY_KEY_SUFFIX = 'sourceInformation';
+export const LET_TOKEN = 'let';
+export const PURE_DATE_FUNCTIONS_NAMESPACE = 'meta::pure::functions::date';
 
 export const RESERVERD_PACKAGE_NAMES = ['$implicit'];
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

Support open data cube query with parameters that use function

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
