### PR TITLE
Add #SQL accessor inference for DataProduct tests

### DIFF
--- a/.changeset/common-papers-pump.md
+++ b/.changeset/common-papers-pump.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio-deployment': patch
+---
+
+feat: infer #SQL i()/p() accessors for DataProduct test-data setup

--- a/.changeset/common-papers-pump.md
+++ b/.changeset/common-papers-pump.md
@@ -1,5 +1,6 @@
 ---
-'@finos/legend-application-studio-deployment': patch
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
 ---
 
 feat: infer #SQL i()/p() accessors for DataProduct test-data setup

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -17,7 +17,6 @@
 import {
   type Accessor,
   type AccessPoint,
-  type DataResolver,
   type PackageableElement,
   type TestSuite,
   type RawLambda,
@@ -125,26 +124,6 @@ const isIngestOrDataProductAccessor = (
 
 const getAccessPointDisplayLabel = (accessPoint: AccessPoint): string =>
   accessPoint.id;
-
-const isResolverForElementPath = (
-  resolver: DataResolver,
-  elementPath: string,
-): resolver is BaseDataResolver | ReferenceDataResolver =>
-  (resolver instanceof BaseDataResolver ||
-    resolver instanceof ReferenceDataResolver) &&
-  resolver.element.value.path === elementPath;
-
-const removeSelfDataResolvers = (
-  suite: DataProductTestSuite,
-  currentDataProductPath: string,
-): void => {
-  if (!suite.testData?.length) {
-    return;
-  }
-  suite.testData = suite.testData.filter(
-    (resolver) => !isResolverForElementPath(resolver, currentDataProductPath),
-  );
-};
 
 interface ElementDataItem {
   id: string;
@@ -610,9 +589,6 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
         byElement.set(acc.accessorOwner, grp);
       }
       for (const [elementPath, accs] of byElement) {
-        if (elementPath === this.testableState.dataProduct.path) {
-          continue;
-        }
         const element =
           this.editorStore.graphManagerState.graph.getNullableElement(
             elementPath,
@@ -657,8 +633,6 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
         'Access Point accessors cannot be resolved',
       );
     }
-    removeSelfDataResolvers(this.suite, this.testableState.dataProduct.path);
-
     const assertion = new EqualToRelation();
     assertion.id = 'assert_1';
     const expectedRelElement = new RelationElement();
@@ -782,9 +756,6 @@ export class DataProductTestableState {
    */
   init(): void {
     const dp = this.dataProduct;
-    for (const suite of dp.tests) {
-      removeSelfDataResolvers(suite, dp.path);
-    }
     this.suiteStates = dp.tests.map(
       (s) => new DataProductTestSuiteState(this.editorStore, this, s),
     );
@@ -890,8 +861,6 @@ export class DataProductTestableState {
         'Access Point accessors cannot be resolved',
       );
     }
-    removeSelfDataResolvers(suite, dp.path);
-
     // Create one initial test with EqualToRelation assertion
     const test = new DataProductAccessPointTest();
     test.id = testName;

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -584,9 +584,9 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
       // Group by element, merge into existing resolvers or create new ones
       const byElement = new Map<string, Accessor[]>();
       for (const acc of resolvedAccessors) {
-        const grp = byElement.get(acc.accessorOwner) ?? [];
+        const grp = byElement.get(acc.parentElement.path) ?? [];
         grp.push(acc);
-        byElement.set(acc.accessorOwner, grp);
+        byElement.set(acc.parentElement.path, grp);
       }
       for (const [elementPath, accs] of byElement) {
         const element =
@@ -633,6 +633,7 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
         'Access Point accessors cannot be resolved',
       );
     }
+
     const assertion = new EqualToRelation();
     assertion.id = 'assert_1';
     const expectedRelElement = new RelationElement();
@@ -835,9 +836,9 @@ export class DataProductTestableState {
       );
       const byElement = new Map<string, Accessor[]>();
       for (const acc of externalAccessors) {
-        const grp = byElement.get(acc.accessorOwner) ?? [];
+        const grp = byElement.get(acc.parentElement.path) ?? [];
         grp.push(acc);
-        byElement.set(acc.accessorOwner, grp);
+        byElement.set(acc.parentElement.path, grp);
       }
       for (const [elementPath, accs] of byElement) {
         const element =
@@ -861,6 +862,7 @@ export class DataProductTestableState {
         'Access Point accessors cannot be resolved',
       );
     }
+
     // Create one initial test with EqualToRelation assertion
     const test = new DataProductAccessPointTest();
     test.id = testName;

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -17,6 +17,7 @@
 import {
   type Accessor,
   type AccessPoint,
+  type DataResolver,
   type PackageableElement,
   type TestSuite,
   type RawLambda,
@@ -124,6 +125,26 @@ const isIngestOrDataProductAccessor = (
 
 const getAccessPointDisplayLabel = (accessPoint: AccessPoint): string =>
   accessPoint.id;
+
+const isResolverForElementPath = (
+  resolver: DataResolver,
+  elementPath: string,
+): resolver is BaseDataResolver | ReferenceDataResolver =>
+  (resolver instanceof BaseDataResolver ||
+    resolver instanceof ReferenceDataResolver) &&
+  resolver.element.value.path === elementPath;
+
+const removeSelfDataResolvers = (
+  suite: DataProductTestSuite,
+  currentDataProductPath: string,
+): void => {
+  if (!suite.testData?.length) {
+    return;
+  }
+  suite.testData = suite.testData.filter(
+    (resolver) => !isResolverForElementPath(resolver, currentDataProductPath),
+  );
+};
 
 interface ElementDataItem {
   id: string;
@@ -578,7 +599,7 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
       resolvedAccessors = all.filter(
         (accessor) =>
           isIngestOrDataProductAccessor(accessor) &&
-          accessor.parentElement.path !== this.testableState.dataProduct.path,
+          accessor.accessorOwner !== this.testableState.dataProduct.path,
       );
     }
 
@@ -586,11 +607,14 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
       // Group by element, merge into existing resolvers or create new ones
       const byElement = new Map<string, Accessor[]>();
       for (const acc of resolvedAccessors) {
-        const grp = byElement.get(acc.parentElement.path) ?? [];
+        const grp = byElement.get(acc.accessorOwner) ?? [];
         grp.push(acc);
-        byElement.set(acc.parentElement.path, grp);
+        byElement.set(acc.accessorOwner, grp);
       }
       for (const [elementPath, accs] of byElement) {
+        if (elementPath === this.testableState.dataProduct.path) {
+          continue;
+        }
         const element =
           this.editorStore.graphManagerState.graph.getNullableElement(
             elementPath,
@@ -635,6 +659,7 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
         'Access Point accessors cannot be resolved',
       );
     }
+    removeSelfDataResolvers(this.suite, this.testableState.dataProduct.path);
 
     const assertion = new EqualToRelation();
     assertion.id = 'assert_1';
@@ -759,6 +784,9 @@ export class DataProductTestableState {
    */
   init(): void {
     const dp = this.dataProduct;
+    for (const suite of dp.tests) {
+      removeSelfDataResolvers(suite, dp.path);
+    }
     this.suiteStates = dp.tests.map(
       (s) => new DataProductTestSuiteState(this.editorStore, this, s),
     );
@@ -836,15 +864,18 @@ export class DataProductTestableState {
       const externalAccessors = all.filter(
         (accessor) =>
           isIngestOrDataProductAccessor(accessor) &&
-          accessor.parentElement.path !== dp.path,
+          accessor.accessorOwner !== dp.path,
       );
       const byElement = new Map<string, Accessor[]>();
       for (const acc of externalAccessors) {
-        const grp = byElement.get(acc.parentElement.path) ?? [];
+        const grp = byElement.get(acc.accessorOwner) ?? [];
         grp.push(acc);
-        byElement.set(acc.parentElement.path, grp);
+        byElement.set(acc.accessorOwner, grp);
       }
       for (const [elementPath, accs] of byElement) {
+        if (elementPath === dp.path) {
+          continue;
+        }
         const element =
           this.editorStore.graphManagerState.graph.getNullableElement(
             elementPath,
@@ -866,6 +897,7 @@ export class DataProductTestableState {
         'Access Point accessors cannot be resolved',
       );
     }
+    removeSelfDataResolvers(suite, dp.path);
 
     // Create one initial test with EqualToRelation assertion
     const test = new DataProductAccessPointTest();

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -596,10 +596,8 @@ export class DataProductTestSuiteState extends TestableTestSuiteEditorState {
           rawLambdaForTest,
           this.editorStore.graphManagerState.graph,
         )) as Accessor[];
-      resolvedAccessors = all.filter(
-        (accessor) =>
-          isIngestOrDataProductAccessor(accessor) &&
-          accessor.accessorOwner !== this.testableState.dataProduct.path,
+      resolvedAccessors = all.filter((accessor) =>
+        isIngestOrDataProductAccessor(accessor),
       );
     }
 
@@ -861,10 +859,8 @@ export class DataProductTestableState {
           rawLambdaForSuite,
           this.editorStore.graphManagerState.graph,
         )) as Accessor[];
-      const externalAccessors = all.filter(
-        (accessor) =>
-          isIngestOrDataProductAccessor(accessor) &&
-          accessor.accessorOwner !== dp.path,
+      const externalAccessors = all.filter((accessor) =>
+        isIngestOrDataProductAccessor(accessor),
       );
       const byElement = new Map<string, Accessor[]>();
       for (const acc of externalAccessors) {
@@ -873,9 +869,6 @@ export class DataProductTestableState {
         byElement.set(acc.accessorOwner, grp);
       }
       for (const [elementPath, accs] of byElement) {
-        if (elementPath === dp.path) {
-          continue;
-        }
         const element =
           this.editorStore.graphManagerState.graph.getNullableElement(
             elementPath,

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/helpers/V1_AccessorHelper.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/helpers/V1_AccessorHelper.ts
@@ -68,6 +68,7 @@ import {
   V1_DataProductAccessor,
   V1_IngestDefinitionAccessor,
   V1_RelationStoreAccessor,
+  V1_SQLAccessor,
 } from '../model/valueSpecification/raw/classInstance/relation/V1_RelationStoreAccessor.js';
 import type { V1_ValueSpecification } from '../model/valueSpecification/V1_ValueSpecification.js';
 import {
@@ -356,6 +357,72 @@ const collectV1AccessorsFromValueSpecification = (
   graph: PureModel | undefined,
   visitedFunctions: Set<ConcreteFunctionDefinition>,
 ): void => {
+  const addSqlAccessorIfAbsent = (
+    existingAccessors: V1_Accessor[],
+    accessor: V1_Accessor,
+  ): void => {
+    const accessorKey = `${accessor.INSTANCE_TYPE}|${accessor.path.join('.')}`;
+    const exists = existingAccessors.some(
+      (candidate) =>
+        `${candidate.INSTANCE_TYPE}|${candidate.path.join('.')}` ===
+        accessorKey,
+    );
+    if (!exists) {
+      existingAccessors.push(accessor);
+    }
+  };
+
+  const extractAccessorsFromSQL = (sql: string): V1_Accessor[] => {
+    const sqlAccessors: V1_Accessor[] = [];
+    const ingestAccessorPattern =
+      /\bi\s*\(\s*(?<path>'[^']+'|"[^"]+"|[^\)]+)\s*\)/gi;
+    const dataProductAccessorPattern =
+      /\bp\s*\(\s*(?<path>'[^']+'|"[^"]+"|[^\)]+)\s*\)/gi;
+
+    const addParsedAccessor = (
+      rawPath: string,
+      createAccessor: () => V1_Accessor,
+    ): void => {
+      if (rawPath.length === 0) {
+        return;
+      }
+      const unquotedPath =
+        rawPath.startsWith("'") || rawPath.startsWith('"')
+          ? rawPath.slice(1, -1)
+          : rawPath;
+      const normalizedPath = unquotedPath.replace(/\s*\.\s*/g, '.');
+      const separatorIndex = normalizedPath.lastIndexOf('.');
+      const accessor = createAccessor();
+      if (separatorIndex > 0 && separatorIndex < normalizedPath.length - 1) {
+        accessor.path = [
+          normalizedPath.slice(0, separatorIndex),
+          normalizedPath.slice(separatorIndex + 1),
+        ];
+      } else {
+        accessor.path = [normalizedPath];
+      }
+      addSqlAccessorIfAbsent(sqlAccessors, accessor);
+    };
+
+    let match: RegExpExecArray | null = ingestAccessorPattern.exec(sql);
+    while (match) {
+      addParsedAccessor((match.groups?.path ?? '').trim(), () => {
+        return new V1_IngestDefinitionAccessor();
+      });
+      match = ingestAccessorPattern.exec(sql);
+    }
+
+    match = dataProductAccessorPattern.exec(sql);
+    while (match) {
+      addParsedAccessor((match.groups?.path ?? '').trim(), () => {
+        return new V1_DataProductAccessor();
+      });
+      match = dataProductAccessorPattern.exec(sql);
+    }
+
+    return sqlAccessors;
+  };
+
   if (visited.has(valueSpec)) {
     return;
   }
@@ -370,6 +437,10 @@ const collectV1AccessorsFromValueSpecification = (
     ) {
       if (!accessors.includes(val)) {
         accessors.push(val);
+      }
+    } else if (val instanceof V1_SQLAccessor) {
+      for (const accessor of extractAccessorsFromSQL(val.sql)) {
+        addSqlAccessorIfAbsent(accessors, accessor);
       }
     }
   } else if (valueSpec instanceof V1_AppliedFunction) {

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/helpers/__tests__/V1_AccessorHelper.SQL.test.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/helpers/__tests__/V1_AccessorHelper.SQL.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2026-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, describe, expect, test } from '@jest/globals';
+import { guaranteeNonNullable } from '@finos/legend-shared';
+import { unitTest } from '@finos/legend-shared/test';
+import { RawLambda } from '../../../../../../graph/metamodel/pure/rawValueSpecification/RawLambda.js';
+import { V1_resolveAccessorsFromRawLambda } from '../V1_AccessorHelper.js';
+import {
+  V1_DataProductAccessor,
+  V1_IngestDefinitionAccessor,
+} from '../../model/valueSpecification/raw/classInstance/relation/V1_RelationStoreAccessor.js';
+import {
+  TEST__buildGraphWithEntities,
+  TEST__getTestGraphManagerState,
+} from '../../../../../__test-utils__/GraphManagerTestUtils.js';
+
+const graphManagerState = TEST__getTestGraphManagerState();
+
+beforeAll(async () => {
+  await TEST__buildGraphWithEntities(graphManagerState, []);
+});
+
+describe(
+  unitTest('resolveAccessorsFromRawLambda - SQL accessor support'),
+  () => {
+    test('extracts ingest accessor from SQL i(...) call', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: "select id from i('my::pack::MyIngest.MyDataSet')",
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(1);
+      const accessor = guaranteeNonNullable(accessors[0]);
+      expect(accessor).toBeInstanceOf(V1_IngestDefinitionAccessor);
+      expect(accessor.path).toEqual(['my::pack::MyIngest', 'MyDataSet']);
+    });
+
+    test('extracts ingest accessor with unquoted SQL i(...) syntax', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: 'select id from i(my::pack::MyIngest . MyDataSet)',
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(1);
+      expect(guaranteeNonNullable(accessors[0]).path).toEqual([
+        'my::pack::MyIngest',
+        'MyDataSet',
+      ]);
+    });
+
+    test('deduplicates repeated SQL ingest accessor references', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: "select id from i('my::pack::MyIngest.MyDataSet') union all select id from i('my::pack::MyIngest.MyDataSet')",
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(1);
+      expect(guaranteeNonNullable(accessors[0]).path).toEqual([
+        'my::pack::MyIngest',
+        'MyDataSet',
+      ]);
+    });
+
+    test('extracts data product accessor from SQL p(...) call', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: "select id from p('my::dp::Product.apId')",
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(1);
+      const accessor = guaranteeNonNullable(accessors[0]);
+      expect(accessor).toBeInstanceOf(V1_DataProductAccessor);
+      expect(accessor.path).toEqual(['my::dp::Product', 'apId']);
+    });
+
+    test('extracts data product accessor with unquoted SQL p(...) syntax', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: 'select id from p(my::dp::Product . apId)',
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(1);
+      const accessor = guaranteeNonNullable(accessors[0]);
+      expect(accessor).toBeInstanceOf(V1_DataProductAccessor);
+      expect(accessor.path).toEqual(['my::dp::Product', 'apId']);
+    });
+
+    test('deduplicates repeated SQL data product accessor references', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: "select id from p('my::dp::Product.apId') union all select id from p('my::dp::Product.apId')",
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(1);
+      const accessor = guaranteeNonNullable(accessors[0]);
+      expect(accessor).toBeInstanceOf(V1_DataProductAccessor);
+      expect(accessor.path).toEqual(['my::dp::Product', 'apId']);
+    });
+
+    test('extracts ingest and data product accessors from same SQL', () => {
+      const rawLambda = new RawLambda(
+        [],
+        [
+          {
+            _type: 'classInstance',
+            type: 'SQL',
+            value: {
+              sql: "select a.id from i('my::pack::MyIngest.MyDataSet') a join p('my::dp::Product.apId') b on a.id = b.id",
+            },
+          },
+        ],
+      );
+
+      const accessors = guaranteeNonNullable(
+        V1_resolveAccessorsFromRawLambda(
+          rawLambda,
+          graphManagerState.graphManager,
+          graphManagerState.pluginManager.getPureProtocolProcessorPlugins(),
+        ),
+      );
+
+      expect(accessors).toHaveLength(2);
+      expect(accessors).toContainEqual(
+        expect.objectContaining({
+          path: ['my::pack::MyIngest', 'MyDataSet'],
+        }),
+      );
+      expect(accessors).toContainEqual(
+        expect.objectContaining({
+          path: ['my::dp::Product', 'apId'],
+        }),
+      );
+    });
+  },
+);


### PR DESCRIPTION
### Summary
This change adds SQL accessor inference for raw lambdas so ingest and DataProduct accessors referenced inside SQL expressions can be discovered as part of the existing accessor-resolution flow.

Previously, SQL-based access points were treated as opaque SQL strings, which meant accessor references embedded in #SQL{...}# were not inferred during test-data setup. With this update, supported SQL accessor patterns are resolved and can participate in DataProduct test inference the same way as non-SQL accessor forms.