### PR TITLE
Diff view table creation, and accept changes button for testing

### DIFF
--- a/.changeset/three-moments-decide.md
+++ b/.changeset/three-moments-decide.md
@@ -1,0 +1,11 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Created diff view tables for regular non-JSON objects and added "accept" button functionality to update expected test results with actual function output.
+
+This change enhances the testing workflow by:
+
+- Displaying visual diff tables for non-JSON object comparisons
+- Providing an "accept" button to quickly update expected results
+- Streamlining the process of updating test expectations when function behavior changes


### PR DESCRIPTION
## Summary

Created diff view tables for regular non-JSON objects and added "accept" button functionality to update expected test results with actual function output.
This change enhances the testing workflow by:

Displaying visual diff tables for non-JSON object comparisons within tests
Providing an "accept" button to quickly update expected results for json and non-json tests
Streamlining the process of updating test expectations when function behavior changes

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)


