### PR TITLE
Remove runtime or accessors requirement from adding function tests

### DIFF
--- a/.changeset/goofy-stamps-float.md
+++ b/.changeset/goofy-stamps-float.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Remove runtime or accessors requirement from adding function tests

--- a/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/data-editor/RelationElementsDataEditor.tsx
@@ -30,7 +30,7 @@ import {
   clsx,
   CustomSelectorInput,
 } from '@finos/legend-art';
-import { RelationElement } from '@finos/legend-graph';
+import { RelationElement, RelationRowTestData } from '@finos/legend-graph';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import type {
   RelationElementsDataState,
@@ -99,7 +99,9 @@ const NewRelationElementModal = observer(
           const relationElement = new RelationElement();
           relationElement.paths = [option.value];
           relationElement.columns = option.columns;
-          relationElement.rows = [];
+          const emptyRow = new RelationRowTestData();
+          emptyRow.values = option.columns.map(() => '');
+          relationElement.rows = [emptyRow];
           dataState.addRelationElement(relationElement);
         }
       } else {
@@ -110,7 +112,7 @@ const NewRelationElementModal = observer(
         }
         const relationElement = new RelationElement();
         relationElement.columns = [];
-        relationElement.rows = [];
+        relationElement.rows = [new RelationRowTestData()];
         relationElement.paths = path;
         dataState.addRelationElement(relationElement);
       }

--- a/packages/legend-application-studio/src/components/editor/editor-group/function-activator/__tests__/FunctionActivator.test.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/function-activator/__tests__/FunctionActivator.test.tsx
@@ -16,10 +16,16 @@
 
 import { expect, test } from '@jest/globals';
 import { MockedMonacoEditorInstance } from '@finos/legend-lego/code-editor/test';
-import { createSpy, integrationTest } from '@finos/legend-shared/test';
+import {
+  createSpy,
+  integrationTest,
+  type TEMPORARY__JestMatcher,
+} from '@finos/legend-shared/test';
+import { noop } from '@finos/legend-shared';
 import {
   fireEvent,
   getByDisplayValue,
+  getByPlaceholderText,
   getByText,
   getByTitle,
   queryByRole,
@@ -30,6 +36,7 @@ import {
   TEST__setUpEditorWithDefaultSDLCData,
 } from '../../../__test-utils__/EditorComponentTestUtils.js';
 import TEST_DATA__SimpleRelationalModel from './TEST_DATA__SimpleRelationalEntities.json' with { type: 'json' };
+import TEST_DATA__DataProductQueryEntities from './TEST_DATA__DataProductQueryEntities.json' with { type: 'json' };
 import { LEGEND_STUDIO_TEST_ID } from '../../../../../__lib__/LegendStudioTesting.js';
 import {
   type V1_PureGraphManager,
@@ -38,6 +45,7 @@ import {
 import { LegendStudioPluginManager } from '../../../../../application/LegendStudioPluginManager.js';
 import { TEST_DATA_SimpleSnowflakeArtifact } from './TEST_DATA_SimpleSnowflakeArtifact.js';
 import { SnowflakeAppFunctionActivatorEdtiorState } from '../../../../../stores/editor/editor-state/element-editor-state/function-activator/SnowflakeAppFunctionActivatorEditorState.js';
+import { FunctionEditorState } from '../../../../../stores/editor/editor-state/element-editor-state/FunctionEditorState.js';
 
 const pluginManager = LegendStudioPluginManager.create();
 pluginManager.usePresets([new Core_GraphManagerPreset()]).install();
@@ -186,3 +194,111 @@ test(integrationTest('Test change detection in function editor'), async () => {
 
   expect(functionChange).toBeDefined();
 });
+
+test(
+  integrationTest(
+    'Create function test suite warns (not errors) when query has no runtime or accessors',
+  ),
+  async () => {
+    const MOCK__editorStore = TEST__provideMockedEditorStore({
+      pluginManager,
+    });
+    const renderResult = await TEST__setUpEditorWithDefaultSDLCData(
+      MOCK__editorStore,
+      {
+        entities: TEST_DATA__DataProductQueryEntities,
+      },
+    );
+    MockedMonacoEditorInstance.getValue.mockReturnValue('');
+    MockedMonacoEditorInstance.getRawOptions.mockReturnValue({
+      readOnly: true,
+    });
+
+    const functionPath = 'com::entity::appendOnlyQuery__Relation_1_';
+    const functionElement =
+      MOCK__editorStore.graphManagerState.graph.getFunction(functionPath);
+
+    // Navigate via the explorer tree to open the function editor
+    const explorerTree = renderResult.getByTestId(
+      LEGEND_STUDIO_TEST_ID.EXPLORER_TREES,
+    );
+    fireEvent.click(getByText(explorerTree, 'com'));
+    await waitFor(() => getByText(explorerTree, 'entity'));
+    fireEvent.click(getByText(explorerTree, 'entity'));
+    const functionDisplayName = 'appendOnlyQuery():Relation<Any>[1]';
+    await waitFor(() => getByText(explorerTree, functionDisplayName));
+    fireEvent.click(getByText(explorerTree, functionDisplayName));
+
+    const functionEditor = await waitFor(() =>
+      renderResult.getByTestId(LEGEND_STUDIO_TEST_ID.FUNCTION_EDITOR),
+    );
+    const functionEditorState =
+      MOCK__editorStore.tabManagerState.getCurrentEditorState(
+        FunctionEditorState,
+      );
+
+    // Sanity check: the function has no runtime binding (the warning scenario)
+    expect(
+      functionEditorState.functionTestableEditorState.associatedRuntimes
+        ?.length ?? 0,
+    ).toBe(0);
+
+    // Navigate to the Test Suites tab
+    fireEvent.click(getByText(functionEditor, 'Test Suites'));
+
+    const testSuitesPanel = await waitFor(() =>
+      renderResult.getByTestId(LEGEND_STUDIO_TEST_ID.EDITOR_GROUP_CONTENT),
+    );
+
+    // Spy on notifications BEFORE triggering suite creation
+    const warnSpy = createSpy(
+      MOCK__editorStore.applicationStore.notificationService,
+      'notifyWarning',
+    ).mockImplementation(noop);
+    const errorSpy = createSpy(
+      MOCK__editorStore.applicationStore.notificationService,
+      'notifyError',
+    ).mockImplementation(noop);
+
+    // Open the Create Function Test Suite modal via the blank placeholder
+    fireEvent.click(getByText(testSuitesPanel, 'Add Test Suite'));
+    const createSuiteModal = await waitFor(() =>
+      renderResult.getByRole('dialog'),
+    );
+    expect(
+      getByText(createSuiteModal, 'Create Function Test Suite'),
+    ).toBeDefined();
+
+    // Fill in suite + test names
+    const suiteNameInput = getByPlaceholderText(createSuiteModal, 'Suite Name');
+    fireEvent.change(suiteNameInput, { target: { value: 'mySuite' } });
+    const testNameInput = getByPlaceholderText(createSuiteModal, 'Test Name');
+    fireEvent.change(testNameInput, { target: { value: 'myTest' } });
+
+    // Click Create - should warn (not error) and still create the suite
+    fireEvent.click(getByText(createSuiteModal, 'Create'));
+
+    await waitFor(() =>
+      expect(warnSpy as TEMPORARY__JestMatcher).toHaveBeenCalled(),
+    );
+    const warnMessages = (
+      warnSpy as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls.map((args) => String(args[0]));
+    expect(
+      warnMessages.some((msg) =>
+        msg.includes(
+          'No runtime or accessors found, or they could not be resolved. For Relational (non-Lakehouse) function testing, please ensure that your query is bound to a runtime',
+        ),
+      ),
+    ).toBe(true);
+    expect(errorSpy as TEMPORARY__JestMatcher).not.toHaveBeenCalled();
+
+    // The suite should have been created on the function despite the warning
+    await waitFor(() =>
+      expect(functionElement.tests.length).toBeGreaterThan(0),
+    );
+    const createdSuite = functionElement.tests[0];
+    expect(createdSuite?.id).toBe('mySuite');
+    expect(createdSuite?.tests[0]?.id).toBe('myTest');
+  },
+);

--- a/packages/legend-application-studio/src/components/editor/editor-group/function-activator/__tests__/TEST_DATA__DataProductQueryEntities.json
+++ b/packages/legend-application-studio/src/components/editor/editor-group/function-activator/__tests__/TEST_DATA__DataProductQueryEntities.json
@@ -1,0 +1,550 @@
+[
+  {
+    "path": "com::entity::LegalEntity",
+    "content": {
+      "_type": "class",
+      "name": "LegalEntity",
+      "package": "com::entity",
+      "properties": [
+        {
+          "genericType": {
+            "rawType": {
+              "_type": "packageableType",
+              "fullPath": "String"
+            }
+          },
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "entityId"
+        },
+        {
+          "genericType": {
+            "rawType": {
+              "_type": "packageableType",
+              "fullPath": "String"
+            }
+          },
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "name"
+        }
+      ]
+    },
+    "classifierPath": "meta::pure::metamodel::type::Class"
+  },
+  {
+    "path": "com::entity::appendOnlyQuery__Relation_1_",
+    "content": {
+      "_type": "function",
+      "body": [
+        {
+          "_type": "func",
+          "function": "with",
+          "parameters": [
+            {
+              "_type": "func",
+              "function": "project",
+              "parameters": [
+                {
+                  "_type": "func",
+                  "function": "getAll",
+                  "parameters": [
+                    {
+                      "_type": "packageableElementPtr",
+                      "fullPath": "com::entity::LegalEntity",
+                      "sourceInformation": {
+                        "endColumn": 26,
+                        "endLine": 58,
+                        "sourceId": "",
+                        "startColumn": 3,
+                        "startLine": 58
+                      }
+                    }
+                  ],
+                  "sourceInformation": {
+                    "endColumn": 32,
+                    "endLine": 58,
+                    "sourceId": "",
+                    "startColumn": 27,
+                    "startLine": 58
+                  }
+                },
+                {
+                  "_type": "classInstance",
+                  "sourceInformation": {
+                    "endColumn": 6,
+                    "endLine": 62,
+                    "sourceId": "",
+                    "startColumn": 6,
+                    "startLine": 59
+                  },
+                  "type": "colSpecArray",
+                  "value": {
+                    "colSpecs": [
+                      {
+                        "function1": {
+                          "_type": "lambda",
+                          "body": [
+                            {
+                              "_type": "property",
+                              "parameters": [
+                                {
+                                  "_type": "var",
+                                  "name": "x",
+                                  "sourceInformation": {
+                                    "endColumn": 21,
+                                    "endLine": 60,
+                                    "sourceId": "",
+                                    "startColumn": 20,
+                                    "startLine": 60
+                                  }
+                                }
+                              ],
+                              "property": "entityId",
+                              "sourceInformation": {
+                                "endColumn": 30,
+                                "endLine": 60,
+                                "sourceId": "",
+                                "startColumn": 23,
+                                "startLine": 60
+                              }
+                            }
+                          ],
+                          "parameters": [
+                            {
+                              "_type": "var",
+                              "name": "x"
+                            }
+                          ],
+                          "sourceInformation": {
+                            "endColumn": 30,
+                            "endLine": 60,
+                            "sourceId": "",
+                            "startColumn": 19,
+                            "startLine": 60
+                          }
+                        },
+                        "name": "entityId",
+                        "sourceInformation": {
+                          "endColumn": 30,
+                          "endLine": 60,
+                          "sourceId": "",
+                          "startColumn": 8,
+                          "startLine": 60
+                        }
+                      },
+                      {
+                        "function1": {
+                          "_type": "lambda",
+                          "body": [
+                            {
+                              "_type": "property",
+                              "parameters": [
+                                {
+                                  "_type": "var",
+                                  "name": "x",
+                                  "sourceInformation": {
+                                    "endColumn": 17,
+                                    "endLine": 61,
+                                    "sourceId": "",
+                                    "startColumn": 16,
+                                    "startLine": 61
+                                  }
+                                }
+                              ],
+                              "property": "name",
+                              "sourceInformation": {
+                                "endColumn": 22,
+                                "endLine": 61,
+                                "sourceId": "",
+                                "startColumn": 19,
+                                "startLine": 61
+                              }
+                            }
+                          ],
+                          "parameters": [
+                            {
+                              "_type": "var",
+                              "name": "x"
+                            }
+                          ],
+                          "sourceInformation": {
+                            "endColumn": 22,
+                            "endLine": 61,
+                            "sourceId": "",
+                            "startColumn": 15,
+                            "startLine": 61
+                          }
+                        },
+                        "name": "name",
+                        "sourceInformation": {
+                          "endColumn": 22,
+                          "endLine": 61,
+                          "sourceId": "",
+                          "startColumn": 8,
+                          "startLine": 61
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourceInformation": {
+                "endColumn": 41,
+                "endLine": 58,
+                "sourceId": "",
+                "startColumn": 35,
+                "startLine": 58
+              }
+            },
+            {
+              "_type": "packageableElementPtr",
+              "fullPath": "com::entity::EntityDataProductAppendOnly",
+              "sourceInformation": {
+                "endColumn": 44,
+                "endLine": 64,
+                "sourceId": "",
+                "startColumn": 5,
+                "startLine": 64
+              }
+            }
+          ],
+          "sourceInformation": {
+            "endColumn": 9,
+            "endLine": 63,
+            "sourceId": "",
+            "startColumn": 6,
+            "startLine": 63
+          }
+        }
+      ],
+      "name": "appendOnlyQuery__Relation_1_",
+      "package": "com::entity",
+      "parameters": [],
+      "postConstraints": [],
+      "preConstraints": [],
+      "returnGenericType": {
+        "rawType": {
+          "_type": "packageableType",
+          "fullPath": "meta::pure::metamodel::relation::Relation"
+        },
+        "typeArguments": [
+          {
+            "rawType": {
+              "_type": "packageableType",
+              "fullPath": "meta::pure::metamodel::type::Any"
+            }
+          }
+        ]
+      },
+      "returnMultiplicity": {
+        "lowerBound": 1,
+        "upperBound": 1
+      }
+    },
+    "classifierPath": "meta::pure::metamodel::function::ConcreteFunctionDefinition"
+  },
+  {
+    "path": "store::lakehouse::EntityDatabase",
+    "content": {
+      "_type": "relational",
+      "filters": [],
+      "includedStoreSpecifications": [
+        {
+          "packageableElementPointer": {
+            "path": "com::entity::EntityAppendOnly"
+          },
+          "storeType": "Ingest"
+        }
+      ],
+      "joins": [],
+      "name": "EntityDatabase",
+      "package": "store::lakehouse",
+      "schemas": []
+    },
+    "classifierPath": "meta::relational::metamodel::Database"
+  },
+  {
+    "path": "com::entity::EntityMappingAppendOnly",
+    "content": {
+      "_type": "mapping",
+      "classMappings": [
+        {
+          "_type": "relational",
+          "class": "com::entity::LegalEntity",
+          "distinct": false,
+          "mainTable": {
+            "_type": "Table",
+            "database": "store::lakehouse::EntityDatabase",
+            "mainTableDb": "store::lakehouse::EntityDatabase",
+            "schema": "ENTITY_DATA2",
+            "table": "LEGALENTITY"
+          },
+          "primaryKey": [
+            {
+              "_type": "column",
+              "column": "ENTITY_ID",
+              "table": {
+                "_type": "Table",
+                "database": "store::lakehouse::EntityDatabase",
+                "mainTableDb": "store::lakehouse::EntityDatabase",
+                "schema": "ENTITY_DATA2",
+                "table": "LEGALENTITY"
+              },
+              "tableAlias": "LEGALENTITY"
+            }
+          ],
+          "propertyMappings": [
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "com::entity::LegalEntity",
+                "property": "entityId"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "ENTITY_ID",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::lakehouse::EntityDatabase",
+                  "mainTableDb": "store::lakehouse::EntityDatabase",
+                  "schema": "ENTITY_DATA2",
+                  "table": "LEGALENTITY"
+                },
+                "tableAlias": "LEGALENTITY"
+              }
+            },
+            {
+              "_type": "relationalPropertyMapping",
+              "property": {
+                "class": "com::entity::LegalEntity",
+                "property": "name"
+              },
+              "relationalOperation": {
+                "_type": "column",
+                "column": "name",
+                "table": {
+                  "_type": "Table",
+                  "database": "store::lakehouse::EntityDatabase",
+                  "mainTableDb": "store::lakehouse::EntityDatabase",
+                  "schema": "ENTITY_DATA2",
+                  "table": "LEGALENTITY"
+                },
+                "tableAlias": "LEGALENTITY"
+              }
+            }
+          ],
+          "root": true
+        }
+      ],
+      "enumerationMappings": [],
+      "includedMappings": [],
+      "name": "EntityMappingAppendOnly",
+      "package": "com::entity",
+      "tests": []
+    },
+    "classifierPath": "meta::pure::mapping::Mapping"
+  },
+  {
+    "path": "com::entity::EntityDataProductAppendOnly",
+    "content": {
+      "_type": "dataProduct",
+      "accessPointGroups": [
+        {
+          "_type": "modelAccessPointGroup",
+          "description": "desc",
+          "diagrams": [
+            {
+              "title": "Entity Diagram",
+              "description": "Entity data model diagram",
+              "diagram": {
+                "path": "com::entity::EntityDiagram"
+              }
+            }
+          ],
+          "id": "modelAccessPointGroup",
+          "mapping": {
+            "path": "com::entity::EntityMappingAppendOnly"
+          }
+        }
+      ],
+      "description": "Entity DataProduct (AppendOnly), one stop shop for Entity Data",
+      "name": "EntityDataProductAppendOnly",
+      "package": "com::entity",
+      "title": "EntityDataProduct"
+    },
+    "classifierPath": "meta::external::catalog::dataProduct::specification::metamodel::DataProduct"
+  },
+  {
+    "path": "com::entity::EntityAppendOnly",
+    "content": {
+      "_type": "ingestDefinition",
+      "datasetGroup": "ENTITY_DATA2",
+      "datasets": [
+        {
+          "ingestPartitionColumns": [],
+          "name": "LEGALENTITY",
+          "preprocessors": [],
+          "primaryKey": [],
+          "privacyClassification": {
+            "sensitivity": "DP00"
+          },
+          "source": {
+            "_type": "serializedSource",
+            "schema": {
+              "_type": "relationType",
+              "columns": [
+                {
+                  "genericType": {
+                    "multiplicityArguments": [],
+                    "rawType": {
+                      "_type": "packageableType",
+                      "fullPath": "Varchar",
+                      "sourceInformation": {
+                        "endColumn": 28,
+                        "endLine": 18,
+                        "sourceId": "",
+                        "startColumn": 18,
+                        "startLine": 18
+                      }
+                    },
+                    "typeArguments": [],
+                    "typeVariableValues": [
+                      {
+                        "_type": "integer",
+                        "sourceInformation": {
+                          "endColumn": 27,
+                          "endLine": 18,
+                          "sourceId": "",
+                          "startColumn": 26,
+                          "startLine": 18
+                        },
+                        "value": 32
+                      }
+                    ]
+                  },
+                  "multiplicity": {
+                    "lowerBound": 0,
+                    "upperBound": 1
+                  },
+                  "name": "ENTITY_ID",
+                  "sourceInformation": {
+                    "endColumn": 28,
+                    "endLine": 18,
+                    "sourceId": "",
+                    "startColumn": 7,
+                    "startLine": 18
+                  }
+                },
+                {
+                  "genericType": {
+                    "multiplicityArguments": [],
+                    "rawType": {
+                      "_type": "packageableType",
+                      "fullPath": "Varchar",
+                      "sourceInformation": {
+                        "endColumn": 23,
+                        "endLine": 19,
+                        "sourceId": "",
+                        "startColumn": 13,
+                        "startLine": 19
+                      }
+                    },
+                    "typeArguments": [],
+                    "typeVariableValues": [
+                      {
+                        "_type": "integer",
+                        "sourceInformation": {
+                          "endColumn": 22,
+                          "endLine": 19,
+                          "sourceId": "",
+                          "startColumn": 21,
+                          "startLine": 19
+                        },
+                        "value": 32
+                      }
+                    ]
+                  },
+                  "multiplicity": {
+                    "lowerBound": 0,
+                    "upperBound": 1
+                  },
+                  "name": "name",
+                  "sourceInformation": {
+                    "endColumn": 23,
+                    "endLine": 19,
+                    "sourceId": "",
+                    "startColumn": 7,
+                    "startLine": 19
+                  }
+                }
+              ],
+              "sourceInformation": {
+                "endColumn": 4,
+                "endLine": 20,
+                "sourceId": "",
+                "startColumn": 15,
+                "startLine": 17
+              }
+            }
+          },
+          "storageLayoutClusterColumns": [],
+          "storageLayoutPartitionColumns": []
+        }
+      ],
+      "name": "EntityAppendOnly",
+      "owner": {
+        "_type": "appDir",
+        "prodParallel": {
+          "appDirId": 1,
+          "level": "DEPLOYMENT"
+        },
+        "production": {
+          "appDirId": 2,
+          "level": "DEPLOYMENT"
+        }
+      },
+      "package": "com::entity",
+      "readMode": {
+        "_type": "Undefined",
+        "format": {
+          "_type": "CSV",
+          "fieldDelimiter": ",",
+          "headerRowsToSkipCount": 0,
+          "parseHeader": false,
+          "recordDelimiter": "\n"
+        }
+      },
+      "sourceInformation": {
+        "endColumn": 1,
+        "endLine": 22,
+        "sourceId": "",
+        "startColumn": 1,
+        "startLine": 15
+      },
+      "stereotypes": [],
+      "taggedValues": [],
+      "testSuites": [],
+      "writeMode": {
+        "_type": "append_only"
+      }
+    },
+    "classifierPath": "meta::external::ingest::specification::metamodel::IngestDefinition"
+  },
+  {
+    "path": "com::entity::EntityDiagram",
+    "content": {
+      "_type": "diagram",
+      "classViews": [],
+      "generalizationViews": [],
+      "name": "EntityDiagram",
+      "package": "com::entity",
+      "propertyViews": []
+    },
+    "classifierPath": "meta::pure::metamodel::diagram::Diagram"
+  }
+]

--- a/packages/legend-application-studio/src/components/editor/editor-group/function-activator/testable/FunctionTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/function-activator/testable/FunctionTestableEditor.tsx
@@ -861,20 +861,9 @@ const FunctionTestDataPanel = observer(
   (props: { functionTestSuiteState: FunctionTestSuiteState }) => {
     const { functionTestSuiteState } = props;
     const dataState = functionTestSuiteState.dataState;
-    const hasIngestOrDataProductAccessors =
-      functionTestSuiteState.functionTestableState
-        .resolvedIngestOrDataProductAccessors.length > 0;
     const hasTestData = Boolean(dataState.dataHolder.testData?.length);
 
     const addStoreTestData = (): void => {
-      if (!dataState.availableElementsToAdd.length) {
-        functionTestSuiteState.editorStore.applicationStore.notificationService.notifyWarning(
-          hasIngestOrDataProductAccessors
-            ? `All referenced elements' data is already present`
-            : `No elements available to add`,
-        );
-        return;
-      }
       dataState.setShowAddElementModal(true);
     };
 
@@ -923,7 +912,9 @@ const FunctionTestDataPanel = observer(
                         tabIndex={-1}
                       >
                         <div className="testable-test-explorer__item__label__text">
-                          {td.element.value.path}
+                          <span title={td.element.value.path}>
+                            {td.element.value.name}
+                          </span>
                         </div>
                         <div className="mapping-test-explorer__item__actions">
                           <button
@@ -1076,26 +1067,6 @@ const FunctionTestsPanel = observer(
 const FunctionTestSuiteEditor = observer(
   (props: { functionTestSuiteState: FunctionTestSuiteState }) => {
     const { functionTestSuiteState } = props;
-    const hasTestData = Boolean(
-      functionTestSuiteState.dataState.dataHolder.testData?.length,
-    );
-    const hasIngestOrDataProductAccessors =
-      functionTestSuiteState.functionTestableState
-        .resolvedIngestOrDataProductAccessors.length > 0;
-    const showTestDataPanel =
-      functionTestSuiteState.functionTestableState.containsRuntime ||
-      hasIngestOrDataProductAccessors ||
-      hasTestData;
-
-    if (!showTestDataPanel) {
-      // No test data — just show the tests panel full width
-      return (
-        <div className="service-test-suite-editor">
-          <FunctionTestsPanel functionTestSuiteState={functionTestSuiteState} />
-        </div>
-      );
-    }
-
     return (
       <div className="service-test-suite-editor">
         <ResizablePanelGroup orientation="horizontal">

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/function-activator/testable/FunctionTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/function-activator/testable/FunctionTestableState.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { action, flow, flowResult, makeObservable, observable } from 'mobx';
+import {
+  action,
+  flow,
+  flowResult,
+  makeObservable,
+  observable,
+  runInAction,
+} from 'mobx';
 import type { EditorStore } from '../../../../EditorStore.js';
 import type { FunctionEditorState } from '../../FunctionEditorState.js';
 import {
@@ -43,6 +50,8 @@ import {
   type ValueSpecification,
   type TestAssertion,
   type AccessorOwner,
+  type AbstractPureGraphManager,
+  type PackageableElement,
   FunctionParameterValue,
   VariableExpression,
   FunctionTest,
@@ -57,8 +66,11 @@ import {
   InstanceValue,
   PackageableElementReference,
   Database,
+  DataProduct,
+  IngestDefinition,
   PackageableElementExplicitReference,
   observe_ValueSpecification,
+  observe_RelationElementsData,
   buildLambdaVariableExpressions,
   EqualTo,
   EqualToRelation,
@@ -72,7 +84,7 @@ import {
   type Accessor,
   DataProductAccessor,
   IngestionAccessor,
-  RelationalStoreAccessor,
+  getAccessorItemLabelForElement,
   V1_buildRelationElementsDataFromAccessors,
 } from '@finos/legend-graph';
 import {
@@ -191,6 +203,28 @@ const resolveRuntimesFromQuery = (
   }
 };
 
+interface ElementDataItem {
+  id: string;
+  label: string;
+}
+
+const getElementDataItems = (
+  element: PackageableElement,
+  graphManager: AbstractPureGraphManager,
+): ElementDataItem[] => {
+  if (element instanceof DataProduct) {
+    return element.accessPointGroups
+      .flatMap((g) => g.accessPoints)
+      .map((ap) => ({ id: ap.id, label: ap.id }));
+  }
+  if (element instanceof IngestDefinition) {
+    return graphManager
+      .getIngestDefinitionDatasetNames(element)
+      .map((name) => ({ id: name, label: name }));
+  }
+  return [];
+};
+
 export class FunctionStoreTestDataState {
   readonly editorStore: EditorStore;
   readonly testDataState: FunctionTestDataState;
@@ -239,51 +273,69 @@ export class FunctionStoreTestDataState {
     embeddedDataState: RelationElementsDataState,
   ): Promise<void> {
     const parentElement = this.storeTestData.element.value;
-    const accessors =
-      this.testDataState.functionTestableState
-        .resolvedIngestOrDataProductAccessors;
-    const parentAccessors = accessors.filter(
-      (a) => a.accessorOwner === parentElement.path,
+    const graphManager = this.editorStore.graphManagerState.graphManager;
+    const graph = this.editorStore.graphManagerState.graph;
+
+    // For Database parents, fall back to the schema+table form
+    if (parentElement instanceof Database) {
+      embeddedDataState.setAccessorOptions(undefined, undefined);
+      return;
+    }
+
+    const items = getElementDataItems(parentElement, graphManager);
+    if (items.length === 0) {
+      embeddedDataState.setAccessorOptions(undefined, undefined);
+      return;
+    }
+    const typeLabel = getAccessorItemLabelForElement(
+      parentElement as AccessorOwner,
     );
-    if (!parentAccessors.length) {
-      embeddedDataState.setAccessorOptions(undefined, undefined);
-      return;
-    }
-    const firstAccessor = parentAccessors[0];
-    if (!firstAccessor) {
-      embeddedDataState.setAccessorOptions(undefined, undefined);
-      return;
-    }
-
-    const columnOverrides = new Map<string, string[]>();
-    for (const accessor of parentAccessors) {
-      const cols = accessor.relationType.columns.map((col) => col.name);
-      if (cols.length > 0) {
-        columnOverrides.set(accessor.accessor, cols);
-      }
-    }
-
-    const typeLabel = firstAccessor.accessorLabel;
-    const options = parentAccessors.map((a) => ({
-      label: a.accessor,
-      value: a.accessor,
-      columns: columnOverrides.get(a.accessor) ?? [],
-    }));
-
-    if (columnOverrides.size > 0) {
+    const options = await Promise.all(
+      items.map(async (item) => {
+        let columns: string[] = [];
+        try {
+          if (parentElement instanceof IngestDefinition) {
+            const accessor =
+              await graphManager.createAccessorFromPackageableElement(
+                parentElement,
+                graph,
+                { schemaName: undefined, tableName: item.id },
+              );
+            if (accessor) {
+              columns = accessor.relationType.columns.map((c) => c.name);
+            }
+          } else if (parentElement instanceof DataProduct) {
+            const accessor = await graphManager.buildDataProductAccessor(
+              parentElement,
+              graph,
+              { tableName: item.id },
+            );
+            if (accessor) {
+              columns = accessor.relationType.columns.map((c) => c.name);
+            }
+          }
+        } catch {}
+        return { label: item.label, value: item.id, columns };
+      }),
+    );
+    runInAction(() => {
+      embeddedDataState.setAccessorOptions(options, typeLabel);
+      const columnsByItem = new Map(
+        options
+          .filter((o) => o.columns.length > 0)
+          .map((o) => [o.value, o.columns]),
+      );
       for (const relState of embeddedDataState.relationElementStates) {
         const rel = relState.relationElement;
         if (rel.columns.length === 0) {
           const key = rel.paths[rel.paths.length - 1];
-          const cols = key ? columnOverrides.get(key) : undefined;
+          const cols = key ? columnsByItem.get(key) : undefined;
           if (cols) {
             rel.columns = cols;
           }
         }
       }
-    }
-
-    embeddedDataState.setAccessorOptions(options, typeLabel);
+    });
   }
 
   setDataElementModal(val: boolean): void {
@@ -655,34 +707,38 @@ class FunctionTestDataState {
     return (this.dataHolder.testData ?? []).map((td) => td.element.value.path);
   }
 
-  get availableElementsToAdd(): { path: string }[] {
-    const accessors =
-      this.functionTestableState.resolvedIngestOrDataProductAccessors;
+  get availableElementsToAdd(): PackageableElement[] {
+    const graph = this.editorStore.graphManagerState.graph;
     const existingPaths = new Set(this.existingElementPaths);
-    const parentPaths = new Set<string>();
-    for (const accessor of accessors) {
-      const parentPath = accessor.path[0];
-      if (parentPath && !existingPaths.has(parentPath)) {
-        parentPaths.add(parentPath);
-      }
-    }
-    return Array.from(parentPaths).map((path) => ({ path }));
+    const candidates: PackageableElement[] = [
+      ...graph.ingests,
+      ...graph.dataProducts,
+      ...graph.databases,
+    ];
+    return candidates.filter((e) => !existingPaths.has(e.path));
   }
 
   addDataElement(elementPath: string): void {
-    const accessors =
-      this.functionTestableState.resolvedIngestOrDataProductAccessors;
-    const group = accessors.filter((a) => a.path[0] === elementPath);
-    if (!group.length) {
+    const element =
+      this.editorStore.graphManagerState.graph.getNullableElement(elementPath);
+    if (!element) {
       return;
     }
-    const element =
-      this.editorStore.graphManagerState.graph.getElement(elementPath);
     const data = new FunctionTestData();
     data.element = PackageableElementExplicitReference.create(
       element as AccessorOwner,
     );
-    data.data = V1_buildRelationElementsDataFromAccessors(group);
+    const matchingAccessors = this.functionTestableState.cachedAccessors.filter(
+      (a) => a.accessorOwner === elementPath,
+    );
+    if (matchingAccessors.length) {
+      data.data = V1_buildRelationElementsDataFromAccessors(matchingAccessors);
+    } else {
+      const relData = new RelationElementsData();
+      relData.relationElements = [];
+      data.data = relData;
+    }
+    observe_RelationElementsData(data.data as RelationElementsData);
     if (!this.dataHolder.testData) {
       this.dataHolder.testData = [];
     }
@@ -966,36 +1022,9 @@ export class FunctionTestableState extends TestablePackageableElementEditorState
 
     const ingestOrDataProductAccessors =
       this.resolvedIngestOrDataProductAccessors;
-    const databaseAccessors = this.cachedAccessors.filter(
-      (a) => a instanceof RelationalStoreAccessor,
-    );
 
     try {
-      if (ingestOrDataProductAccessors.length) {
-        // Group by parent element path and create test data per parent
-        const parentElementMap = new Map<string, Accessor[]>();
-        for (const accessor of ingestOrDataProductAccessors) {
-          const key = accessor.accessorOwner;
-          if (key) {
-            const group = parentElementMap.get(key) ?? [];
-            group.push(accessor);
-            parentElementMap.set(key, group);
-          }
-        }
-        functionSuite.testData = Array.from(parentElementMap.entries()).map(
-          ([parentPath, group]) => {
-            const data = new FunctionTestData();
-            const element =
-              this.editorStore.graphManagerState.graph.getElement(parentPath);
-            data.element = PackageableElementExplicitReference.create(
-              element as AccessorOwner,
-            );
-            data.data = V1_buildRelationElementsDataFromAccessors(group);
-            return data;
-          },
-        );
-      } else {
-        // No ingest/data product accessors found — try runtime-based approach
+      if (!ingestOrDataProductAccessors.length) {
         const engineRuntimes = this.associatedRuntimes;
         if (engineRuntimes?.length) {
           assertTrue(
@@ -1047,10 +1076,44 @@ export class FunctionTestableState extends TestablePackageableElementEditorState
             type.path === CORE_PURE_PATH.RELATION ||
             type.path === CORE_PURE_PATH.TABULAR_DATASET
           ) {
-            this.editorStore.applicationStore.notificationService.notifyError(
-              `Unable to create function test suite: no runtime or accessors found, or they could not be resolved`,
+            this.editorStore.applicationStore.notificationService.notifyWarning(
+              `No runtime or accessors found, or they could not be resolved. For Relational (non-Lakehouse) function testing, please ensure that your query is bound to a runtime`,
             );
-            return;
+            // continue: still allow the user to create the suite/test and
+            // add test data manually
+          }
+        }
+      }
+
+      if (this.cachedAccessors.length) {
+        const accessorsByOwner = new Map<string, Accessor[]>();
+        for (const accessor of this.cachedAccessors) {
+          const key = accessor.accessorOwner;
+          if (key) {
+            const group = accessorsByOwner.get(key) ?? [];
+            group.push(accessor);
+            accessorsByOwner.set(key, group);
+          }
+        }
+        if (!functionSuite.testData) {
+          functionSuite.testData = [];
+        }
+        for (const [parentPath, group] of accessorsByOwner.entries()) {
+          const builtData = V1_buildRelationElementsDataFromAccessors(group);
+          const existing = functionSuite.testData.find(
+            (td) => td.element.value.path === parentPath,
+          );
+          if (existing) {
+            existing.data = builtData;
+          } else {
+            const element =
+              this.editorStore.graphManagerState.graph.getElement(parentPath);
+            const data = new FunctionTestData();
+            data.element = PackageableElementExplicitReference.create(
+              element as AccessorOwner,
+            );
+            data.data = builtData;
+            functionSuite.testData.push(data);
           }
         }
       }
@@ -1062,10 +1125,7 @@ export class FunctionTestableState extends TestablePackageableElementEditorState
       return;
     }
 
-    const hasTestData =
-      this.containsRuntime ||
-      ingestOrDataProductAccessors.length > 0 ||
-      databaseAccessors.length > 0;
+    const hasTestData = this.containsRuntime || this.cachedAccessors.length > 0;
     yield createFunctionTest(
       testName,
       this.editorStore.changeDetectionState.observerContext,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
Remove runtime or accessors requirement from adding function tests
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [x] Test(s) added
- [x] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
