### PR TITLE
Fix bug with toggling form mode making editors not respond to changes

### DIFF
--- a/.changeset/stupid-nails-burn.md
+++ b/.changeset/stupid-nails-burn.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Fix bug with toggling form mode making editors not respond to changes

--- a/packages/legend-application-studio/src/stores/editor/GraphEditFormModeState.ts
+++ b/packages/legend-application-studio/src/stores/editor/GraphEditFormModeState.ts
@@ -332,12 +332,6 @@ export class GraphEditFormModeState extends GraphEditorMode {
 
       this.editorStore.explorerTreeState.reprocess();
 
-      /**
-       * Re-build the editor states which were opened before from the information we have stored before
-       * creating the new graph
-       */
-      this.editorStore.tabManagerState.recoverTabs();
-
       this.editorStore.applicationStore.logService.info(
         LogEvent.create(GRAPH_MANAGER_EVENT.UPDATE_AND_REBUILD_GRAPH__SUCCESS),
         '[TOTAL]',
@@ -359,6 +353,15 @@ export class GraphEditFormModeState extends GraphEditorMode {
       );
 
       // ======= FINISHED (RE)START CHANGE DETECTION =======
+
+      /**
+       * Re-build the editor states which were opened before from the information we have stored before
+       * creating the new graph.
+       * NOTE: We must recover the tabs after we have called observeGraph above. Otherwise, the tab states
+       * will be recreated using the graph elements before they get observed, and this will cause the editor
+       * components to not update when users make changes, since mobx will not be able to detect the changes.
+       */
+      this.editorStore.tabManagerState.recoverTabs();
     } catch (error) {
       assertErrorThrown(error);
       this.editorStore.applicationStore.logService.error(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This PR fixes a bug with toggling between text mode and form mode.

### Steps to reproduce
1. Open an element editor
2. Toggle text mode then back to form mode

### Actual behavior
User's actions no longer update the element in form mode.

### Expected behavior
User should still be able to edit the element in form mode.

This bug was happening because in the code here (https://github.com/finos/legend-studio/blob/master/packages/legend-application-studio/src/stores/editor/GraphEditFormModeState.ts#L339) we were recovering the tabs before we observed the graph, so when we recovered the tabs while switching back to form mode, the tab states weren't using observed elements.

This PR moves the recover tabs step after the graph is observed to fix this bug.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
Example of bug:
![BugExample](https://github.com/user-attachments/assets/a1d998dd-b866-4543-8b77-dd1c066e9230)

Behavior after fix:
![BugFix](https://github.com/user-attachments/assets/2ede0407-36f1-4ea5-9be3-28f50e71d77a)
