### PR TITLE
feat: add plan generation functionality to data quality reconciliation

### DIFF
--- a/.changeset/small-dogs-unite.md
+++ b/.changeset/small-dogs-unite.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+---

--- a/packages/legend-extension-dsl-data-quality/src/components/DataQualityRelationComparisonEditor.tsx
+++ b/packages/legend-extension-dsl-data-quality/src/components/DataQualityRelationComparisonEditor.tsx
@@ -58,6 +58,7 @@ import {
 } from '@finos/legend-application';
 import {
   BasicValueSpecificationEditor,
+  ExecutionPlanViewer,
   LambdaEditor,
   LambdaParameterValuesEditor,
   type LambdaParameterState,
@@ -256,7 +257,7 @@ export const DataQualityRelationComparisonEditor = observer(() => {
   const targetColumnOptions = state.targetColumnOptions;
   const combinedColumnOptions = state.combinedColumnOptions;
 
-  const isRunning = state.isRunning;
+  const isRunning = state.isRunning || state.isGeneratingPlan;
   const executionResult = state.executionResult;
   const isFetchingColumns = state.fetchColumnsState.isInProgress;
   const hasColumnFetchError = state.hasColumnFetchError;
@@ -279,6 +280,10 @@ export const DataQualityRelationComparisonEditor = observer(() => {
 
   const runTargetQuery = applicationStore.guardUnhandledError(() =>
     flowResult(state.handleRun(RECONCILIATION_EXECUTION_TYPE.TARGET_QUERY)),
+  );
+
+  const generatePlan = applicationStore.guardUnhandledError(() =>
+    flowResult(state.generatePlan()),
   );
 
   const retryFetchColumns = applicationStore.guardUnhandledError(() =>
@@ -464,6 +469,18 @@ export const DataQualityRelationComparisonEditor = observer(() => {
     );
   }, [combinedColumnOptions, comparison.columnsToCompare]);
 
+  // Keys are implicitly included in the comparison, so hide them from the
+  // "Columns to Compare" dropdown options. However, to avoid breaking existing
+  // flows where the same field was put in both lists, keep any column that is
+  // currently selected as a "column to compare" visible even if it is also a key.
+  const columnsToCompareOptions = useMemo(() => {
+    const keySet = new Set(comparison.keys);
+    const selectedColumns = new Set(comparison.columnsToCompare);
+    return combinedColumnOptions.filter(
+      ({ value }) => !keySet.has(value) || selectedColumns.has(value),
+    );
+  }, [combinedColumnOptions, comparison.keys, comparison.columnsToCompare]);
+
   return (
     <div className="data-quality-relation-comparison-editor">
       <Panel>
@@ -540,6 +557,12 @@ export const DataQualityRelationComparisonEditor = observer(() => {
                         onClick={runTargetQuery}
                       >
                         Run Target Query
+                      </MenuContentItem>
+                      <MenuContentItem
+                        className="btn__dropdown-combo__option"
+                        onClick={generatePlan}
+                      >
+                        Generate Plan
                       </MenuContentItem>
                     </MenuContent>
                   }
@@ -687,7 +710,7 @@ export const DataQualityRelationComparisonEditor = observer(() => {
                     values.map((option) => option.value),
                   )
                 }
-                options={combinedColumnOptions}
+                options={columnsToCompareOptions}
                 placeholder="Select columns to compare..."
                 disabled={columnsDisabled}
                 darkMode={darkMode}
@@ -751,13 +774,15 @@ export const DataQualityRelationComparisonEditor = observer(() => {
                 </div>
                 {isRunning && (
                   <div className="data-quality-relation-comparison-editor__result__status">
-                    {state.currentExecutionType ===
-                    RECONCILIATION_EXECUTION_TYPE.RECONCILIATION
-                      ? 'Running Data Comparison...'
+                    {state.isGeneratingPlan
+                      ? 'Generating Plan...'
                       : state.currentExecutionType ===
-                          RECONCILIATION_EXECUTION_TYPE.SOURCE_QUERY
-                        ? 'Running Source Query...'
-                        : 'Running Target Query...'}
+                          RECONCILIATION_EXECUTION_TYPE.RECONCILIATION
+                        ? 'Running Data Comparison...'
+                        : state.currentExecutionType ===
+                            RECONCILIATION_EXECUTION_TYPE.SOURCE_QUERY
+                          ? 'Running Source Query...'
+                          : 'Running Target Query...'}
                   </div>
                 )}
                 <div className="data-quality-relation-comparison-editor__result__analytics">
@@ -790,6 +815,7 @@ export const DataQualityRelationComparisonEditor = observer(() => {
       {state.comparisonParametersEditorState.showModal && (
         <DataQualityRelationComparisonParametersEditor state={state} />
       )}
+      <ExecutionPlanViewer executionPlanState={state.executionPlanState} />
     </div>
   );
 });

--- a/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityRelationComparisonConfigurationState.ts
+++ b/packages/legend-extension-dsl-data-quality/src/components/states/DataQualityRelationComparisonConfigurationState.ts
@@ -30,6 +30,7 @@ import {
   type PackageableElement,
   type ExecutionResult,
   type RawLambda,
+  type RawExecutionPlan,
   RawVariableExpression,
   buildSourceInformationSourceId,
   buildLambdaVariableExpressions,
@@ -54,6 +55,7 @@ import {
 import {
   buildExecutionParameterValues,
   doesLambdaParameterStateContainFunctionValues,
+  ExecutionPlanState,
   ParameterInstanceValuesEditorState,
   LambdaEditorState,
   LambdaParametersState,
@@ -295,6 +297,10 @@ export class DataQualityRelationComparisonConfigurationState extends ElementEdit
   targetParametersState: ComparisonParametersState;
   comparisonParametersEditorState = new ParameterInstanceValuesEditorState();
 
+  // Plan generation state
+  isGeneratingPlan = false;
+  executionPlanState: ExecutionPlanState;
+
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
 
@@ -316,6 +322,11 @@ export class DataQualityRelationComparisonConfigurationState extends ElementEdit
 
     this.sourceParametersState = new ComparisonParametersState(this);
     this.targetParametersState = new ComparisonParametersState(this);
+
+    this.executionPlanState = new ExecutionPlanState(
+      this.editorStore.applicationStore,
+      this.editorStore.graphManagerState,
+    );
 
     makeObservable(this, {
       setKeys: action,
@@ -355,6 +366,8 @@ export class DataQualityRelationComparisonConfigurationState extends ElementEdit
       handleRun: flow,
       run: flow,
       cancelRun: flow,
+      generatePlan: flow,
+      isGeneratingPlan: observable,
       openComparisonParametersModal: action,
     });
   }
@@ -668,6 +681,52 @@ export class DataQualityRelationComparisonConfigurationState extends ElementEdit
         LogEvent.create(GRAPH_MANAGER_EVENT.EXECUTION_FAILURE),
         error,
       );
+    }
+  }
+
+  *generatePlan(): GeneratorFn<void> {
+    if (this.isGeneratingPlan) {
+      return;
+    }
+    try {
+      this.isGeneratingPlan = true;
+      const model = this.editorStore.graphManagerState.graph;
+      const md5Strategy = guaranteeType(this.element.strategy, MD5HashStrategy);
+      const extension = getDataQualityPureGraphManagerExtension(
+        this.editorStore.graphManagerState.graphManager,
+      );
+      const rawPlan = (yield extension.generateReconciliationPlan(model, {
+        source: this.buildSourceLambda(),
+        target: this.buildTargetLambda(),
+        keys: this.element.keys,
+        colsForHash: this.element.columnsToCompare,
+        limit: this.limit,
+        aggregatedHash: md5Strategy.aggregatedHash,
+        sourceHashCol: md5Strategy.sourceHashColumn,
+        targetHashCol: md5Strategy.targetHashColumn,
+        includeColumnValues: true,
+      })) as RawExecutionPlan;
+
+      try {
+        this.executionPlanState.setRawPlan(rawPlan);
+        const plan =
+          this.editorStore.graphManagerState.graphManager.buildExecutionPlan(
+            rawPlan,
+            this.editorStore.graphManagerState.graph,
+          );
+        this.executionPlanState.initialize(plan);
+      } catch {
+        //do nothing
+      }
+    } catch (error) {
+      assertErrorThrown(error);
+      this.editorStore.applicationStore.logService.error(
+        LogEvent.create(GRAPH_MANAGER_EVENT.EXECUTION_FAILURE),
+        error,
+      );
+      this.editorStore.applicationStore.notificationService.notifyError(error);
+    } finally {
+      this.isGeneratingPlan = false;
     }
   }
 

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureGraphManagerExtension.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/DSL_DataQuality_PureGraphManagerExtension.ts
@@ -92,6 +92,11 @@ export abstract class DSL_DataQuality_PureGraphManagerExtension extends Abstract
     graph: PureModel,
     options: DQReconciliationInputOptions,
   ): Promise<ExecutionResult>;
+
+  abstract generateReconciliationPlan(
+    graph: PureModel,
+    options: DQReconciliationInputOptions,
+  ): Promise<RawExecutionPlan>;
 }
 
 export const getDataQualityPureGraphManagerExtension = (

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DSL_Data_Quality_PureGraphManagerExtension.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DSL_Data_Quality_PureGraphManagerExtension.ts
@@ -83,6 +83,7 @@ const DQ_FETCH_RULE_SUGGESTIONS = 'fetch rule suggestions';
 const DQ_DEBUG_EXECUTION_PLAN = 'debug execution plan';
 const DQ_FETCH_PROPERTY_PATH_TREE = 'dq fetch property path tree';
 const DQ_EXECUTE_RECONCILIATION = 'execute reconciliation';
+const DQ_GENERATE_RECONCILIATION_PLAN = 'generate reconciliation plan';
 
 export class V1_DQExecuteInput {
   clientVersion: string | undefined;
@@ -697,6 +698,32 @@ export class V1_DSL_Data_Quality_PureGraphManagerExtension extends DSL_DataQuali
       runTargetQuery: true,
     });
     return this.runReconciliationWithInput(input);
+  };
+
+  generateReconciliationPlan = async (
+    graph: PureModel,
+    options: DQReconciliationInputOptions,
+  ): Promise<RawExecutionPlan> => {
+    const input = this.createReconciliationInput(graph, options);
+    const serializedInput =
+      V1_DQReconciliationInput.serialization.toJson(input);
+
+    // TODO: improve abstraction so that we do not need to access the engine server client directly
+    const engineServerClient = guaranteeType(
+      this.graphManager.engine,
+      V1_RemoteEngine,
+      'generateReconciliationPlan is only supported by remote engine',
+    ).getEngineServerClient();
+
+    return engineServerClient.postWithTracing(
+      engineServerClient.getTraceData(DQ_GENERATE_RECONCILIATION_PLAN),
+      `${engineServerClient._pure()}/dataquality/reconciliation/generatePlan`,
+      serializedInput,
+      {},
+      undefined,
+      undefined,
+      { enableCompression: true },
+    );
   };
 
   private async runReconciliationWithInput(


### PR DESCRIPTION
- On recon page adds button in dropdown to generate plan for recon lamda
- When users select columnsToCompare in recon form mode, we filter out columns already selected in keys, however keep it backwards compatible so if user already has a column in keys and columns to compare it should still work. 