### PR TITLE
add support for runtime field in DQ relation validation for text mode

### DIFF
--- a/.changeset/yellow-chairs-smile.md
+++ b/.changeset/yellow-chairs-smile.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+---
+
+support runtime field in dq relation validation protocol

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DataQualityValidationConfiguration.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DataQualityValidationConfiguration.ts
@@ -147,6 +147,7 @@ export class V1_DataQualityRelationValidationsConfiguration
 {
   query!: V1_DataQualityRelationQueryLambda;
   validations: V1_DataQualityRelationValidation[] = [];
+  runtime?: V1_PackageableElementPointer | undefined;
   taggedValues: V1_TaggedValue[] = [];
   stereotypes: V1_StereotypePtr[] = [];
 

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationBuilderHelper.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationBuilderHelper.ts
@@ -322,6 +322,12 @@ export function V1_buildDataQualityRelationValidationConfiguration(
   element.validations = elementProtocol.validations.map((validation) =>
     V1_buildDataQualityRelationValidation(validation, context),
   );
+  element.runtime = elementProtocol.runtime
+    ? (context.resolveElement(
+        elementProtocol.runtime.path,
+        false,
+      ) as PackageableElementImplicitReference<PackageableRuntime>)
+    : undefined;
 }
 
 export function V1_buildDataQualityServiceValidationConfiguration(

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationTransformer.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationTransformer.ts
@@ -206,6 +206,12 @@ export function V1_transformDataQualityRelationValidationConfiguration(
   protocol.validations = metamodel.validations.map((validation) =>
     V1_transformDataQualityRelationValidation(validation, context),
   );
+  protocol.runtime = metamodel.runtime
+    ? new V1_PackageableElementPointer(
+        PackageableElementPointerType.RUNTIME,
+        metamodel.runtime.valueForSerialization ?? '',
+      )
+    : undefined;
   protocol.query = new V1_DataQualityRelationQueryLambda();
   protocol.query.body = metamodel.query.body;
   protocol.query.parameters = metamodel.query.parameters.map(

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/V1_DSL_DataQuality_ProtocolHelper.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/V1_DSL_DataQuality_ProtocolHelper.ts
@@ -188,6 +188,10 @@ const V1_dataQualityRelationValidationModelSchema = (
     name: primitive(),
     package: primitive(),
     query: usingModelSchema(V1_rawLambdaModelSchemaParameters),
+    runtime: optionalCustom(
+      (val) => serialize(V1_packageableElementPointerModelSchema, val),
+      (val) => deserialize(V1_packageableElementPointerModelSchema, val),
+    ),
     validations: list(usingModelSchema(V1_relationValidationModelSchema)),
     stereotypes: customListWithSchema(V1_stereotypePtrModelSchema, {
       INTERNAL__forceReturnEmptyInTest: true,

--- a/packages/legend-extension-dsl-data-quality/src/graph/metamodel/pure/packageableElements/data-quality/DataQualityValidationConfiguration.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph/metamodel/pure/packageableElements/data-quality/DataQualityValidationConfiguration.ts
@@ -167,6 +167,7 @@ export class DataQualityRelationValidationConfiguration
 {
   query!: DataQualityRelationQueryLambda;
   validations: DataQualityRelationValidation[] = [];
+  runtime?: PackageableElementReference<PackageableRuntime> | undefined;
 
   protected override get _elementHashCode(): string {
     return hashArray([

--- a/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_DataQualityRelationValidation.pure
+++ b/packages/legend-manual-tests/src/__tests__/roundtrip-grammar/cases/DSL_DataQualityRelationValidation.pure
@@ -74,3 +74,29 @@ DataQualityRelationValidation model::relationValidation
     }
    ];
 }
+
+DataQualityRelationValidation model::relationValidation_separateRuntime
+{
+   query: |#>{store::db.table1}#->select(~[property_1]);
+   runtime: model::DummyRuntime;
+   validations: [
+   {
+     name: 'propertyNotEmpty';
+     assertion: row|$row.property_1->isNotEmpty();
+     type: ROW_LEVEL;
+    }
+   ];
+}
+
+DataQualityRelationValidation model::relationValidation_aggregate
+{
+   query: |#>{store::db.table1}#->select(~[property_1])->from(model::DummyRuntime);
+   validations: [
+   {
+     name: 'datasetNotEmpty';
+     assertion: rel|$rel->relationNotEmpty();
+     type: AGGREGATE;
+    }
+   ];
+}
+


### PR DESCRIPTION
Runtime field is added in dataquality specification for relation validation. This merge request adds support for the same in studio text mode.