### PR TITLE
Add release notes for DataCube

### DIFF
--- a/.changeset/wise-trees-change.md
+++ b/.changeset/wise-trees-change.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-data-cube': patch
+---
+
+Add release notes for DataCube

--- a/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
@@ -38,6 +38,7 @@ import {
 import { useEffect } from 'react';
 import { LegendDataCubeSettingStorageKey } from '../../__lib__/LegendDataCubeSetting.js';
 import type { LegendDataCubeBuilderStore } from '../../stores/builder/LegendDataCubeBuilderStore.js';
+import { ReleaseViewer } from '@finos/legend-application';
 
 const LegendDataCubeBuilderHeader = observer(() => {
   const store = useLegendDataCubeBuilderStore();
@@ -66,8 +67,33 @@ const LegendDataCubeBuilderHeader = observer(() => {
   );
 });
 
+export const LegendDataCubeReleaseLogManager = observer(() => {
+  const store = useLegendDataCubeBuilderStore();
+  const applicationStore = store.application;
+  const releaseService = applicationStore.releaseNotesService;
+
+  if (!releaseService.isConfigured) {
+    return null;
+  }
+  const releaseNotes = releaseService.releaseNotes ?? [];
+
+  return (
+    <div className="legend-datacube-release-notes h-full items-center p-3">
+      <div className="my-0.5 flex font-mono">
+        New features, enhancements and bug fixes that were released
+      </div>
+      <div className="p-2">
+        {releaseNotes.map((e) => (
+          <ReleaseViewer key={e.version} releaseNotes={e} />
+        ))}
+      </div>
+    </div>
+  );
+});
+
 export const LegendDataCubeAbout = observer(() => {
   const store = useLegendDataCubeBuilderStore();
+  const applicationStore = store.application;
   const config = store.application.config;
 
   return (
@@ -87,6 +113,15 @@ export const LegendDataCubeAbout = observer(() => {
       <div className="my-0.5 flex font-mono">
         <div>Build Time:</div>
         <div className="ml-1 font-bold">{config.appVersionBuildTime}</div>
+      </div>
+      <div
+        onClick={() => {
+          store.releaseLogDisplay.open();
+          applicationStore.releaseNotesService.setReleaseLog(true);
+        }}
+        className="my-0.5 flex cursor-pointer font-bold text-sky-500 underline"
+      >
+        <div>Details of Released Versions</div>
       </div>
       <div className="mt-3 rounded-sm bg-white px-4 py-2">
         <div className="my-0.5 flex font-mono">

--- a/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
@@ -67,6 +67,31 @@ const LegendDataCubeBuilderHeader = observer(() => {
   );
 });
 
+// For showing latest release notes (since last version
+// loaded by user)
+export const LegendDataCubeReleaseNotesManager = observer(() => {
+  const store = useLegendDataCubeBuilderStore();
+  const applicationStore = store.application;
+  const releaseService = applicationStore.releaseNotesService;
+  const releaseNotes = releaseService.showableVersions();
+
+  applicationStore.releaseNotesService.updateViewedVersion();
+
+  return (
+    <div className="legend-datacube-release-notes h-full items-center p-3">
+      <div className="my-0.5 flex font-mono">
+        New features, enhancements and bug fixes that were released
+      </div>
+      <div className="p-2">
+        {releaseNotes?.map((e) => (
+          <ReleaseViewer key={e.version} releaseNotes={e} />
+        ))}
+      </div>
+    </div>
+  );
+});
+
+// For showing all release notes.
 export const LegendDataCubeReleaseLogManager = observer(() => {
   const store = useLegendDataCubeBuilderStore();
   const applicationStore = store.application;
@@ -76,6 +101,8 @@ export const LegendDataCubeReleaseLogManager = observer(() => {
     return null;
   }
   const releaseNotes = releaseService.releaseNotes ?? [];
+
+  applicationStore.releaseNotesService.updateViewedVersion();
 
   return (
     <div className="legend-datacube-release-notes h-full items-center p-3">
@@ -115,10 +142,7 @@ export const LegendDataCubeAbout = observer(() => {
         <div className="ml-1 font-bold">{config.appVersionBuildTime}</div>
       </div>
       <div
-        onClick={() => {
-          store.releaseLogDisplay.open();
-          applicationStore.releaseNotesService.setReleaseLog(true);
-        }}
+        onClick={() => store.releaseLogDisplay.open()}
         className="my-0.5 flex cursor-pointer font-bold text-sky-500 underline"
       >
         <div>Details of Released Versions</div>
@@ -284,6 +308,18 @@ export const LegendDataCubeBuilder = withLegendDataCubeBuilderStore(
         .loadDataCube(dataCubeId)
         .catch((error) => store.alertService.alertUnhandledError(error));
     }, [store, dataCubeId]);
+
+    useEffect(() => {
+      const releaseService = application.releaseNotesService;
+      const releaseNotes = releaseService.showableVersions();
+      const isOpen = releaseService.showCurrentReleaseModal;
+
+      if (releaseService.isConfigured && isOpen && releaseNotes?.length) {
+        store.releaseNotesDisplay.open();
+      } else {
+        releaseService.updateViewedVersion();
+      }
+    }, [application]);
 
     if (!store.initializeState.hasSucceeded) {
       return (

--- a/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
@@ -97,7 +97,7 @@ export const LegendDataCubeReleaseLogManager = observer(
 
 export const LegendDataCubeAbout = observer(() => {
   const store = useLegendDataCubeBuilderStore();
-  const applicationStore = store.application;
+  const releaseService = store.application.releaseNotesService;
   const config = store.application.config;
 
   return (
@@ -118,12 +118,14 @@ export const LegendDataCubeAbout = observer(() => {
         <div>Build Time:</div>
         <div className="ml-1 font-bold">{config.appVersionBuildTime}</div>
       </div>
-      <div
-        onClick={() => store.releaseLogDisplay.open()}
-        className="my-0.5 flex cursor-pointer font-bold text-sky-500 underline"
-      >
-        <div>Details of Released Versions</div>
-      </div>
+      {releaseService.isConfigured && (
+        <div
+          onClick={() => store.releaseLogDisplay.open()}
+          className="my-0.5 flex cursor-pointer font-bold text-sky-500 underline"
+        >
+          <div>Details of Released Versions</div>
+        </div>
+      )}
       <div className="mt-3 rounded-sm bg-white px-4 py-2">
         <div className="my-0.5 flex font-mono">
           <div>Engine Server:</div>

--- a/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
@@ -67,56 +67,33 @@ const LegendDataCubeBuilderHeader = observer(() => {
   );
 });
 
-// For showing latest release notes (since last version
-// loaded by user)
-export const LegendDataCubeReleaseNotesManager = observer(() => {
-  const store = useLegendDataCubeBuilderStore();
-  const applicationStore = store.application;
-  const releaseService = applicationStore.releaseNotesService;
-  const releaseNotes = releaseService.showableVersions();
+export const LegendDataCubeReleaseLogManager = observer(
+  (props: { showOnlyLatestNotes: boolean }) => {
+    const { showOnlyLatestNotes } = props;
+    const store = useLegendDataCubeBuilderStore();
+    const applicationStore = store.application;
+    const releaseService = applicationStore.releaseNotesService;
+    const releaseNotes =
+      (showOnlyLatestNotes
+        ? releaseService.showableVersions()
+        : releaseService.releaseNotes) ?? [];
 
-  applicationStore.releaseNotesService.updateViewedVersion();
+    applicationStore.releaseNotesService.updateViewedVersion();
 
-  return (
-    <div className="legend-datacube-release-notes h-full items-center p-3">
-      <div className="my-0.5 flex font-mono">
-        New features, enhancements and bug fixes that were released
+    return (
+      <div className="legend-datacube-release-notes h-full items-center p-3">
+        <div className="my-0.5 flex font-mono">
+          New features, enhancements and bug fixes that were released
+        </div>
+        <div className="p-2">
+          {releaseNotes.map((e) => (
+            <ReleaseViewer key={e.version} releaseNotes={e} />
+          ))}
+        </div>
       </div>
-      <div className="p-2">
-        {releaseNotes?.map((e) => (
-          <ReleaseViewer key={e.version} releaseNotes={e} />
-        ))}
-      </div>
-    </div>
-  );
-});
-
-// For showing all release notes.
-export const LegendDataCubeReleaseLogManager = observer(() => {
-  const store = useLegendDataCubeBuilderStore();
-  const applicationStore = store.application;
-  const releaseService = applicationStore.releaseNotesService;
-
-  if (!releaseService.isConfigured) {
-    return null;
-  }
-  const releaseNotes = releaseService.releaseNotes ?? [];
-
-  applicationStore.releaseNotesService.updateViewedVersion();
-
-  return (
-    <div className="legend-datacube-release-notes h-full items-center p-3">
-      <div className="my-0.5 flex font-mono">
-        New features, enhancements and bug fixes that were released
-      </div>
-      <div className="p-2">
-        {releaseNotes.map((e) => (
-          <ReleaseViewer key={e.version} releaseNotes={e} />
-        ))}
-      </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 export const LegendDataCubeAbout = observer(() => {
   const store = useLegendDataCubeBuilderStore();

--- a/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/LegendDataCubeBuilder.tsx
@@ -298,7 +298,7 @@ export const LegendDataCubeBuilder = withLegendDataCubeBuilderStore(
       } else {
         releaseService.updateViewedVersion();
       }
-    }, [application]);
+    }, [application, store.releaseNotesDisplay]);
 
     if (!store.initializeState.hasSucceeded) {
       return (

--- a/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
+++ b/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
@@ -180,7 +180,7 @@ export class LegendDataCubeBuilderStore {
       () => <LegendDataCubeReleaseLogManager showOnlyLatestNotes={false} />,
       {
         ...DEFAULT_ALERT_WINDOW_CONFIG,
-        height: 350,
+        height: 500,
       },
     );
     this.releaseNotesDisplay = this.layoutService.newDisplay(
@@ -188,7 +188,7 @@ export class LegendDataCubeBuilderStore {
       () => <LegendDataCubeReleaseLogManager showOnlyLatestNotes={true} />,
       {
         ...DEFAULT_ALERT_WINDOW_CONFIG,
-        height: 250,
+        height: 350,
       },
     );
 

--- a/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
+++ b/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
@@ -59,7 +59,10 @@ import {
 import type { DepotServerClient } from '@finos/legend-server-depot';
 import { LegendDataCubeBlockingWindowState } from '../../components/LegendDataCubeBlockingWindow.js';
 import { LegendDataCubeDeleteConfirmation } from '../../components/builder/LegendDataCubeDeleteConfirmation.js';
-import { LegendDataCubeAbout } from '../../components/builder/LegendDataCubeBuilder.js';
+import {
+  LegendDataCubeAbout,
+  LegendDataCubeReleaseLogManager,
+} from '../../components/builder/LegendDataCubeBuilder.js';
 import { LegendDataCubeSourceViewer } from '../../components/builder/LegendDataCubeSourceViewer.js';
 
 export class LegendDataCubeBuilderState {
@@ -122,6 +125,7 @@ export class LegendDataCubeBuilderStore {
 
   readonly initializeState = ActionState.create();
   readonly aboutDisplay: DisplayState;
+  readonly releaseLogDisplay: DisplayState;
 
   readonly creator: LegendDataCubeCreatorState;
 
@@ -167,6 +171,15 @@ export class LegendDataCubeBuilderStore {
         x: -50,
         y: 50,
         center: false,
+      },
+    );
+
+    this.releaseLogDisplay = this.layoutService.newDisplay(
+      'Release Log',
+      () => <LegendDataCubeReleaseLogManager />,
+      {
+        ...DEFAULT_ALERT_WINDOW_CONFIG,
+        height: 250,
       },
     );
 

--- a/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
+++ b/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
@@ -62,7 +62,6 @@ import { LegendDataCubeDeleteConfirmation } from '../../components/builder/Legen
 import {
   LegendDataCubeAbout,
   LegendDataCubeReleaseLogManager,
-  LegendDataCubeReleaseNotesManager,
 } from '../../components/builder/LegendDataCubeBuilder.js';
 import { LegendDataCubeSourceViewer } from '../../components/builder/LegendDataCubeSourceViewer.js';
 
@@ -178,7 +177,7 @@ export class LegendDataCubeBuilderStore {
 
     this.releaseLogDisplay = this.layoutService.newDisplay(
       'Release Log',
-      () => <LegendDataCubeReleaseLogManager />,
+      () => <LegendDataCubeReleaseLogManager showOnlyLatestNotes={false} />,
       {
         ...DEFAULT_ALERT_WINDOW_CONFIG,
         height: 350,
@@ -186,7 +185,7 @@ export class LegendDataCubeBuilderStore {
     );
     this.releaseNotesDisplay = this.layoutService.newDisplay(
       'Release Notes',
-      () => <LegendDataCubeReleaseNotesManager />,
+      () => <LegendDataCubeReleaseLogManager showOnlyLatestNotes={true} />,
       {
         ...DEFAULT_ALERT_WINDOW_CONFIG,
         height: 250,

--- a/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
+++ b/packages/legend-application-data-cube/src/stores/builder/LegendDataCubeBuilderStore.tsx
@@ -62,6 +62,7 @@ import { LegendDataCubeDeleteConfirmation } from '../../components/builder/Legen
 import {
   LegendDataCubeAbout,
   LegendDataCubeReleaseLogManager,
+  LegendDataCubeReleaseNotesManager,
 } from '../../components/builder/LegendDataCubeBuilder.js';
 import { LegendDataCubeSourceViewer } from '../../components/builder/LegendDataCubeSourceViewer.js';
 
@@ -126,6 +127,7 @@ export class LegendDataCubeBuilderStore {
   readonly initializeState = ActionState.create();
   readonly aboutDisplay: DisplayState;
   readonly releaseLogDisplay: DisplayState;
+  readonly releaseNotesDisplay: DisplayState;
 
   readonly creator: LegendDataCubeCreatorState;
 
@@ -177,6 +179,14 @@ export class LegendDataCubeBuilderStore {
     this.releaseLogDisplay = this.layoutService.newDisplay(
       'Release Log',
       () => <LegendDataCubeReleaseLogManager />,
+      {
+        ...DEFAULT_ALERT_WINDOW_CONFIG,
+        height: 350,
+      },
+    );
+    this.releaseNotesDisplay = this.layoutService.newDisplay(
+      'Release Notes',
+      () => <LegendDataCubeReleaseNotesManager />,
       {
         ...DEFAULT_ALERT_WINDOW_CONFIG,
         height: 250,

--- a/packages/legend-application-data-cube/style/index.scss
+++ b/packages/legend-application-data-cube/style/index.scss
@@ -14,4 +14,56 @@
  * limitations under the License.
  */
 
-// nothing
+.legend-datacube-release-notes {
+  .release-viewer {
+    background-color: var(--tw-color-white);
+    margin-bottom: 1rem;
+
+    &__version {
+      font-weight: bold;
+      padding-left: 0.5rem;
+      padding-top: 0.5rem;
+    }
+
+    &__content {
+      padding: 0.5rem;
+    }
+
+    &__update {
+      padding-left: 0.5rem;
+
+      &__description {
+        padding-left: 0.5rem;
+      }
+
+      &-type {
+        margin: 0.25rem 0;
+      }
+
+      &__items {
+        padding-top: 0.25rem;
+      }
+
+      &__item {
+        display: flex;
+        margin: 0 0 0.5rem;
+
+        &-btn {
+          color: var(--tw-color-sky-500);
+        }
+
+        &-btn-bug {
+          color: var(--tw-color-red-500) !important;
+        }
+      }
+
+      &__link {
+        padding-left: 0.5rem;
+
+        &-btn {
+          color: var(--tw-color-sky-500);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This PR adds release notes for DataCube similar to what exists for Studio and Query. We add some styling to the `legend-application-data-cube` package to apply styling to the existing classes that are used in the shared `ReleaseViewer` component.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->

Opening release log:
![ReleaseLog](https://github.com/user-attachments/assets/c0043f67-2dc6-4b29-bd60-3bdd616826b9)

Release log doesn't show if release service isn't configured:
![ReleaseNotesNotConfigured](https://github.com/user-attachments/assets/fe01215b-ee17-42a9-b6d8-d55179300dcb)

Release notes show when new version is loaded (but doesn't show after user refreshes):
![NewVersion](https://github.com/user-attachments/assets/f17fb6b2-c42c-4065-86bf-10d452cbf81e)

Release notes don't show on first load (simulated by clearing cache/cookies and refreshing):
![ReloadingWithCookiesCleared](https://github.com/user-attachments/assets/5ad3edc2-505b-4821-8d4a-02e8ef9b2958)