### PR TITLE
Preserve native types for accepted values

### DIFF
--- a/.changeset/whole-schools-join.md
+++ b/.changeset/whole-schools-join.md
@@ -1,0 +1,7 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+fix(EqualToAssertFailViewer): Preserve native types for accepted values
+
+Previously, accepting actual values for primitive types like integers and floats incorrectly stored them as strings. This commit ensures `EqualToAssertFailViewer` parses and sets these values to their correct native types (number or boolean) based on the expected


### PR DESCRIPTION
## Summary

(EqualToAssertFailViewer): Preserve native types for accepted values
Previously, accepting actual values for primitive types like integers and floats incorrectly stored them as strings. This commit ensures EqualToAssertFailViewer parses and sets these values to their correct native types (number or boolean) based on the expected
## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)
