### PR TITLE
Return function activator validations to the UI

### DIFF
--- a/.changeset/real-jokes-judge.md
+++ b/.changeset/real-jokes-judge.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Update validation result structure

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_EngineServerClient.ts
@@ -1006,7 +1006,7 @@ export class V1_EngineServerClient extends AbstractServerClient {
 
   validateFunctionActivator(
     input: PlainObject<V1_FunctionActivatorInput>,
-  ): Promise<PlainObject<V1_FunctionActivatorError>[]> {
+  ): Promise<PlainObject<V1_FunctionActivatorError>> {
     return this.postWithTracing(
       this.getTraceData(CORE_ENGINE_ACTIVITY_TRACE.VALIDATE_FUNCTION_ACTIVATOR),
       `${this._functionActivator()}/validate`,

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_RemoteEngine.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/V1_RemoteEngine.ts
@@ -1312,16 +1312,16 @@ export class V1_RemoteEngine implements V1_GraphManagerEngine {
   async validateFunctionActivator(
     input: V1_FunctionActivatorInput,
   ): Promise<void> {
-    const errors = await this.engineServerClient.validateFunctionActivator(
-      V1_FunctionActivatorInput.serialization.toJson(input),
+    const response = V1_FunctionActivatorError.serialization.fromJson(
+      await this.engineServerClient.validateFunctionActivator(
+        V1_FunctionActivatorInput.serialization.toJson(input),
+      ),
     );
-    if (errors.length) {
+
+    if (response.errors.length) {
       throw new Error(
-        `Function activator validation failed:\n${errors
-          .map((error) =>
-            V1_FunctionActivatorError.serialization.fromJson(error),
-          )
-          .map((error) => `- ${error.message}`)
+        `Function activator validation failed:\n${response.errors
+          .map((error) => `\n ${error.message}`)
           .join('\n')}`,
       );
     }

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/functionActivator/V1_FunctionActivatorError.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/engine/functionActivator/V1_FunctionActivatorError.ts
@@ -14,15 +14,25 @@
  * limitations under the License.
  */
 
-import { primitive, createModelSchema } from 'serializr';
+import { primitive, createModelSchema, list, object } from 'serializr';
 import { SerializationFactory } from '@finos/legend-shared';
 
-export class V1_FunctionActivatorError {
+class Message {
   message!: string;
+}
+
+createModelSchema(Message, {
+  message: primitive(),
+});
+
+export class V1_FunctionActivatorError {
+  errors: Message[] = [];
+  warnings: Message[] = [];
 
   static readonly serialization = new SerializationFactory(
     createModelSchema(V1_FunctionActivatorError, {
-      message: primitive(),
+      errors: list(object(Message)),
+      warnings: list(object(Message)),
     }),
   );
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Return reason for failed validations on the UI after clicking on "Validate" on the Activator Editor

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
