### PR TITLE
Allow optional date parameters to default to 'No Value' in query execution

### DIFF
--- a/.changeset/two-cloths-yell.md
+++ b/.changeset/two-cloths-yell.md
@@ -1,0 +1,4 @@
+---
+'@finos/legend-query-builder': patch
+---
+Allow optional Date parameters (multiplicity [0..1]) to default to "No Value" instead of forcing a date, and omit them from execution payload when unset.

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
@@ -887,12 +887,14 @@ test(
     const paramLambda = TEST_DATA__simpeDateParameters(
       PRIMITIVE_TYPE.STRICTDATE,
     );
-    // Override multiplicity from [1..1] to [0..1]
-    (
-      paramLambda.parameters as {
-        multiplicity: { lowerBound: number; upperBound: number };
-      }[]
-    )[0]!.multiplicity = { lowerBound: 0, upperBound: 1 };
+    const firstParam = guaranteeNonNullable(
+      (
+        paramLambda.parameters as {
+          multiplicity: { lowerBound: number; upperBound: number };
+        }[]
+      )[0],
+    );
+    firstParam.multiplicity = { lowerBound: 0, upperBound: 1 };
 
     await act(async () => {
       queryBuilderState.initializeWithQuery(

--- a/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
+++ b/packages/legend-query-builder/src/components/__tests__/QueryBuilderParametersPanel.test.tsx
@@ -870,3 +870,52 @@ test(
     expect(getByText(executeDialog, 'var_1')).toStrictEqual(parameterValue);
   },
 );
+test(
+  integrationTest(
+    'Query builder optional date parameter shows No Value by default',
+  ),
+  async () => {
+    const { renderResult, queryBuilderState } = await TEST__setUpQueryBuilder(
+      TEST_DATA__ComplexRelationalModel,
+      stub_RawLambda(),
+      'model::relational::tests::simpleRelationalMapping',
+      'model::MyRuntime',
+      TEST_DATA__ModelCoverageAnalysisResult_ComplexRelational,
+    );
+
+    // StrictDate with [0..1] multiplicity (optional)
+    const paramLambda = TEST_DATA__simpeDateParameters(
+      PRIMITIVE_TYPE.STRICTDATE,
+    );
+    // Override multiplicity from [1..1] to [0..1]
+    (
+      paramLambda.parameters as {
+        multiplicity: { lowerBound: number; upperBound: number };
+      }[]
+    )[0]!.multiplicity = { lowerBound: 0, upperBound: 1 };
+
+    await act(async () => {
+      queryBuilderState.initializeWithQuery(
+        create_RawLambda(paramLambda.parameters, paramLambda.body),
+      );
+    });
+
+    await waitFor(() =>
+      renderResult.getByTestId(QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS),
+    );
+    const parameterPanel = renderResult.getByTestId(
+      QUERY_BUILDER_TEST_ID.QUERY_BUILDER_PARAMETERS,
+    );
+    expect(getByText(parameterPanel, 'var_1')).not.toBeNull();
+
+    // Open the execute dialog
+    fireEvent.click(renderResult.getByText('Run Query'));
+    const executeDialog = await waitFor(() => renderResult.getByRole('dialog'));
+    expect(getByText(executeDialog, 'Set Parameter Values'));
+    expect(getByText(executeDialog, 'var_1')).not.toBeNull();
+    expect(getByText(executeDialog, 'StrictDate')).not.toBeNull();
+
+    // The key assertion: optional date should show 'No Value', not 'Today'
+    expect(getByText(executeDialog, 'No Value')).not.toBeNull();
+  },
+);

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -1517,7 +1517,6 @@ const DateInstanceValueEditorInner = <
         updateValueSpecification={updateValueSpecification}
         hasError={
           valueSpecification instanceof PrimitiveInstanceValue &&
-          valueSpecification.values[0] !== null &&
           !isValidInstanceValue(valueSpecification)
         }
         handleBlur={handleBlur}

--- a/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
+++ b/packages/legend-query-builder/src/components/shared/BasicValueSpecificationEditor.tsx
@@ -1517,6 +1517,7 @@ const DateInstanceValueEditorInner = <
         updateValueSpecification={updateValueSpecification}
         hasError={
           valueSpecification instanceof PrimitiveInstanceValue &&
+          valueSpecification.values[0] !== null &&
           !isValidInstanceValue(valueSpecification)
         }
         handleBlur={handleBlur}

--- a/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
+++ b/packages/legend-query-builder/src/components/shared/CustomDatePicker.tsx
@@ -511,12 +511,13 @@ export const CustomDatePicker = <
   const applicationStore = useApplicationStore();
   // For some cases where types need to be matched strictly.
   // Some options need to be filtered out for DateTime.
-  const targetDateOptionsEnum = typeCheckOption.match
-    ? Object.values([
-        CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_TIME,
-        CUSTOM_DATE_PICKER_OPTION.NOW,
-      ])
+  const allOptions = typeCheckOption.match
+    ? [CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_TIME, CUSTOM_DATE_PICKER_OPTION.NOW]
     : Object.values(CUSTOM_DATE_PICKER_OPTION);
+  const targetDateOptionsEnum = allOptions.filter(
+    (o) => o !== CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
+  );
+
   const [datePickerOption, setDatePickerOption] = useState(
     buildDatePickerOption(valueSpecification, applicationStore),
   );

--- a/packages/legend-query-builder/src/components/shared/CustomDatePickerHelper.ts
+++ b/packages/legend-query-builder/src/components/shared/CustomDatePickerHelper.ts
@@ -947,24 +947,30 @@ export const buildDatePickerOption = (
     }
   } else if (valueSpecification instanceof PrimitiveInstanceValue) {
     const _path = valueSpecification.genericType.value.rawType.path;
-    if (_path === PRIMITIVE_TYPE.LATESTDATE) {
-      return new DatePickerOption(
-        CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
-        CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
-      );
-    }
-    if (valueSpecification.values[0] === null) {
-      return new DatePickerOption(
-        CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
-        CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
-      );
-    }
-    return new DatePickerOption(
-      valueSpecification.values[0] as string,
-      _path === PRIMITIVE_TYPE.DATETIME
-        ? CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_TIME
-        : CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_DATE,
-    );
+    const isDateType =
+      _path === PRIMITIVE_TYPE.STRICTDATE ||
+      _path === PRIMITIVE_TYPE.DATE ||
+      _path === PRIMITIVE_TYPE.DATETIME;
+    const isEmpty =
+      !valueSpecification.values.length ||
+      valueSpecification.values[0] === null ||
+      valueSpecification.values[0] === undefined;
+    return _path === PRIMITIVE_TYPE.LATESTDATE
+      ? new DatePickerOption(
+          CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
+          CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
+        )
+      : isDateType && isEmpty
+        ? new DatePickerOption(
+            CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
+            CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
+          )
+        : new DatePickerOption(
+            valueSpecification.values[0] as string,
+            _path === PRIMITIVE_TYPE.DATETIME
+              ? CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_TIME
+              : CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_DATE,
+          );
   } else {
     if (valueSpecification instanceof V1_CLatestDate) {
       return new DatePickerOption(

--- a/packages/legend-query-builder/src/components/shared/CustomDatePickerHelper.ts
+++ b/packages/legend-query-builder/src/components/shared/CustomDatePickerHelper.ts
@@ -103,6 +103,7 @@ export enum CUSTOM_DATE_PICKER_OPTION {
   PREVIOUS_DAY_OF_WEEK = 'Previous ... of Week',
   FIRST_DAY_OF = 'First day of...',
   LATEST_DATE = 'Latest Date',
+  NO_VALUE = 'No Value',
 }
 
 export enum CUSTOM_DATE_OPTION_UNIT {
@@ -945,21 +946,25 @@ export const buildDatePickerOption = (
         return new DatePickerOption('', '');
     }
   } else if (valueSpecification instanceof PrimitiveInstanceValue) {
-    return valueSpecification.genericType.value.rawType.path ===
-      PRIMITIVE_TYPE.LATESTDATE
-      ? new DatePickerOption(
-          CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
-          CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
-        )
-      : new DatePickerOption(
-          (valueSpecification.values[0] ?? '') as string,
-          valueSpecification.values[0] === null
-            ? ''
-            : valueSpecification.genericType.value.rawType.path ===
-                PRIMITIVE_TYPE.DATETIME
-              ? CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_TIME
-              : CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_DATE,
-        );
+    const _path = valueSpecification.genericType.value.rawType.path;
+    if (_path === PRIMITIVE_TYPE.LATESTDATE) {
+      return new DatePickerOption(
+        CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
+        CUSTOM_DATE_PICKER_OPTION.LATEST_DATE,
+      );
+    }
+    if (valueSpecification.values[0] === null) {
+      return new DatePickerOption(
+        CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
+        CUSTOM_DATE_PICKER_OPTION.NO_VALUE,
+      );
+    }
+    return new DatePickerOption(
+      valueSpecification.values[0] as string,
+      _path === PRIMITIVE_TYPE.DATETIME
+        ? CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_TIME
+        : CUSTOM_DATE_PICKER_OPTION.ABSOLUTE_DATE,
+    );
   } else {
     if (valueSpecification instanceof V1_CLatestDate) {
       return new DatePickerOption(

--- a/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
+++ b/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
@@ -49,6 +49,7 @@ import {
   uuid,
   isNonNullable,
   guaranteeNonNullable,
+  isEmpty,
 } from '@finos/legend-shared';
 import { makeObservable, observable, action, computed } from 'mobx';
 import {
@@ -134,9 +135,10 @@ export const buildExecutionParameterValues = (
       (ps) =>
         !(
           ps.value instanceof PrimitiveInstanceValue &&
-          (!ps.value.values.length ||
-            ps.value.values[0] === null ||
-            ps.value.values[0] === undefined) &&
+          (ps.value.genericType.value.rawType === PrimitiveType.STRICTDATE ||
+            ps.value.genericType.value.rawType === PrimitiveType.DATE ||
+            ps.value.genericType.value.rawType === PrimitiveType.DATETIME) &&
+          isEmpty(ps.value.values[0]) &&
           areMultiplicitiesEqual(
             ps.parameter.multiplicity,
             Multiplicity.ZERO_ONE,

--- a/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
+++ b/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
@@ -51,7 +51,10 @@ import {
   guaranteeNonNullable,
 } from '@finos/legend-shared';
 import { makeObservable, observable, action, computed } from 'mobx';
-import { generateVariableExpressionMockValue } from './ValueSpecificationEditorHelper.js';
+import {
+  buildDefaultInstanceValue,
+  generateVariableExpressionMockValue,
+} from './ValueSpecificationEditorHelper.js';
 import {
   valueSpecification_setGenericType,
   valueSpecification_setMultiplicity,
@@ -127,6 +130,13 @@ export const buildExecutionParameterValues = (
 ): ParameterValue[] =>
   paramStates
     .filter((ps) => !doesLambdaParameterStateContainFunctionValues(ps))
+    .filter(
+      (ps) =>
+        !(
+          ps.value instanceof PrimitiveInstanceValue &&
+          ps.value.values[0] === null
+        ),
+    )
     .map((queryParamState) => {
       const paramValue = new ParameterValue();
       paramValue.name = queryParamState.parameter.name;
@@ -244,6 +254,21 @@ export class LambdaParameterState implements Hashable {
   }
 
   mockParameterValue(): void {
+    const t = this.variableType;
+    const isOptionalDate =
+      (t === PrimitiveType.STRICTDATE ||
+        t === PrimitiveType.DATE ||
+        t === PrimitiveType.DATETIME) &&
+      areMultiplicitiesEqual(
+        this.parameter.multiplicity,
+        Multiplicity.ZERO_ONE,
+      );
+    if (isOptionalDate) {
+      this.setValue(
+        buildDefaultInstanceValue(this.graph, t, this.observerContext, false),
+      );
+      return;
+    }
     this.setValue(
       generateVariableExpressionMockValue(
         this.parameter,

--- a/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
+++ b/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
@@ -134,8 +134,13 @@ export const buildExecutionParameterValues = (
       (ps) =>
         !(
           ps.value instanceof PrimitiveInstanceValue &&
-          ps.value.values[0] === null &&
-          ps.parameter.multiplicity.lowerBound === 0
+          (!ps.value.values.length ||
+            ps.value.values[0] === null ||
+            ps.value.values[0] === undefined) &&
+          areMultiplicitiesEqual(
+            ps.parameter.multiplicity,
+            Multiplicity.ZERO_ONE,
+          )
         ),
     )
     .map((queryParamState) => {

--- a/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
+++ b/packages/legend-query-builder/src/stores/shared/LambdaParameterState.ts
@@ -134,7 +134,8 @@ export const buildExecutionParameterValues = (
       (ps) =>
         !(
           ps.value instanceof PrimitiveInstanceValue &&
-          ps.value.values[0] === null
+          ps.value.values[0] === null &&
+          ps.parameter.multiplicity.lowerBound === 0
         ),
     )
     .map((queryParamState) => {
@@ -264,11 +265,17 @@ export class LambdaParameterState implements Hashable {
         Multiplicity.ZERO_ONE,
       );
     if (isOptionalDate) {
-      this.setValue(
-        buildDefaultInstanceValue(this.graph, t, this.observerContext, false),
+      const nullDateValue = buildDefaultInstanceValue(
+        this.graph,
+        t,
+        this.observerContext,
+        false,
       );
+      nullDateValue.multiplicity = this.parameter.multiplicity;
+      this.setValue(nullDateValue);
       return;
     }
+
     this.setValue(
       generateVariableExpressionMockValue(
         this.parameter,


### PR DESCRIPTION
## Problem

When a query has Date parameters with multiplicity `[0..1]` (optional), the parameter value dialog

defaults to "Today" / "Now" with no way to leave the parameter unset. This forces users to provide

a date value even when the parameter is optional.


## Solution


- Optional Date/StrictDate/DateTime parameters (`[0..1]`) now default to "No Value" instead of a

  concrete date.

- Parameters set to "No Value" are omitted from the execution payload sent to the Engine.

