### PR TITLE
feat: add new dataspace profile for Power BI Artifact generation

### DIFF
--- a/.changeset/large-mangos-agree.md
+++ b/.changeset/large-mangos-agree.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-extension-dsl-data-space': patch
+---
+
+New dataspace profile for Power BI artifact generation.
+

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/DSL_DataSpace_PureGraphManagerPlugin.ts
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/DSL_DataSpace_PureGraphManagerPlugin.ts
@@ -31,6 +31,8 @@ export const PURE_ENTERPRISE_PROFILE_TAXONOMY_NODE_STEREOTYPE = 'taxonomyNodes';
 export const PURE_DATA_SPACE_INFO_PROFILE_PATH =
   'meta::pure::metamodel::dataSpace::profiles::DataSpaceInfo';
 export const PURE_DATA_SPACE_INFO_PROFILE_VERIFIED_STEREOTYPE = 'Verified';
+export const PURE_POWERBI_ARTIFACT_GENERATION_PROFILE_PATH =
+  'meta::external::powerbi::profiles::PowerBIArtifactGeneration';
 
 export class DSL_DataSpace_PureGraphManagerPlugin extends PureGraphManagerPlugin {
   constructor() {
@@ -38,7 +40,11 @@ export class DSL_DataSpace_PureGraphManagerPlugin extends PureGraphManagerPlugin
   }
 
   override getExtraExposedSystemElementPath(): string[] {
-    return [PURE_ENTERPRISE_PROFILE_PATH, PURE_DATA_SPACE_INFO_PROFILE_PATH];
+    return [
+      PURE_ENTERPRISE_PROFILE_PATH,
+      PURE_DATA_SPACE_INFO_PROFILE_PATH,
+      PURE_POWERBI_ARTIFACT_GENERATION_PROFILE_PATH,
+    ];
   }
 
   override getExtraPureGraphManagerExtensionBuilders(): PureGraphManagerExtensionBuilder[] {

--- a/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/V1_DSL_DataSpace_SystemModels.json
+++ b/packages/legend-extension-dsl-data-space/src/graph-manager/protocol/pure/v1/V1_DSL_DataSpace_SystemModels.json
@@ -7,6 +7,12 @@
       "tags": ["taxonomyNodes"]
     },
     {
+      "package": "meta::external::powerbi::profiles",
+      "_type": "profile",
+      "name": "PowerBIArtifactGeneration",
+      "stereotypes": ["DirectQuery", "Import"]
+    },
+    {
       "_type": "profile",
       "name": "DataSpaceInfo",
       "package": "meta::pure::metamodel::dataSpace::profiles",


### PR DESCRIPTION
## Summary
- A new dataspace profile for opting into Power BI artifact generation

## How did you test this change?
- Manually tested the graph generation for dataspaces with this new profile/stereotype

