### PR TITLE
Fix access point table height

### DIFF
--- a/.changeset/little-otters-cheat.md
+++ b/.changeset/little-otters-cheat.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-product': patch
+---
+
+Fix access point table height

--- a/packages/legend-extension-dsl-data-product/src/components/DataProduct/DataProductDataAccess.tsx
+++ b/packages/legend-extension-dsl-data-product/src/components/DataProduct/DataProductDataAccess.tsx
@@ -406,7 +406,7 @@ const TDSColumnCellRenderer = (props: {
             {selectedTab === DataProductTabs.COLUMNS && (
               <Box
                 className={clsx(
-                  'data-product__viewer__more-info__columns-grid',
+                  'data-product__viewer__more-info__columns-grid ag-theme-balham',
                   {
                     'data-product__viewer__more-info__columns-grid--auto-height':
                       (accessPointRelationType?.columns.length ?? 0) <=
@@ -420,18 +420,16 @@ const TDSColumnCellRenderer = (props: {
                   },
                 )}
               >
-                <div className="ag-theme-balham">
-                  <DataGrid
-                    rowData={accessPointRelationType?.columns ?? []}
-                    columnDefs={relationColumnDefs}
-                    domLayout={
-                      (accessPointRelationType?.columns.length ?? 0) >
-                      MAX_GRID_AUTO_HEIGHT_ROWS
-                        ? 'normal'
-                        : 'autoHeight'
-                    }
-                  />
-                </div>
+                <DataGrid
+                  rowData={accessPointRelationType?.columns ?? []}
+                  columnDefs={relationColumnDefs}
+                  domLayout={
+                    (accessPointRelationType?.columns.length ?? 0) >
+                    MAX_GRID_AUTO_HEIGHT_ROWS
+                      ? 'normal'
+                      : 'autoHeight'
+                  }
+                />
               </Box>
             )}
             {selectedTab === DataProductTabs.GRAMMAR && (


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

Remove div around access point table so we properly set the height of the underlying datagrid.

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
