### PR TITLE
adding helper functions for supporting encoding in base64 characters

### DIFF
--- a/.changeset/seven-paths-attack.md
+++ b/.changeset/seven-paths-attack.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-query': patch
+'@finos/legend-application': patch
+---
+
+adding helper function to adding base64 safe characters

--- a/packages/legend-application-query/src/__lib__/LegendQueryNavigation.ts
+++ b/packages/legend-application-query/src/__lib__/LegendQueryNavigation.ts
@@ -23,6 +23,7 @@ import {
   stringifyQueryParams,
 } from '@finos/legend-shared';
 import { generateGAVCoordinates } from '@finos/legend-storage';
+import { btoaURLSafe } from '@finos/legend-application';
 import { DataProductAccessType } from '@finos/legend-graph';
 
 export enum LEGEND_QUERY_ROUTE_PATTERN_TOKEN {
@@ -363,10 +364,18 @@ export const EXTERNAL_APPLICATION_NAVIGATION__generateTaxonomyDataspaceViewUrl =
 export const EXTERNAL_APPLICATION_NAVIGATION__generateNewDataCubeUrl = (
   dataCubeApplicationUrl: string,
   sourceData: object,
-): string =>
-  `${dataCubeApplicationUrl}?sourceData=${encodeURIComponent(
-    btoa(JSON.stringify(sourceData)),
+  options?: {
+    addUrlSafeBase64Characters?: boolean | undefined;
+  },
+): string => {
+  const sourceDataString = JSON.stringify(sourceData);
+  const encodedSourceData = options?.addUrlSafeBase64Characters
+    ? btoaURLSafe(sourceDataString)
+    : btoa(sourceDataString);
+  return `${dataCubeApplicationUrl}?sourceData=${encodeURIComponent(
+    encodedSourceData,
   )}`;
+};
 
 /**
  * @external_application_navigation This depends on Legend Marketplace routing and is hardcoded so it's potentially brittle

--- a/packages/legend-application/src/__lib__/LegendApplicationNavigation.ts
+++ b/packages/legend-application/src/__lib__/LegendApplicationNavigation.ts
@@ -36,16 +36,27 @@ export const EXTERNAL_APPLICATION_NAVIGATION__generateStudioProjectViewUrl = (
     versionId,
   )}${entityPath ? `/entity/${entityPath}` : ''}`;
 
+export const btoaURLSafe = (value: string): string =>
+  btoa(value).replace(/\+/g, '-').replace(/\//g, '_');
+
 /**
  * @external_application_navigation This depends on Legend DataCube routing and is hardcoded so it's potentially brittle
  */
 export const EXTERNAL_APPLICATION_NAVIGATION__generateNewDataCubeUrl = (
   dataCubeApplicationUrl: string,
   sourceData: object,
-): string =>
-  `${dataCubeApplicationUrl}?sourceData=${encodeURIComponent(
-    btoa(JSON.stringify(sourceData)),
+  options?: {
+    addUrlSafeBase64Characters?: boolean | undefined;
+  },
+): string => {
+  const sourceDataString = JSON.stringify(sourceData);
+  const encodedSourceData = options?.addUrlSafeBase64Characters
+    ? btoaURLSafe(sourceDataString)
+    : btoa(sourceDataString);
+  return `${dataCubeApplicationUrl}?sourceData=${encodeURIComponent(
+    encodedSourceData,
   )}`;
+};
 
 /**
  * @external_application_navigation This depends on Registry routing and is hardcoded so it's potentially brittle

--- a/packages/legend-application/src/__lib__/LegendApplicationNavigation.ts
+++ b/packages/legend-application/src/__lib__/LegendApplicationNavigation.ts
@@ -37,7 +37,7 @@ export const EXTERNAL_APPLICATION_NAVIGATION__generateStudioProjectViewUrl = (
   )}${entityPath ? `/entity/${entityPath}` : ''}`;
 
 export const btoaURLSafe = (value: string): string =>
-  btoa(value).replace(/\+/g, '-').replace(/\//g, '_');
+  btoa(value).replaceAll('+', '-').replaceAll('/', '_');
 
 /**
  * @external_application_navigation This depends on Legend DataCube routing and is hardcoded so it's potentially brittle


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Creating a helper function to add base64 safe characters
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [X] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
