### PR TITLE
Fetch matview dataset's Relation type for query builder and testing

### DIFF
--- a/.changeset/bold-coins-teach.md
+++ b/.changeset/bold-coins-teach.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Make V1_createAccessorFromPackageableElement async -- it now handles fetching the columns from matview datasets' RawLambdas. The sync version (like before) is called V1_createAccessorFromPackageableElementWithNonFunctionSources and is still used in building value specs

--- a/.changeset/bold-melons-cross.md
+++ b/.changeset/bold-melons-cross.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Updates to call now async functions

--- a/.changeset/plain-emus-drive.md
+++ b/.changeset/plain-emus-drive.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application-query': patch
+---

--- a/.changeset/some-lies-melt.md
+++ b/.changeset/some-lies-melt.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Make changeAccessorOwner and changeAccessor async

--- a/packages/legend-application-query/src/stores/__tests__/QueryBuilderBuildLambdaPersistence.test.ts
+++ b/packages/legend-application-query/src/stores/__tests__/QueryBuilderBuildLambdaPersistence.test.ts
@@ -794,7 +794,7 @@ describe(unitTest('Accessor – buildQuery vs buildQueryForPersistence'), () => 
       );
 
       const ingest = guaranteeNonNullable(graphManagerState.graph.ingests[0]);
-      state.changeAccessorOwner(ingest);
+      await state.changeAccessorOwner(ingest);
       state.changeSelectedRuntime(
         guaranteeNonNullable(state.compatibleRuntimes[0]),
       );
@@ -821,7 +821,7 @@ describe(unitTest('Accessor – buildQuery vs buildQueryForPersistence'), () => 
       );
 
       const ingest = guaranteeNonNullable(graphManagerState.graph.ingests[0]);
-      state.changeAccessorOwner(ingest);
+      await state.changeAccessorOwner(ingest);
       state.changeSelectedRuntime(
         guaranteeNonNullable(state.compatibleRuntimes[0]),
       );

--- a/packages/legend-application-studio/src/components/editor/editor-group/accessor/AccessorQueryBuilderHelper.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/accessor/AccessorQueryBuilderHelper.tsx
@@ -45,7 +45,7 @@ export const queryAccessorSource = async (
             editorStore.applicationStore.config.options.queryBuilderConfig,
             editorStore.editorMode.getSourceInfo(),
           );
-          queryBuilderState.changeAccessorOwner(element);
+          await queryBuilderState.changeAccessorOwner(element);
           const compatibleRuntimes = getCompatibleRuntimesFromAccessorOwner(
             element,
             editorStore.graphManagerState,

--- a/packages/legend-application-studio/src/components/editor/editor-group/accessor/__tests__/AccessorQueryBuilderHelper.test.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/accessor/__tests__/AccessorQueryBuilderHelper.test.tsx
@@ -69,7 +69,7 @@ describe(integrationTest('Promote accessor query to function'), () => {
       QueryBuilderAdvancedWorkflowState.INSTANCE,
       QueryBuilderActionConfig.INSTANCE,
     );
-    queryBuilderState.changeAccessorOwner(ingest);
+    await queryBuilderState.changeAccessorOwner(ingest);
     const compatibleRuntimes = getCompatibleRuntimesFromAccessorOwner(
       ingest,
       MOCK__editorStore.graphManagerState,
@@ -129,7 +129,7 @@ describe(integrationTest('Promote accessor query to function'), () => {
       QueryBuilderAdvancedWorkflowState.INSTANCE,
       QueryBuilderActionConfig.INSTANCE,
     );
-    queryBuilderState.changeAccessorOwner(database);
+    await queryBuilderState.changeAccessorOwner(database);
     const compatibleRuntimes = getCompatibleRuntimesFromAccessorOwner(
       database,
       MOCK__editorStore.graphManagerState,

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/DataProductEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/DataProductEditor.tsx
@@ -847,7 +847,7 @@ export const LakehouseDataProductAccessPointEditor = observer(
                 applicationStore.config.options.queryBuilderConfig,
                 editorStore.editorMode.getSourceInfo(),
               );
-              queryBuilderState.changeAccessorOwner(ingestDefinition);
+              await queryBuilderState.changeAccessorOwner(ingestDefinition);
               const compatibleRuntimes = getCompatibleRuntimesFromAccessorOwner(
                 ingestDefinition,
                 editorStore.graphManagerState,

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -322,11 +322,12 @@ export class DataProductElementTestDataState {
         let columns: string[] = [];
         try {
           if (element instanceof IngestDefinition) {
-            const accessor = graphManager.createAccessorFromPackageableElement(
-              element,
-              graph,
-              { schemaName: undefined, tableName: item.id },
-            );
+            const accessor =
+              await graphManager.createAccessorFromPackageableElement(
+                element,
+                graph,
+                { schemaName: undefined, tableName: item.id },
+              );
             if (accessor) {
               columns = accessor.relationType.columns.map((c) => c.name);
             }

--- a/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/AbstractPureGraphManager.ts
@@ -454,7 +454,7 @@ export abstract class AbstractPureGraphManager {
       schemaName: string | undefined;
       tableName: string | undefined;
     },
-  ): Accessor | undefined;
+  ): Promise<Accessor | undefined>;
 
   abstract buildDataProductAccessor(
     element: DataProduct,

--- a/packages/legend-graph/src/graph-manager/__tests__/V1_AccessorHelper.test.ts
+++ b/packages/legend-graph/src/graph-manager/__tests__/V1_AccessorHelper.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, describe, expect, beforeAll } from '@jest/globals';
+import { test, describe, expect, beforeAll, jest } from '@jest/globals';
 import { unitTest } from '@finos/legend-shared/test';
 import { guaranteeNonNullable, type PlainObject } from '@finos/legend-shared';
 import {
@@ -25,7 +25,10 @@ import {
   DataProductAccessor,
   AccessorInstanceValue,
 } from '../../graph/metamodel/pure/packageableElements/relation/Accessor.js';
-import { IngestDefinition } from '../../graph/metamodel/pure/packageableElements/ingest/IngestDefinition.js';
+import {
+  IngestDefinition,
+  type MatViewDataSet,
+} from '../../graph/metamodel/pure/packageableElements/ingest/IngestDefinition.js';
 import { Database } from '../../graph/metamodel/pure/packageableElements/store/relational/model/Database.js';
 import { DataProduct } from '../../graph/metamodel/pure/dataProduct/DataProduct.js';
 import {
@@ -64,6 +67,12 @@ import {
   TEST__getTestGraphManagerState,
   TEST__buildGraphWithEntities,
 } from '../__test-utils__/GraphManagerTestUtils.js';
+import { RawLambda } from '../../graph/metamodel/pure/rawValueSpecification/RawLambda.js';
+import {
+  RelationTypeMetadata,
+  RelationTypeColumnMetadata,
+} from '../action/relation/RelationTypeMetadata.js';
+import { Multiplicity } from '../../graph/metamodel/pure/packageableElements/domain/Multiplicity.js';
 
 // ──────────────────────────────────────────────────────────
 // Shared graph setup
@@ -75,13 +84,13 @@ beforeAll(async () => {
   await TEST__buildGraphWithEntities(graphManagerState, []);
 });
 
-const createAccessorFromPackageableElement = (
+const createAccessorFromPackageableElement = async (
   element: AccessorOwner,
   options?: {
     schemaName: string | undefined;
     tableName: string | undefined;
   },
-): Accessor | undefined =>
+): Promise<Accessor | undefined> =>
   graphManagerState.graphManager.createAccessorFromPackageableElement(
     element,
     graphManagerState.graph,
@@ -160,7 +169,7 @@ const createTestDatabase = (
 describe(
   unitTest('createAccessorFromPackageableElement — IngestDefinition'),
   () => {
-    test('creates IngestionAccessor with first dataset when tableName not specified', () => {
+    test('creates IngestionAccessor with first dataset when tableName not specified', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'dataset1',
@@ -176,7 +185,7 @@ describe(
       ]);
 
       const accessor = guaranteeNonNullable(
-        createAccessorFromPackageableElement(ingest),
+        await createAccessorFromPackageableElement(ingest),
       );
 
       expect(accessor).toBeInstanceOf(IngestionAccessor);
@@ -192,7 +201,7 @@ describe(
       );
     });
 
-    test('creates IngestionAccessor for a specific dataset by tableName', () => {
+    test('creates IngestionAccessor for a specific dataset by tableName', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'dataset1',
@@ -208,7 +217,7 @@ describe(
       ]);
 
       const accessor = guaranteeNonNullable(
-        createAccessorFromPackageableElement(ingest, {
+        await createAccessorFromPackageableElement(ingest, {
           tableName: 'dataset2',
           schemaName: undefined,
         }),
@@ -225,7 +234,7 @@ describe(
       );
     });
 
-    test('returns undefined when tableName does not match any dataset', () => {
+    test('returns undefined when tableName does not match any dataset', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'dataset1',
@@ -233,7 +242,7 @@ describe(
         },
       ]);
 
-      const accessor = createAccessorFromPackageableElement(ingest, {
+      const accessor = await createAccessorFromPackageableElement(ingest, {
         tableName: 'nonexistent',
         schemaName: undefined,
       });
@@ -241,16 +250,16 @@ describe(
       expect(accessor).toBeUndefined();
     });
 
-    test('returns undefined when ingest has no datasets', () => {
+    test('returns undefined when ingest has no datasets', async () => {
       const ingest = new IngestDefinition('EmptyIngest');
       ingest.content = {} as PlainObject;
 
-      const accessor = createAccessorFromPackageableElement(ingest);
+      const accessor = await createAccessorFromPackageableElement(ingest);
 
       expect(accessor).toBeUndefined();
     });
 
-    test('maps Pure type paths to correct PrimitiveTypes', () => {
+    test('maps Pure type paths to correct PrimitiveTypes', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'ds',
@@ -269,7 +278,7 @@ describe(
       ]);
 
       const accessor = guaranteeNonNullable(
-        createAccessorFromPackageableElement(ingest, {
+        await createAccessorFromPackageableElement(ingest, {
           tableName: 'ds',
           schemaName: undefined,
         }),
@@ -293,7 +302,7 @@ describe(
       expect(getType('col_number')).toBe(PrimitiveType.NUMBER);
     });
 
-    test('resolves fully qualified type paths', () => {
+    test('resolves fully qualified type paths', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'ds',
@@ -307,7 +316,7 @@ describe(
       ]);
 
       const accessor = guaranteeNonNullable(
-        createAccessorFromPackageableElement(ingest, {
+        await createAccessorFromPackageableElement(ingest, {
           tableName: 'ds',
           schemaName: undefined,
         }),
@@ -319,7 +328,7 @@ describe(
       ).toBe(PrimitiveType.INTEGER);
     });
 
-    test('defaults to STRING for unknown type paths', () => {
+    test('defaults to STRING for unknown type paths', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'ds',
@@ -328,7 +337,7 @@ describe(
       ]);
 
       const accessor = guaranteeNonNullable(
-        createAccessorFromPackageableElement(ingest, {
+        await createAccessorFromPackageableElement(ingest, {
           tableName: 'ds',
           schemaName: undefined,
         }),
@@ -340,7 +349,7 @@ describe(
       ).toBe(PrimitiveType.STRING);
     });
 
-    test('accessor path and labels are correct', () => {
+    test('accessor path and labels are correct', async () => {
       const ingest = createTestIngestDefinition('test::MyIngest', [
         {
           name: 'myDataset',
@@ -348,10 +357,10 @@ describe(
         },
       ]);
 
-      const accessor = createAccessorFromPackageableElement(ingest, {
+      const accessor = (await createAccessorFromPackageableElement(ingest, {
         tableName: 'myDataset',
         schemaName: undefined,
-      }) as IngestionAccessor;
+      })) as IngestionAccessor;
 
       expect(accessor.accessorOwnerLabel).toBe('Ingestion Source');
       expect(accessor.accessorLabel).toBe('Dataset');
@@ -366,7 +375,7 @@ describe(
 // ──────────────────────────────────────────────────────────
 
 describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
-  test('creates RelationalStoreAccessor for a specific table', () => {
+  test('creates RelationalStoreAccessor for a specific table', async () => {
     const db = createTestDatabase('test::MyDB', [
       {
         name: 'public',
@@ -383,7 +392,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     ]);
 
     const accessor = guaranteeNonNullable(
-      createAccessorFromPackageableElement(db, {
+      await createAccessorFromPackageableElement(db, {
         schemaName: 'public',
         tableName: 'PERSON',
       }),
@@ -402,7 +411,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     );
   });
 
-  test('maps relational data types to correct PrimitiveTypes', () => {
+  test('maps relational data types to correct PrimitiveTypes', async () => {
     const db = createTestDatabase('test::MyDB', [
       {
         name: 'default',
@@ -436,7 +445,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     ]);
 
     const accessor = guaranteeNonNullable(
-      createAccessorFromPackageableElement(db, {
+      await createAccessorFromPackageableElement(db, {
         schemaName: 'default',
         tableName: 'TYPES_TABLE',
       }),
@@ -485,7 +494,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     expect(getType('col_varbinary')).toBe(PrimitiveType.BINARY);
   });
 
-  test('returns undefined when schema does not exist', () => {
+  test('returns undefined when schema does not exist', async () => {
     const db = createTestDatabase('test::MyDB', [
       {
         name: 'public',
@@ -498,7 +507,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
       },
     ]);
 
-    const accessor = createAccessorFromPackageableElement(db, {
+    const accessor = await createAccessorFromPackageableElement(db, {
       schemaName: 'nonexistent',
       tableName: 'T',
     });
@@ -506,7 +515,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     expect(accessor).toBeUndefined();
   });
 
-  test('returns undefined when table does not exist', () => {
+  test('returns undefined when table does not exist', async () => {
     const db = createTestDatabase('test::MyDB', [
       {
         name: 'public',
@@ -519,7 +528,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
       },
     ]);
 
-    const accessor = createAccessorFromPackageableElement(db, {
+    const accessor = await createAccessorFromPackageableElement(db, {
       schemaName: 'public',
       tableName: 'nonexistent',
     });
@@ -527,7 +536,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     expect(accessor).toBeUndefined();
   });
 
-  test('accessor path and labels are correct', () => {
+  test('accessor path and labels are correct', async () => {
     const db = createTestDatabase('test::MyDB', [
       {
         name: 'mySchema',
@@ -540,10 +549,10 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
       },
     ]);
 
-    const accessor = createAccessorFromPackageableElement(db, {
+    const accessor = (await createAccessorFromPackageableElement(db, {
       schemaName: 'mySchema',
       tableName: 'myTable',
-    }) as RelationalStoreAccessor;
+    })) as RelationalStoreAccessor;
 
     expect(accessor.accessorOwnerLabel).toBe('Relational Database');
     expect(accessor.accessorLabel).toBe('Table');
@@ -551,7 +560,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     expect(accessor.path).toEqual(['MyDB', 'mySchema', 'myTable']);
   });
 
-  test('handles multiple schemas and tables', () => {
+  test('handles multiple schemas and tables', async () => {
     const db = createTestDatabase('test::MyDB', [
       {
         name: 'schema1',
@@ -581,7 +590,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     ]);
 
     const accessorA = guaranteeNonNullable(
-      createAccessorFromPackageableElement(db, {
+      await createAccessorFromPackageableElement(db, {
         schemaName: 'schema1',
         tableName: 'TABLE_A',
       }),
@@ -592,7 +601,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     );
 
     const accessorB = guaranteeNonNullable(
-      createAccessorFromPackageableElement(db, {
+      await createAccessorFromPackageableElement(db, {
         schemaName: 'schema2',
         tableName: 'TABLE_B',
       }),
@@ -600,7 +609,7 @@ describe(unitTest('createAccessorFromPackageableElement — Database'), () => {
     expect(accessorB.relationType.columns).toHaveLength(2);
 
     const accessorC = guaranteeNonNullable(
-      createAccessorFromPackageableElement(db, {
+      await createAccessorFromPackageableElement(db, {
         schemaName: 'schema2',
         tableName: 'TABLE_C',
       }),
@@ -693,3 +702,204 @@ describe(unitTest('Accessor model classes'), () => {
     expect(typeof instanceValue.hashCode).toBe('string');
   });
 });
+
+describe(
+  unitTest(
+    'createAccessorFromPackageableElement — IngestDefinition (matview datasets)',
+  ),
+  () => {
+    const createMatViewDataSet = (
+      name: string,
+      lambdaBody?: object,
+    ): MatViewDataSet => ({
+      name,
+      source: {
+        function: new RawLambda([], lambdaBody ?? {}),
+      },
+    });
+
+    const createMockRelationTypeMetadata = (
+      columns: { name: string; type: string }[],
+    ): RelationTypeMetadata => {
+      const metadata = new RelationTypeMetadata();
+      metadata.columns = columns.map(
+        (col) =>
+          new RelationTypeColumnMetadata(
+            col.type,
+            col.name,
+            new Multiplicity(1, 1),
+          ),
+      );
+      return metadata;
+    };
+
+    test('creates IngestionAccessor from first matview dataset when no non-matview datasets exist and tableName not specified', async () => {
+      const ingest = new IngestDefinition('MatviewIngest');
+      // content has only the same datasets as the matview list (no non-matview)
+      ingest.content = {
+        datasets: [
+          {
+            name: 'matview_ds1',
+            primaryKey: [],
+            source: {
+              _type: 'ingestSource',
+              schema: { _type: 'schema', columns: [] },
+            },
+          },
+          {
+            name: 'matview_ds2',
+            primaryKey: [],
+            source: {
+              _type: 'ingestSource',
+              schema: { _type: 'schema', columns: [] },
+            },
+          },
+        ],
+      } as PlainObject;
+      ingest.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS = [
+        createMatViewDataSet('matview_ds1'),
+        createMatViewDataSet('matview_ds2'),
+      ];
+
+      const mockMetadata = createMockRelationTypeMetadata([
+        { name: 'id', type: 'Integer' },
+        { name: 'amount', type: 'Float' },
+      ]);
+
+      const spy = jest
+        .spyOn(graphManagerState.graphManager, 'getLambdaRelationType')
+        .mockResolvedValue(mockMetadata);
+
+      const accessor = guaranteeNonNullable(
+        await createAccessorFromPackageableElement(ingest),
+      );
+
+      expect(accessor).toBeInstanceOf(IngestionAccessor);
+      expect(accessor.accessor).toBe('matview_ds1');
+      expect(accessor.parentElement).toBe(ingest);
+      expect(accessor.relationType.columns).toHaveLength(2);
+      expect(guaranteeNonNullable(accessor.relationType.columns[0]).name).toBe(
+        'id',
+      );
+      expect(guaranteeNonNullable(accessor.relationType.columns[1]).name).toBe(
+        'amount',
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        ingest.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS[0]?.source.function,
+        graphManagerState.graph,
+      );
+
+      spy.mockRestore();
+    });
+
+    test('creates IngestionAccessor for a specific matview dataset by tableName', async () => {
+      const ingest = new IngestDefinition('MatviewIngest');
+      ingest.content = {} as PlainObject;
+      ingest.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS = [
+        createMatViewDataSet('matview_ds1'),
+        createMatViewDataSet('matview_ds2'),
+      ];
+
+      const mockMetadata = createMockRelationTypeMetadata([
+        { name: 'name', type: 'String' },
+        { name: 'active', type: 'Boolean' },
+        { name: 'score', type: 'Decimal' },
+      ]);
+
+      const spy = jest
+        .spyOn(graphManagerState.graphManager, 'getLambdaRelationType')
+        .mockResolvedValue(mockMetadata);
+
+      const accessor = guaranteeNonNullable(
+        await createAccessorFromPackageableElement(ingest, {
+          tableName: 'matview_ds2',
+          schemaName: undefined,
+        }),
+      );
+
+      expect(accessor).toBeInstanceOf(IngestionAccessor);
+      expect(accessor.accessor).toBe('matview_ds2');
+      expect(accessor.relationType.columns).toHaveLength(3);
+      expect(guaranteeNonNullable(accessor.relationType.columns[0]).name).toBe(
+        'name',
+      );
+      expect(guaranteeNonNullable(accessor.relationType.columns[1]).name).toBe(
+        'active',
+      );
+      expect(guaranteeNonNullable(accessor.relationType.columns[2]).name).toBe(
+        'score',
+      );
+      expect(spy).toHaveBeenCalledWith(
+        ingest.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS[1]?.source.function,
+        graphManagerState.graph,
+      );
+
+      spy.mockRestore();
+    });
+
+    test('falls through to non-matview path when non-matview datasets exist and tableName not specified', async () => {
+      const ingest = new IngestDefinition('MixedIngest');
+      // content has both matview and non-matview datasets
+      ingest.content = {
+        datasets: [
+          {
+            name: 'regular_ds',
+            primaryKey: [],
+            source: {
+              _type: 'ingestSource',
+              schema: {
+                _type: 'schema',
+                columns: [
+                  {
+                    name: 'id',
+                    genericType: {
+                      rawType: {
+                        _type: 'packageableType',
+                        fullPath: 'Integer',
+                      },
+                    },
+                    multiplicity: { lowerBound: 1, upperBound: 1 },
+                  },
+                ],
+              },
+            },
+          },
+          {
+            name: 'matview_ds1',
+            primaryKey: [],
+            source: {
+              _type: 'ingestSource',
+              schema: { _type: 'schema', columns: [] },
+            },
+          },
+        ],
+      } as PlainObject;
+      ingest.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS = [
+        createMatViewDataSet('matview_ds1'),
+      ];
+
+      const spy = jest.spyOn(
+        graphManagerState.graphManager,
+        'getLambdaRelationType',
+      );
+
+      // Should use the non-matview dataset (regular_ds) via the sync path
+      const accessor = guaranteeNonNullable(
+        await createAccessorFromPackageableElement(ingest),
+      );
+
+      expect(accessor).toBeInstanceOf(IngestionAccessor);
+      // The sync path picks the first dataset in content.datasets
+      expect(accessor.accessor).toBe('regular_ds');
+      expect(accessor.relationType.columns).toHaveLength(1);
+      expect(guaranteeNonNullable(accessor.relationType.columns[0]).name).toBe(
+        'id',
+      );
+      // Should NOT have called getLambdaRelationType since it fell through
+      expect(spy).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+  },
+);

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/V1_PureGraphManager.ts
@@ -2150,14 +2150,14 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
 
   //
 
-  override createAccessorFromPackageableElement(
+  override async createAccessorFromPackageableElement(
     element: PackageableElement,
     graph: PureModel,
     options?: {
       schemaName?: string | undefined;
       tableName?: string | undefined;
     },
-  ): Accessor | undefined {
+  ): Promise<Accessor | undefined> {
     if (
       !(element instanceof IngestDefinition) &&
       !(element instanceof Database)
@@ -2170,7 +2170,12 @@ export class V1_PureGraphManager extends AbstractPureGraphManager {
       this.graphBuilderExtensions,
       this.logService,
     ).build();
-    return V1_createAccessorFromPackageableElement(element, context, options);
+    return V1_createAccessorFromPackageableElement(
+      element,
+      context,
+      this,
+      options,
+    );
   }
 
   override async buildDataProductAccessor(

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/helpers/V1_AccessorHelper.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/helpers/V1_AccessorHelper.ts
@@ -230,7 +230,7 @@ export const V1_buildRelationTypeFromAccessPointImplementation = (
  * For IngestDefinition: requires `datasetName` to identify the dataset.
  * For Database: requires `schemaName` and `tableName` to identify the table.
  */
-export const V1_createAccessorFromPackageableElement = (
+export const V1_createAccessorFromPackageableElementWithNonFunctionSources = (
   element: AccessorOwner,
   context: V1_GraphBuilderContext,
   options?: {
@@ -239,6 +239,7 @@ export const V1_createAccessorFromPackageableElement = (
   },
 ): Accessor | undefined => {
   if (element instanceof IngestDefinition) {
+    const datasetName = options?.tableName;
     const content = returnUndefOnError(() =>
       V1_deserializeIngestDefinitionContent(element.content),
     );
@@ -246,7 +247,6 @@ export const V1_createAccessorFromPackageableElement = (
     if (!content) {
       return undefined;
     }
-    const datasetName = options?.tableName;
     const dataset = datasetName
       ? content.datasets?.find((ds) => ds.name === datasetName)
       : content.datasets?.[0];
@@ -311,6 +311,67 @@ const buildRelationTypeFromMetadata = (
     return new RelationColumn(col.name, resolvedGenericType);
   });
   return relationType;
+};
+
+export const V1_createAccessorFromPackageableElement = async (
+  element: AccessorOwner,
+  context: V1_GraphBuilderContext,
+  graphManager: AbstractPureGraphManager,
+  options?: {
+    schemaName?: string | undefined;
+    tableName?: string | undefined;
+  },
+): Promise<Accessor | undefined> => {
+  if (element instanceof IngestDefinition) {
+    const datasetName = options?.tableName;
+    const content = returnUndefOnError(() =>
+      V1_deserializeIngestDefinitionContent(element.content),
+    );
+    let matviewDataSet;
+    if (datasetName) {
+      matviewDataSet = element.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS?.find(
+        (ds) => ds.name === datasetName,
+      );
+    } else if (element.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS?.length) {
+      // Prefer non-matview datasets - only use matview if no non-matview dataset exists
+      const matviewNames = new Set(
+        element.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS.map((ds) => ds.name),
+      );
+      const hasNonMatviewDataset = content?.datasets?.some(
+        (ds) => !matviewNames.has(ds.name),
+      );
+      matviewDataSet = hasNonMatviewDataset
+        ? undefined
+        : element.TEMPORARY_MATVIEW_FUNCTION_DATA_SETS[0];
+    }
+    if (matviewDataSet) {
+      const relationTypeMetadata = await graphManager.getLambdaRelationType(
+        matviewDataSet.source.function,
+        context.graph,
+      );
+      const relationType = buildRelationTypeFromMetadata(
+        relationTypeMetadata,
+        context,
+      );
+      addMilestonedColumnsForWriteMode(
+        relationType,
+        content?.writeMode,
+        context,
+      );
+      return new IngestionAccessor(
+        element.path,
+        undefined,
+        matviewDataSet.name,
+        relationType,
+        element,
+      );
+    }
+  }
+  return V1_createAccessorFromPackageableElementWithNonFunctionSources(
+    element,
+    context,
+    options,
+  );
 };
 
 export const V1_buildDataProductAccessor = async (

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/to/helpers/V1_ValueSpecificationBuilderHelper.ts
@@ -135,9 +135,9 @@ import {
   DataProduct,
   LakehouseAccessPoint,
 } from '../../../../../../../../graph/metamodel/pure/dataProduct/DataProduct.js';
-import { V1_createAccessorFromPackageableElement } from '../../../../helpers/V1_AccessorHelper.js';
 import { Database } from '../../../../../../../../graph/metamodel/pure/packageableElements/store/relational/model/Database.js';
 import { IngestDefinition } from '../../../../../../../../graph/metamodel/pure/packageableElements/ingest/IngestDefinition.js';
+import { V1_createAccessorFromPackageableElementWithNonFunctionSources } from '../../../../helpers/V1_AccessorHelper.js';
 
 const buildPrimtiveInstanceValue = (
   type: PRIMITIVE_TYPE,
@@ -562,10 +562,14 @@ export class V1_ValueSpecificationBuilder
           Database,
         );
         const accessor = guaranteeNonNullable(
-          V1_createAccessorFromPackageableElement(db, this.context, {
-            schemaName,
-            tableName,
-          }),
+          V1_createAccessorFromPackageableElementWithNonFunctionSources(
+            db,
+            this.context,
+            {
+              schemaName,
+              tableName,
+            },
+          ),
           `Can't build accessor for database '${dbPath}'`,
         );
         const accessorInstanceValue = new AccessorInstanceValue();
@@ -587,9 +591,13 @@ export class V1_ValueSpecificationBuilder
           IngestDefinition,
         );
         const accessor = guaranteeNonNullable(
-          V1_createAccessorFromPackageableElement(ingestDef, this.context, {
-            tableName: datasetName,
-          }),
+          V1_createAccessorFromPackageableElementWithNonFunctionSources(
+            ingestDef,
+            this.context,
+            {
+              tableName: datasetName,
+            },
+          ),
           `Can't build accessor for ingest definition '${ingestPath}'`,
         );
         const accessorInstanceValue = new AccessorInstanceValue();

--- a/packages/legend-graph/src/index.ts
+++ b/packages/legend-graph/src/index.ts
@@ -888,6 +888,7 @@ export {
 } from './graph/metamodel/pure/packageableElements/relation/Accessor.js';
 export {
   V1_createAccessorFromPackageableElement,
+  V1_createAccessorFromPackageableElementWithNonFunctionSources,
   V1_resolveAccessorsFromRawLambda,
   V1_buildRelationElementsDataFromAccessors,
   V1_buildRelationTypeFromAccessPointImplementation,

--- a/packages/legend-query-builder/src/components/__tests__/AccessorQueryBuilder.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/AccessorQueryBuilder.test.tsx
@@ -33,7 +33,6 @@ import {
 import { QUERY_BUILDER_TEST_ID } from '../../__lib__/QueryBuilderTesting.js';
 import {
   TEST__setUpAccessorQueryBuilder,
-  selectFirstOptionFromCustomSelectorInput,
   dragAndDrop,
 } from '../__test-utils__/QueryBuilderComponentTestUtils.js';
 import { guaranteeNonNullable } from '@finos/legend-shared';
@@ -61,7 +60,7 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
       renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_SETUP),
     );
     // No source selected => no accessor options => accessor selector hidden
-    expect(queryByText(setupPanel, 'Data Set')).toBeNull();
+    expect(queryByText(setupPanel, 'Dataset')).toBeNull();
   });
 
   test('renders placeholder text for empty selectors', async () => {
@@ -106,7 +105,7 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
       queryBuilderState.graphManagerState.graph.ingests[0],
     );
     await act(async () => {
-      queryBuilderState.changeAccessorOwner(ingest);
+      await queryBuilderState.changeAccessorOwner(ingest);
     });
 
     const setupPanel = await waitFor(() =>
@@ -129,7 +128,7 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
       queryBuilderState.graphManagerState.usableDatabases[0],
     );
     await act(async () => {
-      queryBuilderState.changeAccessorOwner(db);
+      await queryBuilderState.changeAccessorOwner(db);
     });
 
     const setupPanel = await waitFor(() =>
@@ -156,8 +155,8 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
     const ingest = guaranteeNonNullable(
       queryBuilderState.graphManagerState.graph.ingests[0],
     );
-    act(() => {
-      queryBuilderState.changeAccessorOwner(ingest);
+    await act(async () => {
+      await queryBuilderState.changeAccessorOwner(ingest);
     });
 
     const runtimes = queryBuilderState.compatibleRuntimes;
@@ -174,8 +173,8 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
     const db = guaranteeNonNullable(
       queryBuilderState.graphManagerState.usableDatabases[0],
     );
-    act(() => {
-      queryBuilderState.changeAccessorOwner(db);
+    await act(async () => {
+      await queryBuilderState.changeAccessorOwner(db);
     });
 
     const runtimes = queryBuilderState.compatibleRuntimes;
@@ -242,14 +241,19 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
     // Initially no source selected
     expect(queryBuilderState.selectedAccessorOwner).toBeUndefined();
 
-    // Select first source from dropdown
-    const sourceContainer = guaranteeNonNullable(
-      getByText(setupPanel, 'Source').parentElement,
+    // Select first available accessor owner
+    const firstOwner = guaranteeNonNullable(
+      queryBuilderState.accessorOwners[0],
     );
-    selectFirstOptionFromCustomSelectorInput(sourceContainer, false, false);
+    await act(async () => {
+      await queryBuilderState.changeAccessorOwner(firstOwner);
+    });
 
     // Source should now be selected
     expect(queryBuilderState.selectedAccessorOwner).not.toBeUndefined();
+
+    // Verify the source selector in the UI reflects the change
+    expect(getByText(setupPanel, 'Source')).not.toBeNull();
   });
 
   test('renders full query builder with accessor setup panel from ingest lambda', async () => {
@@ -287,7 +291,7 @@ describe(integrationTest('AccessorQueryBuilder setup panel'), () => {
       queryBuilderState.graphManagerState.graph.ingests[0],
     );
     await act(async () => {
-      queryBuilderState.changeAccessorOwner(ingest);
+      await queryBuilderState.changeAccessorOwner(ingest);
     });
 
     // Verify filter panel IS shown (accessor mode now supports it)

--- a/packages/legend-query-builder/src/components/workflows/AccessorQueryBuilder.tsx
+++ b/packages/legend-query-builder/src/components/workflows/AccessorQueryBuilder.tsx
@@ -55,11 +55,13 @@ const AccessorQueryBuilderSetupPanelContent = observer(
           (opt) => opt.value === queryBuilderState.selectedAccessorOwner,
         ) ?? null)
       : null;
-    const changeAccessorOwner = (val: AccessorOwnerOption): void => {
+    const changeAccessorOwner = async (
+      val: AccessorOwnerOption,
+    ): Promise<void> => {
       if (val.value === queryBuilderState.selectedAccessorOwner) {
         return;
       }
-      queryBuilderState.changeAccessorOwner(val.value);
+      await queryBuilderState.changeAccessorOwner(val.value);
     };
     const accessorOwnerFilterOption = createFilter({
       ignoreCase: true,
@@ -79,8 +81,8 @@ const AccessorQueryBuilderSetupPanelContent = observer(
             opt.value.schemaName === queryBuilderState.sourceAccessor.schema,
         ) ?? null)
       : null;
-    const changeAccessor = (val: AccessorOption): void => {
-      queryBuilderState.changeAccessor(val.value);
+    const changeAccessor = async (val: AccessorOption): Promise<void> => {
+      await queryBuilderState.changeAccessor(val.value);
     };
     const showAccessorSelector = accessorOptions.length > 0;
 
@@ -130,7 +132,9 @@ const AccessorQueryBuilderSetupPanelContent = observer(
               className="panel__content__form__section__dropdown query-builder__setup__config-group__item__selector"
               placeholder="Choose a source..."
               options={accessorOwnerOptions}
-              onChange={changeAccessorOwner}
+              onChange={(val: AccessorOwnerOption): void => {
+                changeAccessorOwner(val).catch(() => undefined);
+              }}
               value={selectedAccessorOwnerOption}
               darkMode={
                 !applicationStore.layoutService
@@ -158,7 +162,9 @@ const AccessorQueryBuilderSetupPanelContent = observer(
                 className="panel__content__form__section__dropdown query-builder__setup__config-group__item__selector"
                 placeholder={`Choose a ${queryBuilderState.accessorLabel.toLocaleLowerCase()}...`}
                 options={accessorOptions}
-                onChange={changeAccessor}
+                onChange={(val: AccessorOption): void => {
+                  changeAccessor(val).catch(() => undefined);
+                }}
                 value={selectedAccessorOption}
                 darkMode={
                   !applicationStore.layoutService

--- a/packages/legend-query-builder/src/stores/__tests__/QueryBuilderAccessorFilter.test.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/QueryBuilderAccessorFilter.test.ts
@@ -76,7 +76,7 @@ describe(unitTest('AccessorQueryBuilder filter with relation columns'), () => {
     const ingest = guaranteeNonNullable(
       queryBuilderState.graphManagerState.graph.ingests[0],
     );
-    queryBuilderState.changeAccessorOwner(ingest);
+    await queryBuilderState.changeAccessorOwner(ingest);
 
     // Verify filter panel is shown
     expect(queryBuilderState.filterState.showPanel).toBe(true);
@@ -161,7 +161,7 @@ describe(unitTest('AccessorQueryBuilder filter with relation columns'), () => {
     const ingest = guaranteeNonNullable(
       queryBuilderState.graphManagerState.graph.ingests[0],
     );
-    queryBuilderState.changeAccessorOwner(ingest);
+    await queryBuilderState.changeAccessorOwner(ingest);
 
     const relationType = guaranteeNonNullable(
       queryBuilderState.sourceRelationType,
@@ -213,7 +213,7 @@ describe(unitTest('AccessorQueryBuilder filter with relation columns'), () => {
     const ingest = guaranteeNonNullable(
       queryBuilderState.graphManagerState.graph.ingests[0],
     );
-    queryBuilderState.changeAccessorOwner(ingest);
+    await queryBuilderState.changeAccessorOwner(ingest);
 
     const relationType = guaranteeNonNullable(
       queryBuilderState.sourceRelationType,

--- a/packages/legend-query-builder/src/stores/workflows/accessor/AccessorQueryBuilderState.ts
+++ b/packages/legend-query-builder/src/stores/workflows/accessor/AccessorQueryBuilderState.ts
@@ -35,7 +35,7 @@ import type {
 } from '../../query-workflow/QueryBuilderWorkFlowState.js';
 import type { QueryBuilderConfig } from '../../../graph-manager/QueryBuilderConfig.js';
 import { renderAccessorQueryBuilderSetupPanelContent } from '../../../components/workflows/AccessorQueryBuilder.js';
-import { action, computed, makeObservable } from 'mobx';
+import { action, computed, makeObservable, runInAction } from 'mobx';
 import type { QueryableSourceInfo } from '@finos/legend-storage';
 import { buildElementOption } from '@finos/legend-lego/graph-editor';
 import { getCompatibleRuntimesFromAccessorOwner } from './AccessorQueryBuilderHelper.js';
@@ -159,26 +159,28 @@ export class AccessorQueryBuilderState extends QueryBuilderState {
     }
   }
 
-  changeAccessorOwner(accessorOwner: AccessorOwner): void {
+  async changeAccessorOwner(accessorOwner: AccessorOwner): Promise<void> {
     const accessor =
-      this.graphManagerState.graphManager.createAccessorFromPackageableElement(
+      await this.graphManagerState.graphManager.createAccessorFromPackageableElement(
         accessorOwner,
         this.graphManagerState.graph,
       );
     if (accessor) {
-      this.changeSourceElement(accessor);
-      this.configureFilterPanelsForAccessor();
+      runInAction(() => {
+        this.changeSourceElement(accessor);
+        this.configureFilterPanelsForAccessor();
+      });
     }
   }
 
-  changeAccessor(value: {
+  async changeAccessor(value: {
     schemaName?: string | undefined;
     tableName: string;
-  }): void {
+  }): Promise<void> {
     const owner = this.selectedAccessorOwner;
     if (owner) {
       const accessor =
-        this.graphManagerState.graphManager.createAccessorFromPackageableElement(
+        await this.graphManagerState.graphManager.createAccessorFromPackageableElement(
           owner,
           this.graphManagerState.graph,
           {
@@ -187,8 +189,10 @@ export class AccessorQueryBuilderState extends QueryBuilderState {
           },
         );
       if (accessor) {
-        this.changeSourceElement(accessor);
-        this.configureFilterPanelsForAccessor();
+        runInAction(() => {
+          this.changeSourceElement(accessor);
+          this.configureFilterPanelsForAccessor();
+        });
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->
Fetch matview dataset's Relation type for query builder and testing
## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
