### PR TITLE
feat(query-builder): add dotted-underline UX cue on stats bar count values with frequency chart

### DIFF
--- a/.changeset/jolly-games-wash.md
+++ b/.changeset/jolly-games-wash.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-query-deployment': patch
+'@finos/legend-query-builder': patch
+---
+
+feat(query-builder): add dotted-underline UX cue on stats bar count values with frequency chart

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderTDSCellSelectionStatsBar.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderTDSCellSelectionStatsBar.test.tsx
@@ -289,6 +289,37 @@ describe('QueryBuilderTDSCellSelectionStatsBar', () => {
     expect(screen.queryByText('beta')).toBeNull();
   });
 
+  test('applies --with-chart class to Count, Unique Count and Empty Count values when frequencies are provided', () => {
+    const { container } = render(
+      <QueryBuilderTDSCellSelectionStatsBar
+        stats={STATS_WITH_FREQ}
+        cellCount={10}
+        countReady={true}
+        darkMode={false}
+      />,
+    );
+    const withChartValues = container.querySelectorAll(
+      '.query-builder__result__tds-grid__stats-bar__item__value--with-chart',
+    );
+    // Count, Unique Count, and Empty Count should all have the blue-underline cue
+    expect(withChartValues.length).toBe(3);
+  });
+
+  test('does not apply --with-chart class to value spans when no frequencies', () => {
+    const { container } = render(
+      <QueryBuilderTDSCellSelectionStatsBar
+        stats={BASE_STATS}
+        cellCount={10}
+        countReady={true}
+        darkMode={false}
+      />,
+    );
+    const withChartValues = container.querySelectorAll(
+      '.query-builder__result__tds-grid__stats-bar__item__value--with-chart',
+    );
+    expect(withChartValues.length).toBe(0);
+  });
+
   // --- Dark mode ---
 
   test('applies dark mode class', () => {

--- a/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSCellSelectionStatsBar.tsx
+++ b/packages/legend-query-builder/src/components/result/tds/QueryBuilderTDSCellSelectionStatsBar.tsx
@@ -280,7 +280,17 @@ export const QueryBuilderTDSCellSelectionStatsBar = observer(
           <span className="query-builder__result__tds-grid__stats-bar__item__label">
             Count:
           </span>
-          <span className="query-builder__result__tds-grid__stats-bar__item__value">
+          <span
+            className={clsx(
+              'query-builder__result__tds-grid__stats-bar__item__value',
+              {
+                'query-builder__result__tds-grid__stats-bar__item__value--with-chart':
+                  !loading &&
+                  stats.valueFrequencies !== undefined &&
+                  stats.valueFrequencies.length > 0,
+              },
+            )}
+          >
             {countReady ? cellCount : <StatsSpinner />}
           </span>
           {!loading &&
@@ -305,7 +315,17 @@ export const QueryBuilderTDSCellSelectionStatsBar = observer(
           <span className="query-builder__result__tds-grid__stats-bar__item__label">
             Unique Count:
           </span>
-          <span className="query-builder__result__tds-grid__stats-bar__item__value">
+          <span
+            className={clsx(
+              'query-builder__result__tds-grid__stats-bar__item__value',
+              {
+                'query-builder__result__tds-grid__stats-bar__item__value--with-chart':
+                  !loading &&
+                  stats.valueFrequencies !== undefined &&
+                  stats.valueFrequencies.length > 0,
+              },
+            )}
+          >
             {loading ? <StatsSpinner /> : stats.uniqueCount}
           </span>
           {!loading &&
@@ -330,7 +350,17 @@ export const QueryBuilderTDSCellSelectionStatsBar = observer(
           <span className="query-builder__result__tds-grid__stats-bar__item__label">
             Empty Count:
           </span>
-          <span className="query-builder__result__tds-grid__stats-bar__item__value">
+          <span
+            className={clsx(
+              'query-builder__result__tds-grid__stats-bar__item__value',
+              {
+                'query-builder__result__tds-grid__stats-bar__item__value--with-chart':
+                  !loading &&
+                  stats.valueFrequencies !== undefined &&
+                  stats.valueFrequencies.length > 0,
+              },
+            )}
+          >
             {loading ? <StatsSpinner /> : stats.nullCount}
           </span>
           {!loading &&

--- a/packages/legend-query-builder/style/_query-builder.scss
+++ b/packages/legend-query-builder/style/_query-builder.scss
@@ -1675,7 +1675,7 @@
         position: relative;
 
         &--has-tooltip {
-          cursor: default;
+          cursor: pointer;
 
           &:hover .query-builder__result__tds-grid__stats-bar__freq-tooltip {
             display: block;
@@ -1689,6 +1689,17 @@
 
         &__value {
           color: var(--color-dark-grey-500);
+
+          &--with-chart {
+            color: var(--color-blue-40);
+            text-decoration: underline;
+            text-decoration-style: dotted;
+            cursor: pointer;
+
+            &:hover {
+              text-decoration-style: solid;
+            }
+          }
         }
 
         // Inline spinner shown for each value while stats are being computed


### PR DESCRIPTION
## Summary

Add dotted-underline UX cue on stats bar count values with frequency chart to help discovery of the frequency summary tooltip 

## How did you test this change?

- [x ] Test(s) added
- [x ] Manual testing

