### PR TITLE
fix: percentile() aggregate emits Float instead of Decimal for percentile argument

### DIFF
--- a/.changeset/percentile-float-fix.md
+++ b/.changeset/percentile-float-fix.md
@@ -1,0 +1,9 @@
+---
+'@finos/legend-query-builder': patch
+---
+
+Fix `percentile()` aggregate emitting `Decimal` instead of `Float` for the percentile argument.
+
+`buildAggregateExpression` was creating the percentile `PrimitiveInstanceValue` with `PrimitiveType.NUMBER` (the abstract supertype). The V1 transformer has no direct wire representation for `Number` and intentionally falls back to `Decimal`, producing `{"_type":"decimal"}` → PURE grammar `0.8D`. The Engine correctly rejects this because the registered signature is `percentile(Number[*], Float[1], ...)` — `Decimal` and `Float` are distinct concrete subtypes.
+
+Fix: change the generic type to `PrimitiveType.FLOAT` so the transformer takes the `FLOAT` branch → `{"_type":"float"}` → `0.8` → matches `Float[1]`.

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderFetchStructure.test.tsx
@@ -45,6 +45,7 @@ import {
   TEST_DATA__simpleGraphFetchWithSubtype,
   TEST_DATA__projectionWithDerivation,
   TEST_DATA__simpleProjectionWithSubtypesInDeepLevel,
+  TEST_DATA__projectionWithPercentileAggregation,
 } from '../../stores/__tests__/TEST_DATA__QueryBuilder_Generic.js';
 import {
   TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
@@ -76,6 +77,7 @@ import {
 } from '../../stores/fetch-structure/tds/projection/QueryBuilderProjectionColumnState.js';
 import { QueryBuilderTDSState } from '../../stores/fetch-structure/tds/QueryBuilderTDSState.js';
 import { QueryBuilderGraphFetchTreeState } from '../../stores/fetch-structure/graph-fetch/QueryBuilderGraphFetchTreeState.js';
+import { QueryBuilderAggregateOperator_Percentile } from '../../stores/fetch-structure/tds/aggregation/operators/QueryBuilderAggregateOperator_Percentile.js';
 import {
   TEST__setUpQueryBuilder,
   dragAndDrop,
@@ -1922,6 +1924,76 @@ test(
       }),
     );
     await waitFor(() => getByText(projectionPanel, '50'));
+
+    // Verify the serialized query encodes the percentile argument as 'float', not 'decimal'.
+    // Before the fix, PrimitiveType.NUMBER was used in buildAggregateExpression; the V1
+    // transformer degrades NUMBER → Decimal → {"_type":"decimal"} → "0.5D" in PURE grammar,
+    // which the server rejects: "Can't match percentile(Number[*],Decimal[1],...)".
+    // After the fix, PrimitiveType.FLOAT → {"_type":"float"} → "0.5" → matches Float[1].
+    act(() => {
+      const serialized =
+        queryBuilderState.graphManagerState.graphManager.serializeRawValueSpecification(
+          queryBuilderState.buildQuery(),
+        );
+      const serializedStr = JSON.stringify(serialized);
+      expect(serializedStr).toContain('"_type":"float"');
+      expect(serializedStr).not.toContain('"_type":"decimal"');
+    });
+  },
+);
+
+test(
+  integrationTest(
+    'Query builder correctly loads percentile aggregation lambda into operator state',
+  ),
+  async () => {
+    const { queryBuilderState } = await TEST__setUpQueryBuilder(
+      TEST_DATA__ComplexRelationalModel,
+      stub_RawLambda(),
+      'model::relational::tests::simpleRelationalMapping',
+      'model::MyRuntime',
+      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
+    );
+
+    // Load a lambda containing both a 4-param and a 2-param percentile aggregate.
+    // This exercises buildAggregateColumnState — the read-back path from JSON → operator state.
+    await act(async () => {
+      queryBuilderState.initializeWithQuery(
+        create_RawLambda(
+          TEST_DATA__projectionWithPercentileAggregation.parameters,
+          TEST_DATA__projectionWithPercentileAggregation.body,
+        ),
+      );
+    });
+
+    const tdsState = guaranteeType(
+      queryBuilderState.fetchStructureState.implementation,
+      QueryBuilderTDSState,
+    );
+
+    // Two agg columns: [0] = 4-param percentile(x, 0.45, true, false)
+    //                  [1] = 2-param percentile(x, 0.36)
+    expect(tdsState.aggregationState.columns).toHaveLength(2);
+
+    // 4-param: percentile value 0.45 → stored as 45 (percent), acending=true, continuous=false
+    const op0 = guaranteeType(
+      tdsState.aggregationState.columns[0]?.operator,
+      QueryBuilderAggregateOperator_Percentile,
+      'First agg column must be a percentile operator',
+    );
+    expect(op0.percentile).toBeCloseTo(45);
+    expect(op0.acending).toBe(true);
+    expect(op0.continuous).toBe(false);
+
+    // 2-param: percentile value 0.36 → stored as 36, no ascending/continuous set
+    const op1 = guaranteeType(
+      tdsState.aggregationState.columns[1]?.operator,
+      QueryBuilderAggregateOperator_Percentile,
+      'Second agg column must be a percentile operator',
+    );
+    expect(op1.percentile).toBeCloseTo(36);
+    expect(op1.acending).toBeUndefined();
+    expect(op1.continuous).toBeUndefined();
   },
 );
 

--- a/packages/legend-query-builder/src/stores/__tests__/QueryBuilderProcessingRoundtrip.test.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/QueryBuilderProcessingRoundtrip.test.ts
@@ -72,7 +72,10 @@ import {
 } from './TEST_DATA__QueryBuilder_GraphFetch.js';
 import { TEST__LegendApplicationPluginManager } from '../__test-utils__/QueryBuilderStateTestUtils.js';
 import { TEST_DATA__lambda_ContantExpression_MultiConstantAndCalculatedVariables } from './TEST_DATA__QueryBuilder_ConstantExpression.js';
-import { TEST_DATA__projectionWithWAVGAggregation } from './TEST_DATA__QueryBuilder_Generic.js';
+import {
+  TEST_DATA__projectionWithWAVGAggregation,
+  TEST_DATA__projectionWithPercentileAggregation,
+} from './TEST_DATA__QueryBuilder_Generic.js';
 import {
   TEST_DATA_typedTDSMax,
   TEST_DATA_typedTDSPercentRank,
@@ -266,6 +269,11 @@ const cases: RoundtripTestCase[] = [
   ['Simple slice() function', relationalCtx, TEST_DATA__projectWithSlice],
   // aggregation
   ['wavg() function', projectionCtx, TEST_DATA__projectionWithWAVGAggregation],
+  [
+    'percentile() function — percentile arg must serialize as float, not decimal',
+    projectionCtx,
+    TEST_DATA__projectionWithPercentileAggregation,
+  ],
   //typed TDS
   ['typed rank() function', olapGroupbyCtx, TEST_DATA_typedTDSRank],
   ['typed max() function', olapGroupbyCtx, TEST_DATA_typedTDSMax],

--- a/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
+++ b/packages/legend-query-builder/src/stores/__tests__/TEST_DATA__QueryBuilder_Generic.ts
@@ -2023,7 +2023,7 @@ export const TEST_DATA__projectionWithPercentileAggregation = {
                           name: 'x',
                         },
                         {
-                          _type: 'decimal',
+                          _type: 'float',
                           value: 0.45,
                         },
                         {
@@ -2083,7 +2083,7 @@ export const TEST_DATA__projectionWithPercentileAggregation = {
                           name: 'x',
                         },
                         {
-                          _type: 'decimal',
+                          _type: 'float',
                           value: 0.36,
                         },
                       ],

--- a/packages/legend-query-builder/src/stores/fetch-structure/tds/aggregation/operators/QueryBuilderAggregateOperator_Percentile.ts
+++ b/packages/legend-query-builder/src/stores/fetch-structure/tds/aggregation/operators/QueryBuilderAggregateOperator_Percentile.ts
@@ -114,9 +114,7 @@ export class QueryBuilderAggregateOperator_Percentile
       extractElementNameFromPath(QUERY_BUILDER_SUPPORTED_FUNCTIONS.PERCENTILE),
     );
     const percentile = new PrimitiveInstanceValue(
-      GenericTypeExplicitReference.create(
-        new GenericType(PrimitiveType.NUMBER),
-      ),
+      GenericTypeExplicitReference.create(new GenericType(PrimitiveType.FLOAT)),
     );
     percentile.values = [percentileValue];
     if (


### PR DESCRIPTION
`buildAggregateExpression` in `QueryBuilderAggregateOperator_Percentile` was
constructing the percentile `PrimitiveInstanceValue` with `PrimitiveType.NUMBER`
(the abstract numeric supertype). The V1 value-specification transformer has no
direct wire representation for `Number` and intentionally falls back to `Decimal`,
producing `{"_type":"decimal","value":0.8}` → PURE grammar `0.8D`. The Engine
correctly rejects this because the registered function signature is:

```
percentile(Number[*], Float[1], Boolean[1], Boolean[1]): Number[0..1]
```

`Decimal` and `Float` are distinct concrete subtypes of `Number` and are not
interchangeable in the PURE type system.

**Fix:** change the generic type from `PrimitiveType.NUMBER` to `PrimitiveType.FLOAT`
so the transformer takes the `FLOAT` branch → `V1_CFloat` →
`{"_type":"float","value":0.8}` → PURE grammar `0.8` → matches `Float[1]`.

### Files changed

| File | Change |
|---|---|
| `…/QueryBuilderAggregateOperator_Percentile.ts` | `PrimitiveType.NUMBER` → `PrimitiveType.FLOAT` (one line) |
| `…/TEST_DATA__QueryBuilder_Generic.ts` | Updated test data: `"_type":"decimal"` → `"_type":"float"` |
| `…/QueryBuilderFetchStructure.test.tsx` | Added serialization-check test + load-back roundtrip test |
| `…/QueryBuilderProcessingRoundtrip.test.ts` | Added `percentile()` roundtrip case |
| `.changeset/percentile-float-fix.md` | `patch` changeset for `@finos/legend-query-builder` |