### PR TITLE
Fix classifier paths for DQ elements

### DIFF
--- a/.changeset/warm-pots-stay.md
+++ b/.changeset/warm-pots-stay.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+---
+
+Fix classifier paths for data quality elements

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureProtocolProcessorPlugin.ts
@@ -85,7 +85,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
     );
   }
 
-  override V1_getExtraElementBuilders(): V1_ElementBuilder[] {
+  override V1_getExtraElementBuilders(): V1_ElementBuilder<V1_PackageableElement>[] {
     return [
       new V1_ElementBuilder<V1_DataQualityClassValidationsConfiguration>({
         elementClassName: V1_DATA_QUALITY_PROTOCOL_TYPE,
@@ -228,7 +228,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
       (
         protocol: V1_PackageableElement,
         plugins: PureProtocolProcessorPlugin[],
-      ): PlainObject | undefined => {
+      ): PlainObject<V1_PackageableElement> | undefined => {
         if (protocol instanceof V1_DataQualityClassValidationsConfiguration) {
           return V1_serializeDataQualityClassValidation(protocol, plugins);
         }
@@ -250,7 +250,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
       (
         protocol: V1_GraphFetchTree,
         plugins: PureProtocolProcessorPlugin[],
-      ): PlainObject | undefined => {
+      ): PlainObject<V1_GraphFetchTree> | undefined => {
         if (protocol instanceof V1_DataQualityPropertyGraphFetchTree) {
           return serialize(
             V1_propertyGraphFetchTreeModelSchema(plugins),
@@ -267,7 +267,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
   override V1_getExtraGraphFetchProtocolDeserializers(): V1_GraphFetchDeserializer[] {
     return [
       (
-        json: PlainObject,
+        json: PlainObject<V1_GraphFetchTree>,
         plugins: PureProtocolProcessorPlugin[],
       ): V1_GraphFetchTree | undefined => {
         if (json._type === V1_DATA_QUALITY_PROPERTY_GRAPH_FETCH_TREE_TYPE) {
@@ -287,7 +287,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
   override V1_getExtraElementProtocolDeserializers(): V1_ElementProtocolDeserializer[] {
     return [
       (
-        json: PlainObject,
+        json: PlainObject<V1_PackageableElement>,
         plugins: PureProtocolProcessorPlugin[],
       ): V1_PackageableElement | undefined => {
         if (json._type === V1_DATA_QUALITY_PROTOCOL_TYPE) {

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureProtocolProcessorPlugin.ts
@@ -73,8 +73,7 @@ import {
   V1_rootGraphFetchTreeModelSchema,
 } from './v1/transformation/V1_DSL_DataQuality_ValueSpecificationSerializer.js';
 
-const DATA_QUALITY_CLASSIFIER_PATH =
-  'meta::external::dataquality::DataQuality';
+const DATA_QUALITY_CLASSIFIER_PATH = 'meta::external::dataquality::DataQuality';
 const DATA_QUALITY_RELATION_VALIDATION_CLASSIFIER_PATH =
   'meta::external::dataquality::DataQualityRelationValidation';
 
@@ -86,7 +85,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
     );
   }
 
-  override V1_getExtraElementBuilders(): V1_ElementBuilder<V1_PackageableElement>[] {
+  override V1_getExtraElementBuilders(): V1_ElementBuilder[] {
     return [
       new V1_ElementBuilder<V1_DataQualityClassValidationsConfiguration>({
         elementClassName: V1_DATA_QUALITY_PROTOCOL_TYPE,
@@ -212,7 +211,9 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
   override V1_getExtraElementClassifierPathGetters(): V1_ElementProtocolClassifierPathGetter[] {
     return [
       (protocol: V1_PackageableElement): string | undefined => {
-        if (protocol instanceof V1_DataQualityRelationValidationsConfiguration) {
+        if (
+          protocol instanceof V1_DataQualityRelationValidationsConfiguration
+        ) {
           return DATA_QUALITY_RELATION_VALIDATION_CLASSIFIER_PATH;
         } else if (protocol instanceof V1_DataQualityValidationsConfiguration) {
           return DATA_QUALITY_CLASSIFIER_PATH;
@@ -227,7 +228,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
       (
         protocol: V1_PackageableElement,
         plugins: PureProtocolProcessorPlugin[],
-      ): PlainObject<V1_PackageableElement> | undefined => {
+      ): PlainObject | undefined => {
         if (protocol instanceof V1_DataQualityClassValidationsConfiguration) {
           return V1_serializeDataQualityClassValidation(protocol, plugins);
         }
@@ -249,7 +250,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
       (
         protocol: V1_GraphFetchTree,
         plugins: PureProtocolProcessorPlugin[],
-      ): PlainObject<V1_GraphFetchTree> | undefined => {
+      ): PlainObject | undefined => {
         if (protocol instanceof V1_DataQualityPropertyGraphFetchTree) {
           return serialize(
             V1_propertyGraphFetchTreeModelSchema(plugins),
@@ -266,7 +267,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
   override V1_getExtraGraphFetchProtocolDeserializers(): V1_GraphFetchDeserializer[] {
     return [
       (
-        json: PlainObject<V1_GraphFetchTree>,
+        json: PlainObject,
         plugins: PureProtocolProcessorPlugin[],
       ): V1_GraphFetchTree | undefined => {
         if (json._type === V1_DATA_QUALITY_PROPERTY_GRAPH_FETCH_TREE_TYPE) {
@@ -286,7 +287,7 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
   override V1_getExtraElementProtocolDeserializers(): V1_ElementProtocolDeserializer[] {
     return [
       (
-        json: PlainObject<V1_PackageableElement>,
+        json: PlainObject,
         plugins: PureProtocolProcessorPlugin[],
       ): V1_PackageableElement | undefined => {
         if (json._type === V1_DATA_QUALITY_PROTOCOL_TYPE) {

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureProtocolProcessorPlugin.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureProtocolProcessorPlugin.ts
@@ -74,7 +74,9 @@ import {
 } from './v1/transformation/V1_DSL_DataQuality_ValueSpecificationSerializer.js';
 
 const DATA_QUALITY_CLASSIFIER_PATH =
-  'meta::pure::metamodel::dataquality::DataQuality';
+  'meta::external::dataquality::DataQuality';
+const DATA_QUALITY_RELATION_VALIDATION_CLASSIFIER_PATH =
+  'meta::external::dataquality::DataQualityRelationValidation';
 
 export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolProcessorPlugin {
   constructor() {
@@ -210,7 +212,9 @@ export class DSL_DataQuality_PureProtocolProcessorPlugin extends PureProtocolPro
   override V1_getExtraElementClassifierPathGetters(): V1_ElementProtocolClassifierPathGetter[] {
     return [
       (protocol: V1_PackageableElement): string | undefined => {
-        if (protocol instanceof V1_DataQualityValidationsConfiguration) {
+        if (protocol instanceof V1_DataQualityRelationValidationsConfiguration) {
+          return DATA_QUALITY_RELATION_VALIDATION_CLASSIFIER_PATH;
+        } else if (protocol instanceof V1_DataQualityValidationsConfiguration) {
           return DATA_QUALITY_CLASSIFIER_PATH;
         }
         return undefined;


### PR DESCRIPTION
## Summary

Classifier paths for DQ elements were incorrect resulting in the files being committed as .json files instead of .pure files.

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

Ran locally and committed DQ element changes and verified that these are now committed as .pure files.

