### PR TITLE
Fix bug with fetching enum values from project dependency

### DIFF
--- a/.changeset/stupid-teeth-thank.md
+++ b/.changeset/stupid-teeth-thank.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-data-cube': patch
+---
+
+Fix bug with fetching enum values from project dependency

--- a/packages/legend-application-data-cube/src/components/__tests__/TEST_DATA__DSL_DataSpace_Entities.json
+++ b/packages/legend-application-data-cube/src/components/__tests__/TEST_DATA__DSL_DataSpace_Entities.json
@@ -955,5 +955,28 @@
       "title": "COVID Sample Data"
     },
     "classifierPath": "meta::pure::metamodel::dataSpace::DataSpace"
+  },
+  {
+    "classifierPath": "meta::pure::metamodel::type::Enumeration",
+    "path": "enum::MonthEnum",
+    "content": {
+      "_type": "Enumeration",
+      "name": "MonthEnum",
+      "package": "enum",
+      "values": [
+        { "value": "January" },
+        { "value": "February" },
+        { "value": "March" },
+        { "value": "April" },
+        { "value": "May" },
+        { "value": "June" },
+        { "value": "July" },
+        { "value": "August" },
+        { "value": "September" },
+        { "value": "October" },
+        { "value": "November" },
+        { "value": "December" }
+      ]
+    }
   }
 ]

--- a/packages/legend-application-data-cube/src/stores/LegendDataCubeDataCubeEngine.ts
+++ b/packages/legend-application-data-cube/src/stores/LegendDataCubeDataCubeEngine.ts
@@ -108,6 +108,8 @@ import {
   DataCubeQueryFilterOperator,
   _primitiveValue,
   _defaultPrimitiveTypeValue,
+  isPrimitiveType,
+  _property,
 } from '@finos/legend-data-cube';
 import {
   isNonNullable,
@@ -1173,10 +1175,13 @@ export class LegendDataCubeDataCubeEngine extends DataCubeEngine {
             const defaultValueString = queryInfo.defaultParameterValues?.find(
               (val) => val.name === parameter.name,
             )?.content;
+            // If not a primitive value, assume enum type.
             const defaultValueSpec =
               defaultValueString !== undefined
                 ? await this.parseValueSpecification(defaultValueString)
-                : _primitiveValue(type, _defaultPrimitiveTypeValue(type));
+                : isPrimitiveType(type)
+                  ? _primitiveValue(type, _defaultPrimitiveTypeValue(type))
+                  : _property('', [_elementPtr(type)]);
             return { variable: parameter, valueSpec: defaultValueSpec };
           }
           return undefined;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This PR fixes a bug with how DataCube fetches enum values to use in its V1_BasicValueSpecificationEditor components. If an enumeration doesn't exist in the project of the DataCube query, then it checks dependency projects for the enum value.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
