### PR TITLE
Fix how DataCube handles enum params

### DIFF
--- a/packages/legend-application-data-cube/src/components/builder/source/LegendQueryDataCubeSourceBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/source/LegendQueryDataCubeSourceBuilder.tsx
@@ -27,7 +27,6 @@ import { cn, DataCubeIcon, useDropdownMenu } from '@finos/legend-art';
 import {
   debounce,
   formatDistanceToNow,
-  guaranteeIsString,
   guaranteeType,
   quantifyList,
 } from '@finos/legend-shared';
@@ -35,9 +34,8 @@ import { flowResult } from 'mobx';
 import { useRef, useState, useMemo, useEffect } from 'react';
 import {
   _defaultPrimitiveTypeValue,
-  _elementPtr,
+  _enumValue,
   _primitiveValue,
-  _property,
   FormButton,
   FormCheckbox,
   FormCodeEditor,
@@ -360,13 +358,11 @@ export const LegendQueryDataCubeSourceBuilder = observer(
                         );
                       } else {
                         // If not a primitive, assume it is an enum
-                        const typeParam = _elementPtr(
-                          guaranteeIsString(packageableType.fullPath),
-                        );
-                        const enumValueSpec = _property('', [typeParam]);
                         sourceBuilder.setQueryParameterValue(
                           name,
-                          V1_observe_ValueSpecification(enumValueSpec),
+                          V1_observe_ValueSpecification(
+                            _enumValue('', packageableType.fullPath),
+                          ),
                         );
                       }
                     };

--- a/packages/legend-data-cube/src/index.tsx
+++ b/packages/legend-data-cube/src/index.tsx
@@ -65,7 +65,6 @@ export * from './components/DataCubePlaceholder.js';
 export {
   _collection,
   _elementPtr,
-  _enumeration,
   _enumValue,
   _function,
   _lambda,

--- a/packages/legend-data-cube/src/stores/core/DataCubeQueryBuilderUtils.ts
+++ b/packages/legend-data-cube/src/stores/core/DataCubeQueryBuilderUtils.ts
@@ -48,8 +48,7 @@ import {
   V1_CStrictDate,
   V1_CStrictTime,
   V1_CString,
-  V1_Enumeration,
-  V1_EnumValue,
+  V1_CEnumValue,
   V1_GenericTypeInstance,
   V1_Lambda,
   V1_Multiplicity,
@@ -254,22 +253,11 @@ export function _primitiveValue(
   }
 }
 
-export function _enumValue(value: string): V1_EnumValue {
-  const enumValue = new V1_EnumValue();
+export function _enumValue(value: string, fullPath: string): V1_CEnumValue {
+  const enumValue = new V1_CEnumValue();
   enumValue.value = value;
+  enumValue.fullPath = fullPath;
   return enumValue;
-}
-
-export function _enumeration(
-  enumerationPackage: string,
-  enumerationName: string,
-  values: V1_EnumValue[],
-): V1_Enumeration {
-  const enumeration = new V1_Enumeration();
-  enumeration.package = enumerationPackage;
-  enumeration.name = enumerationName;
-  enumeration.values = values;
-  return enumeration;
 }
 
 export function _elementPtr(fullPath: string) {

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -193,6 +193,7 @@ export { V1_CString } from './graph-manager/protocol/pure/v1/model/valueSpecific
 export { V1_CBoolean } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_CBoolean.js';
 export { V1_CByteArray } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_CByteArray.js';
 export { V1_CDecimal } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_CDecimal.js';
+export { V1_EnumValue as V1_CEnumValue } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_EnumValue.js';
 export { V1_CInteger } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_CInteger.js';
 export { V1_CFloat } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_CFloat.js';
 export { V1_CDate } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_CDate.js';
@@ -204,6 +205,7 @@ export { V1_ClassInstance } from './graph-manager/protocol/pure/v1/model/valueSp
 export { V1_PackageableElementPtr } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_PackageableElementPtr.js';
 export { V1_ColSpec } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/classInstance/relation/V1_ColSpec.js';
 export { V1_ColSpecArray } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/classInstance/relation/V1_ColSpecArray.js';
+export { V1_DataTypeValueSpecification } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_DataTypeValueSpecification.js';
 export { V1_PrimitiveValueSpecification } from './graph-manager/protocol/pure/v1/model/valueSpecification/raw/V1_PrimitiveValueSpecification.js';
 export { V1_INTERNAL__UnknownFunctionActivator } from './graph-manager/protocol/pure/v1/model/packageableElements/function/V1_INTERNAL__UnknownFunctionActivator.js';
 export { V1_ConcreteFunctionDefinition } from './graph-manager/protocol/pure/v1/model/packageableElements/function/V1_ConcreteFunctionDefinition.js';

--- a/packages/legend-query-builder/src/components/__tests__/V1_BasicValueSpecificationEditor.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/V1_BasicValueSpecificationEditor.test.tsx
@@ -24,35 +24,51 @@ import {
   PRIMITIVE_TYPE,
   V1_AppliedFunction,
   V1_AppliedProperty,
+  V1_CEnumValue,
   V1_CFloat,
   V1_CInteger,
   V1_CLatestDate,
   V1_Collection,
   V1_CString,
+  V1_Enumeration,
+  V1_EnumValue,
   V1_Multiplicity,
   V1_observe_ValueSpecification,
-  V1_PackageableElementPtr,
 } from '@finos/legend-graph';
 import { guaranteeNonNullable, guaranteeType } from '@finos/legend-shared';
 import { TEST__setUpV1BasicValueSpecificationEditor } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
 import { TEST__LegendApplicationPluginManager } from '../../stores/__test-utils__/QueryBuilderStateTestUtils.js';
-import {
-  V1_AppliedProperty_setProperty,
-  V1_PrimitiveValue_setValue,
-} from '../../stores/shared/V1_ValueSpecificationModifierHelper.js';
+import { V1_PrimitiveValue_setValue } from '../../stores/shared/V1_ValueSpecificationModifierHelper.js';
 import { CUSTOM_DATE_PICKER_OPTION } from '../shared/CustomDatePickerHelper.js';
 import { QUERY_BUILDER_SUPPORTED_FUNCTIONS } from '../../graph/QueryBuilderMetaModelConst.js';
 import {
   _collection,
   _defaultPrimitiveTypeValue,
   _elementPtr,
-  _enumeration,
   _enumValue,
   _primitiveValue,
   _property,
   _type,
 } from '@finos/legend-data-cube';
 import { integrationTest } from '@finos/legend-shared/test';
+
+function _packageableEnumeration(
+  enumerationPackage: string,
+  enumerationName: string,
+  values: V1_EnumValue[],
+): V1_Enumeration {
+  const enumeration = new V1_Enumeration();
+  enumeration.package = enumerationPackage;
+  enumeration.name = enumerationName;
+  enumeration.values = values;
+  return enumeration;
+}
+
+function _packageableEnumValue(value: string): V1_EnumValue {
+  const enumValue = new V1_EnumValue();
+  enumValue.value = value;
+  return enumValue;
+}
 
 test(
   integrationTest(
@@ -607,21 +623,21 @@ test(
     const pluginManager = TEST__LegendApplicationPluginManager.create();
 
     let enumValueSpec = V1_observe_ValueSpecification(
-      _property('Mr', [_elementPtr('test::myEnum')]),
-    ) as V1_AppliedProperty;
-    const enumeration = _enumeration('test', 'myEnum', [
-      _enumValue('Mr'),
-      _enumValue('Mrs'),
-      _enumValue('Ms'),
-      _enumValue('Dr'),
+      _enumValue('Mr', 'test::myEnum'),
+    ) as V1_CEnumValue;
+    const enumeration = _packageableEnumeration('test', 'myEnum', [
+      _packageableEnumValue('Mr'),
+      _packageableEnumValue('Mrs'),
+      _packageableEnumValue('Ms'),
+      _packageableEnumValue('Dr'),
     ]);
 
     const setValueSpecification = (newVal: V1_ValueSpecification): void => {
-      enumValueSpec = guaranteeType(newVal, V1_AppliedProperty);
+      enumValueSpec = guaranteeType(newVal, V1_CEnumValue);
     };
 
     const resetValue = (): void => {
-      V1_AppliedProperty_setProperty(enumValueSpec, '');
+      V1_PrimitiveValue_setValue(enumValueSpec as V1_CEnumValue, '');
     };
 
     TEST__setUpV1BasicValueSpecificationEditor(pluginManager, {
@@ -650,19 +666,14 @@ test(
 
     await screen.findByText('Mrs');
 
-    expect(enumValueSpec instanceof V1_AppliedProperty).toBeTruthy();
-    expect(enumValueSpec.property).toBe('Mrs');
-    expect(
-      enumValueSpec.parameters[0] instanceof V1_PackageableElementPtr,
-    ).toBeTruthy();
-    expect(
-      (enumValueSpec.parameters[0] as V1_PackageableElementPtr).fullPath,
-    ).toBe('test::myEnum');
+    expect(enumValueSpec instanceof V1_CEnumValue).toBeTruthy();
+    expect(enumValueSpec.value).toBe('Mrs');
+    expect(enumValueSpec.fullPath).toBe('test::myEnum');
 
     // Test that resetting value shows error styling
     fireEvent.click(screen.getByTitle('Reset'));
     await screen.findByDisplayValue('');
-    expect(enumValueSpec.property).toBe('');
+    expect(enumValueSpec.value).toBe('');
     expect(
       inputElement.parentElement?.parentElement?.parentElement?.parentElement
         ?.classList,
@@ -939,11 +950,11 @@ test(
     let enumCollectionValue = V1_observe_ValueSpecification(
       _collection([_property('Mr', [_elementPtr('test::myEnum')])]),
     );
-    const enumeration = _enumeration('test', 'myEnum', [
-      _enumValue('Mr'),
-      _enumValue('Mrs'),
-      _enumValue('Ms'),
-      _enumValue('Dr'),
+    const enumeration = _packageableEnumeration('test', 'myEnum', [
+      _packageableEnumValue('Mr'),
+      _packageableEnumValue('Mrs'),
+      _packageableEnumValue('Ms'),
+      _packageableEnumValue('Dr'),
     ]);
 
     const setValueSpecification = (val: V1_ValueSpecification): void => {

--- a/packages/legend-query-builder/src/components/shared/V1_BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/V1_BasicValueSpecificationEditor.tsx
@@ -27,14 +27,13 @@ import {
   V1_CBoolean,
   V1_CDateTime,
   V1_CDecimal,
+  V1_CEnumValue,
   V1_CFloat,
   V1_CInteger,
   V1_CLatestDate,
   V1_Collection,
   V1_CStrictDate,
   V1_CString,
-  V1_EnumValue,
-  V1_observe_AppliedProperty,
   V1_observe_ValueSpecification,
   V1_PackageableType,
   V1_PrimitiveValueSpecification,
@@ -56,7 +55,6 @@ import {
   StringPrimitiveInstanceValueEditor,
 } from './BasicValueSpecificationEditor.js';
 import {
-  V1_AppliedProperty_setProperty,
   V1_Collection_setValues,
   V1_PrimitiveValue_setValue,
 } from '../../stores/shared/V1_ValueSpecificationModifierHelper.js';
@@ -70,9 +68,8 @@ import {
   DatePickerOption,
 } from './CustomDatePickerHelper.js';
 import {
-  _elementPtr,
+  _enumValue,
   _primitiveValue,
-  _property,
   isPrimitiveType,
 } from '@finos/legend-data-cube';
 import {
@@ -109,7 +106,7 @@ const V1_stringifyValue = (values: V1_ValueSpecification[]): string => {
           } else {
             return val;
           }
-        } else if (val instanceof V1_EnumValue) {
+        } else if (val instanceof V1_CEnumValue) {
           return val.value;
         } else if (val instanceof V1_AppliedProperty) {
           return val.property;
@@ -297,20 +294,17 @@ export const V1_BasicValueSpecificationEditor = forwardRef<
         value: enumValue.value,
       }));
       return (
-        <EnumInstanceValueEditor<V1_AppliedProperty>
-          valueSpecification={guaranteeType(
-            valueSpecification,
-            V1_AppliedProperty,
-          )}
-          valueSelector={(val: V1_AppliedProperty) => val.property}
+        <EnumInstanceValueEditor<V1_CEnumValue>
+          valueSpecification={guaranteeType(valueSpecification, V1_CEnumValue)}
+          valueSelector={(val: V1_CEnumValue) => val.value}
           options={options}
           className={className}
           resetValue={resetValue}
           updateValueSpecification={(
-            _valueSpecification: V1_AppliedProperty,
+            _valueSpecification: V1_CEnumValue,
             value: string | null,
           ) => {
-            V1_AppliedProperty_setProperty(
+            V1_PrimitiveValue_setValue(
               _valueSpecification,
               guaranteeNonNullable(value),
             );
@@ -371,8 +365,8 @@ export const V1_BasicValueSpecificationEditor = forwardRef<
         return V1_observe_ValueSpecification(primitiveVal);
       } else {
         // If not a primitive, assume it is an enum
-        const typeParam = _elementPtr(packageableType.fullPath);
-        return V1_observe_AppliedProperty(_property(text, [typeParam]));
+        const enumVal = _enumValue(text, packageableType.fullPath);
+        return V1_observe_ValueSpecification(enumVal);
       }
     };
     const enumOptions = enumeration?.values.map((enumValue) => ({

--- a/packages/legend-query-builder/src/stores/shared/V1_ValueSpecificationEditorHelper.ts
+++ b/packages/legend-query-builder/src/stores/shared/V1_ValueSpecificationEditorHelper.ts
@@ -23,15 +23,15 @@ import {
   V1_CDate,
   V1_CDateTime,
   V1_CDecimal,
+  V1_CEnumValue,
   V1_CFloat,
   V1_CInteger,
   V1_Collection,
   V1_CStrictDate,
   V1_CStrictTime,
   V1_CString,
-  V1_EnumValue,
+  V1_DataTypeValueSpecification,
   V1_Multiplicity,
-  V1_PrimitiveValueSpecification,
 } from '@finos/legend-graph';
 import { buildDatePickerOption } from '../../components/shared/CustomDatePickerHelper.js';
 import type {
@@ -65,9 +65,9 @@ export const getV1_ValueSpecificationStringValue = (
     valueSpecification instanceof V1_CBoolean ||
     valueSpecification instanceof V1_CByteArray ||
     valueSpecification instanceof V1_CDecimal ||
+    valueSpecification instanceof V1_CEnumValue ||
     valueSpecification instanceof V1_CFloat ||
-    valueSpecification instanceof V1_CInteger ||
-    valueSpecification instanceof V1_EnumValue
+    valueSpecification instanceof V1_CInteger
   ) {
     return valueSpecification.value.toString();
   } else if (valueSpecification instanceof V1_AppliedProperty) {
@@ -93,10 +93,13 @@ export const isValidV1_ValueSpecification = (
   multiplicity: V1_Multiplicity,
 ): boolean => {
   const isRequired = multiplicity.lowerBound >= 1;
-  if (valueSpecification instanceof V1_PrimitiveValueSpecification) {
+  if (valueSpecification instanceof V1_DataTypeValueSpecification) {
     // required and no values provided. LatestDate doesn't have any values so we skip that check for it.
     if (isRequired) {
-      if (valueSpecification instanceof V1_CString) {
+      if (
+        valueSpecification instanceof V1_CString ||
+        valueSpecification instanceof V1_CEnumValue
+      ) {
         return valueSpecification.value.length > 0;
       } else if (
         valueSpecification instanceof V1_CBoolean ||


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

This PR updates how DataCube handles Legend Query sources that have enum params. Previously, enum params were stored as `V1_AppliedProperty` instances, but now we store them as `V1_EnumValue` value specification instances. This fixes the error being thrown by engine when we executed the query, because engine expects `V1_EnumValue` type for enum params instead of `V1_AppliedProperty`.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
