### PR TITLE
feat: improve DataProduct test editor UX and gate suite-level testing tab by environment flag

### DIFF
--- a/.changeset/dataproduct-ui-revamp.md
+++ b/.changeset/dataproduct-ui-revamp.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+DataProduct UI revamp: replace flex-div grid with a table layout, add hover-reveal column delete buttons, simplify export to CSV-only, add "Upload CSV" label, and hide column definitions in test/assertion contexts.

--- a/.changeset/dataproduct-ui-revamp.md
+++ b/.changeset/dataproduct-ui-revamp.md
@@ -2,4 +2,4 @@
 '@finos/legend-application-studio': patch
 ---
 
-DataProduct UI revamp: replace flex-div grid with a table layout, add hover-reveal column delete buttons, simplify export to CSV-only, add "Upload CSV" label, and hide column definitions in test/assertion contexts.
+DataProduct test-data editor refresh: use table-based row/column rendering with hover-reveal column delete, move top controls to written label-plus-icon actions (Add Column/Add Row/Upload CSV), keep Export CSV written out at the footer right, keep clear-data at the footer left, and streamline column-definition visibility for test/assertion flows.

--- a/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
@@ -338,16 +338,59 @@ export const RelationElementEditor = observer(
                 Test Data ({embeddedData.rows.length} rows)
               </div>
             </div>
-            {hideColumnDefinitions ? (
-              <button
-                className="btn--icon btn--dark btn--sm"
-                onClick={addColumn}
-                disabled={!canEditColumns}
-                title="Add Column"
-              >
-                <PlusIcon />
-              </button>
-            ) : null}
+            <div className="relation-test-data-editor__toolbar">
+              <div className="relation-test-data-editor__toolbar__left">
+                <div className="relation-test-data-editor__action-control">
+                  <span className="relation-test-data-editor__action-control__label">
+                    Add Column
+                  </span>
+                  <button
+                    className="btn--icon btn--dark btn--sm"
+                    onClick={addColumn}
+                    disabled={!canEditColumns}
+                    title="Add Column"
+                  >
+                    <PlusIcon />
+                  </button>
+                </div>
+                <div className="relation-test-data-editor__action-control">
+                  <span className="relation-test-data-editor__action-control__label">
+                    Add Row
+                  </span>
+                  <button
+                    className="btn--icon btn--dark btn--sm"
+                    onClick={addRow}
+                    disabled={isReadOnly || embeddedData.columns.length === 0}
+                    title="Add Row"
+                  >
+                    <PlusIcon />
+                  </button>
+                </div>
+              </div>
+              <div className="relation-test-data-editor__toolbar__right">
+                <div className="relation-test-data-editor__import-controls">
+                  <span className="relation-test-data-editor__import-controls__label">
+                    Upload CSV
+                  </span>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".csv"
+                    onChange={handleFileUpload}
+                    style={{ display: 'none' }}
+                    disabled={isReadOnly}
+                  />
+                  <button
+                    className="btn--icon btn--dark btn--sm"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isReadOnly}
+                    title="Upload CSV"
+                  >
+                    <UploadIcon />
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
           {!hideColumnDefinitions ? (
             <div className="relation-test-data-editor__columns">
@@ -355,14 +398,6 @@ export const RelationElementEditor = observer(
                 <div className="relation-test-data-editor__section-title">
                   Column Definitions
                 </div>
-                <button
-                  className="btn--icon btn--dark btn--sm"
-                  onClick={addColumn}
-                  disabled={!canEditColumns}
-                  title="Add Column"
-                >
-                  <PlusIcon />
-                </button>
               </div>
               <div className="relation-test-data-editor__columns-grid">
                 {embeddedData.columns.map((column, index) => (
@@ -472,17 +507,8 @@ export const RelationElementEditor = observer(
             </div>
           )}
 
-          <div className="relation-test-data-editor__export-controls">
-            <div className="relation-test-data-editor__export-controls__btn-group">
-              <button
-                className="btn--icon btn--dark btn--sm"
-                onClick={addRow}
-                disabled={isReadOnly || embeddedData.columns.length === 0}
-                title="Add Row"
-              >
-                <PlusIcon />
-              </button>
-
+          <div className="relation-test-data-editor__footer-actions">
+            <div className="relation-test-data-editor__footer-actions__left">
               <button
                 className="btn--icon btn--dark btn--sm"
                 onClick={handleClearData}
@@ -492,35 +518,20 @@ export const RelationElementEditor = observer(
                 <TrashIcon />
               </button>
             </div>
-            <button
-              className="btn--icon btn--dark btn--sm"
-              onClick={exportCSV}
-              disabled={isReadOnly}
-              title="Export as CSV"
-            >
-              <FileImportIcon />
-            </button>
-
-            <div className="relation-test-data-editor__import-controls">
-              <span className="relation-test-data-editor__import-controls__label">
-                Upload CSV
-              </span>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".csv"
-                onChange={handleFileUpload}
-                style={{ display: 'none' }}
-                disabled={isReadOnly}
-              />
-              <button
-                className="btn--icon btn--dark btn--sm"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={isReadOnly}
-                title="Upload CSV"
-              >
-                <UploadIcon />
-              </button>
+            <div className="relation-test-data-editor__footer-actions__right">
+              <div className="relation-test-data-editor__action-control">
+                <span className="relation-test-data-editor__action-control__label">
+                  Export CSV
+                </span>
+                <button
+                  className="btn--icon btn--dark btn--sm"
+                  onClick={exportCSV}
+                  disabled={isReadOnly}
+                  title="Export as CSV"
+                >
+                  <FileImportIcon />
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
@@ -223,15 +223,13 @@ export const RelationElementEditor = observer(
   (props: {
     relationElementState: RelationElementState;
     isReadOnly: boolean;
+    hideColumnDefinitions?: boolean;
   }) => {
-    const { relationElementState, isReadOnly } = props;
+    const { relationElementState, isReadOnly, hideColumnDefinitions } = props;
     const editorStore = useEditorStore();
     const embeddedData = relationElementState.relationElement;
     const canEditColumns =
       !isReadOnly && relationElementState.supportsColumnEditing;
-    const [exportFormat, setExportFormat] = useState<'json' | 'csv' | 'sql'>(
-      'json',
-    );
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const addColumn = (): void => {
@@ -297,39 +295,13 @@ export const RelationElementEditor = observer(
       }
     };
 
-    const exportData = (): void => {
-      let content = '';
-      let filename = '';
-      let mimeType = '';
-
-      switch (exportFormat) {
-        case 'json':
-          content = relationElementState.exportJSON();
-          filename = 'test_data.json';
-          mimeType = 'application/json';
-          break;
-        case 'csv':
-          content = relationElementState.exportCSV();
-          filename = 'test_data.csv';
-          mimeType = 'text/csv';
-          break;
-        case 'sql':
-          content = relationElementState.exportSQL();
-          filename = 'test_data.sql';
-          mimeType = 'text/sql';
-          break;
-        default:
-          content = relationElementState.exportJSON();
-          filename = 'test_data.json';
-          mimeType = 'application/json';
-          break;
-      }
-
-      const blob = new Blob([content], { type: mimeType });
+    const exportCSV = (): void => {
+      const content = relationElementState.exportCSV();
+      const blob = new Blob([content], { type: 'text/csv' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = filename;
+      a.download = 'test_data.csv';
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -359,53 +331,66 @@ export const RelationElementEditor = observer(
 
     return (
       <div className="relation-test-data-editor__content">
-        <div className="relation-test-data-editor__columns">
-          <div className="relation-test-data-editor__section-header">
-            <div className="relation-test-data-editor__section-title">
-              Column Definitions
-            </div>
-            <button
-              className="btn--icon btn--dark btn--sm"
-              onClick={addColumn}
-              disabled={!canEditColumns}
-              title="Add Column"
-            >
-              <PlusIcon />
-            </button>
-          </div>
-          <div className="relation-test-data-editor__columns-grid">
-            {embeddedData.columns.map((column, index) => (
-              <div
-                key={`column-${guaranteeNonNullable(index)}`}
-                className="relation-test-data-editor__column-row"
-              >
-                <input
-                  className="relation-test-data-editor__column-input"
-                  type="text"
-                  value={column}
-                  onChange={(e) => updateColumn(index, e.target.value)}
-                  placeholder="Column Name"
-                  disabled={!canEditColumns}
-                />
-                <button
-                  className="btn--icon btn--caution btn--dark btn--sm"
-                  onClick={() => removeColumn(index)}
-                  disabled={!canEditColumns}
-                  title="Remove Column"
-                >
-                  <TimesIcon />
-                </button>
-              </div>
-            ))}
-          </div>
-        </div>
-
         <div className="relation-test-data-editor__data">
           <div className="relation-test-data-editor__section-header">
-            <div className="relation-test-data-editor__section-title">
-              Test Data ({embeddedData.rows.length} rows)
+            <div className="relation-test-data-editor__section-header__left">
+              <div className="relation-test-data-editor__section-title">
+                Test Data ({embeddedData.rows.length} rows)
+              </div>
             </div>
+            {hideColumnDefinitions ? (
+              <button
+                className="btn--icon btn--dark btn--sm"
+                onClick={addColumn}
+                disabled={!canEditColumns}
+                title="Add Column"
+              >
+                <PlusIcon />
+              </button>
+            ) : null}
           </div>
+          {!hideColumnDefinitions ? (
+            <div className="relation-test-data-editor__columns">
+              <div className="relation-test-data-editor__section-header">
+                <div className="relation-test-data-editor__section-title">
+                  Column Definitions
+                </div>
+                <button
+                  className="btn--icon btn--dark btn--sm"
+                  onClick={addColumn}
+                  disabled={!canEditColumns}
+                  title="Add Column"
+                >
+                  <PlusIcon />
+                </button>
+              </div>
+              <div className="relation-test-data-editor__columns-grid">
+                {embeddedData.columns.map((column, index) => (
+                  <div
+                    key={`column-${guaranteeNonNullable(index)}`}
+                    className="relation-test-data-editor__column-row"
+                  >
+                    <input
+                      className="relation-test-data-editor__column-input"
+                      type="text"
+                      value={column}
+                      onChange={(e) => updateColumn(index, e.target.value)}
+                      placeholder="Column Name"
+                      disabled={!canEditColumns}
+                    />
+                    <button
+                      className="btn--icon btn--caution btn--dark btn--sm"
+                      onClick={() => removeColumn(index)}
+                      disabled={!canEditColumns}
+                      title="Remove Column"
+                    >
+                      <TimesIcon />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
           {embeddedData.rows.length === 0 ? (
             <div className="relation-test-data-editor__empty-data">
               <div className="relation-test-data-editor__empty-text">
@@ -415,58 +400,75 @@ export const RelationElementEditor = observer(
             </div>
           ) : (
             <div className="relation-test-data-editor__data-grid">
-              <div className="relation-test-data-editor__data-header">
-                {embeddedData.columns.map((column) => (
-                  <div
-                    key={column}
-                    className="relation-test-data-editor__data-header-cell"
-                  >
-                    {column}
-                    {/* <span className="relation-test-data-editor__data-type">
-                  ({column.type})
-                </span> */}
-                  </div>
-                ))}
-                <div className="relation-test-data-editor__data-header-cell relation-test-data-editor__data-actions">
-                  Actions
-                </div>
-              </div>
-              {embeddedData.rows.map((row, rowIndex) => (
-                <div
-                  key={`row-${guaranteeNonNullable(rowIndex)}`}
-                  className="relation-test-data-editor__data-row"
-                >
-                  {embeddedData.columns.map((column, columnIndex) => (
-                    <div
-                      key={column}
-                      className="relation-test-data-editor__data-cell"
+              <table className="relation-test-data-editor__table">
+                <thead>
+                  <tr>
+                    {embeddedData.columns.map((column, columnIndex) => (
+                      <th
+                        key={column}
+                        className="relation-test-data-editor__th"
+                      >
+                        <div className="relation-test-data-editor__th__inner">
+                          <span className="relation-test-data-editor__th__label">
+                            {column}
+                          </span>
+                          <button
+                            className="btn--icon btn--caution btn--dark btn--sm relation-test-data-editor__th__delete"
+                            onClick={() => removeColumn(columnIndex)}
+                            disabled={!canEditColumns}
+                            title={`Remove column ${column}`}
+                          >
+                            <TimesIcon />
+                          </button>
+                        </div>
+                      </th>
+                    ))}
+                    <th className="relation-test-data-editor__th relation-test-data-editor__th--actions" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {embeddedData.rows.map((_row, rowIndex) => (
+                    <tr
+                      key={`row-${guaranteeNonNullable(rowIndex)}`}
+                      className="relation-test-data-editor__tr"
                     >
-                      <input
-                        type="text"
-                        value={relationElementState.getDisplayValue(
-                          rowIndex,
-                          columnIndex,
-                        )}
-                        onChange={(e) =>
-                          updateCellValue(rowIndex, columnIndex, e.target.value)
-                        }
-                        disabled={isReadOnly}
-                        className="relation-test-data-editor__data-input"
-                      />
-                    </div>
+                      {embeddedData.columns.map((column, columnIndex) => (
+                        <td
+                          key={column}
+                          className="relation-test-data-editor__td"
+                        >
+                          <input
+                            type="text"
+                            value={relationElementState.getDisplayValue(
+                              rowIndex,
+                              columnIndex,
+                            )}
+                            onChange={(e) =>
+                              updateCellValue(
+                                rowIndex,
+                                columnIndex,
+                                e.target.value,
+                              )
+                            }
+                            disabled={isReadOnly}
+                            className="relation-test-data-editor__data-input"
+                          />
+                        </td>
+                      ))}
+                      <td className="relation-test-data-editor__td relation-test-data-editor__td--actions">
+                        <button
+                          className="btn--icon btn--caution btn--dark btn--sm relation-test-data-editor__icon-button--compact"
+                          onClick={() => removeRow(rowIndex)}
+                          disabled={isReadOnly}
+                          title="Remove Row"
+                        >
+                          <TimesIcon />
+                        </button>
+                      </td>
+                    </tr>
                   ))}
-                  <div className="relation-test-data-editor__data-cell relation-test-data-editor__data-actions">
-                    <button
-                      className="btn--icon btn--caution btn--dark btn--sm"
-                      onClick={() => removeRow(rowIndex)}
-                      disabled={isReadOnly}
-                      title="Remove Row"
-                    >
-                      <TimesIcon />
-                    </button>
-                  </div>
-                </div>
-              ))}
+                </tbody>
+              </table>
             </div>
           )}
 
@@ -482,7 +484,7 @@ export const RelationElementEditor = observer(
               </button>
 
               <button
-                className="btn--icon btn--caution btn--dark btn--sm"
+                className="btn--icon btn--dark btn--sm"
                 onClick={handleClearData}
                 disabled={isReadOnly || embeddedData.rows.length === 0}
                 title="Clear All Data"
@@ -490,30 +492,14 @@ export const RelationElementEditor = observer(
                 <TrashIcon />
               </button>
             </div>
-            <div className="relation-test-data-editor__export-format">
-              <label htmlFor="exportFormat">Export as:</label>
-              <select
-                id="exportFormat"
-                value={exportFormat}
-                onChange={(e) =>
-                  setExportFormat(e.target.value as 'json' | 'csv' | 'sql')
-                }
-                disabled={isReadOnly}
-                className="relation-test-data-editor__export-select"
-              >
-                <option value="json">JSON</option>
-                <option value="csv">CSV</option>
-                <option value="sql">SQL INSERT</option>
-              </select>
-              <button
-                className="btn--icon btn--dark btn--sm"
-                onClick={exportData}
-                disabled={isReadOnly}
-                title={`Export as ${exportFormat.toUpperCase()}`}
-              >
-                <FileImportIcon />
-              </button>
-            </div>
+            <button
+              className="btn--icon btn--dark btn--sm"
+              onClick={exportCSV}
+              disabled={isReadOnly}
+              title="Export as CSV"
+            >
+              <FileImportIcon />
+            </button>
 
             <div className="relation-test-data-editor__import-controls">
               <input
@@ -528,7 +514,7 @@ export const RelationElementEditor = observer(
                 className="btn--icon btn--dark btn--sm"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={isReadOnly}
-                title="Upload a file of CSV"
+                title="Upload CSV"
               >
                 <UploadIcon />
               </button>

--- a/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
@@ -413,7 +413,7 @@ export const RelationElementEditor = observer(
                             {column}
                           </span>
                           <button
-                            className="btn--icon btn--caution btn--dark btn--sm relation-test-data-editor__th__delete"
+                            className="relation-test-data-editor__th__delete"
                             onClick={() => removeColumn(columnIndex)}
                             disabled={!canEditColumns}
                             title={`Remove column ${column}`}

--- a/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
@@ -502,6 +502,9 @@ export const RelationElementEditor = observer(
             </button>
 
             <div className="relation-test-data-editor__import-controls">
+              <span className="relation-test-data-editor__import-controls__label">
+                Upload CSV
+              </span>
               <input
                 ref={fileInputRef}
                 type="file"
@@ -531,8 +534,10 @@ export const RelationElementsDataEditor = observer(
     dataState: RelationElementsDataState;
     isReadOnly: boolean;
     isSharedData?: boolean | undefined;
+    hideColumnDefinitions?: boolean;
   }) => {
-    const { dataState, isReadOnly, isSharedData } = props;
+    const { dataState, isReadOnly, isSharedData, hideColumnDefinitions } =
+      props;
 
     useApplicationNavigationContext(
       LEGEND_STUDIO_APPLICATION_NAVIGATION_CONTEXT_KEY.EMBEDDED_DATA_RELATIONAL_EDITOR,
@@ -637,6 +642,9 @@ export const RelationElementsDataEditor = observer(
             <RelationElementEditor
               relationElementState={dataState.activeRelationElement}
               isReadOnly={isReadOnly}
+              {...(hideColumnDefinitions !== undefined
+                ? { hideColumnDefinitions }
+                : {})}
             />
           )}
         </PanelContent>

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/DataProductEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/DataProductEditor.tsx
@@ -2231,6 +2231,9 @@ const AccessPointGroupTab = observer(
 const DataProductSidebar = observer(
   (props: { dataProductEditorState: DataProductEditorState }) => {
     const { dataProductEditorState } = props;
+    const showTestingTab =
+      dataProductEditorState.editorStore.applicationStore.config.options
+        .NonProductionFeatureFlag;
     const sidebarTabs = [
       {
         label: DATA_PRODUCT_TAB.HOME,
@@ -2246,11 +2249,15 @@ const DataProductSidebar = observer(
         title: 'Operational Metadata',
         icon: <GearSuggestIcon />,
       },
-      {
-        label: DATA_PRODUCT_TAB.TESTING,
-        title: 'Testing',
-        icon: <FlaskIcon />,
-      },
+      ...(showTestingTab
+        ? [
+            {
+              label: DATA_PRODUCT_TAB.TESTING,
+              title: 'Testing',
+              icon: <FlaskIcon />,
+            },
+          ]
+        : []),
       {
         label: DATA_PRODUCT_TAB.SUPPORT,
         icon: <QuestionCircleIcon />,
@@ -3359,6 +3366,8 @@ export const DataProductEditor = observer(() => {
   const [showPreview, setShowPreview] = useState(false);
   const [dataProductViewerState, setDataProductViewerState] =
     useState<DataProductViewerState>();
+  const showTestingTab =
+    editorStore.applicationStore.config.options.NonProductionFeatureFlag;
 
   const selectedActivity = dataProductEditorState.selectedTab;
   const renderActivivtyBarTab = (): React.ReactNode => {
@@ -3392,12 +3401,12 @@ export const DataProductEditor = observer(() => {
           />
         );
       case DATA_PRODUCT_TAB.TESTING:
-        return (
+        return showTestingTab ? (
           <DataProductTestableEditor
             dataProductEditorState={dataProductEditorState}
             isReadOnly={isReadOnly}
           />
-        );
+        ) : null;
       default:
         return null;
     }
@@ -3412,6 +3421,15 @@ export const DataProductEditor = observer(() => {
       dataProductEditorState.editorStore.applicationStore.alertUnhandledError,
     );
   }, [dataProductEditorState]);
+
+  useEffect(() => {
+    if (
+      !showTestingTab &&
+      dataProductEditorState.selectedTab === DATA_PRODUCT_TAB.TESTING
+    ) {
+      dataProductEditorState.setSelectedTab(DATA_PRODUCT_TAB.HOME);
+    }
+  }, [dataProductEditorState, showTestingTab]);
 
   useEffect(
     () =>

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -387,6 +387,7 @@ const ElementTestDataEditor = observer(
       <RelationElementsDataEditor
         dataState={dataState}
         isReadOnly={isReadOnly}
+        hideColumnDefinitions={true}
       />
     );
   },
@@ -764,7 +765,7 @@ const DataProductTestSuiteEditor = observer(
     return (
       <div className="service-test-suite-editor">
         <ResizablePanelGroup orientation="horizontal">
-          <ResizablePanel size={300} minSize={28}>
+          <ResizablePanel size={580} minSize={28}>
             <DataProductTestDataEditor
               testDataState={suiteState.testDataState}
               isReadOnly={isReadOnly}

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -346,7 +346,9 @@ const ElementTestDataItem = observer(
           tabIndex={-1}
         >
           <div className="testable-test-explorer__item__label__text">
-            {elementState.element.path}
+            <span title={elementState.element.path}>
+              {elementState.element.name}
+            </span>
           </div>
           {!isReadOnly && (
             <div className="mapping-test-explorer__item__actions">

--- a/packages/legend-application-studio/src/components/editor/editor-group/testable/TestableSharedComponents.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/testable/TestableSharedComponents.tsx
@@ -610,13 +610,6 @@ const DataProductEqualToRelationAssertionEditor = observer(
 
     return (
       <div className="service-test-data-editor panel">
-        <div className="function-testable-editor__header">
-          <div className="function-testable-editor__header__title">
-            <div className="function-testable-editor__header__title__label">
-              expected
-            </div>
-          </div>
-        </div>
         <div className="panel__content__form__section">
           <div className="panel__content__form__section__header__label">
             Access Point: {testState.accessPointLabel}
@@ -626,6 +619,7 @@ const DataProductEqualToRelationAssertionEditor = observer(
           <RelationElementEditor
             relationElementState={relationElementState}
             isReadOnly={isReadOnly}
+            hideColumnDefinitions={true}
           />
         ) : (
           <BlankPanelPlaceholder

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -35,7 +35,9 @@ import {
   TestError,
   TestExecutionStatus,
   EqualToRelation,
+  RelationRowTestData,
   observe_RelationElement,
+  observe_RelationRowTestData,
   observe_RelationElementsData,
   observe_DataProductTestSuite,
   IngestDefinition,
@@ -76,10 +78,12 @@ const createEmptyRelationElement = (
   itemId: string,
   columns: string[] = [],
 ): RelationElement => {
+  const row = observe_RelationRowTestData(new RelationRowTestData());
+  row.values = columns.map(() => '');
   const relationElement = new RelationElement();
   relationElement.paths = [itemId];
   relationElement.columns = columns;
-  relationElement.rows = [];
+  relationElement.rows = [row];
   return observe_RelationElement(relationElement);
 };
 
@@ -635,9 +639,11 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
     const assertion = new EqualToRelation();
     assertion.id = 'assert_1';
     const expectedRelElement = new RelationElement();
+    const expectedRow = observe_RelationRowTestData(new RelationRowTestData());
+    expectedRow.values = inferredColumns.map(() => '');
     expectedRelElement.paths = [accessPointId];
     expectedRelElement.columns = inferredColumns;
-    expectedRelElement.rows = [];
+    expectedRelElement.rows = [expectedRow];
     observe_RelationElement(expectedRelElement);
     assertion.expected = expectedRelElement;
     test.assertions = [assertion];
@@ -870,9 +876,11 @@ export class DataProductTestableState {
     const assertion = new EqualToRelation();
     assertion.id = 'assert_1';
     const expectedRelElement = new RelationElement();
+    const expectedRow = observe_RelationRowTestData(new RelationRowTestData());
+    expectedRow.values = inferredColumns.map(() => '');
     expectedRelElement.paths = [accessPointId];
     expectedRelElement.columns = inferredColumns;
-    expectedRelElement.rows = [];
+    expectedRelElement.rows = [expectedRow];
     observe_RelationElement(expectedRelElement);
     assertion.expected = expectedRelElement;
     test.assertions = [assertion];

--- a/packages/legend-application-studio/style/components/editor/_data-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-editor.scss
@@ -765,16 +765,35 @@
     }
 
     &__delete {
-      color: transparent;
+      opacity: 0;
+      pointer-events: none;
       flex-shrink: 0;
+      width: 1.6rem;
+      height: 1.6rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 0.2rem;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      color: var(--color-light-grey-400);
+      transition:
+        opacity 0.12s,
+        color 0.12s;
 
       svg {
         font-size: 1rem;
       }
+
+      &:hover {
+        color: var(--color-red-100);
+      }
     }
 
     &:hover &__delete {
-      color: var(--color-dark-grey-500);
+      opacity: 1;
+      pointer-events: auto;
     }
   }
 
@@ -856,44 +875,6 @@
     &__btn-group {
       display: flex;
       gap: 1rem;
-    }
-  }
-
-  &__export-format {
-    display: flex;
-    align-items: center;
-    gap: 0.8rem;
-    flex-wrap: nowrap;
-
-    label {
-      color: var(--color-light-grey-200);
-      font-size: 1.3rem;
-      font-weight: 500;
-      white-space: nowrap;
-    }
-
-    .btn {
-      margin-left: 0.5rem;
-    }
-  }
-
-  &__export-select {
-    height: 2.8rem;
-    padding: 0 1rem;
-    background: var(--color-dark-grey-200);
-    border: 0.1rem solid var(--color-dark-grey-300);
-    border-radius: 0.2rem;
-    color: var(--color-light-grey-200);
-    font-size: 1.3rem;
-
-    &:focus {
-      border-color: var(--color-blue-200);
-      outline: none;
-    }
-
-    &:disabled {
-      background: var(--color-dark-grey-300);
-      color: var(--color-dark-grey-500);
     }
   }
 

--- a/packages/legend-application-studio/style/components/editor/_data-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-editor.scss
@@ -625,6 +625,12 @@
       align-items: center;
       gap: 0.5rem;
     }
+
+    &__left {
+      display: flex;
+      align-items: center;
+      gap: 0.8rem;
+    }
   }
 
   &__section-title {
@@ -713,50 +719,70 @@
   }
 
   &__data-grid {
-    display: flex;
-    flex-direction: column;
     border: 0.1rem solid var(--color-dark-grey-300);
     border-radius: 0.2rem;
-    overflow: hidden;
+    overflow-x: auto;
   }
 
-  &__data-header {
-    display: flex;
+  &__table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  &__th {
+    position: relative;
     background: var(--color-dark-grey-200);
-    border-bottom: 0.1rem solid var(--color-dark-grey-300);
-  }
-
-  &__data-header-cell {
-    flex: 1;
-    padding: 1rem;
-    font-weight: 500;
     color: var(--color-light-grey-100);
+    font-weight: 500;
     font-size: 1.2rem;
+    text-align: left;
+    white-space: nowrap;
     border-right: 0.1rem solid var(--color-dark-grey-300);
+    border-bottom: 0.1rem solid var(--color-dark-grey-300);
+    padding: 0;
 
     &:last-child {
       border-right: none;
     }
 
-    &.relation-test-data-editor__data-actions {
-      flex: 0 0 8rem;
-      text-align: center;
+    &--actions {
+      width: 5rem;
+    }
+
+    &__inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.4rem;
+      min-width: 8rem;
+      padding: 0.6rem 1rem;
+    }
+
+    &__label {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    &__delete {
+      color: transparent;
+      flex-shrink: 0;
+
+      svg {
+        font-size: 1rem;
+      }
+    }
+
+    &:hover &__delete {
+      color: var(--color-dark-grey-500);
     }
   }
 
-  &__data-type {
-    font-weight: 400;
-    color: var(--color-dark-grey-500);
-    font-size: 1.1rem;
-    margin-left: 0.5rem;
-  }
-
-  &__data-row {
-    display: flex;
-    border-bottom: 0.1rem solid var(--color-dark-grey-300);
-
+  &__tr {
     &:last-child {
-      border-bottom: none;
+      td {
+        border-bottom: none;
+      }
     }
 
     &:hover {
@@ -764,20 +790,28 @@
     }
   }
 
-  &__data-cell {
-    flex: 1;
+  &__td {
     padding: 0.5rem;
     border-right: 0.1rem solid var(--color-dark-grey-300);
+    border-bottom: 0.1rem solid var(--color-dark-grey-300);
+    vertical-align: middle;
 
     &:last-child {
       border-right: none;
     }
 
-    &.relation-test-data-editor__data-actions {
-      flex: 0 0 8rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+    &--actions {
+      width: 5rem;
+      text-align: center;
+    }
+  }
+
+  &__icon-button--compact {
+    width: 1.8rem;
+    height: 1.8rem;
+
+    svg {
+      font-size: 0.9rem;
     }
   }
 

--- a/packages/legend-application-studio/style/components/editor/_data-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-editor.scss
@@ -633,6 +633,28 @@
     }
   }
 
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-left: 1rem;
+    flex: 1;
+
+    &__left {
+      display: flex;
+      align-items: center;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+    }
+
+    &__right {
+      display: flex;
+      align-items: center;
+      margin-left: auto;
+    }
+  }
+
   &__section-title {
     font-weight: 500;
     color: var(--color-light-grey-200);
@@ -855,26 +877,29 @@
     }
   }
 
-  &__export-controls {
+  &__footer-actions {
     display: flex;
-    gap: 1.2rem;
-    flex-wrap: wrap;
-    align-items: center;
-    margin-top: 1.5rem;
-    padding-top: 1.5rem;
-    border-top: 0.1rem solid var(--color-dark-grey-300);
     justify-content: space-between;
+    align-items: center;
+    margin-top: 1rem;
 
-    .btn {
+    &__left,
+    &__right {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      white-space: nowrap;
     }
+  }
 
-    &__btn-group {
-      display: flex;
-      gap: 1rem;
+  &__action-control {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+
+    &__label {
+      color: var(--color-light-grey-200);
+      font-size: 1.3rem;
+      font-weight: 500;
+      white-space: nowrap;
     }
   }
 
@@ -896,10 +921,27 @@
   }
 
   @media (width <= 768px) {
-    &__export-controls {
+    &__section-header {
       flex-direction: column;
       align-items: flex-start;
       gap: 1rem;
+    }
+
+    &__toolbar {
+      margin-left: 0;
+      width: 100%;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.8rem;
+
+      &__left {
+        width: 100%;
+      }
+
+      &__right {
+        width: 100%;
+        margin-left: 0;
+      }
 
       .btn {
         width: auto;
@@ -907,14 +949,8 @@
       }
     }
 
-    &__export-format {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.5rem;
-
-      .btn {
-        margin-left: 0;
-      }
+    &__footer-actions {
+      width: 100%;
     }
   }
 }

--- a/packages/legend-application-studio/style/components/editor/_data-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-editor.scss
@@ -902,6 +902,13 @@
     align-items: center;
     gap: 0.8rem;
 
+    &__label {
+      color: var(--color-light-grey-200);
+      font-size: 1.3rem;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+
     .btn {
       white-space: nowrap;
     }


### PR DESCRIPTION
This PR combines the recent DataProduct testing updates across both internal MRs into one external/public summary.

### Summary
* Refactors the DataProduct relation test-data editor to a cleaner table-based UI.
* Improves test-data actions and layout (written controls for Add Row/Add Column, Upload/Export placement, footer actions alignment).
* Keeps column-delete actions lightweight with hover-reveal behavior.
* Simplifies export behavior to CSV-focused flow.
* Hides column-definition editing in DataProduct test/assertion contexts where schema is already defined.
* Seeds default empty rows for suite-level and expected relation test data to reduce setup friction.
* Updates test-data element labeling to show a short name with full path on hover.
