### PR TITLE
Add support for test parameters in Data Product access points

### DIFF
--- a/.changeset/funky-meals-smash.md
+++ b/.changeset/funky-meals-smash.md
@@ -1,0 +1,6 @@
+---
+'@finos/legend-application-studio': patch
+'@finos/legend-graph': patch
+---
+
+Add Data Product access point test parameter support in Studio, including form-mode editing and round-trip preservation for test parameters.

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -925,24 +925,24 @@ const DataProductTestEditor = observer(
                 <div className="data-product-test-editor__assertion">
                   {hasQueryParameters && (
                     <div className="data-product-test-editor__parameters-panel-container">
-                      <div className="service-test-data-editor panel data-product-test-editor__parameters-panel">
-                        <div className="service-test-suite-editor__header data-product-test-editor__parameters-header">
-                          <div className="service-test-suite-editor__header__title data-product-test-editor__parameters-header__title">
-                            <div className="service-test-suite-editor__header__title__label data-product-test-editor__parameters-header__title__label">
+                      <div className="panel data-product-test-editor__parameters-panel">
+                        <div className="data-product-test-editor__parameters-header">
+                          <div className="data-product-test-editor__parameters-header__title">
+                            <div className="data-product-test-editor__parameters-header__title__label">
                               Parameters
                             </div>
                           </div>
                           <div className="panel__header__actions data-product-test-editor__parameters-header__actions">
                             <button
-                              className="panel__header__action service-execution-editor__test-data__generate-btn data-product-test-editor__parameters-header__action"
+                              className="panel__header__action data-product-test-editor__parameters-header__action data-product-test-editor__parameters-header__generate-btn"
                               onClick={generateParameterValues}
                               disabled={!testState.newParamOptions.length}
                               title="Generate test parameter values"
                               tabIndex={-1}
                             >
-                              <div className="service-execution-editor__test-data__generate-btn__label">
-                                <RefreshIcon className="service-execution-editor__test-data__generate-btn__label__icon" />
-                                <div className="service-execution-editor__test-data__generate-btn__label__title">
+                              <div className="data-product-test-editor__parameters-header__generate-btn__label">
+                                <RefreshIcon className="data-product-test-editor__parameters-header__generate-btn__label__icon" />
+                                <div className="data-product-test-editor__parameters-header__generate-btn__label__title">
                                   Generate
                                 </div>
                               </div>
@@ -958,7 +958,7 @@ const DataProductTestEditor = observer(
                             </button>
                           </div>
                         </div>
-                        <div className="service-test-editor__setup__parameters data-product-test-editor__parameters">
+                        <div className="data-product-test-editor__parameters">
                           {testState.parameterValueStates.map((paramState) => (
                             <DataProductTestParameterEditor
                               key={paramState.uuid}

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -511,11 +511,11 @@ const DataProductTestDataEditor = observer(
 
     return (
       <div
-        className={clsx('service-test-data-editor panel', {
-          'service-test-data-editor--no-data': !hasTestData,
+        className={clsx('data-product-test-data-editor panel', {
+          'data-product-test-data-editor--no-data': !hasTestData,
         })}
       >
-        <div className="service-test-data-editor__data">
+        <div className="data-product-test-data-editor__data">
           <ResizablePanelGroup orientation="vertical">
             {/* Left: elements list — always visible */}
             <ResizablePanel minSize={100} size={180}>
@@ -537,7 +537,7 @@ const DataProductTestDataEditor = observer(
                 )}
               </div>
               {!hasTestData ? (
-                <div className="service-test-data-editor__warning">
+                <div className="data-product-test-data-editor__warning">
                   <ErrorWarnIcon />
                   <span>Add an element to configure test data</span>
                 </div>
@@ -734,7 +734,7 @@ const DataProductTestParameterEditor = observer(
             tooltipText="This parameter was preserved but cannot currently be edited in form mode"
           />
         ) : contentTypeParamPair && primitiveValueSpecification ? (
-          <div className="service-test-editor__setup__parameter__code-editor">
+          <div className="data-product-test-editor__parameter__code-editor">
             <textarea
               className="panel__content__form__section__textarea value-spec-editor__input"
               spellCheck={false}
@@ -754,9 +754,9 @@ const DataProductTestParameterEditor = observer(
                 contentTypeParamPair={contentTypeParamPair}
               />
             )}
-            <div className="service-test-editor__setup__parameter__value__actions">
+            <div className="data-product-test-editor__parameter__value__actions">
               <button
-                className="service-test-editor__setup__parameter__code-editor__expand-btn"
+                className="data-product-test-editor__parameter__code-editor__expand-btn"
                 onClick={openInPopUp}
                 tabIndex={-1}
                 title="Open in a popup..."
@@ -764,7 +764,7 @@ const DataProductTestParameterEditor = observer(
                 <FilledWindowMaximizeIcon />
               </button>
               <button
-                className="btn--icon btn--dark btn--sm service-test-editor__setup__parameter__code-editor__expand-btn"
+                className="btn--icon btn--dark btn--sm data-product-test-editor__parameter__code-editor__expand-btn"
                 disabled={isReadOnly || paramIsRequired}
                 onClick={(): void =>
                   testState.removeParamValueState(paramState)
@@ -779,7 +779,7 @@ const DataProductTestParameterEditor = observer(
             </div>
           </div>
         ) : (
-          <div className="service-test-editor__setup__parameter__value">
+          <div className="data-product-test-editor__parameter__value">
             <BasicValueSpecificationEditor
               valueSpecification={valueSpecificationParamState.valueSpec}
               setValueSpecification={(val: ValueSpecification): void => {
@@ -799,7 +799,7 @@ const DataProductTestParameterEditor = observer(
                 valueSpecificationParamState.resetValueSpec();
               }}
             />
-            <div className="service-test-editor__setup__parameter__value__actions">
+            <div className="data-product-test-editor__parameter__value__actions">
               <button
                 className="btn--icon btn--dark btn--sm"
                 disabled={isReadOnly || paramIsRequired}
@@ -914,7 +914,7 @@ const DataProductTestEditor = observer(
     return (
       <div className="function-test-editor panel">
         <div className="panel__header">
-          <div className="panel__header service-test-editor__header--with-tabs">
+          <div className="panel__header data-product-test-editor__header--with-tabs">
             <div className="panel__header__title__content">Assertion</div>
           </div>
         </div>
@@ -934,15 +934,15 @@ const DataProductTestEditor = observer(
                           </div>
                           <div className="panel__header__actions data-product-test-editor__parameters-header__actions">
                             <button
-                              className="panel__header__action data-product-test-editor__parameters-header__action data-product-test-editor__parameters-header__generate-btn"
+                              className="panel__header__action data-product-test-editor__generate-btn"
                               onClick={generateParameterValues}
                               disabled={!testState.newParamOptions.length}
                               title="Generate test parameter values"
                               tabIndex={-1}
                             >
-                              <div className="data-product-test-editor__parameters-header__generate-btn__label">
-                                <RefreshIcon className="data-product-test-editor__parameters-header__generate-btn__label__icon" />
-                                <div className="data-product-test-editor__parameters-header__generate-btn__label__title">
+                              <div className="data-product-test-editor__generate-btn__label">
+                                <RefreshIcon className="data-product-test-editor__generate-btn__label__icon" />
+                                <div className="data-product-test-editor__generate-btn__label__title">
                                   Generate
                                 </div>
                               </div>
@@ -1028,8 +1028,8 @@ const DataProductTestsEditor = observer(
     const selectedTest = suiteState.selectTestState;
 
     return (
-      <div className="panel service-test-editor">
-        <div className="service-test-editor__content">
+      <div className="panel data-product-test-editor__tests">
+        <div className="data-product-test-editor__tests__content">
           <ResizablePanelGroup orientation="vertical">
             <ResizablePanel minSize={100} size={200}>
               <div className="binding-editor__header">
@@ -1113,7 +1113,7 @@ const DataProductTestSuiteEditor = observer(
     const isReadOnly = testableState.dataProductEditorState.isReadOnly;
 
     return (
-      <div className="service-test-suite-editor">
+      <div className="data-product-test-suite-editor">
         <ResizablePanelGroup orientation="horizontal">
           <ResizablePanel size={580} minSize={28}>
             <DataProductTestDataEditor
@@ -1199,7 +1199,7 @@ export const DataProductTestableEditor = observer(
       testSuite_setId(guaranteeNonNullable(testableState.suiteToRename), val);
 
     return (
-      <Panel className="service-test-suite-editor">
+      <Panel className="data-product-test-suite-editor">
         <PanelLoadingIndicator
           isLoading={testableState.runningAllTestsState.isInProgress}
         />
@@ -1220,14 +1220,14 @@ export const DataProductTestableEditor = observer(
 
         <PanelHeader>
           {dp.tests.length ? (
-            <PanelHeader className="service-test-suite-editor__header service-test-suite-editor__header--with-tabs">
+            <PanelHeader className="data-product-test-suite-editor__header data-product-test-suite-editor__header--with-tabs">
               <div className="uml-element-editor__tabs">
                 {dp.tests.map((suite) => (
                   <div
                     key={suite.id}
                     onClick={(): void => changeSuite(suite)}
-                    className={clsx('service-test-suite-editor__tab', {
-                      'service-test-suite-editor__tab--active':
+                    className={clsx('data-product-test-suite-editor__tab', {
+                      'data-product-test-suite-editor__tab--active':
                         selectedSuiteState?.suite === suite,
                     })}
                   >
@@ -1255,7 +1255,7 @@ export const DataProductTestableEditor = observer(
             </PanelHeaderActionItem>
           </PanelHeaderActions>
         </PanelHeader>
-        <Panel className="service-test-suite-editor">
+        <Panel className="data-product-test-suite-editor">
           {selectedSuiteState && (
             <DataProductTestSuiteEditor suiteState={selectedSuiteState} />
           )}

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -54,13 +54,14 @@ import {
   LakehouseAccessPoint,
   PrimitiveInstanceValue,
   PrimitiveType,
+  type RawLambda,
   type DataProductTestSuite,
   type ValueSpecification,
 } from '@finos/legend-graph';
 import type { DataProductEditorState } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/DataProductEditorState.js';
 import {
-  DataProductTestParameterState,
   DataProductValueSpecificationTestParameterState,
+  type DataProductTestParameterState,
   type DataProductTestableState,
   type DataProductTestSuiteState,
   type DataProductTestState,
@@ -900,12 +901,15 @@ const DataProductTestEditor = observer(
     const accessPoint = testState.suiteState.testableState.ownAccessPoints.find(
       (ap) => ap.id === testState.test.accessPointId,
     );
-    let accessPointQuery;
+    let accessPointQuery: RawLambda | undefined;
     if (accessPoint instanceof LakehouseAccessPoint) {
       accessPointQuery = accessPoint.func;
     } else if (accessPoint instanceof FunctionAccessPoint) {
       accessPointQuery = accessPoint.query;
     }
+    const hasQueryParameters = Boolean(
+      testState.queryVariableExpressions.length,
+    );
 
     return (
       <div className="function-test-editor panel">
@@ -928,22 +932,16 @@ const DataProductTestEditor = observer(
                     overflow: 'hidden',
                   }}
                 >
-                  <div
-                    style={{
-                      flex: '0 0 32%',
-                      minHeight: '12rem',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    <div className="panel__content__form__section">
-                      <div className="panel__content__form__section__header__label">
-                        Access Point: {testState.accessPointLabel}
-                      </div>
-                    </div>
-
-                    {Boolean(testState.queryVariableExpressions.length) && (
+                  {hasQueryParameters && (
+                    <div
+                      style={{
+                        flex: '0 0 32%',
+                        minHeight: '12rem',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        overflow: 'hidden',
+                      }}
+                    >
                       <div
                         className="service-test-data-editor panel"
                         style={{
@@ -1010,11 +1008,11 @@ const DataProductTestEditor = observer(
                           ))}
                         </div>
                       </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
                   <div
                     style={{
-                      flex: 1,
+                      flex: hasQueryParameters ? 1 : '1 1 100%',
                       minHeight: 0,
                       overflow: 'hidden',
                     }}

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -922,44 +922,19 @@ const DataProductTestEditor = observer(
           {selectedTab === TESTABLE_TEST_TAB.ASSERTION && (
             <>
               {selectedAssertion ? (
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    width: '100%',
-                    height: '100%',
-                    minHeight: 0,
-                    overflow: 'hidden',
-                  }}
-                >
+                <div className="data-product-test-editor__assertion">
                   {hasQueryParameters && (
-                    <div
-                      style={{
-                        flex: '0 0 32%',
-                        minHeight: '12rem',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      <div
-                        className="service-test-data-editor panel"
-                        style={{
-                          display: 'flex',
-                          flexDirection: 'column',
-                          flex: 1,
-                          minHeight: 0,
-                        }}
-                      >
-                        <div className="service-test-suite-editor__header">
-                          <div className="service-test-suite-editor__header__title">
-                            <div className="service-test-suite-editor__header__title__label">
+                    <div className="data-product-test-editor__parameters-panel-container">
+                      <div className="service-test-data-editor panel data-product-test-editor__parameters-panel">
+                        <div className="service-test-suite-editor__header data-product-test-editor__parameters-header">
+                          <div className="service-test-suite-editor__header__title data-product-test-editor__parameters-header__title">
+                            <div className="service-test-suite-editor__header__title__label data-product-test-editor__parameters-header__title__label">
                               Parameters
                             </div>
                           </div>
-                          <div className="panel__header__actions">
+                          <div className="panel__header__actions data-product-test-editor__parameters-header__actions">
                             <button
-                              className="panel__header__action service-execution-editor__test-data__generate-btn"
+                              className="panel__header__action service-execution-editor__test-data__generate-btn data-product-test-editor__parameters-header__action"
                               onClick={generateParameterValues}
                               disabled={!testState.newParamOptions.length}
                               title="Generate test parameter values"
@@ -973,7 +948,7 @@ const DataProductTestEditor = observer(
                               </div>
                             </button>
                             <button
-                              className="panel__header__action"
+                              className="panel__header__action data-product-test-editor__parameters-header__action"
                               tabIndex={-1}
                               disabled={!testState.newParamOptions.length}
                               onClick={addParameter}
@@ -983,14 +958,7 @@ const DataProductTestEditor = observer(
                             </button>
                           </div>
                         </div>
-                        <div
-                          className="service-test-editor__setup__parameters"
-                          style={{
-                            overflowY: 'auto',
-                            flex: 1,
-                            minHeight: 0,
-                          }}
-                        >
+                        <div className="service-test-editor__setup__parameters data-product-test-editor__parameters">
                           {testState.parameterValueStates.map((paramState) => (
                             <DataProductTestParameterEditor
                               key={paramState.uuid}
@@ -1011,11 +979,13 @@ const DataProductTestEditor = observer(
                     </div>
                   )}
                   <div
-                    style={{
-                      flex: hasQueryParameters ? 1 : '1 1 100%',
-                      minHeight: 0,
-                      overflow: 'hidden',
-                    }}
+                    className={clsx(
+                      'data-product-test-editor__assertion-result',
+                      {
+                        'data-product-test-editor__assertion-result--full':
+                          !hasQueryParameters,
+                      },
+                    )}
                   >
                     <TestAssertionEditor
                       testAssertionState={selectedAssertion}

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -24,6 +24,7 @@ import {
   CustomSelectorInput,
   Dialog,
   ErrorWarnIcon,
+  FilledWindowMaximizeIcon,
   MenuContent,
   MenuContentItem,
   Modal,
@@ -40,6 +41,7 @@ import {
   PanelLoadingIndicator,
   PlayIcon,
   PlusIcon,
+  RefreshIcon,
   ResizablePanel,
   ResizablePanelGroup,
   ResizablePanelSplitter,
@@ -47,9 +49,17 @@ import {
   RunAllIcon,
   TimesIcon,
 } from '@finos/legend-art';
-import type { DataProductTestSuite } from '@finos/legend-graph';
+import {
+  FunctionAccessPoint,
+  LakehouseAccessPoint,
+  PrimitiveInstanceValue,
+  PrimitiveType,
+  type DataProductTestSuite,
+  type ValueSpecification,
+} from '@finos/legend-graph';
 import type { DataProductEditorState } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/DataProductEditorState.js';
 import {
+  DataProductValueSpecificationTestParameterState,
   type DataProductTestableState,
   type DataProductTestSuiteState,
   type DataProductTestState,
@@ -63,14 +73,28 @@ import {
   getTestableResultFromTestResult,
 } from '../../../../../stores/editor/sidebar-state/testable/GlobalTestRunnerState.js';
 import { RelationElementsDataEditor } from '../../data-editor/RelationElementsDataEditor.js';
-import { validateTestableId } from '../../../../../stores/editor/utils/TestableUtils.js';
-import { useEditorStore } from '../../../EditorStoreProvider.js';
-import { guaranteeNonNullable } from '@finos/legend-shared';
 import {
+  getContentTypeWithParamFromQuery,
+  type TestParamContentType,
+  validateTestableId,
+} from '../../../../../stores/editor/utils/TestableUtils.js';
+import { useEditorStore } from '../../../EditorStoreProvider.js';
+import {
+  filterByType,
+  guaranteeNonNullable,
+  prettyCONSTName,
+} from '@finos/legend-shared';
+import {
+  ExternalFormatParameterEditorModal,
   RenameModal,
   TestAssertionEditor,
 } from '../../testable/TestableSharedComponents.js';
 import { testSuite_setId } from '../../../../../stores/graph-modifier/Testable_GraphModifierHelper.js';
+import { TESTABLE_TEST_TAB } from '../../../../../stores/editor/editor-state/element-editor-state/testable/TestableEditorState.js';
+import {
+  BasicValueSpecificationEditor,
+  instanceValue_setValue,
+} from '@finos/legend-query-builder';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Create Suite Modal — test name + access point (datasets are auto-inferred)
@@ -638,26 +662,404 @@ const TestItem = observer(
 // Test Editor — shows SETUP (input data) and ASSERTION (expected + result) tabs
 // ──────────────────────────────────────────────────────────────────────────────
 
+const DataProductTestParameterEditor = observer(
+  (props: {
+    isReadOnly: boolean;
+    paramState: DataProductValueSpecificationTestParameterState;
+    testState: DataProductTestState;
+    contentTypeParamPair: TestParamContentType | undefined;
+  }) => {
+    const { testState, paramState, isReadOnly, contentTypeParamPair } = props;
+    const [showPopUp, setShowPopUp] = useState(false);
+    const paramIsRequired =
+      paramState.varExpression.multiplicity.lowerBound > 0;
+    const type = contentTypeParamPair
+      ? contentTypeParamPair.contentType
+      : (paramState.varExpression.genericType?.value.rawType.name ?? 'unknown');
+    const paramValue =
+      paramState.varExpression.genericType?.value.rawType === PrimitiveType.BYTE
+        ? atob(
+            (paramState.valueSpec as PrimitiveInstanceValue)
+              .values[0] as string,
+          )
+        : ((paramState.valueSpec as PrimitiveInstanceValue)
+            .values[0] as string);
+
+    const openInPopUp = (): void => setShowPopUp(!showPopUp);
+    const closePopUp = (): void => setShowPopUp(false);
+    const updateParamValue = (val: string): void => {
+      if (paramState.valueSpec instanceof PrimitiveInstanceValue) {
+        instanceValue_setValue(
+          paramState.valueSpec,
+          paramState.varExpression.genericType?.value.rawType ===
+            PrimitiveType.BYTE
+            ? btoa(val)
+            : val,
+          0,
+          testState.editorStore.changeDetectionState.observerContext,
+        );
+        paramState.updateValueSpecification(paramState.valueSpec);
+      }
+    };
+
+    return (
+      <div
+        key={paramState.parameterValue.name}
+        className="panel__content__form__section"
+      >
+        <div className="panel__content__form__section__header__label">
+          {paramState.parameterValue.name}
+          <button
+            className={clsx('type-tree__node__type__label', {})}
+            tabIndex={-1}
+            title={type}
+          >
+            {type}
+          </button>
+        </div>
+        {contentTypeParamPair ? (
+          <div className="service-test-editor__setup__parameter__code-editor">
+            <textarea
+              className="panel__content__form__section__textarea value-spec-editor__input"
+              spellCheck={false}
+              value={paramValue}
+              placeholder={
+                ((paramState.valueSpec as PrimitiveInstanceValue)
+                  .values[0] as string) === ''
+                  ? '(empty)'
+                  : undefined
+              }
+              onChange={(event) => {
+                updateParamValue(event.target.value);
+              }}
+            />
+            {showPopUp && (
+              <ExternalFormatParameterEditorModal
+                valueSpec={paramState.valueSpec}
+                varExpression={paramState.varExpression}
+                isReadOnly={isReadOnly}
+                onClose={closePopUp}
+                updateParamValue={updateParamValue}
+                contentTypeParamPair={contentTypeParamPair}
+              />
+            )}
+            <div className="service-test-editor__setup__parameter__value__actions">
+              <button
+                className="service-test-editor__setup__parameter__code-editor__expand-btn"
+                onClick={openInPopUp}
+                tabIndex={-1}
+                title="Open in a popup..."
+              >
+                <FilledWindowMaximizeIcon />
+              </button>
+              <button
+                className="btn--icon btn--dark btn--sm service-test-editor__setup__parameter__code-editor__expand-btn"
+                disabled={isReadOnly || paramIsRequired}
+                onClick={(): void =>
+                  testState.removeParamValueState(paramState)
+                }
+                tabIndex={-1}
+                title={
+                  paramIsRequired ? 'Parameter Required' : 'Remove Parameter'
+                }
+              >
+                <TimesIcon />
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="service-test-editor__setup__parameter__value">
+            <BasicValueSpecificationEditor
+              valueSpecification={paramState.valueSpec}
+              setValueSpecification={(val: ValueSpecification): void => {
+                paramState.updateValueSpecification(val);
+              }}
+              graph={testState.editorStore.graphManagerState.graph}
+              observerContext={
+                testState.editorStore.changeDetectionState.observerContext
+              }
+              typeCheckOption={{
+                expectedType:
+                  paramState.varExpression.genericType?.value.rawType ??
+                  PrimitiveType.STRING,
+              }}
+              className="query-builder__parameters__value__editor"
+              resetValue={(): void => {
+                paramState.resetValueSpec();
+              }}
+            />
+            <div className="service-test-editor__setup__parameter__value__actions">
+              <button
+                className="btn--icon btn--dark btn--sm"
+                disabled={isReadOnly || paramIsRequired}
+                onClick={(): void =>
+                  testState.removeParamValueState(paramState)
+                }
+                tabIndex={-1}
+                title={
+                  paramIsRequired ? 'Parameter Required' : 'Remove Parameter'
+                }
+              >
+                <TimesIcon />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+const NewDataProductParameterModal = observer(
+  (props: { testState: DataProductTestState; isReadOnly: boolean }) => {
+    const { testState, isReadOnly } = props;
+    const applicationStore = testState.editorStore.applicationStore;
+    const currentOption = {
+      value: testState.newParameterValueName,
+      label: testState.newParameterValueName,
+    };
+    const options = testState.newParamOptions;
+    const closeModal = (): void => testState.setShowNewParameterModal(false);
+    const onChange = (val: { label: string; value: string } | null): void => {
+      if (val === null) {
+        testState.setNewParameterValueName('');
+      } else if (val.value !== testState.newParameterValueName) {
+        testState.setNewParameterValueName(val.value);
+      }
+    };
+    return (
+      <Dialog
+        open={testState.showNewParameterModal}
+        onClose={closeModal}
+        classes={{ container: 'search-modal__container' }}
+        slotProps={{
+          paper: {
+            classes: { root: 'search-modal__inner-container' },
+          },
+        }}
+      >
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            testState.addParameterValue();
+          }}
+          className="modal modal--dark search-modal"
+        >
+          <div className="modal__title">New Test Parameter Value</div>
+          <CustomSelectorInput
+            className="panel__content__form__section__dropdown"
+            options={options}
+            onChange={onChange}
+            value={currentOption}
+            escapeClearsValue={true}
+            darkMode={
+              !applicationStore.layoutService
+                .TEMPORARY__isLightColorThemeEnabled
+            }
+            disabled={isReadOnly}
+          />
+          <div className="search-modal__actions">
+            <button className="btn btn--dark" disabled={isReadOnly}>
+              Add
+            </button>
+          </div>
+        </form>
+      </Dialog>
+    );
+  },
+);
+
 const DataProductTestEditor = observer(
   (props: { testState: DataProductTestState; isReadOnly: boolean }) => {
-    const { testState } = props;
+    const { testState, isReadOnly } = props;
+    const selectedTab = testState.selectedTab;
     const selectedAssertion = testState.selectedAsertionState;
+
+    useEffect(() => {
+      testState.syncWithQuery();
+    }, [testState]);
+
+    const addParameter = (): void => {
+      testState.openNewParamModal();
+    };
+
+    const generateParameterValues = (): void => {
+      testState.generateTestParameterValues();
+    };
+
+    const accessPoint = testState.suiteState.testableState.ownAccessPoints.find(
+      (ap) => ap.id === testState.test.accessPointId,
+    );
+    const accessPointQuery = accessPoint
+      ? accessPoint instanceof LakehouseAccessPoint
+        ? accessPoint.func
+        : accessPoint instanceof FunctionAccessPoint
+          ? accessPoint.query
+          : undefined
+      : undefined;
+
+    const tabs = [TESTABLE_TEST_TAB.ASSERTION];
 
     return (
       <div className="function-test-editor panel">
         <div className="panel__header">
           <div className="panel__header service-test-editor__header--with-tabs">
-            <div className="panel__header__title__content">Assertion</div>
+            <div className="uml-element-editor__tabs">
+              {tabs.map((tab) => (
+                <div
+                  key={tab}
+                  onClick={(): void => testState.setSelectedTab(tab)}
+                  className={clsx('service-test-editor__tab', {
+                    'service-test-editor__tab--active':
+                      tab === testState.selectedTab,
+                  })}
+                >
+                  {prettyCONSTName(tab)}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
         <div className="panel">
-          {selectedAssertion && (
-            <TestAssertionEditor testAssertionState={selectedAssertion} />
+          {selectedTab === TESTABLE_TEST_TAB.ASSERTION && (
+            <>
+              {selectedAssertion ? (
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    width: '100%',
+                    height: '100%',
+                    minHeight: 0,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      flex: '0 0 32%',
+                      minHeight: '12rem',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div className="panel__content__form__section">
+                      <div className="panel__content__form__section__header__label">
+                        Access Point: {testState.accessPointLabel}
+                      </div>
+                    </div>
+
+                    {Boolean(testState.queryVariableExpressions.length) && (
+                      <div
+                        className="service-test-data-editor panel"
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          flex: 1,
+                          minHeight: 0,
+                        }}
+                      >
+                        <div className="service-test-suite-editor__header">
+                          <div className="service-test-suite-editor__header__title">
+                            <div className="service-test-suite-editor__header__title__label">
+                              Parameters
+                            </div>
+                          </div>
+                          <div className="panel__header__actions">
+                            <button
+                              className="panel__header__action service-execution-editor__test-data__generate-btn"
+                              onClick={generateParameterValues}
+                              disabled={!testState.newParamOptions.length}
+                              title="Generate test parameter values"
+                              tabIndex={-1}
+                            >
+                              <div className="service-execution-editor__test-data__generate-btn__label">
+                                <RefreshIcon className="service-execution-editor__test-data__generate-btn__label__icon" />
+                                <div className="service-execution-editor__test-data__generate-btn__label__title">
+                                  Generate
+                                </div>
+                              </div>
+                            </button>
+                            <button
+                              className="panel__header__action"
+                              tabIndex={-1}
+                              disabled={!testState.newParamOptions.length}
+                              onClick={addParameter}
+                              title="Add Parameter Value"
+                            >
+                              <PlusIcon />
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          className="service-test-editor__setup__parameters"
+                          style={{
+                            overflowY: 'auto',
+                            flex: 1,
+                            minHeight: 0,
+                          }}
+                        >
+                          {testState.parameterValueStates
+                            .filter(
+                              filterByType(
+                                DataProductValueSpecificationTestParameterState,
+                              ),
+                            )
+                            .map((paramState) => (
+                              <DataProductTestParameterEditor
+                                key={paramState.uuid}
+                                isReadOnly={isReadOnly}
+                                paramState={paramState}
+                                testState={testState}
+                                contentTypeParamPair={getContentTypeWithParamFromQuery(
+                                  accessPointQuery,
+                                  testState.editorStore,
+                                ).find(
+                                  (pair) =>
+                                    pair.param ===
+                                    paramState.parameterValue.name,
+                                )}
+                              />
+                            ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <div
+                    style={{
+                      flex: 1,
+                      minHeight: 0,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <TestAssertionEditor
+                      testAssertionState={selectedAssertion}
+                    />
+                  </div>
+                </div>
+              ) : null}
+            </>
           )}
-          {!selectedAssertion && (
-            <BlankPanelPlaceholder
-              text="No assertion"
-              tooltipText="No assertion configured for this test"
+          {selectedTab === TESTABLE_TEST_TAB.ASSERTION &&
+            !selectedAssertion && (
+              <BlankPanelPlaceholder
+                text="No assertion"
+                tooltipText="No assertion configured for this test"
+              />
+            )}
+
+          {selectedTab === TESTABLE_TEST_TAB.SETUP && (
+            <>
+              <BlankPanelPlaceholder
+                text="No setup configuration"
+                tooltipText="Parameters are configured in the Assertion tab"
+              />
+            </>
+          )}
+          {testState.showNewParameterModal && (
+            <NewDataProductParameterModal
+              testState={testState}
+              isReadOnly={isReadOnly}
             />
           )}
         </div>

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -59,6 +59,7 @@ import {
 } from '@finos/legend-graph';
 import type { DataProductEditorState } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/DataProductEditorState.js';
 import {
+  DataProductTestParameterState,
   DataProductValueSpecificationTestParameterState,
   type DataProductTestableState,
   type DataProductTestSuiteState,
@@ -79,11 +80,7 @@ import {
   validateTestableId,
 } from '../../../../../stores/editor/utils/TestableUtils.js';
 import { useEditorStore } from '../../../EditorStoreProvider.js';
-import {
-  filterByType,
-  guaranteeNonNullable,
-  prettyCONSTName,
-} from '@finos/legend-shared';
+import { guaranteeNonNullable } from '@finos/legend-shared';
 import {
   ExternalFormatParameterEditorModal,
   RenameModal,
@@ -665,40 +662,53 @@ const TestItem = observer(
 const DataProductTestParameterEditor = observer(
   (props: {
     isReadOnly: boolean;
-    paramState: DataProductValueSpecificationTestParameterState;
+    paramState: DataProductTestParameterState;
     testState: DataProductTestState;
     contentTypeParamPair: TestParamContentType | undefined;
   }) => {
     const { testState, paramState, isReadOnly, contentTypeParamPair } = props;
     const [showPopUp, setShowPopUp] = useState(false);
-    const paramIsRequired =
-      paramState.varExpression.multiplicity.lowerBound > 0;
+    const valueSpecificationParamState =
+      paramState instanceof DataProductValueSpecificationTestParameterState
+        ? paramState
+        : undefined;
+    const paramExpression = valueSpecificationParamState?.varExpression;
+    const paramIsRequired = (paramExpression?.multiplicity.lowerBound ?? 0) > 0;
     const type = contentTypeParamPair
       ? contentTypeParamPair.contentType
-      : (paramState.varExpression.genericType?.value.rawType.name ?? 'unknown');
+      : (paramExpression?.genericType?.value.rawType.name ?? 'unknown');
+    const primitiveValueSpecification =
+      valueSpecificationParamState?.valueSpec instanceof PrimitiveInstanceValue
+        ? valueSpecificationParamState.valueSpec
+        : undefined;
+    const primitiveValue = primitiveValueSpecification?.values[0] as
+      | string
+      | undefined;
     const paramValue =
-      paramState.varExpression.genericType?.value.rawType === PrimitiveType.BYTE
-        ? atob(
-            (paramState.valueSpec as PrimitiveInstanceValue)
-              .values[0] as string,
-          )
-        : ((paramState.valueSpec as PrimitiveInstanceValue)
-            .values[0] as string);
+      paramExpression?.genericType?.value.rawType === PrimitiveType.BYTE &&
+      primitiveValue !== undefined
+        ? atob(primitiveValue)
+        : (primitiveValue ?? '');
 
     const openInPopUp = (): void => setShowPopUp(!showPopUp);
     const closePopUp = (): void => setShowPopUp(false);
     const updateParamValue = (val: string): void => {
-      if (paramState.valueSpec instanceof PrimitiveInstanceValue) {
+      if (
+        primitiveValueSpecification &&
+        valueSpecificationParamState &&
+        paramExpression
+      ) {
         instanceValue_setValue(
-          paramState.valueSpec,
-          paramState.varExpression.genericType?.value.rawType ===
-            PrimitiveType.BYTE
+          primitiveValueSpecification,
+          paramExpression.genericType?.value.rawType === PrimitiveType.BYTE
             ? btoa(val)
             : val,
           0,
           testState.editorStore.changeDetectionState.observerContext,
         );
-        paramState.updateValueSpecification(paramState.valueSpec);
+        valueSpecificationParamState.updateValueSpecification(
+          primitiveValueSpecification,
+        );
       }
     };
 
@@ -717,26 +727,26 @@ const DataProductTestParameterEditor = observer(
             {type}
           </button>
         </div>
-        {contentTypeParamPair ? (
+        {!valueSpecificationParamState || !paramExpression ? (
+          <BlankPanelPlaceholder
+            text="Unsupported parameter value"
+            tooltipText="This parameter was preserved but cannot currently be edited in form mode"
+          />
+        ) : contentTypeParamPair && primitiveValueSpecification ? (
           <div className="service-test-editor__setup__parameter__code-editor">
             <textarea
               className="panel__content__form__section__textarea value-spec-editor__input"
               spellCheck={false}
               value={paramValue}
-              placeholder={
-                ((paramState.valueSpec as PrimitiveInstanceValue)
-                  .values[0] as string) === ''
-                  ? '(empty)'
-                  : undefined
-              }
+              placeholder={primitiveValue === '' ? '(empty)' : undefined}
               onChange={(event) => {
                 updateParamValue(event.target.value);
               }}
             />
             {showPopUp && (
               <ExternalFormatParameterEditorModal
-                valueSpec={paramState.valueSpec}
-                varExpression={paramState.varExpression}
+                valueSpec={valueSpecificationParamState.valueSpec}
+                varExpression={paramExpression}
                 isReadOnly={isReadOnly}
                 onClose={closePopUp}
                 updateParamValue={updateParamValue}
@@ -770,9 +780,9 @@ const DataProductTestParameterEditor = observer(
         ) : (
           <div className="service-test-editor__setup__parameter__value">
             <BasicValueSpecificationEditor
-              valueSpecification={paramState.valueSpec}
+              valueSpecification={valueSpecificationParamState.valueSpec}
               setValueSpecification={(val: ValueSpecification): void => {
-                paramState.updateValueSpecification(val);
+                valueSpecificationParamState.updateValueSpecification(val);
               }}
               graph={testState.editorStore.graphManagerState.graph}
               observerContext={
@@ -780,12 +790,12 @@ const DataProductTestParameterEditor = observer(
               }
               typeCheckOption={{
                 expectedType:
-                  paramState.varExpression.genericType?.value.rawType ??
+                  paramExpression.genericType?.value.rawType ??
                   PrimitiveType.STRING,
               }}
               className="query-builder__parameters__value__editor"
               resetValue={(): void => {
-                paramState.resetValueSpec();
+                valueSpecificationParamState.resetValueSpec();
               }}
             />
             <div className="service-test-editor__setup__parameter__value__actions">
@@ -890,34 +900,18 @@ const DataProductTestEditor = observer(
     const accessPoint = testState.suiteState.testableState.ownAccessPoints.find(
       (ap) => ap.id === testState.test.accessPointId,
     );
-    const accessPointQuery = accessPoint
-      ? accessPoint instanceof LakehouseAccessPoint
-        ? accessPoint.func
-        : accessPoint instanceof FunctionAccessPoint
-          ? accessPoint.query
-          : undefined
-      : undefined;
-
-    const tabs = [TESTABLE_TEST_TAB.ASSERTION];
+    let accessPointQuery;
+    if (accessPoint instanceof LakehouseAccessPoint) {
+      accessPointQuery = accessPoint.func;
+    } else if (accessPoint instanceof FunctionAccessPoint) {
+      accessPointQuery = accessPoint.query;
+    }
 
     return (
       <div className="function-test-editor panel">
         <div className="panel__header">
           <div className="panel__header service-test-editor__header--with-tabs">
-            <div className="uml-element-editor__tabs">
-              {tabs.map((tab) => (
-                <div
-                  key={tab}
-                  onClick={(): void => testState.setSelectedTab(tab)}
-                  className={clsx('service-test-editor__tab', {
-                    'service-test-editor__tab--active':
-                      tab === testState.selectedTab,
-                  })}
-                >
-                  {prettyCONSTName(tab)}
-                </div>
-              ))}
-            </div>
+            <div className="panel__header__title__content">Assertion</div>
           </div>
         </div>
         <div className="panel">
@@ -999,28 +993,21 @@ const DataProductTestEditor = observer(
                             minHeight: 0,
                           }}
                         >
-                          {testState.parameterValueStates
-                            .filter(
-                              filterByType(
-                                DataProductValueSpecificationTestParameterState,
-                              ),
-                            )
-                            .map((paramState) => (
-                              <DataProductTestParameterEditor
-                                key={paramState.uuid}
-                                isReadOnly={isReadOnly}
-                                paramState={paramState}
-                                testState={testState}
-                                contentTypeParamPair={getContentTypeWithParamFromQuery(
-                                  accessPointQuery,
-                                  testState.editorStore,
-                                ).find(
-                                  (pair) =>
-                                    pair.param ===
-                                    paramState.parameterValue.name,
-                                )}
-                              />
-                            ))}
+                          {testState.parameterValueStates.map((paramState) => (
+                            <DataProductTestParameterEditor
+                              key={paramState.uuid}
+                              isReadOnly={isReadOnly}
+                              paramState={paramState}
+                              testState={testState}
+                              contentTypeParamPair={getContentTypeWithParamFromQuery(
+                                accessPointQuery,
+                                testState.editorStore,
+                              ).find(
+                                (pair) =>
+                                  pair.param === paramState.parameterValue.name,
+                              )}
+                            />
+                          ))}
                         </div>
                       </div>
                     )}
@@ -1047,15 +1034,6 @@ const DataProductTestEditor = observer(
                 tooltipText="No assertion configured for this test"
               />
             )}
-
-          {selectedTab === TESTABLE_TEST_TAB.SETUP && (
-            <>
-              <BlankPanelPlaceholder
-                text="No setup configuration"
-                tooltipText="Parameters are configured in the Assertion tab"
-              />
-            </>
-          )}
           {testState.showNewParameterModal && (
             <NewDataProductParameterModal
               testState={testState}

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -98,9 +98,6 @@ const createEmptyRelationElement = (
   return observe_RelationElement(relationElement);
 };
 
-const getTrimmedParameterName = (name: unknown): string =>
-  typeof name === 'string' ? name.trim() : '';
-
 /**
  * Returns the lambda for an access point (handles both LakehouseAccessPoint
  * and FunctionAccessPoint).
@@ -331,7 +328,7 @@ export class DataProductTestState extends TestableTestEditorState {
     }
 
     const unnamedParams = params.filter(
-      (p) => !getTrimmedParameterName(p.name),
+      (p) => !(typeof p.name === 'string' ? p.name.trim() : ''),
     );
     if (!unnamedParams.length) {
       return;
@@ -339,7 +336,7 @@ export class DataProductTestState extends TestableTestEditorState {
 
     const takenNames = new Set(
       params
-        .map((p) => getTrimmedParameterName(p.name))
+        .map((p) => (typeof p.name === 'string' ? p.name.trim() : ''))
         .filter((name) => Boolean(name)),
     );
 

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -98,6 +98,9 @@ const createEmptyRelationElement = (
   return observe_RelationElement(relationElement);
 };
 
+const getTrimmedParameterName = (name: unknown): string =>
+  typeof name === 'string' ? name.trim() : '';
+
 /**
  * Returns the lambda for an access point (handles both LakehouseAccessPoint
  * and FunctionAccessPoint).
@@ -327,13 +330,17 @@ export class DataProductTestState extends TestableTestEditorState {
       return;
     }
 
-    const unnamedParams = params.filter((p) => !(p.name ?? '').trim());
+    const unnamedParams = params.filter(
+      (p) => !getTrimmedParameterName(p.name),
+    );
     if (!unnamedParams.length) {
       return;
     }
 
     const takenNames = new Set(
-      params.map((p) => (p.name ?? '').trim()).filter((name) => Boolean(name)),
+      params
+        .map((p) => getTrimmedParameterName(p.name))
+        .filter((name) => Boolean(name)),
     );
 
     expressions.forEach((expr) => {

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -327,17 +327,13 @@ export class DataProductTestState extends TestableTestEditorState {
       return;
     }
 
-    const unnamedParams = params.filter(
-      (p) => !(typeof p.name === 'string' ? p.name.trim() : ''),
-    );
+    const unnamedParams = params.filter((p) => !p.name);
     if (!unnamedParams.length) {
       return;
     }
 
     const takenNames = new Set(
-      params
-        .map((p) => (typeof p.name === 'string' ? p.name.trim() : ''))
-        .filter((name) => Boolean(name)),
+      params.map((p) => p.name).filter((name) => Boolean(name)),
     );
 
     expressions.forEach((expr) => {

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -317,11 +317,6 @@ export class DataProductTestState extends TestableTestEditorState {
     this.buildTestDataRelationState().catch(noop());
   }
 
-  /**
-   * Backward compatibility: Data Product grammar test calls can come in as
-   * positional args (e.g. `ap('Human')`) without parameter names. In form mode
-   * we key by variable name, so align unnamed values to query variables first.
-   */
   private normalizePositionalParameters(): void {
     const params = this.test.parameters ?? [];
     if (!params.length) {

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -21,6 +21,7 @@ import {
   type TestSuite,
   type RawLambda,
   type AccessorOwner,
+  type ValueSpecification,
   DataProduct,
   FunctionAccessPoint,
   LakehouseAccessPoint,
@@ -35,21 +36,31 @@ import {
   TestError,
   TestExecutionStatus,
   EqualToRelation,
+  FunctionParameterValue,
   RelationRowTestData,
+  VariableExpression,
+  observe_FunctionParameterValue,
   observe_RelationElement,
   observe_RelationRowTestData,
   observe_RelationElementsData,
   observe_DataProductTestSuite,
+  observe_ValueSpecification,
+  buildLambdaVariableExpressions,
   IngestDefinition,
   getAccessorItemLabelForElement,
   type AbstractPureGraphManager,
 } from '@finos/legend-graph';
 import {
   type GeneratorFn,
+  type PlainObject,
   ActionState,
   assertErrorThrown,
+  filterByType,
+  guaranteeNonNullable,
+  isNonNullable,
   deleteEntry,
   addUniqueEntry,
+  returnUndefOnError,
   uuid,
   noop,
 } from '@finos/legend-shared';
@@ -73,6 +84,7 @@ import {
   TestableTestEditorState,
   TestableTestSuiteEditorState,
 } from '../../testable/TestableEditorState.js';
+import { generateVariableExpressionMockValue } from '@finos/legend-query-builder';
 
 const createEmptyRelationElement = (
   itemId: string,
@@ -178,6 +190,73 @@ const inferDataProductItemColumns = async (
 
 // ─── Per-test state ──────────────────────────────────────────────────────────
 
+export class DataProductTestParameterState {
+  readonly uuid = uuid();
+  readonly editorStore: EditorStore;
+  readonly testState: DataProductTestState;
+  parameterValue: FunctionParameterValue;
+
+  constructor(
+    parameterValue: FunctionParameterValue,
+    editorStore: EditorStore,
+    testState: DataProductTestState,
+  ) {
+    this.editorStore = editorStore;
+    this.testState = testState;
+    this.parameterValue = parameterValue;
+  }
+}
+
+export class DataProductValueSpecificationTestParameterState extends DataProductTestParameterState {
+  valueSpec: ValueSpecification;
+  varExpression: VariableExpression;
+
+  constructor(
+    parameterValue: FunctionParameterValue,
+    editorStore: EditorStore,
+    testState: DataProductTestState,
+    valueSpec: ValueSpecification,
+    varExpression: VariableExpression,
+  ) {
+    super(parameterValue, editorStore, testState);
+    makeObservable(this, {
+      valueSpec: observable,
+      updateValueSpecification: action,
+      updateParameterValue: action,
+      resetValueSpec: action,
+    });
+    this.valueSpec = valueSpec;
+    this.varExpression = varExpression;
+  }
+
+  updateValueSpecification(val: ValueSpecification): void {
+    this.valueSpec = observe_ValueSpecification(
+      val,
+      this.editorStore.changeDetectionState.observerContext,
+    );
+    this.updateParameterValue();
+  }
+
+  updateParameterValue(): void {
+    const updatedValueSpec =
+      this.editorStore.graphManagerState.graphManager.serializeValueSpecification(
+        this.valueSpec,
+      );
+    this.parameterValue.value = updatedValueSpec;
+  }
+
+  resetValueSpec(): void {
+    const mockValue = generateVariableExpressionMockValue(
+      this.varExpression,
+      this.editorStore.graphManagerState.graph,
+      this.editorStore.changeDetectionState.observerContext,
+    );
+    if (mockValue) {
+      this.updateValueSpecification(mockValue);
+    }
+  }
+}
+
 export class DataProductTestState extends TestableTestEditorState {
   readonly suiteState: DataProductTestSuiteState;
   override test: DataProductAccessPointTest;
@@ -185,6 +264,9 @@ export class DataProductTestState extends TestableTestEditorState {
 
   /** Wraps assertion.expected — drives both column definitions and test data rows. */
   testDataRelationState: RelationElementState | undefined;
+  parameterValueStates: DataProductTestParameterState[] = [];
+  newParameterValueName = '';
+  showNewParameterModal = false;
 
   constructor(
     suiteState: DataProductTestSuiteState,
@@ -206,6 +288,9 @@ export class DataProductTestState extends TestableTestEditorState {
       runningTestAction: observable,
       // own observable
       testDataRelationState: observable,
+      parameterValueStates: observable,
+      newParameterValueName: observable,
+      showNewParameterModal: observable,
       // actions from base class
       setSelectedTab: action,
       setAssertionToRename: action,
@@ -214,12 +299,247 @@ export class DataProductTestState extends TestableTestEditorState {
       openAssertion: action,
       resetResult: action,
       handleTestResult: action,
+      setNewParameterValueName: action,
+      setShowNewParameterModal: action,
+      openNewParamModal: action,
+      addParameterValue: action,
+      addExpressionParameterValue: action,
+      syncWithQuery: action,
+      generateTestParameterValues: action,
+      removeParamValueState: action,
       // flow from base class
       runTest: flow,
     });
     this.suiteState = suiteState;
     this.test = test;
+    this.normalizePositionalParameters();
+    this.parameterValueStates = this.buildParameterStates();
     this.buildTestDataRelationState().catch(noop());
+  }
+
+  /**
+   * Backward compatibility: Data Product grammar test calls can come in as
+   * positional args (e.g. `ap('Human')`) without parameter names. In form mode
+   * we key by variable name, so align unnamed values to query variables first.
+   */
+  private normalizePositionalParameters(): void {
+    const params = this.test.parameters ?? [];
+    if (!params.length) {
+      return;
+    }
+
+    const expressions = this.queryVariableExpressions;
+    if (!expressions.length) {
+      return;
+    }
+
+    const unnamedParams = params.filter((p) => !p.name.trim());
+    if (!unnamedParams.length) {
+      return;
+    }
+
+    const takenNames = new Set(
+      params.map((p) => p.name.trim()).filter((name) => Boolean(name)),
+    );
+
+    expressions.forEach((expr) => {
+      if (!takenNames.has(expr.name)) {
+        const nextUnnamed = unnamedParams.shift();
+        if (nextUnnamed) {
+          nextUnnamed.name = expr.name;
+          takenNames.add(expr.name);
+        }
+      }
+    });
+  }
+
+  get queryVariableExpressions(): VariableExpression[] {
+    const accessPoint = this.suiteState.testableState.ownAccessPoints.find(
+      (ap) => ap.id === this.test.accessPointId,
+    );
+    const query = accessPoint ? getAccessPointLambda(accessPoint) : undefined;
+    if (!query) {
+      return [];
+    }
+    return buildLambdaVariableExpressions(
+      query,
+      this.editorStore.graphManagerState,
+    ).filter(filterByType(VariableExpression));
+  }
+
+  get newParamOptions(): { value: string; label: string }[] {
+    const queryVarExpressions = this.queryVariableExpressions;
+    const currentParams = this.test.parameters ?? [];
+    return queryVarExpressions
+      .filter((v) => !currentParams.find((i) => i.name === v.name))
+      .map((e) => ({ value: e.name, label: e.name }));
+  }
+
+  setNewParameterValueName(val: string): void {
+    this.newParameterValueName = val;
+  }
+
+  setShowNewParameterModal(val: boolean): void {
+    this.showNewParameterModal = val;
+  }
+
+  openNewParamModal(): void {
+    this.setShowNewParameterModal(true);
+    const option = this.newParamOptions[0];
+    if (option) {
+      this.newParameterValueName = option.value;
+    }
+  }
+
+  addParameterValue(): void {
+    try {
+      const expressions = this.queryVariableExpressions;
+      const expression = guaranteeNonNullable(
+        expressions.find((v) => v.name === this.newParameterValueName),
+      );
+      this.addExpressionParameterValue(expression);
+    } catch (error) {
+      assertErrorThrown(error);
+      this.editorStore.applicationStore.notificationService.notifyError(error);
+    } finally {
+      this.setShowNewParameterModal(false);
+    }
+  }
+
+  syncWithQuery(): void {
+    this.normalizePositionalParameters();
+
+    this.parameterValueStates.forEach((paramState) => {
+      const expression = this.queryVariableExpressions.find(
+        (v) => v.name === paramState.parameterValue.name,
+      );
+      if (!expression) {
+        deleteEntry(this.parameterValueStates, paramState);
+        deleteEntry(this.test.parameters ?? [], paramState.parameterValue);
+      }
+    });
+
+    this.queryVariableExpressions.forEach((v) => {
+      const multiplicity = v.multiplicity;
+      const isRequired = multiplicity.lowerBound > 0;
+      const paramState = this.parameterValueStates.find(
+        (p) => p.parameterValue.name === v.name,
+      );
+      if (!paramState && isRequired) {
+        this.addExpressionParameterValue(v);
+      }
+    });
+  }
+
+  addExpressionParameterValue(expression: VariableExpression): void {
+    try {
+      const mockValue = guaranteeNonNullable(
+        generateVariableExpressionMockValue(
+          expression,
+          this.editorStore.graphManagerState.graph,
+          this.editorStore.changeDetectionState.observerContext,
+        ),
+      );
+      const paramValue = observe_FunctionParameterValue(
+        new FunctionParameterValue(),
+      );
+      paramValue.name = expression.name;
+      paramValue.value =
+        this.editorStore.graphManagerState.graphManager.serializeValueSpecification(
+          mockValue,
+        );
+      if (this.test.parameters) {
+        this.test.parameters.push(paramValue);
+      } else {
+        this.test.parameters = [paramValue];
+      }
+      const paramValueState =
+        new DataProductValueSpecificationTestParameterState(
+          paramValue,
+          this.editorStore,
+          this,
+          observe_ValueSpecification(
+            mockValue,
+            this.editorStore.changeDetectionState.observerContext,
+          ),
+          expression,
+        );
+      this.parameterValueStates.push(paramValueState);
+    } catch (error) {
+      assertErrorThrown(error);
+      this.editorStore.applicationStore.notificationService.notifyError(error);
+    }
+  }
+
+  generateTestParameterValues(): void {
+    try {
+      const varExpressions = this.queryVariableExpressions;
+      const parameterValueStates = varExpressions
+        .map((varExpression) => {
+          const mockValue = generateVariableExpressionMockValue(
+            varExpression,
+            this.editorStore.graphManagerState.graph,
+            this.editorStore.changeDetectionState.observerContext,
+          );
+          if (mockValue) {
+            const paramValue = observe_FunctionParameterValue(
+              new FunctionParameterValue(),
+            );
+            paramValue.name = varExpression.name;
+            paramValue.value =
+              this.editorStore.graphManagerState.graphManager.serializeValueSpecification(
+                mockValue,
+              );
+            return new DataProductValueSpecificationTestParameterState(
+              paramValue,
+              this.editorStore,
+              this,
+              mockValue,
+              varExpression,
+            );
+          }
+          return undefined;
+        })
+        .filter(isNonNullable);
+      this.test.parameters = parameterValueStates.map((s) => s.parameterValue);
+      this.parameterValueStates = parameterValueStates;
+    } catch (error) {
+      assertErrorThrown(error);
+      this.editorStore.applicationStore.notificationService.notifyError(
+        `Unable to generate parameter values: ${error.message}`,
+      );
+    }
+  }
+
+  buildParameterStates(): DataProductTestParameterState[] {
+    const varExpressions = this.queryVariableExpressions;
+    const paramValues = this.test.parameters ?? [];
+    return paramValues.map((paramValue) => {
+      const spec = returnUndefOnError(() =>
+        this.editorStore.graphManagerState.graphManager.buildValueSpecification(
+          paramValue.value as PlainObject,
+          this.editorStore.graphManagerState.graph,
+        ),
+      );
+      const expression = varExpressions.find((e) => e.name === paramValue.name);
+      return spec && expression
+        ? new DataProductValueSpecificationTestParameterState(
+            paramValue,
+            this.editorStore,
+            this,
+            observe_ValueSpecification(
+              spec,
+              this.editorStore.changeDetectionState.observerContext,
+            ),
+            expression,
+          )
+        : new DataProductTestParameterState(paramValue, this.editorStore, this);
+    });
+  }
+
+  removeParamValueState(paramState: DataProductTestParameterState): void {
+    deleteEntry(this.parameterValueStates, paramState);
+    deleteEntry(this.test.parameters ?? [], paramState.parameterValue);
   }
 
   private async buildTestDataRelationState(): Promise<void> {

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -57,7 +57,6 @@ import {
   assertErrorThrown,
   filterByType,
   guaranteeNonNullable,
-  isNonNullable,
   deleteEntry,
   addUniqueEntry,
   returnUndefOnError,
@@ -328,13 +327,13 @@ export class DataProductTestState extends TestableTestEditorState {
       return;
     }
 
-    const unnamedParams = params.filter((p) => !p.name.trim());
+    const unnamedParams = params.filter((p) => !(p.name ?? '').trim());
     if (!unnamedParams.length) {
       return;
     }
 
     const takenNames = new Set(
-      params.map((p) => p.name.trim()).filter((name) => Boolean(name)),
+      params.map((p) => (p.name ?? '').trim()).filter((name) => Boolean(name)),
     );
 
     expressions.forEach((expr) => {
@@ -495,7 +494,10 @@ export class DataProductTestState extends TestableTestEditorState {
           }
           return undefined;
         })
-        .filter(isNonNullable);
+        .filter(
+          (value): value is DataProductValueSpecificationTestParameterState =>
+            value !== undefined,
+        );
       this.test.parameters = parameterValueStates.map((s) => s.parameterValue);
       this.parameterValueStates = parameterValueStates;
     } catch (error) {

--- a/packages/legend-application-studio/style/components/editor/_data-product-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-product-editor.scss
@@ -382,6 +382,45 @@
     min-height: 0;
   }
 
+  &__parameters-header {
+    @include flexVCenter;
+
+    justify-content: space-between;
+    min-height: 3.4rem;
+    padding: 0 0.5rem;
+  }
+
+  &__parameters-header__title {
+    @include flexVCenter;
+  }
+
+  &__parameters-header__title__label {
+    @include flexVCenter;
+
+    text-transform: uppercase;
+    font-weight: 500;
+  }
+
+  &__parameters-header__actions {
+    @include flexVCenter;
+  }
+
+  &__parameters-header__action {
+    @include flexCenter;
+  }
+
+  &__parameters-header__generate-btn {
+    padding: 0 0.7rem;
+  }
+
+  &__parameters-header__generate-btn__label {
+    @include flexVCenter;
+  }
+
+  &__parameters-header__generate-btn__label__icon {
+    margin-right: 0.5rem;
+  }
+
   &__parameters {
     overflow-y: auto;
     flex: 1;

--- a/packages/legend-application-studio/style/components/editor/_data-product-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-product-editor.scss
@@ -357,6 +357,48 @@
   }
 }
 
+.data-product-test-editor {
+  &__assertion {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__parameters-panel-container {
+    flex: 0 0 32%;
+    min-height: 12rem;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  &__parameters-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  &__parameters {
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+  }
+
+  &__assertion-result {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+
+    &--full {
+      flex: 1 1 100%;
+    }
+  }
+}
+
 .access-point-editor {
   padding: 0.5rem;
   padding-left: 0.25rem;

--- a/packages/legend-application-studio/style/components/editor/_data-product-editor.scss
+++ b/packages/legend-application-studio/style/components/editor/_data-product-editor.scss
@@ -380,51 +380,145 @@
     flex-direction: column;
     flex: 1;
     min-height: 0;
+    border-bottom: 0.1rem solid var(--color-dark-grey-200);
   }
 
   &__parameters-header {
     @include flexVCenter;
+    @include flexHSpaceBetween;
 
-    justify-content: space-between;
-    min-height: 3.4rem;
-    padding: 0 0.5rem;
+    cursor: default;
+    background: var(--color-dark-grey-50);
+    color: var(--color-light-grey-300);
+    height: 2.8rem;
+    min-height: 2.8rem;
+    position: relative;
+    z-index: 1;
+    border: 0.1rem solid var(--color-dark-grey-200);
+    box-shadow: var(--color-light-shade-280) 0 0.1rem 0.5rem 0;
   }
 
   &__parameters-header__title {
     @include flexVCenter;
+
+    padding-left: 0.5rem;
+    user-select: none;
   }
 
   &__parameters-header__title__label {
-    @include flexVCenter;
-
-    text-transform: uppercase;
-    font-weight: 500;
+    height: 1.8rem;
+    line-height: 1.8rem;
+    border-radius: 0.1rem;
+    padding: 0 0.5rem;
+    color: var(--color-light-grey-200);
+    background: var(--color-dark-grey-250);
+    font-size: 1.1rem;
+    cursor: default;
+    margin-right: 0.5rem;
+    white-space: nowrap;
   }
 
   &__parameters-header__actions {
-    @include flexVCenter;
-  }
-
-  &__parameters-header__action {
-    @include flexCenter;
-  }
-
-  &__parameters-header__generate-btn {
-    padding: 0 0.7rem;
-  }
-
-  &__parameters-header__generate-btn__label {
-    @include flexVCenter;
-  }
-
-  &__parameters-header__generate-btn__label__icon {
-    margin-right: 0.5rem;
+    display: flex;
+    height: 100%;
   }
 
   &__parameters {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 1rem;
     overflow-y: auto;
     flex: 1;
     min-height: 0;
+  }
+
+  &__generate-btn {
+    @include flexVCenter;
+
+    height: 100%;
+    width: 10rem;
+    padding-right: 0.5rem;
+
+    &__label {
+      @include flexVCenter;
+
+      height: 2.2rem;
+      background: var(--color-blue-200);
+      padding: 1rem;
+      border-radius: 0.2rem;
+    }
+
+    &__label__icon {
+      font-size: 1.6rem;
+      color: var(--color-light-grey-180);
+    }
+
+    &__label__title {
+      margin-left: 0.5rem;
+      color: var(--color-light-grey-180);
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+
+    &__label:hover &__label__icon,
+    &__label:hover &__label__title {
+      color: var(--color-light-grey-50);
+    }
+
+    &[disabled] &__label {
+      background: var(--color-dark-grey-250);
+    }
+
+    &[disabled] &__label__icon,
+    &[disabled] &__label__title {
+      color: var(--color-dark-grey-500);
+    }
+  }
+
+  &__header--with-tabs {
+    padding-left: 0.5rem;
+    color: var(--color-light-grey-300);
+    font-weight: bold;
+    background: var(--color-dark-grey-50);
+    border-bottom: 0.1rem solid var(--color-dark-grey-200);
+  }
+
+  &__parameter__code-editor {
+    @include flexVCenter;
+
+    &__expand-btn {
+      @include flexCenter;
+
+      height: 8rem;
+      width: 2.8rem;
+      background: var(--color-dark-grey-280);
+      border-left: 0.1rem solid var(--color-dark-grey-280);
+      border-right: 0.1rem solid var(--color-dark-grey-280);
+      color: var(--color-light-grey-100);
+      border-radius: 0;
+      cursor: pointer;
+    }
+  }
+
+  &__parameter__value {
+    display: flex;
+
+    &__actions {
+      @include flexCenter;
+
+      padding-left: 0.5rem;
+    }
+  }
+
+  &__tests {
+    height: 100%;
+    width: 100%;
+
+    &__content {
+      height: calc(100% - 2.8rem);
+      background: var(--color-dark-grey-50);
+    }
   }
 
   &__assertion-result {
@@ -435,6 +529,89 @@
     &--full {
       flex: 1 1 100%;
     }
+  }
+}
+
+.data-product-test-data-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-bottom: 0.1rem solid var(--color-dark-grey-200) !important;
+  overflow-y: auto !important;
+
+  &__data {
+    width: 100%;
+    height: calc(100% - 2.8rem);
+    background: var(--color-dark-grey-50);
+    overflow: auto;
+  }
+
+  &__warning {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-red-300);
+    padding: 0.5rem;
+    font-size: 1.2rem;
+  }
+
+  &--no-data {
+    border: 0.1rem solid var(--color-red-300);
+    border-radius: 0.2rem;
+  }
+}
+
+.data-product-test-suite-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  &__header {
+    @include flexVCenter;
+    @include flexHSpaceBetween;
+
+    cursor: default;
+    background: var(--color-dark-grey-50);
+    color: var(--color-light-grey-300);
+    height: 2.8rem;
+    min-height: 2.8rem;
+    position: relative;
+    z-index: 1;
+    border: 0.1rem solid var(--color-dark-grey-200);
+    box-shadow: var(--color-light-shade-280) 0 0.1rem 0.5rem 0;
+  }
+
+  &__header--with-tabs {
+    padding-left: 0.5rem;
+    color: var(--color-light-grey-300);
+    font-weight: bold;
+    background: var(--color-dark-grey-50);
+    border-bottom: 0.1rem solid var(--color-dark-grey-200);
+  }
+
+  &__tab {
+    @include flexCenter;
+
+    display: inline-flex;
+    height: 100%;
+    color: var(--color-light-grey-400);
+    padding: 0 1rem;
+    border-right: 0.1rem solid var(--color-dark-grey-80);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  &__tab--active {
+    position: relative;
+  }
+
+  &__tab--active::after {
+    content: '';
+    height: 0.2rem;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    background: var(--color-pink-500);
   }
 }
 

--- a/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__DataProductRoundtrip.ts
+++ b/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__DataProductRoundtrip.ts
@@ -641,6 +641,27 @@ export const TEST_DATA__DATAPRODUCT__TEST_SUITES = [
             {
               _type: 'accessPointTest',
               accessPointId: 'employees',
+              parameters: [
+                {
+                  // Positional style from grammar (e.g. ap('Bob')) is represented
+                  // without a parameter name and must survive roundtrip unchanged.
+                  name: '',
+                  value: {
+                    _type: 'instanceValue',
+                    genericType: {
+                      rawType: {
+                        _type: 'packageableType',
+                        fullPath: 'String',
+                      },
+                    },
+                    multiplicity: {
+                      lowerBound: 1,
+                      upperBound: 1,
+                    },
+                    values: ['Bob'],
+                  },
+                },
+              ],
               assertions: [
                 {
                   _type: 'equalToRelation',

--- a/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__DataProductRoundtrip.ts
+++ b/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__DataProductRoundtrip.ts
@@ -602,6 +602,25 @@ export const TEST_DATA__DATAPRODUCT__TEST_SUITES = [
             {
               _type: 'accessPointTest',
               accessPointId: 'persons',
+              parameters: [
+                {
+                  name: 'name',
+                  value: {
+                    _type: 'instanceValue',
+                    genericType: {
+                      rawType: {
+                        _type: 'packageableType',
+                        fullPath: 'String',
+                      },
+                    },
+                    multiplicity: {
+                      lowerBound: 1,
+                      upperBound: 1,
+                    },
+                    values: ['Alice'],
+                  },
+                },
+              ],
               assertions: [
                 {
                   _type: 'equalToRelation',

--- a/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__DataProductRoundtrip.ts
+++ b/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__DataProductRoundtrip.ts
@@ -643,8 +643,6 @@ export const TEST_DATA__DATAPRODUCT__TEST_SUITES = [
               accessPointId: 'employees',
               parameters: [
                 {
-                  // Positional style from grammar (e.g. ap('Bob')) is represented
-                  // without a parameter name and must survive roundtrip unchanged.
                   name: '',
                   value: {
                     _type: 'instanceValue',

--- a/packages/legend-graph/src/graph-manager/action/changeDetection/Testable_ObserverHelper.ts
+++ b/packages/legend-graph/src/graph-manager/action/changeDetection/Testable_ObserverHelper.ts
@@ -40,7 +40,10 @@ import {
   observe_ServiceTestSuite,
 } from './DSL_Service_ObserverHelper.js';
 import { FunctionTest } from '../../../graph/metamodel/pure/packageableElements/function/test/FunctionTest.js';
-import { observe_FunctionTest } from './DomainObserverHelper.js';
+import {
+  observe_FunctionParameterValue,
+  observe_FunctionTest,
+} from './DomainObserverHelper.js';
 
 export const observe_DataProductAccessPointTest = skipObserved(
   (metamodel: DataProductAccessPointTest): DataProductAccessPointTest => {
@@ -48,9 +51,11 @@ export const observe_DataProductAccessPointTest = skipObserved(
       id: observable,
       doc: observable,
       accessPointId: observable,
+      parameters: observable,
       assertions: observable,
       hashCode: computed,
     });
+    metamodel.parameters?.forEach(observe_FunctionParameterValue);
     metamodel.assertions.forEach(observe_TestAssertion);
     return metamodel;
   },

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/model/packageableElements/dataProduct/test/V1_AccessPointTest.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/model/packageableElements/dataProduct/test/V1_AccessPointTest.ts
@@ -17,9 +17,11 @@
 import { hashArray, type Hashable } from '@finos/legend-shared';
 import { V1_AtomicTest } from '../../../test/V1_AtomicTest.js';
 import { CORE_HASH_STRUCTURE } from '../../../../../../../../graph/Core_HashUtils.js';
+import type { V1_FunctionParameterValue } from '../../function/test/V1_FunctionTest.js';
 
 export class V1_AccessPointTest extends V1_AtomicTest implements Hashable {
   accessPointId!: string;
+  parameters: V1_FunctionParameterValue[] | undefined;
 
   get hashCode(): string {
     return hashArray([
@@ -27,6 +29,7 @@ export class V1_AccessPointTest extends V1_AtomicTest implements Hashable {
       this.id,
       this.doc ?? '',
       this.accessPointId,
+      this.parameters ? hashArray(this.parameters) : '',
       hashArray(this.assertions),
     ]);
   }

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/from/V1_DataProductTransformer.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/from/V1_DataProductTransformer.ts
@@ -78,6 +78,7 @@ import { V1_AccessPointTest } from '../../../model/packageableElements/dataProdu
 import { V1_DataProductTestSuite } from '../../../model/packageableElements/dataProduct/test/V1_DataProductTestSuite.js';
 import { V1_transformDataResolver } from './V1_DataResolverTransformer.js';
 import { V1_transformTestAssertion } from './V1_TestTransformer.js';
+import { V1_FunctionParameterValue } from '../../../model/packageableElements/function/test/V1_FunctionTest.js';
 
 const transformAccessPoint = (
   ap: AccessPoint,
@@ -144,6 +145,12 @@ export const V1_transformDataProductAccessPointTest = (
   accessPointTest.id = element.id;
   accessPointTest.doc = element.doc;
   accessPointTest.accessPointId = element.accessPointId;
+  accessPointTest.parameters = element.parameters?.map((p) => {
+    const parameterValue = new V1_FunctionParameterValue();
+    parameterValue.name = p.name;
+    parameterValue.value = p.value;
+    return parameterValue;
+  });
   accessPointTest.assertions = element.assertions.map(
     V1_transformTestAssertion,
   );

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/from/V1_DataProductTransformer.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/from/V1_DataProductTransformer.ts
@@ -145,12 +145,14 @@ export const V1_transformDataProductAccessPointTest = (
   accessPointTest.id = element.id;
   accessPointTest.doc = element.doc;
   accessPointTest.accessPointId = element.accessPointId;
-  accessPointTest.parameters = element.parameters?.map((p) => {
-    const parameterValue = new V1_FunctionParameterValue();
-    parameterValue.name = p.name;
-    parameterValue.value = p.value;
-    return parameterValue;
-  });
+  if (element.parameters?.length) {
+    accessPointTest.parameters = element.parameters.map((p) => {
+      const parameterValue = new V1_FunctionParameterValue();
+      parameterValue.name = p.name;
+      parameterValue.value = p.value;
+      return parameterValue;
+    });
+  }
   accessPointTest.assertions = element.assertions.map(
     V1_transformTestAssertion,
   );

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/to/helpers/V1_DataProductBuilder.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/to/helpers/V1_DataProductBuilder.ts
@@ -82,6 +82,7 @@ import { Association } from '../../../../../../../../graph/metamodel/pure/packag
 import { generateFunctionPrettyName } from '../../../../../../../../graph/helpers/PureLanguageHelper.js';
 import { DataProductAccessPointTest } from '../../../../../../../../graph/metamodel/pure/dataProduct/test/DataProductAccessPointTest.js';
 import { DataProductTestSuite } from '../../../../../../../../graph/metamodel/pure/dataProduct/test/DataProductTestSuite.js';
+import { FunctionParameterValue } from '../../../../../../../../graph/metamodel/pure/packageableElements/function/test/FunctionTest.js';
 import { V1_AccessPointTest } from '../../../../model/packageableElements/dataProduct/test/V1_AccessPointTest.js';
 import type { V1_DataProductTestSuite } from '../../../../model/packageableElements/dataProduct/test/V1_DataProductTestSuite.js';
 import { V1_buildDataResolver } from './V1_DataResolverBuilderHelper.js';
@@ -438,6 +439,12 @@ const V1_buildDataProductAccessPointTest = (
   accessPointTest.__parent = parentSuite;
   accessPointTest.doc = element.doc;
   accessPointTest.accessPointId = element.accessPointId;
+  accessPointTest.parameters = element.parameters?.map((param) => {
+    const parameterValue = new FunctionParameterValue();
+    parameterValue.name = param.name;
+    parameterValue.value = param.value;
+    return parameterValue;
+  });
   accessPointTest.assertions = element.assertions.map((assertion) =>
     V1_buildTestAssertion(assertion, accessPointTest, context),
   );

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DataProductSerializationHelper.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DataProductSerializationHelper.ts
@@ -95,6 +95,7 @@ import {
   V1_deserializeDataResolver,
   V1_serializeDataResolver,
 } from './V1_DataResolverSerializationHelper.js';
+import { V1_parameterValueModelSchema } from './V1_FunctionSerializationHelper.js';
 
 export enum V1_AccessPointType {
   LAKEHOUSE = 'lakehouseAccessPoint',
@@ -133,6 +134,7 @@ const V1_accessPointTestModelSchema = createModelSchema(V1_AccessPointTest, {
   ),
   doc: optional(primitive()),
   id: primitive(),
+  parameters: customListWithSchema(V1_parameterValueModelSchema),
 });
 
 const V1_dataProductTestSuiteModelSchema = (

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DataProductSerializationHelper.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/serializationHelpers/V1_DataProductSerializationHelper.ts
@@ -134,7 +134,7 @@ const V1_accessPointTestModelSchema = createModelSchema(V1_AccessPointTest, {
   ),
   doc: optional(primitive()),
   id: primitive(),
-  parameters: customListWithSchema(V1_parameterValueModelSchema),
+  parameters: optionalCustomListWithSchema(V1_parameterValueModelSchema),
 });
 
 const V1_dataProductTestSuiteModelSchema = (

--- a/packages/legend-graph/src/graph/metamodel/pure/dataProduct/test/DataProductAccessPointTest.ts
+++ b/packages/legend-graph/src/graph/metamodel/pure/dataProduct/test/DataProductAccessPointTest.ts
@@ -17,9 +17,11 @@
 import { hashArray, type Hashable } from '@finos/legend-shared';
 import { AtomicTest } from '../../test/Test.js';
 import { CORE_HASH_STRUCTURE } from '../../../../Core_HashUtils.js';
+import type { FunctionParameterValue } from '../../packageableElements/function/test/FunctionTest.js';
 
 export class DataProductAccessPointTest extends AtomicTest implements Hashable {
   accessPointId!: string;
+  parameters: FunctionParameterValue[] | undefined;
 
   get hashCode(): string {
     return hashArray([
@@ -27,6 +29,7 @@ export class DataProductAccessPointTest extends AtomicTest implements Hashable {
       this.id,
       this.doc ?? '',
       this.accessPointId,
+      this.parameters ? hashArray(this.parameters) : '',
       hashArray(this.assertions),
     ]);
   }


### PR DESCRIPTION
### Summary
Add Data Product access point test parameter support in Studio form mode and preserve those parameters through text/form round-trip.

### Changes
Added Data Product access point test parameters to graph metamodel and V1 protocol model.

Wired parameter transform/build/serialization paths so parameters are not dropped.

Added observer support for Data Product test parameters in change detection.

Added Studio UI/state support to view/edit AP test parameters in form mode.

Ensured and fixed roundtrip to be working for access point test parameters

Updated Data Product round-trip fixture to include AP test parameters.