### PR TITLE
fixed limit api calls and dq responsiveness

### DIFF
--- a/.changeset/grumpy-rooms-tease.md
+++ b/.changeset/grumpy-rooms-tease.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+---

--- a/packages/legend-extension-dsl-data-quality/src/components/DataQualityRelationTrialRuns.tsx
+++ b/packages/legend-extension-dsl-data-quality/src/components/DataQualityRelationTrialRuns.tsx
@@ -27,7 +27,7 @@ import {
 } from '@finos/legend-query-builder';
 import { type ExecutionResult } from '@finos/legend-graph';
 import { prettyDuration } from '@finos/legend-shared';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   DATA_QUALITY_VALIDATION_TEST_ID,
   USER_ATTESTATION_MESSAGE,
@@ -138,6 +138,10 @@ export const DataQualityRelationTrialRuns = observer(
     const [previewLimitValue, setPreviewLimitValue] = useState(
       resultState.previewLimit,
     );
+
+    useEffect(() => {
+      setPreviewLimitValue(resultState.previewLimit);
+    }, [resultState]);
 
     const changePreviewLimit: React.ChangeEventHandler<HTMLInputElement> = (
       event,

--- a/packages/legend-extension-dsl-data-quality/src/components/DataQualityRelationValidationConfigurationEditor.tsx
+++ b/packages/legend-extension-dsl-data-quality/src/components/DataQualityRelationValidationConfigurationEditor.tsx
@@ -24,9 +24,10 @@ import {
 import {
   DATA_QUALITY_RELATION_VALIDATION_EDITOR_TAB,
   DataQualityRelationValidationConfigurationState,
+  DEFAULT_QUERY_LIMIT,
   EXECUTION_TYPE,
 } from './states/DataQualityRelationValidationConfigurationState.js';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   BlankPanelContent,
   CaretDownIcon,
@@ -458,6 +459,17 @@ export const DataQualityRelationValidationConfigurationEditor = observer(() => {
     dataQualityRelationValidationConfigurationState.isRunning ||
     dataQualityRelationValidationConfigurationState.isGeneratingPlan;
 
+  const [limitValue, setLimitValue] = useState(
+    dataQualityRelationValidationConfigurationState.queryLimit,
+  );
+
+  const commitLimit = (): void => {
+    const val =
+      isNaN(limitValue) || limitValue < 1 ? DEFAULT_QUERY_LIMIT : limitValue;
+    setLimitValue(val);
+    dataQualityRelationValidationConfigurationState.setQueryLimit(val);
+  };
+
   const cancelRun = applicationStore.guardUnhandledError(() =>
     flowResult(dataQualityRelationValidationConfigurationState.cancelRun()),
   );
@@ -540,6 +552,26 @@ export const DataQualityRelationValidationConfigurationEditor = observer(() => {
         {selectedTab ===
           DATA_QUALITY_RELATION_VALIDATION_EDITOR_TAB.DEFINITION && (
           <div className="relation-validation-config-editor__actions-bar">
+            <div className="relation-validation-config-editor__actions-bar__limit">
+              <div className="relation-validation-config-editor__actions-bar__limit__label">
+                preview row limit
+              </div>
+              <input
+                className="input--dark relation-validation-config-editor__actions-bar__limit__input"
+                spellCheck={false}
+                type="number"
+                value={Number.isNaN(limitValue) ? '' : limitValue}
+                min={1}
+                placeholder={DEFAULT_QUERY_LIMIT.toString()}
+                onChange={(e) => setLimitValue(parseInt(e.target.value, 10))}
+                onBlur={commitLimit}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    commitLimit();
+                  }
+                }}
+              />
+            </div>
             <div className="btn__dropdown-combo btn__dropdown-combo--primary">
               {dataQualityRelationValidationConfigurationState.isRunning ? (
                 <button

--- a/packages/legend-extension-dsl-data-quality/src/components/DataQualityResultPanel.tsx
+++ b/packages/legend-extension-dsl-data-quality/src/components/DataQualityResultPanel.tsx
@@ -41,7 +41,7 @@ import {
   isNonNullable,
   prettyDuration,
 } from '@finos/legend-shared';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DATA_QUALITY_VALIDATION_TEST_ID } from './constants/DataQualityConstants.js';
 import {
   BlankPanelContent,
@@ -166,6 +166,10 @@ export const DataQualityResultPanel = observer(
     const [previewLimitValue, setPreviewLimitValue] = useState(
       resultState.previewLimit,
     );
+
+    useEffect(() => {
+      setPreviewLimitValue(resultState.previewLimit);
+    }, [resultState]);
 
     const changePreviewLimit: React.ChangeEventHandler<HTMLInputElement> = (
       event,

--- a/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityRelationComparisonConfigurationState.ts
+++ b/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityRelationComparisonConfigurationState.ts
@@ -617,6 +617,7 @@ export class DataQualityRelationComparisonConfigurationState extends ElementEdit
           source: sourceExecutionLambda,
           target: targetExecutionLambda,
           keys: this.element.keys,
+          limit: this.limit,
           colsForHash: this.element.columnsToCompare,
           sourceLambdaParameterValues: sourceParamValues,
         });
@@ -625,6 +626,7 @@ export class DataQualityRelationComparisonConfigurationState extends ElementEdit
           source: sourceExecutionLambda,
           target: targetExecutionLambda,
           keys: this.element.keys,
+          limit: this.limit,
           colsForHash: this.element.columnsToCompare,
           targetLambdaParameterValues: targetParamValues,
         });

--- a/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityRelationValidationConfigurationState.ts
+++ b/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityRelationValidationConfigurationState.ts
@@ -89,6 +89,8 @@ export enum DATA_QUALITY_RELATION_VALIDATION_EDITOR_TAB {
   TRIAL_RUN = 'Trial Run',
 }
 
+export const DEFAULT_QUERY_LIMIT = 1000;
+
 export enum EXECUTION_TYPE {
   EXECUTION = 'EXECUTION',
   PROFILING = 'PROFILING',
@@ -292,6 +294,7 @@ export class DataQualityRelationValidationConfigurationState extends ElementEdit
   isSuggestionPanelOpen = false;
   relationTypeMetadata: RelationTypeMetadata = new RelationTypeMetadata();
   lastRelationColumnsQueryHash: string | undefined = undefined;
+  queryLimit = DEFAULT_QUERY_LIMIT;
 
   constructor(
     editorStore: EditorStore,
@@ -310,6 +313,7 @@ export class DataQualityRelationValidationConfigurationState extends ElementEdit
       lastExecutionType: observable,
       isSuggestionPanelOpen: observable,
       validationStates: observable,
+      queryLimit: observable,
       setSelectedTab: action,
       setRunPromise: action,
       setExecutionResult: action,
@@ -320,6 +324,7 @@ export class DataQualityRelationValidationConfigurationState extends ElementEdit
       applySuggestion: action,
       modifyExistingSuggestion: action,
       deleteValidationState: action,
+      setQueryLimit: action,
       validationElement: computed,
       relationValidationOptions: computed,
       checkForStaleResults: computed,
@@ -470,6 +475,10 @@ export class DataQualityRelationValidationConfigurationState extends ElementEdit
     }
   }
 
+  setQueryLimit(queryLimit: number): void {
+    this.queryLimit = Math.max(1, queryLimit);
+  }
+
   setRunPromise = (promise: Promise<ExecutionResult> | undefined): void => {
     this.runPromise = promise;
   };
@@ -574,6 +583,7 @@ export class DataQualityRelationValidationConfigurationState extends ElementEdit
           : extension.execute(model, packagePath, {
               ...options,
               runQuery: true,
+              queryLimit: this.queryLimit,
             });
 
       this.setRunPromise(promise);

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DSL_Data_Quality_PureGraphManagerExtension.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DSL_Data_Quality_PureGraphManagerExtension.ts
@@ -90,6 +90,7 @@ export class V1_DQExecuteInput {
   lambdaParameterValues: V1_ParameterValue[] = [];
   packagePath!: string;
   defectsLimit: number | undefined;
+  queryLimit: number | undefined;
   allValidationsChecked: boolean | undefined;
   validationName: string | undefined;
   runQuery: boolean | undefined;
@@ -101,6 +102,7 @@ export class V1_DQExecuteInput {
       lambdaParameterValues: customListWithSchema(V1_parameterValueModelSchema),
       packagePath: primitive(),
       defectsLimit: optional(primitive()),
+      queryLimit: optional(primitive()),
       validationName: optional(primitive()),
       runQuery: optional(primitive()),
     }),
@@ -131,6 +133,7 @@ export class V1_DQReconciliationInput {
   keys: string[] = [];
   colsForHash: string[] = [];
   defectLimit: number | undefined;
+  queryLimit: number | undefined;
   aggregatedHash: boolean | undefined;
   sourceHashCol: string | undefined;
   targetHashCol: string | undefined;
@@ -149,6 +152,7 @@ export class V1_DQReconciliationInput {
       keys: list(primitive()),
       colsForHash: list(primitive()),
       defectLimit: optional(primitive()),
+      queryLimit: optional(primitive()),
       aggregatedHash: optional(primitive()),
       sourceHashCol: optional(primitive()),
       targetHashCol: optional(primitive()),
@@ -285,6 +289,9 @@ export class V1_DSL_Data_Quality_PureGraphManagerExtension extends DSL_DataQuali
     dqExecuteInput.packagePath = packagePath;
     dqExecuteInput.defectsLimit = options.previewLimit;
     dqExecuteInput.runQuery = options.runQuery;
+    if (options.runQuery) {
+      dqExecuteInput.queryLimit = options.queryLimit;
+    }
     if (!options.allValidationsChecked) {
       dqExecuteInput.validationName = options.validationName;
     }
@@ -631,17 +638,23 @@ export class V1_DSL_Data_Quality_PureGraphManagerExtension extends DSL_DataQuali
     input.model = graph.origin
       ? this.buildPureModelSDLCPointer(graph.origin, undefined)
       : this.graphManager.getFullGraphModelData(graph);
+    const runningSourceOrTargetQuery =
+      options.runSourceQuery ?? options.runTargetQuery;
     input.source = this.rawLambdaToV1(options.source);
     input.target = this.rawLambdaToV1(options.target);
     input.keys = options.keys;
     input.colsForHash = options.colsForHash;
-    input.defectLimit = options.limit;
     input.aggregatedHash = options.aggregatedHash;
     input.sourceHashCol = options.sourceHashCol;
     input.targetHashCol = options.targetHashCol;
     input.includeColumnValues = options.includeColumnValues;
     input.runSourceQuery = options.runSourceQuery;
     input.runTargetQuery = options.runTargetQuery;
+    if (runningSourceOrTargetQuery) {
+      input.queryLimit = options.limit;
+    } else {
+      input.defectLimit = options.limit;
+    }
     if (options.sourceLambdaParameterValues) {
       input.sourceLambdaParameterValues =
         options.sourceLambdaParameterValues.map(V1_transformParameterValue);

--- a/packages/legend-extension-dsl-data-quality/src/graph/metamodel/pure/packageableElements/data-quality/DataQualityValidationConfiguration.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph/metamodel/pure/packageableElements/data-quality/DataQualityValidationConfiguration.ts
@@ -42,6 +42,7 @@ export interface DQExecuteInputOptions {
   allValidationsChecked?: boolean | undefined;
   validationName?: string | undefined;
   previewLimit?: number | undefined;
+  queryLimit?: number | undefined;
   runQuery?: boolean | undefined;
   serializationFormat?: EXECUTION_SERIALIZATION_FORMAT | undefined;
 }

--- a/packages/legend-extension-dsl-data-quality/style/_data-quality-relation-comparison-editor.scss
+++ b/packages/legend-extension-dsl-data-quality/style/_data-quality-relation-comparison-editor.scss
@@ -55,7 +55,6 @@
     justify-content: end;
     gap: 1rem;
     background: var(--color-bg-app);
-    margin-top: 2rem;
     height: 4rem;
     padding-top: 0.5rem;
 

--- a/packages/legend-extension-dsl-data-quality/style/_data-quality-relation-validation-builder.scss
+++ b/packages/legend-extension-dsl-data-quality/style/_data-quality-relation-validation-builder.scss
@@ -324,11 +324,42 @@
 
   &__actions-bar {
     display: flex;
-    justify-content: end;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1rem;
     background: var(--color-bg-app);
-    margin-top: 2rem;
     height: 4rem;
     padding-top: 0.5rem;
+
+    &__limit {
+      @include flexVCenter;
+
+      flex-shrink: 0;
+      height: 2.8rem;
+    }
+
+    &__limit__label {
+      @include flexVCenter;
+
+      height: 100%;
+      padding: 0 1rem;
+      background: var(--color-dark-grey-280);
+      border-radius: 0.2rem 0 0 0.2rem;
+      color: var(--color-light-grey-300);
+      font-size: 1.2rem;
+      text-transform: lowercase;
+      white-space: nowrap;
+    }
+
+    &__limit__input {
+      width: 7rem;
+      height: 2.8rem;
+      padding: 0 0.8rem;
+      color: var(--color-light-grey-150);
+      background: var(--color-dark-grey-100);
+      border: 0.1rem solid var(--color-dark-grey-300);
+      border-radius: 0.2rem;
+    }
 
     &__cancel-btn {
       padding-right: 2rem;

--- a/packages/legend-extension-dsl-data-quality/style/_data-quality-validation-builder.scss
+++ b/packages/legend-extension-dsl-data-quality/style/_data-quality-validation-builder.scss
@@ -1249,6 +1249,8 @@
   display: flex;
   padding-top: 2px;
   margin-right: 0.5rem;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .data-quality-validation__result__stale-status__icon,
@@ -1335,6 +1337,10 @@
 
   .panel__header {
     margin-right: 0.5rem;
+    height: auto;
+    min-height: 2.8rem;
+    flex-wrap: wrap;
+    gap: 0.3rem 0;
   }
 
   &__content {
@@ -1348,6 +1354,9 @@
     color: var(--color-text-muted);
     margin-left: 0.5rem;
     font-family: 'Roboto Mono', monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__stale-status {
@@ -1423,6 +1432,7 @@
 
     height: 100%;
     padding: 0 0.5rem;
+    flex-shrink: 0;
 
     &__label {
       @include flexCenter;
@@ -1433,6 +1443,7 @@
       border-radius: 0.2rem 0 0 0.2rem;
       font-size: 1.2rem;
       user-select: none;
+      white-space: nowrap;
     }
 
     &__input {
@@ -1454,6 +1465,8 @@
 
     height: 100%;
     padding: 0 0.5rem;
+    flex-shrink: 1;
+    min-width: 0;
 
     &__label {
       @include flexCenter;
@@ -1464,6 +1477,7 @@
       border-radius: 0.2rem 0 0 0.2rem;
       font-size: 1.2rem;
       user-select: none;
+      white-space: nowrap;
     }
 
     &__input {
@@ -1479,6 +1493,8 @@
     }
 
     &__dropdown {
+      min-width: 15rem;
+      max-width: 25rem;
       width: 25rem;
     }
   }
@@ -1570,6 +1586,11 @@
 
   &__header__actions {
     @include flexVCenter;
+
+    height: 2.8rem;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.5rem;
+    justify-content: flex-end;
   }
 
   &__sql__actions {
@@ -1619,6 +1640,7 @@
   &__execute-btn {
     margin: 0 0.3rem;
     height: 100%;
+    flex-shrink: 0;
 
     & &__btn {
       height: 100%;
@@ -1651,6 +1673,7 @@
     }
 
     &__validation {
+      min-width: 10rem;
       width: 12rem;
     }
   }
@@ -1660,6 +1683,7 @@
 
     margin-left: 0.5rem;
     height: 100%;
+    flex-shrink: 0;
     border: 0.1rem solid var(--color-border-default);
     background: var(--color-bg-elevated);
     color: var(--color-text-primary);


### PR DESCRIPTION
## Summary

- Adds functionality for users to specify a limit when querying recon source query, recon target query and dq base query. 
- Fixed responsiveness for dq trial run page

## How did you test this change?

- [x] Manual testing 
