### PR TITLE
feat: parameterize copyright header year

### DIFF
--- a/.changeset/tiny-birds-play.md
+++ b/.changeset/tiny-birds-play.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-dev-utils': patch
+---
+
+Template copyright headers

--- a/packages/legend-dev-utils/CopyrightUtils.js
+++ b/packages/legend-dev-utils/CopyrightUtils.js
@@ -85,7 +85,20 @@ const needsCopyrightHeader = (copyrightText, file) => {
     pkg: {},
     onlyGenerateCommentContent: true,
   });
-  return fileContent.trim().length > 0 && !fileContent.includes(text);
+
+  // For checking existing files, we need to be year-agnostic
+  // Replace the specific year with a regex pattern that matches any 4-digit year
+  const yearAgnosticText = text.replace(
+    /Copyright \(c\) \d{4}/,
+    'Copyright (c) \\d{4}',
+  );
+  const yearAgnosticRegex = new RegExp(
+    yearAgnosticText
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      .replace('\\\\d\\{4\\}', '\\d{4}'),
+  );
+
+  return fileContent.trim().length > 0 && !yearAgnosticRegex.test(fileContent);
 };
 
 const hasCopyrightHeader = (copyrightText, file) => {
@@ -98,7 +111,20 @@ const hasCopyrightHeader = (copyrightText, file) => {
     pkg: {},
     onlyGenerateCommentContent: true,
   });
-  return fileContent.trim().length > 0 && fileContent.includes(text);
+
+  // For checking existing files, we need to be year-agnostic
+  // Replace the specific year with a regex pattern that matches any 4-digit year
+  const yearAgnosticText = text.replace(
+    /Copyright \(c\) \d{4}/,
+    'Copyright (c) \\d{4}',
+  );
+  const yearAgnosticRegex = new RegExp(
+    yearAgnosticText
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      .replace('\\\\d\\{4\\}', '\\d{4}'),
+  );
+
+  return fileContent.trim().length > 0 && yearAgnosticRegex.test(fileContent);
 };
 
 // Jest has a fairly sophisticated check for copyright license header that we used as reference

--- a/scripts/copyright/COPYRIGHT_HEADER.template.txt
+++ b/scripts/copyright/COPYRIGHT_HEADER.template.txt
@@ -1,0 +1,13 @@
+Copyright (c) {{YEAR}}-present, Goldman Sachs
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/scripts/copyright/copyright.config.js
+++ b/scripts/copyright/copyright.config.js
@@ -20,10 +20,33 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Process template text by replacing placeholders with actual values
+ * @param {string} template - Template text with {{PLACEHOLDER}} syntax
+ * @param {object} variables - Object containing variable values
+ * @returns {string} Processed text with placeholders replaced
+ */
+const processTemplate = (template, variables) => {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    return variables[key] !== undefined ? variables[key] : match;
+  });
+};
+
+// Read the template file
+const templateText = readFileSync(
+  resolve(__dirname, './COPYRIGHT_HEADER.template.txt'),
+  {
+    encoding: 'utf-8',
+  },
+);
+
+// Define template variables
+const templateVariables = {
+  YEAR: new Date().getFullYear(),
+};
+
 export default {
   extensions: ['js', 'ts', 'tsx', 'css', 'scss'],
   excludePatterns: [],
-  copyrightText: readFileSync(resolve(__dirname, './COPYRIGHT_HEADER.txt'), {
-    encoding: 'utf-8',
-  }),
+  copyrightText: processTemplate(templateText, templateVariables),
 };


### PR DESCRIPTION
Replace hardcoded "2020" year in copyright headers with dynamic current year.

- Create COPYRIGHT_HEADER.template.txt with {{YEAR}} placeholder
- Add template processing to copyright.config.js that generates current year
- Make copyright checking year-agnostic to accept existing files with any year
- New files get current year (2025) while existing files with older years still pass validation

🤖 Generated with [Claude Code](https://claude.ai/code)
