### PR TITLE
Disable query buttons when no access to the APG

### DIFF
--- a/.changeset/gentle-wolves-shout.md
+++ b/.changeset/gentle-wolves-shout.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-product': patch
+---
+
+Disable Open in SQL Playground, Open in Power BI, and Open in Datacube buttons when user does not have access to the APG.

--- a/packages/legend-extension-dsl-data-product/src/components/DataProduct/DataProductDataAccess.tsx
+++ b/packages/legend-extension-dsl-data-product/src/components/DataProduct/DataProductDataAccess.tsx
@@ -190,6 +190,10 @@ const PowerBiScreen = observer(
       );
     }
 
+    const hasNoAccess =
+      accessPointState.apgState.access === AccessPointGroupAccess.NO_ACCESS ||
+      accessPointState.apgState.access === AccessPointGroupAccess.DENIED;
+
     const loadPowerBi = (): void => {
       if (dataAccessState.dataProductViewerState.openPowerBi) {
         const apg = accessPointState.apgState.apg.id;
@@ -234,8 +238,13 @@ const PowerBiScreen = observer(
         <button
           onClick={loadPowerBi}
           tabIndex={-1}
+          disabled={hasNoAccess}
           className="data-product__viewer__tab-screen__btn"
-          title="Open in Power BI"
+          title={
+            hasNoAccess
+              ? 'You do not have access to this access point group. Please request access first.'
+              : 'Open in Power BI'
+          }
         >
           Open in Power BI
         </button>
@@ -342,13 +351,21 @@ export const SqlPlaygroundScreen = observer(
           .catch(dataAccessState.applicationStore.alertUnhandledError);
       }
     }, [isSqlModalOpen, playgroundState, dataAccessState]);
+    const hasNoAccess =
+      accessPointState.apgState.access === AccessPointGroupAccess.NO_ACCESS ||
+      accessPointState.apgState.access === AccessPointGroupAccess.DENIED;
     return (
       <div className="data-product__viewer__tab-screen">
         <button
           onClick={loadSqlQuery}
           tabIndex={-1}
+          disabled={hasNoAccess}
           className="data-product__viewer__tab-screen__btn"
-          title="Open SQL Playground"
+          title={
+            hasNoAccess
+              ? 'You do not have access to this access point group. Please request access first.'
+              : 'Open SQL Playground'
+          }
         >
           Open SQL Playground
         </button>
@@ -563,6 +580,10 @@ const DataCubeScreen = observer(
       }
     };
 
+    const hasNoAccess =
+      accessPointState.apgState.access === AccessPointGroupAccess.NO_ACCESS ||
+      accessPointState.apgState.access === AccessPointGroupAccess.DENIED;
+
     return (
       <div className="data-product__viewer__tab-screen">
         {!resolvedUserEnv && (
@@ -586,9 +607,13 @@ const DataCubeScreen = observer(
         <button
           onClick={loadDataCube}
           tabIndex={-1}
-          disabled={!(selectedEnvironment ?? resolvedUserEnv)}
+          disabled={hasNoAccess || !(selectedEnvironment ?? resolvedUserEnv)}
           className="data-product__viewer__tab-screen__btn"
-          title="Open in Datacube"
+          title={
+            hasNoAccess
+              ? 'You do not have access to this access point group. Please request access first.'
+              : 'Open in Datacube'
+          }
         >
           Open in Datacube
         </button>

--- a/packages/legend-extension-dsl-data-product/src/components/__tests__/DataProductViewer.test.tsx
+++ b/packages/legend-extension-dsl-data-product/src/components/__tests__/DataProductViewer.test.tsx
@@ -1132,12 +1132,68 @@ describe('DataProductViewer', () => {
     });
 
     test('Access point sql tab has a open sql playground button to open editor to run queries.', async () => {
+      const mockLiteContracts: V1_LiteDataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resourceId: 'MOCK_SDLC_DATAPRODUCT',
+          resourceType: V1_ResourceType.ACCESS_POINT_GROUP,
+          deploymentId: 12345,
+          accessPointGroup: 'GROUP1',
+        },
+      ];
+
+      const mockDataContracts: V1_DataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resource: {
+            _type: V1_AccessPointGroupReferenceType.AccessPointGroupReference,
+            accessPointGroup: 'GROUP1',
+            dataProduct: {
+              name: 'MOCK_SDLC_DATAPRODUCT',
+              owner: {
+                appDirId: 12345,
+              },
+            },
+          },
+        },
+      ];
+
       const { dataProductDataAccessState } =
         await setupLakehouseDataProductTest(
           mockSDLCDataProduct,
           mockEntitlementsSDLCDataProduct,
-          [],
-          [],
+          mockLiteContracts,
+          mockDataContracts,
           {
             groupId: 'test.group',
             artifactId: 'test-artifact',
@@ -1257,6 +1313,331 @@ describe('DataProductViewer', () => {
       const infoIcon = await screen.findByTitle('See Documentation');
       expect(infoIcon).toBeDefined();
       fireEvent.click(infoIcon);
+    });
+
+    test('Access point SQL, Power BI, and Datacube buttons are disabled when user has no access', async () => {
+      const { dataProductDataAccessState } =
+        await setupLakehouseDataProductTest(
+          mockSDLCDataProduct,
+          mockEntitlementsSDLCDataProduct,
+          [],
+          [],
+          {
+            groupId: 'test.group',
+            artifactId: 'test-artifact',
+            versionId: '1.0.0',
+          },
+          getMockDataProductGenerationFilesByType(mockSDLCDataProduct),
+          { openPowerBi: jest.fn(), openDataCube: jest.fn() },
+        );
+
+      await screen.findByText('Mock SDLC Data Product');
+      await screen.findByText('Customer demographics data access point');
+
+      act(() => {
+        dataProductDataAccessState?.setLakehouseIngestEnvironmentSummaries([
+          IngestDeploymentServerConfig.serialization.fromJson({
+            ingestServerUrl: 'https://dev-test.example.com',
+            ingestEnvironmentUrn: 'urn:dev:test',
+            environmentName: 'Development',
+            environmentClassification: 'FULL',
+          }),
+        ]);
+      });
+
+      // Check SQL tab button is disabled
+      const sqlTab = await screen.findByRole('tab', { name: 'SQL' });
+      fireEvent.click(sqlTab);
+      await waitFor(() => {
+        const openSqlPlaygroundBtn = screen.getByTitle(
+          'You do not have access to this access point group. Please request access first.',
+        );
+        expect(openSqlPlaygroundBtn.hasAttribute('disabled')).toBe(true);
+      });
+
+      // Check Power BI tab button is disabled
+      const powerBiTab = await screen.findByRole('tab', {
+        name: 'Power BI',
+      });
+      fireEvent.click(powerBiTab);
+      await waitFor(() => {
+        const openPowerBiBtn = screen.getByTitle(
+          'You do not have access to this access point group. Please request access first.',
+        );
+        expect(openPowerBiBtn.hasAttribute('disabled')).toBe(true);
+      });
+
+      // Check Datacube tab button is disabled
+      const dataCubeTab = await screen.findByRole('tab', {
+        name: 'Datacube',
+      });
+      fireEvent.click(dataCubeTab);
+      await waitFor(() => {
+        const openDataCubeBtn = screen.getByTitle(
+          'You do not have access to this access point group. Please request access first.',
+        );
+        expect(openDataCubeBtn.hasAttribute('disabled')).toBe(true);
+      });
+    });
+
+    test('Access point Power BI tab button is enabled when user has access', async () => {
+      const mockLiteContracts: V1_LiteDataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resourceId: 'MOCK_SDLC_DATAPRODUCT',
+          resourceType: V1_ResourceType.ACCESS_POINT_GROUP,
+          deploymentId: 12345,
+          accessPointGroup: 'GROUP1',
+        },
+      ];
+
+      const mockDataContracts: V1_DataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resource: {
+            _type: V1_AccessPointGroupReferenceType.AccessPointGroupReference,
+            accessPointGroup: 'GROUP1',
+            dataProduct: {
+              name: 'MOCK_SDLC_DATAPRODUCT',
+              owner: {
+                appDirId: 12345,
+              },
+            },
+          },
+        },
+      ];
+
+      const openPowerBiMock = jest.fn();
+      await setupLakehouseDataProductTest(
+        mockSDLCDataProduct,
+        mockEntitlementsSDLCDataProduct,
+        mockLiteContracts,
+        mockDataContracts,
+        {
+          groupId: 'test.group',
+          artifactId: 'test-artifact',
+          versionId: '1.0.0',
+        },
+        getMockDataProductGenerationFilesByType(mockSDLCDataProduct),
+        { openPowerBi: openPowerBiMock },
+      );
+
+      await screen.findByText('Mock SDLC Data Product');
+      await screen.findByText('Customer demographics data access point');
+
+      const powerBiTab = await screen.findByRole('tab', {
+        name: 'Power BI',
+      });
+      fireEvent.click(powerBiTab);
+      const openPowerBiBtn = await screen.findByRole('button', {
+        name: 'Open in Power BI',
+      });
+      expect(openPowerBiBtn).toBeDefined();
+      expect(openPowerBiBtn.hasAttribute('disabled')).toBe(false);
+      fireEvent.click(openPowerBiBtn);
+      expect(openPowerBiMock).toHaveBeenCalledWith('GROUP1');
+    });
+
+    test('Access point Power BI tab button is disabled when user has no access', async () => {
+      const openPowerBiMock = jest.fn();
+      await setupLakehouseDataProductTest(
+        mockSDLCDataProduct,
+        mockEntitlementsSDLCDataProduct,
+        [],
+        [],
+        {
+          groupId: 'test.group',
+          artifactId: 'test-artifact',
+          versionId: '1.0.0',
+        },
+        getMockDataProductGenerationFilesByType(mockSDLCDataProduct),
+        { openPowerBi: openPowerBiMock },
+      );
+
+      await screen.findByText('Mock SDLC Data Product');
+      await screen.findByText('Customer demographics data access point');
+
+      const powerBiTab = await screen.findByRole('tab', {
+        name: 'Power BI',
+      });
+      fireEvent.click(powerBiTab);
+      const openPowerBiBtn = await screen.findByTitle(
+        'You do not have access to this access point group. Please request access first.',
+      );
+      expect(openPowerBiBtn).toBeDefined();
+      expect(openPowerBiBtn.hasAttribute('disabled')).toBe(true);
+      fireEvent.click(openPowerBiBtn);
+      expect(openPowerBiMock).not.toHaveBeenCalled();
+    });
+
+    test('Access point Datacube tab button is enabled when user has access', async () => {
+      const mockLiteContracts: V1_LiteDataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resourceId: 'MOCK_SDLC_DATAPRODUCT',
+          resourceType: V1_ResourceType.ACCESS_POINT_GROUP,
+          deploymentId: 12345,
+          accessPointGroup: 'GROUP1',
+        },
+      ];
+
+      const mockDataContracts: V1_DataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resource: {
+            _type: V1_AccessPointGroupReferenceType.AccessPointGroupReference,
+            accessPointGroup: 'GROUP1',
+            dataProduct: {
+              name: 'MOCK_SDLC_DATAPRODUCT',
+              owner: {
+                appDirId: 12345,
+              },
+            },
+          },
+        },
+      ];
+
+      const openDataCubeMock = jest.fn();
+      const { dataProductDataAccessState } =
+        await setupLakehouseDataProductTest(
+          mockSDLCDataProduct,
+          mockEntitlementsSDLCDataProduct,
+          mockLiteContracts,
+          mockDataContracts,
+          {
+            groupId: 'test.group',
+            artifactId: 'test-artifact',
+            versionId: '1.0.0',
+          },
+          getMockDataProductGenerationFilesByType(mockSDLCDataProduct),
+          { openDataCube: openDataCubeMock },
+        );
+
+      await screen.findByText('Mock SDLC Data Product');
+      await screen.findByText('Customer demographics data access point');
+
+      act(() => {
+        dataProductDataAccessState?.setLakehouseIngestEnvironmentSummaries([
+          IngestDeploymentServerConfig.serialization.fromJson({
+            ingestServerUrl: 'https://dev-test.example.com',
+            ingestEnvironmentUrn: 'urn:dev:test',
+            environmentName: 'Development',
+            environmentClassification: 'FULL',
+          }),
+        ]);
+      });
+
+      const dataCubeTab = await screen.findByRole('tab', {
+        name: 'Datacube',
+      });
+      fireEvent.click(dataCubeTab);
+      const openDataCubeBtn = await screen.findByRole('button', {
+        name: 'Open in Datacube',
+      });
+      expect(openDataCubeBtn).toBeDefined();
+      expect(openDataCubeBtn.hasAttribute('disabled')).toBe(false);
+    });
+
+    test('Access point Datacube tab button is disabled when user has no access', async () => {
+      const openDataCubeMock = jest.fn();
+      const { dataProductDataAccessState } =
+        await setupLakehouseDataProductTest(
+          mockSDLCDataProduct,
+          mockEntitlementsSDLCDataProduct,
+          [],
+          [],
+          {
+            groupId: 'test.group',
+            artifactId: 'test-artifact',
+            versionId: '1.0.0',
+          },
+          getMockDataProductGenerationFilesByType(mockSDLCDataProduct),
+          { openDataCube: openDataCubeMock },
+        );
+
+      await screen.findByText('Mock SDLC Data Product');
+      await screen.findByText('Customer demographics data access point');
+
+      act(() => {
+        dataProductDataAccessState?.setLakehouseIngestEnvironmentSummaries([
+          IngestDeploymentServerConfig.serialization.fromJson({
+            ingestServerUrl: 'https://dev-test.example.com',
+            ingestEnvironmentUrn: 'urn:dev:test',
+            environmentName: 'Development',
+            environmentClassification: 'FULL',
+          }),
+        ]);
+      });
+
+      const dataCubeTab = await screen.findByRole('tab', {
+        name: 'Datacube',
+      });
+      fireEvent.click(dataCubeTab);
+      const openDataCubeBtn = await screen.findByTitle(
+        'You do not have access to this access point group. Please request access first.',
+      );
+      expect(openDataCubeBtn).toBeDefined();
+      expect(openDataCubeBtn.hasAttribute('disabled')).toBe(true);
     });
 
     test('displays ENTITLED button for contract in APPROVED status', async () => {


### PR DESCRIPTION
## Summary
Disable the query (SQL, Datacube and Power BI) buttons when the user does not have access to the access point group

## How did you test this change?

Unit tests added