### PR TITLE
Add result panel tests for stats bar and overflow warning

### DIFF
--- a/packages/legend-manual-tests/src/__tests__/query-execution/TEMPORARY__QueryBuilderExecution.engine-roundtrip-test.tsx
+++ b/packages/legend-manual-tests/src/__tests__/query-execution/TEMPORARY__QueryBuilderExecution.engine-roundtrip-test.tsx
@@ -40,6 +40,7 @@ import {
   V1_PureGraphManager,
   V1_buildExecutionResult,
   V1_deserializeExecutionResult,
+  type TDSResultCellData,
 } from '@finos/legend-graph';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { integrationTest, createSpy } from '@finos/legend-shared/test';
@@ -297,3 +298,204 @@ test(integrationTest('test preview-data query execution'), async () => {
     );
   }
 });
+
+test(
+  integrationTest(
+    'test cell selection stats bar computes numeric stats for selected cells',
+  ),
+  async () => {
+    const { mappingPath, runtimePath, modelFileDir, modelFilePath, rawLambda } =
+      {
+        mappingPath: 'model::RelationalMapping',
+        runtimePath: 'model::Runtime',
+        modelFileDir: 'model',
+        modelFilePath: 'TEST_DATA_QueryBuilder_Query_Execution_model.pure',
+        rawLambda: TEST_DATA_QueryExecution_PreviewData_ExecutionInput,
+      };
+    const entities = await generateModelEntitesFromModelGrammar(
+      resolve(__dirname, modelFileDir),
+      modelFilePath,
+      undefined,
+    );
+    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+      entities,
+      stub_RawLambda(),
+      mappingPath,
+      runtimePath,
+      TEST_DATA_QueryExecution_MappingAnalysisResult,
+    );
+    await act(async () => {
+      queryBuilderState.initializeWithQuery(
+        create_RawLambda(rawLambda.parameters, rawLambda.body),
+      );
+    });
+    const executionInput = await (
+      queryBuilderState.graphManagerState.graphManager as V1_PureGraphManager
+    ).createExecutionInput(
+      queryBuilderState.graphManagerState.graph,
+      guaranteeNonNullable(queryBuilderState.executionContextState.mapping),
+      queryBuilderState.resultState.buildExecutionRawLambda(),
+      guaranteeNonNullable(
+        queryBuilderState.executionContextState.runtimeValue,
+      ),
+      V1_PureGraphManager.DEV_PROTOCOL_VERSION,
+    );
+    const executionResult = await ENGINE_TEST_SUPPORT__execute(executionInput);
+    createSpy(
+      queryBuilderState.graphManagerState.graphManager,
+      'runQuery',
+    ).mockResolvedValue({
+      executionResult: V1_buildExecutionResult(
+        V1_deserializeExecutionResult(executionResult),
+      ),
+    });
+    const queryBuilderResultPanel = await waitFor(() =>
+      renderResult.getByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_PANEL,
+      ),
+    );
+    await act(async () => {
+      fireEvent.click(getByText(queryBuilderResultPanel, 'Run Query'));
+    });
+    await waitFor(() => findByText(queryBuilderResultPanel, 'Age'));
+
+    // `runQuery` clears the cell selection — populate it after the grid renders.
+    const selectedCells: TDSResultCellData[] = [
+      {
+        value: 10,
+        columnName: 'Age',
+        coordinates: { rowIndex: 0, colIndex: 0 },
+      },
+      {
+        value: 20,
+        columnName: 'Age',
+        coordinates: { rowIndex: 1, colIndex: 0 },
+      },
+      {
+        value: 30,
+        columnName: 'Age',
+        coordinates: { rowIndex: 2, colIndex: 0 },
+      },
+      {
+        value: 40,
+        columnName: 'Age',
+        coordinates: { rowIndex: 3, colIndex: 0 },
+      },
+    ];
+    await act(async () => {
+      queryBuilderState.resultState.setSelectedCells(selectedCells);
+    });
+
+    // Wait for Phase 2 (200ms debounce + rAF) to populate numeric stats
+    const statsBar = await waitFor(
+      () => {
+        const el = queryBuilderResultPanel.querySelector(
+          '.query-builder__result__tds-grid__stats-bar',
+        );
+        expect(el).not.toBeNull();
+        expect(el?.textContent).toContain('Sum:');
+        return el as HTMLElement;
+      },
+      { timeout: 2000 },
+    );
+
+    const text = statsBar.textContent ?? '';
+    expect(text).toContain('Count:4');
+    expect(text).toContain('Unique Count:4');
+    expect(text).toContain('Empty Count:0');
+    expect(text).toContain('Min:10');
+    expect(text).toContain('Max:40');
+    expect(text).toContain('Sum:100');
+    expect(text).toContain('Avg:25');
+  },
+);
+
+test(
+  integrationTest(
+    'test result overflow warning when query produces more rows than preview limit',
+  ),
+  async () => {
+    const { mappingPath, runtimePath, modelFileDir, modelFilePath, rawLambda } =
+      {
+        mappingPath: 'model::RelationalMapping',
+        runtimePath: 'model::Runtime',
+        modelFileDir: 'model',
+        modelFilePath: 'TEST_DATA_QueryBuilder_Query_Execution_model.pure',
+        rawLambda: TEST_DATA_QueryExecution_PreviewData_ExecutionInput,
+      };
+    const entities = await generateModelEntitesFromModelGrammar(
+      resolve(__dirname, modelFileDir),
+      modelFilePath,
+      undefined,
+    );
+    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+      entities,
+      stub_RawLambda(),
+      mappingPath,
+      runtimePath,
+      TEST_DATA_QueryExecution_MappingAnalysisResult,
+    );
+    await act(async () => {
+      queryBuilderState.initializeWithQuery(
+        create_RawLambda(rawLambda.parameters, rawLambda.body),
+      );
+    });
+    // Lower the preview limit below the engine row count (the test data
+    // contains 11 Person rows) so processExecutionResult flags overflow.
+    const overflowLimit = 2;
+    await act(async () => {
+      queryBuilderState.resultState.setPreviewLimit(overflowLimit);
+    });
+
+    const executionInput = await (
+      queryBuilderState.graphManagerState.graphManager as V1_PureGraphManager
+    ).createExecutionInput(
+      queryBuilderState.graphManagerState.graph,
+      guaranteeNonNullable(queryBuilderState.executionContextState.mapping),
+      queryBuilderState.resultState.buildExecutionRawLambda(),
+      guaranteeNonNullable(
+        queryBuilderState.executionContextState.runtimeValue,
+      ),
+      V1_PureGraphManager.DEV_PROTOCOL_VERSION,
+    );
+    const executionResult = await ENGINE_TEST_SUPPORT__execute(executionInput);
+    createSpy(
+      queryBuilderState.graphManagerState.graphManager,
+      'runQuery',
+    ).mockResolvedValue({
+      executionResult: V1_buildExecutionResult(
+        V1_deserializeExecutionResult(executionResult),
+      ),
+    });
+
+    const queryBuilderResultPanel = await waitFor(() =>
+      renderResult.getByTestId(
+        QUERY_BUILDER_TEST_ID.QUERY_BUILDER_RESULT_PANEL,
+      ),
+    );
+    await act(async () => {
+      fireEvent.click(getByText(queryBuilderResultPanel, 'Run Query'));
+    });
+    await waitFor(() => findByText(queryBuilderResultPanel, 'Age'));
+
+    expect(queryBuilderState.resultState.isExecutionResultOverflowing).toBe(
+      true,
+    );
+
+    await waitFor(() =>
+      findByText(
+        queryBuilderResultPanel,
+        'Data below is not complete - query produces more rows than the set grid preview limit',
+      ),
+    );
+
+    // The info-icon title surfaces the active preview limit
+    const infoIcon = queryBuilderResultPanel.querySelector(
+      '[title*="The preview limit is set to"]',
+    );
+    expect(infoIcon).not.toBeNull();
+    expect(infoIcon?.getAttribute('title')).toContain(
+      `The preview limit is set to ${overflowLimit}`,
+    );
+  },
+);

--- a/packages/legend-manual-tests/src/__tests__/query-execution/TEMPORARY__QueryBuilderExecution.engine-roundtrip-test.tsx
+++ b/packages/legend-manual-tests/src/__tests__/query-execution/TEMPORARY__QueryBuilderExecution.engine-roundtrip-test.tsx
@@ -357,7 +357,9 @@ test(
     await act(async () => {
       fireEvent.click(getByText(queryBuilderResultPanel, 'Run Query'));
     });
-    await waitFor(() => findByText(queryBuilderResultPanel, 'Age'));
+    await findByText(queryBuilderResultPanel, 'Age', undefined, {
+      timeout: 8000,
+    });
 
     // `runQuery` clears the cell selection — populate it after the grid renders.
     const selectedCells: TDSResultCellData[] = [
@@ -447,12 +449,18 @@ test(
       queryBuilderState.resultState.setPreviewLimit(overflowLimit);
     });
 
+    // Mirror the runQuery flow's `withDataOverflowCheck: true` so the lambda
+    // sent to the engine resolves to take(previewLimit + 1) — i.e. one row
+    // beyond the limit, which is what processExecutionResult uses to detect
+    // overflow.
     const executionInput = await (
       queryBuilderState.graphManagerState.graphManager as V1_PureGraphManager
     ).createExecutionInput(
       queryBuilderState.graphManagerState.graph,
       guaranteeNonNullable(queryBuilderState.executionContextState.mapping),
-      queryBuilderState.resultState.buildExecutionRawLambda(),
+      queryBuilderState.resultState.buildExecutionRawLambda({
+        withDataOverflowCheck: true,
+      }),
       guaranteeNonNullable(
         queryBuilderState.executionContextState.runtimeValue,
       ),
@@ -476,17 +484,17 @@ test(
     await act(async () => {
       fireEvent.click(getByText(queryBuilderResultPanel, 'Run Query'));
     });
-    await waitFor(() => findByText(queryBuilderResultPanel, 'Age'));
+    await findByText(queryBuilderResultPanel, 'Age', undefined, {
+      timeout: 8000,
+    });
 
     expect(queryBuilderState.resultState.isExecutionResultOverflowing).toBe(
       true,
     );
 
-    await waitFor(() =>
-      findByText(
-        queryBuilderResultPanel,
-        'Data below is not complete - query produces more rows than the set grid preview limit',
-      ),
+    await findByText(
+      queryBuilderResultPanel,
+      'Data below is not complete - query produces more rows than the set grid preview limit',
     );
 
     // The info-icon title surfaces the active preview limit


### PR DESCRIPTION
Adds two integration tests in the query-execution roundtrip suite:
- Verifies the cell selection stats bar computes Count, Unique Count, Empty Count, Min, Max, Sum, and Avg for a numeric selection populated via resultState.setSelectedCells (the simple-grid fallback path).
- Verifies that lowering previewLimit below the engine row count flips isExecutionResultOverflowing, surfaces the truncation banner, and that the info icon's title reflects the active limit.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
