### PR TITLE
fix(studio): restore Data Product test parameter UI

### DIFF
--- a/.changeset/olive-doodles-tickle.md
+++ b/.changeset/olive-doodles-tickle.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-studio': patch
+---
+
+Fix a regression in Data Product Testing where access point test parameters were no longer shown after the shared Lakehouse test editor refactor. Restore parameter controls in the Assertion view (above Expected/Result), preserve type/content-type editing behavior, and align formatting with the previous Data Product test UI.

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/__tests__/DataProductEditor.test.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/__tests__/DataProductEditor.test.tsx
@@ -56,36 +56,44 @@ const TEST_DATA__FUNCTION_ACCESS_POINT_WITH_PARAMETER = (() => {
   const entities = JSON.parse(
     JSON.stringify(TEST_DATA__LHDataProduct),
   ) as typeof TEST_DATA__LHDataProduct;
-  const dataProductEntity = entities.find(
-    (entity) => entity.path === 'model::sampleDataProduct',
+  const dataProductEntity = guaranteeNonNullable(
+    entities.find((entity) => entity.path === 'model::sampleDataProduct'),
   );
-  const firstAccessPoint =
-    dataProductEntity?.content?.accessPointGroups?.[0]?.accessPoints?.[0];
-  if (firstAccessPoint) {
-    firstAccessPoint._type = 'functionAccessPoint';
-    firstAccessPoint.id = 'apWithParam';
-    delete firstAccessPoint.func;
-    firstAccessPoint.query = {
-      _type: 'lambda',
-      body: [
-        {
-          _type: 'integer',
-          value: 1,
+  type MutableFunctionAccessPointFixture = {
+    _type: string;
+    id: string;
+    func?: unknown;
+    query?: unknown;
+  };
+  const accessPointGroups = guaranteeNonNullable(
+    dataProductEntity.content.accessPointGroups,
+  );
+  const firstAccessPoint = guaranteeNonNullable(
+    accessPointGroups[0]?.accessPoints[0],
+  ) as MutableFunctionAccessPointFixture;
+  firstAccessPoint._type = 'functionAccessPoint';
+  firstAccessPoint.id = 'apWithParam';
+  delete firstAccessPoint.func;
+  firstAccessPoint.query = {
+    _type: 'lambda',
+    body: [
+      {
+        _type: 'integer',
+        value: 1,
+      },
+    ],
+    parameters: [
+      {
+        _type: 'var',
+        name: 'type',
+        class: 'String',
+        multiplicity: {
+          lowerBound: 1,
+          upperBound: 1,
         },
-      ],
-      parameters: [
-        {
-          _type: 'var',
-          name: 'type',
-          class: 'String',
-          multiplicity: {
-            lowerBound: 1,
-            upperBound: 1,
-          },
-        },
-      ],
-    };
-  }
+      },
+    ],
+  };
   return entities;
 })();
 
@@ -319,12 +327,8 @@ test(
     fireEvent.click(await findByText(editorGroup, 'Testing'));
     fireEvent.click(await findByText(editorGroup, 'Add Test Suite'));
 
-    const createSuiteModal = await findByText(
-      screen.getByRole('dialog'),
-      'Create Test Suite',
-    );
-    const createSuiteDialog =
-      createSuiteModal.closest('.modal') ?? screen.getByRole('dialog');
+    const createSuiteDialog = screen.getByRole('dialog');
+    await findByText(createSuiteDialog, 'Create Test Suite');
 
     const testNameInput = await findByPlaceholderText(
       createSuiteDialog,

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/__tests__/DataProductEditor.test.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/__tests__/DataProductEditor.test.tsx
@@ -52,6 +52,43 @@ import { MockedMonacoEditorInstance } from '@finos/legend-lego/code-editor/test'
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { AP_EMPTY_DESC_WARNING } from '../DataProductEditor.js';
 
+const TEST_DATA__FUNCTION_ACCESS_POINT_WITH_PARAMETER = (() => {
+  const entities = JSON.parse(
+    JSON.stringify(TEST_DATA__LHDataProduct),
+  ) as typeof TEST_DATA__LHDataProduct;
+  const dataProductEntity = entities.find(
+    (entity) => entity.path === 'model::sampleDataProduct',
+  );
+  const firstAccessPoint =
+    dataProductEntity?.content?.accessPointGroups?.[0]?.accessPoints?.[0];
+  if (firstAccessPoint) {
+    firstAccessPoint._type = 'functionAccessPoint';
+    firstAccessPoint.id = 'apWithParam';
+    delete firstAccessPoint.func;
+    firstAccessPoint.query = {
+      _type: 'lambda',
+      body: [
+        {
+          _type: 'integer',
+          value: 1,
+        },
+      ],
+      parameters: [
+        {
+          _type: 'var',
+          name: 'type',
+          class: 'String',
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+        },
+      ],
+    };
+  }
+  return entities;
+})();
+
 const pluginManager = LegendStudioPluginManager.create();
 pluginManager
   .usePresets([
@@ -253,6 +290,57 @@ test(
         renderResult.queryByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER),
       ).toBeNull();
     });
+  },
+);
+
+test(
+  integrationTest(
+    'Function access point query parameters are shown in data product testing',
+  ),
+  async () => {
+    const MOCK__editorStore = TEST__provideMockedEditorStore({ pluginManager });
+    const renderResult = await TEST__setUpEditorWithDefaultSDLCData(
+      MOCK__editorStore,
+      { entities: TEST_DATA__FUNCTION_ACCESS_POINT_WITH_PARAMETER },
+    );
+    MockedMonacoEditorInstance.getRawOptions.mockReturnValue({
+      readOnly: true,
+    });
+
+    await TEST__openElementFromExplorerTree(
+      'model::sampleDataProduct',
+      renderResult,
+    );
+
+    const editorGroup = await waitFor(() =>
+      renderResult.getByTestId(LEGEND_STUDIO_TEST_ID.EDITOR_GROUP),
+    );
+
+    fireEvent.click(await findByText(editorGroup, 'Testing'));
+    fireEvent.click(await findByText(editorGroup, 'Add Test Suite'));
+
+    const createSuiteModal = await findByText(
+      screen.getByRole('dialog'),
+      'Create Test Suite',
+    );
+    const createSuiteDialog =
+      createSuiteModal.closest('.modal') ?? screen.getByRole('dialog');
+
+    const testNameInput = await findByPlaceholderText(
+      createSuiteDialog,
+      'e.g. test_1',
+    );
+    fireEvent.change(testNameInput, { target: { value: 'test_1' } });
+
+    fireEvent.mouseDown(
+      await findByText(createSuiteDialog, 'Select access point...'),
+    );
+    fireEvent.click(await screen.findByText('apWithParam'));
+
+    fireEvent.click(await findByText(createSuiteDialog, 'Create'));
+
+    await findByText(editorGroup, 'Parameters');
+    await findByText(editorGroup, 'type');
   },
 );
 

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -396,7 +396,7 @@ const DataProductTestParameterEditor = observer(
         className="panel__content__form__section"
       >
         <div className="panel__content__form__section__header__label">
-          {`Name: ${paramState.parameterValue.name || '(unnamed)'}`}
+          {paramState.parameterValue.name}
           <button
             className={clsx('type-tree__node__type__label', {})}
             tabIndex={-1}

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -420,8 +420,8 @@ const DataProductTestParameterEditor = observer(
                 value={
                   valueSpecParamState.varExpression.genericType?.value
                     .rawType === PrimitiveType.BYTE
-                    ? atob((valueSpec.values[0] as string) ?? '')
-                    : ((valueSpec.values[0] as string) ?? '')
+                    ? atob(valueSpec.values[0] as string)
+                    : (valueSpec.values[0] as string)
                 }
                 placeholder={
                   (valueSpec.values[0] as string) === '' ? '(empty)' : undefined
@@ -435,7 +435,9 @@ const DataProductTestParameterEditor = observer(
                   onClose={closePopUp}
                   isReadOnly={isReadOnly}
                   updateParamValue={updateParamValue}
-                  contentTypeParamPair={contentTypeParamPair!}
+                  contentTypeParamPair={guaranteeNonNullable(
+                    contentTypeParamPair,
+                  )}
                 />
               )}
               <div className="data-product-test-editor__parameter__value__actions">

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -17,11 +17,13 @@
 import { observer } from 'mobx-react-lite';
 import { flowResult } from 'mobx';
 import {
+  BlankPanelContent,
   BlankPanelPlaceholder,
   clsx,
   ContextMenu,
   CustomSelectorInput,
   Dialog,
+  FilledWindowMaximizeIcon,
   MenuContent,
   MenuContentItem,
   Modal,
@@ -37,20 +39,44 @@ import {
   PanelHeaderActions,
   PanelLoadingIndicator,
   PlusIcon,
+  RefreshIcon,
+  TimesIcon,
 } from '@finos/legend-art';
-import type { DataProductTestSuite } from '@finos/legend-graph';
+import {
+  FunctionAccessPoint,
+  LakehouseAccessPoint,
+  PrimitiveInstanceValue,
+  PrimitiveType,
+  type DataProductTestSuite,
+  type RawLambda,
+  type ValueSpecification,
+} from '@finos/legend-graph';
 import type { DataProductEditorState } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/DataProductEditorState.js';
 import {
+  DataProductValueSpecificationTestParameterState,
+  type DataProductTestParameterState,
+  DataProductTestState,
   type DataProductTestableState,
   type DataProductTestSuiteState,
 } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.js';
-import { forwardRef, useRef, useState } from 'react';
-import { validateTestableId } from '../../../../../stores/editor/utils/TestableUtils.js';
+import { forwardRef, useEffect, useRef, useState } from 'react';
+import {
+  getContentTypeWithParamFromQuery,
+  type TestParamContentType,
+  validateTestableId,
+} from '../../../../../stores/editor/utils/TestableUtils.js';
 import { useEditorStore } from '../../../EditorStoreProvider.js';
 import { guaranteeNonNullable } from '@finos/legend-shared';
-import { RenameModal } from '../../testable/TestableSharedComponents.js';
+import {
+  ExternalFormatParameterEditorModal,
+  RenameModal,
+} from '../../testable/TestableSharedComponents.js';
 import { testSuite_setId } from '../../../../../stores/graph-modifier/Testable_GraphModifierHelper.js';
 import { LakehouseTestSuiteEditor } from '../../testable/LakehouseTestableEditor.js';
+import {
+  BasicValueSpecificationEditor,
+  instanceValue_setValue,
+} from '@finos/legend-query-builder';
 
 // ─── Create Suite Modal ───────────────────────────────────────────────────────
 
@@ -291,6 +317,353 @@ const CreateTestModal = observer(
   },
 );
 
+const getAccessPointQuery = (
+  testState: DataProductTestState,
+): RawLambda | undefined => {
+  const accessPoint = testState.suiteState.testableState.ownAccessPoints.find(
+    (ap) => ap.id === testState.test.accessPointId,
+  );
+  if (accessPoint instanceof LakehouseAccessPoint) {
+    return accessPoint.func;
+  }
+  if (accessPoint instanceof FunctionAccessPoint) {
+    return accessPoint.query;
+  }
+  return undefined;
+};
+
+const DataProductTestParameterEditor = observer(
+  (props: {
+    testState: DataProductTestState;
+    paramState: DataProductTestParameterState;
+    isReadOnly: boolean;
+    contentTypeParamPair: TestParamContentType | undefined;
+  }) => {
+    const { testState, paramState, isReadOnly, contentTypeParamPair } = props;
+    const [showPopUp, setShowPopup] = useState(false);
+    const valueSpecParamState =
+      paramState instanceof DataProductValueSpecificationTestParameterState
+        ? paramState
+        : undefined;
+    const valueSpec = valueSpecParamState?.valueSpec;
+
+    const paramIsRequired = Boolean(
+      testState.queryVariableExpressions.find(
+        (v) =>
+          v.name === paramState.parameterValue.name &&
+          v.multiplicity.lowerBound > 0,
+      ),
+    );
+
+    const showCodeEditor =
+      Boolean(contentTypeParamPair) &&
+      valueSpecParamState?.varExpression.genericType?.value.rawType ===
+        PrimitiveType.STRING &&
+      valueSpec instanceof PrimitiveInstanceValue;
+
+    const type = contentTypeParamPair
+      ? contentTypeParamPair.contentType
+      : (valueSpecParamState?.varExpression.genericType?.value.rawType.name ??
+        'unknown');
+
+    const openInPopUp = (): void => setShowPopup(!showPopUp);
+    const closePopUp = (): void => setShowPopup(false);
+
+    const updateParamValue = (val: string): void => {
+      if (
+        !(valueSpec instanceof PrimitiveInstanceValue) ||
+        !valueSpecParamState
+      ) {
+        return;
+      }
+      const nextValue =
+        valueSpecParamState.varExpression.genericType?.value.rawType ===
+        PrimitiveType.BYTE
+          ? btoa(val)
+          : val;
+      instanceValue_setValue(
+        valueSpec,
+        nextValue,
+        0,
+        testState.editorStore.changeDetectionState.observerContext,
+      );
+      valueSpecParamState.updateValueSpecification(valueSpec);
+    };
+
+    return (
+      <div
+        key={paramState.parameterValue.name}
+        className="panel__content__form__section"
+      >
+        <div className="panel__content__form__section__header__label">
+          {`Name: ${paramState.parameterValue.name || '(unnamed)'}`}
+          <button
+            className={clsx('type-tree__node__type__label', {})}
+            tabIndex={-1}
+            title={type}
+          >
+            {type}
+          </button>
+        </div>
+
+        {!valueSpecParamState && (
+          <BlankPanelContent>Unsupported parameter value</BlankPanelContent>
+        )}
+
+        {valueSpecParamState &&
+          showCodeEditor &&
+          valueSpec instanceof PrimitiveInstanceValue && (
+            <div className="data-product-test-editor__parameter__code-editor">
+              <textarea
+                className="panel__content__form__section__textarea value-spec-editor__input"
+                spellCheck={false}
+                value={
+                  valueSpecParamState.varExpression.genericType?.value
+                    .rawType === PrimitiveType.BYTE
+                    ? atob((valueSpec.values[0] as string) ?? '')
+                    : ((valueSpec.values[0] as string) ?? '')
+                }
+                placeholder={
+                  (valueSpec.values[0] as string) === '' ? '(empty)' : undefined
+                }
+                onChange={(event) => updateParamValue(event.target.value)}
+              />
+              {showPopUp && (
+                <ExternalFormatParameterEditorModal
+                  valueSpec={valueSpecParamState.valueSpec}
+                  varExpression={valueSpecParamState.varExpression}
+                  onClose={closePopUp}
+                  isReadOnly={isReadOnly}
+                  updateParamValue={updateParamValue}
+                  contentTypeParamPair={contentTypeParamPair!}
+                />
+              )}
+              <div className="data-product-test-editor__parameter__value__actions">
+                <button
+                  className="data-product-test-editor__parameter__code-editor__expand-btn"
+                  onClick={openInPopUp}
+                  tabIndex={-1}
+                  title="Open in a popup..."
+                >
+                  <FilledWindowMaximizeIcon />
+                </button>
+                <button
+                  className="btn--icon btn--dark btn--sm data-product-test-editor__parameter__code-editor__expand-btn"
+                  disabled={isReadOnly || paramIsRequired}
+                  onClick={(): void =>
+                    testState.removeParamValueState(paramState)
+                  }
+                  tabIndex={-1}
+                  title={
+                    paramIsRequired ? 'Parameter Required' : 'Remove Parameter'
+                  }
+                >
+                  <TimesIcon />
+                </button>
+              </div>
+            </div>
+          )}
+
+        {valueSpecParamState && !showCodeEditor && (
+          <div className="data-product-test-editor__parameter__value">
+            <BasicValueSpecificationEditor
+              valueSpecification={valueSpecParamState.valueSpec}
+              setValueSpecification={(val: ValueSpecification): void => {
+                valueSpecParamState.updateValueSpecification(val);
+              }}
+              graph={testState.editorStore.graphManagerState.graph}
+              observerContext={
+                testState.editorStore.changeDetectionState.observerContext
+              }
+              typeCheckOption={{
+                expectedType:
+                  valueSpecParamState.varExpression.genericType?.value
+                    .rawType ?? PrimitiveType.STRING,
+              }}
+              className="query-builder__parameters__value__editor"
+              resetValue={(): void => {
+                valueSpecParamState.resetValueSpec();
+              }}
+            />
+            <div className="data-product-test-editor__parameter__value__actions">
+              <button
+                className="btn--icon btn--dark btn--sm"
+                disabled={isReadOnly || paramIsRequired}
+                onClick={(): void =>
+                  testState.removeParamValueState(paramState)
+                }
+                tabIndex={-1}
+                title={
+                  paramIsRequired ? 'Parameter Required' : 'Remove Parameter'
+                }
+              >
+                <TimesIcon />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+const NewDataProductParameterModal = observer(
+  (props: { testState: DataProductTestState; isReadOnly: boolean }) => {
+    const { testState, isReadOnly } = props;
+    const applicationStore = testState.editorStore.applicationStore;
+    const currentOption = {
+      value: testState.newParameterValueName,
+      label: testState.newParameterValueName,
+    };
+    const options = testState.newParamOptions;
+    const closeModal = (): void => testState.setShowNewParameterModal(false);
+    const onChange = (val: { label: string; value: string } | null): void => {
+      if (val === null) {
+        testState.setNewParameterValueName('');
+      } else if (val.value !== testState.newParameterValueName) {
+        testState.setNewParameterValueName(val.value);
+      }
+    };
+
+    return (
+      <Dialog
+        open={testState.showNewParameterModal}
+        onClose={closeModal}
+        classes={{ container: 'search-modal__container' }}
+        slotProps={{
+          paper: {
+            classes: { root: 'search-modal__inner-container' },
+          },
+        }}
+      >
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            testState.addParameterValue();
+          }}
+          className="modal modal--dark search-modal"
+        >
+          <div className="modal__title">New Test Parameter Value</div>
+          <CustomSelectorInput
+            className="panel__content__form__section__dropdown"
+            options={options}
+            onChange={onChange}
+            value={currentOption}
+            escapeClearsValue={true}
+            darkMode={
+              !applicationStore.layoutService
+                .TEMPORARY__isLightColorThemeEnabled
+            }
+            disabled={isReadOnly}
+          />
+          <div className="search-modal__actions">
+            <button className="btn btn--dark" disabled={isReadOnly}>
+              Add
+            </button>
+          </div>
+        </form>
+      </Dialog>
+    );
+  },
+);
+
+const DataProductTestEditorExtension = observer(
+  (props: { testState: DataProductTestState; isReadOnly: boolean }) => {
+    const { testState, isReadOnly } = props;
+
+    useEffect(() => {
+      testState.syncWithQuery();
+    }, [testState]);
+
+    const hasQueryParameters = Boolean(
+      testState.queryVariableExpressions.length,
+    );
+    if (!hasQueryParameters) {
+      return null;
+    }
+
+    const query = getAccessPointQuery(testState);
+    const contentTypeParamPairs = getContentTypeWithParamFromQuery(
+      query,
+      testState.editorStore,
+    );
+
+    const addParameter = (): void => {
+      testState.openNewParamModal();
+    };
+
+    const generateParameterValues = (): void => {
+      testState.generateTestParameterValues();
+    };
+
+    return (
+      <div className="data-product-test-editor__parameters-panel-container">
+        <div className="panel data-product-test-editor__parameters-panel">
+          <div className="data-product-test-editor__parameters-header">
+            <div className="data-product-test-editor__parameters-header__title">
+              <div className="data-product-test-editor__parameters-header__title__label">
+                Parameters
+              </div>
+            </div>
+            <div className="data-product-test-editor__parameters-header__actions">
+              <button
+                className="panel__header__action data-product-test-editor__generate-btn"
+                onClick={generateParameterValues}
+                disabled={!testState.newParamOptions.length}
+                title="Generate test parameter values"
+                tabIndex={-1}
+              >
+                <div className="data-product-test-editor__generate-btn__label">
+                  <RefreshIcon className="data-product-test-editor__generate-btn__label__icon" />
+                  <div className="data-product-test-editor__generate-btn__label__title">
+                    Generate
+                  </div>
+                </div>
+              </button>
+              <button
+                className="panel__header__action"
+                tabIndex={-1}
+                disabled={!testState.newParamOptions.length}
+                onClick={addParameter}
+                title="Add Parameter Value"
+              >
+                <PlusIcon />
+              </button>
+            </div>
+          </div>
+
+          <div className="data-product-test-editor__parameters">
+            {testState.parameterValueStates.map((paramState) => (
+              <DataProductTestParameterEditor
+                key={paramState.uuid}
+                isReadOnly={isReadOnly}
+                paramState={paramState}
+                testState={testState}
+                contentTypeParamPair={contentTypeParamPairs.find(
+                  (pair) => pair.param === paramState.parameterValue.name,
+                )}
+              />
+            ))}
+            {testState.parameterValueStates.length === 0 && (
+              <BlankPanelPlaceholder
+                text="No parameter values"
+                tooltipText="Generate or add a parameter value"
+              />
+            )}
+          </div>
+        </div>
+
+        {testState.showNewParameterModal && (
+          <NewDataProductParameterModal
+            testState={testState}
+            isReadOnly={isReadOnly}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
 // ─── Suite Tab Context Menu ───────────────────────────────────────────────────
 
 const SuiteHeaderTabContextMenu = observer(
@@ -407,6 +780,14 @@ export const DataProductTestableEditor = observer(
               suiteState={selectedSuiteState}
               testableState={testableState}
               isReadOnly={isReadOnly}
+              renderTestStateExtension={(testState) =>
+                testState instanceof DataProductTestState ? (
+                  <DataProductTestEditorExtension
+                    testState={testState}
+                    isReadOnly={isReadOnly}
+                  />
+                ) : null
+              }
             />
           )}
           {!dp.tests.length && (

--- a/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/dataProduct/testable/DataProductTestableEditor.tsx
@@ -43,12 +43,9 @@ import {
   TimesIcon,
 } from '@finos/legend-art';
 import {
-  FunctionAccessPoint,
-  LakehouseAccessPoint,
   PrimitiveInstanceValue,
   PrimitiveType,
   type DataProductTestSuite,
-  type RawLambda,
   type ValueSpecification,
 } from '@finos/legend-graph';
 import type { DataProductEditorState } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/DataProductEditorState.js';
@@ -56,6 +53,7 @@ import {
   DataProductValueSpecificationTestParameterState,
   type DataProductTestParameterState,
   DataProductTestState,
+  getAccessPointLambda,
   type DataProductTestableState,
   type DataProductTestSuiteState,
 } from '../../../../../stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.js';
@@ -317,21 +315,6 @@ const CreateTestModal = observer(
   },
 );
 
-const getAccessPointQuery = (
-  testState: DataProductTestState,
-): RawLambda | undefined => {
-  const accessPoint = testState.suiteState.testableState.ownAccessPoints.find(
-    (ap) => ap.id === testState.test.accessPointId,
-  );
-  if (accessPoint instanceof LakehouseAccessPoint) {
-    return accessPoint.func;
-  }
-  if (accessPoint instanceof FunctionAccessPoint) {
-    return accessPoint.query;
-  }
-  return undefined;
-};
-
 const DataProductTestParameterEditor = observer(
   (props: {
     testState: DataProductTestState;
@@ -584,7 +567,10 @@ const DataProductTestEditorExtension = observer(
       return null;
     }
 
-    const query = getAccessPointQuery(testState);
+    const accessPoint = testState.suiteState.testableState.ownAccessPoints.find(
+      (ap) => ap.id === testState.test.accessPointId,
+    );
+    const query = accessPoint ? getAccessPointLambda(accessPoint) : undefined;
     const contentTypeParamPairs = getContentTypeWithParamFromQuery(
       query,
       testState.editorStore,

--- a/packages/legend-application-studio/src/components/editor/editor-group/testable/LakehouseTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/testable/LakehouseTestableEditor.tsx
@@ -69,6 +69,7 @@ import type {
 import { RelationElementsDataEditor } from '../data-editor/RelationElementsDataEditor.js';
 import { TestAssertionEditor } from './TestableSharedComponents.js';
 import type { EditorStore } from '../../../../stores/editor/EditorStore.js';
+import type { ReactNode } from 'react';
 
 // ─── Public interfaces ────────────────────────────────────────────────────────
 
@@ -341,8 +342,14 @@ export const LakehouseTestDataEditor = observer(
 // ─── Test editor: assertion viewer ────────────────────────────────────────────
 
 export const LakehouseTestEditor = observer(
-  (props: { testState: TestableTestEditorState; isReadOnly: boolean }) => {
-    const { testState } = props;
+  (props: {
+    testState: TestableTestEditorState;
+    isReadOnly: boolean;
+    renderTestStateExtension?: (
+      testState: TestableTestEditorState,
+    ) => ReactNode;
+  }) => {
+    const { testState, renderTestStateExtension } = props;
     const selectedAssertion = testState.selectedAsertionState;
 
     return (
@@ -353,6 +360,7 @@ export const LakehouseTestEditor = observer(
           </div>
         </div>
         <div className="panel">
+          {renderTestStateExtension?.(testState)}
           {selectedAssertion && (
             <TestAssertionEditor testAssertionState={selectedAssertion} />
           )}
@@ -449,8 +457,12 @@ export const LakehouseTestsEditor = observer(
     suiteState: LakehouseSuiteStateForEditor;
     testableState: LakehouseTestableStateForEditor;
     isReadOnly: boolean;
+    renderTestStateExtension?: (
+      testState: TestableTestEditorState,
+    ) => ReactNode;
   }) => {
-    const { suiteState, testableState, isReadOnly } = props;
+    const { suiteState, testableState, isReadOnly, renderTestStateExtension } =
+      props;
     const selectedTest = suiteState.selectTestState;
 
     return (
@@ -513,6 +525,9 @@ export const LakehouseTestsEditor = observer(
                 <LakehouseTestEditor
                   testState={selectedTest}
                   isReadOnly={isReadOnly}
+                  {...(renderTestStateExtension
+                    ? { renderTestStateExtension }
+                    : {})}
                 />
               ) : (
                 <BlankPanelPlaceholder
@@ -535,8 +550,12 @@ export const LakehouseTestSuiteEditor = observer(
     suiteState: LakehouseSuiteStateForEditor;
     testableState: LakehouseTestableStateForEditor;
     isReadOnly: boolean;
+    renderTestStateExtension?: (
+      testState: TestableTestEditorState,
+    ) => ReactNode;
   }) => {
-    const { suiteState, testableState, isReadOnly } = props;
+    const { suiteState, testableState, isReadOnly, renderTestStateExtension } =
+      props;
 
     return (
       <div className="service-test-suite-editor">
@@ -555,6 +574,9 @@ export const LakehouseTestSuiteEditor = observer(
               suiteState={suiteState}
               testableState={testableState}
               isReadOnly={isReadOnly}
+              {...(renderTestStateExtension
+                ? { renderTestStateExtension }
+                : {})}
             />
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/packages/legend-application-studio/src/components/editor/editor-group/testable/LakehouseTestableEditor.tsx
+++ b/packages/legend-application-studio/src/components/editor/editor-group/testable/LakehouseTestableEditor.tsx
@@ -55,7 +55,7 @@ import {
 } from '@finos/legend-art';
 import type { AtomicTest, TestSuite } from '@finos/legend-graph';
 import type { ActionState, GeneratorFn } from '@finos/legend-shared';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import type { TestableTestEditorState } from '../../../../stores/editor/editor-state/element-editor-state/testable/TestableEditorState.js';
 import {
   TESTABLE_RESULT,
@@ -69,7 +69,6 @@ import type {
 import { RelationElementsDataEditor } from '../data-editor/RelationElementsDataEditor.js';
 import { TestAssertionEditor } from './TestableSharedComponents.js';
 import type { EditorStore } from '../../../../stores/editor/EditorStore.js';
-import type { ReactNode } from 'react';
 
 // ─── Public interfaces ────────────────────────────────────────────────────────
 

--- a/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
+++ b/packages/legend-application-studio/src/stores/editor/editor-state/element-editor-state/dataProduct/testable/DataProductTestableState.ts
@@ -93,7 +93,7 @@ export type { LakehouseElementTestDataState as DataProductElementTestDataState }
  * Returns the lambda for an access point (handles both LakehouseAccessPoint
  * and FunctionAccessPoint).
  */
-const getAccessPointLambda = (
+export const getAccessPointLambda = (
   accessPoint: AccessPoint,
 ): RawLambda | undefined =>
   accessPoint instanceof LakehouseAccessPoint


### PR DESCRIPTION
Fixes a regression from the shared test editor refactor where access point test parameters were missing/misplaced in Testing as a result of PR #5345 which introduced testing UI for Matviews and also introduced shared testing components which introduced this bug.

Keeps the shared editor architecture with access points integerated