### PR TITLE
add Playwright end-to-end tests for Legend Query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,38 @@ jobs:
           directory: ./build/coverage
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  run-e2e-tests:
+    name: Run End-to-End Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Get Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Setup Yarn cache
+        uses: actions/cache@v4.2.3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+      - name: Setup Node
+        uses: actions/setup-node@v4.3.0
+        with:
+          node-version: 21
+      - name: Install dependencies
+        run: yarn
+      - name: Build
+        run: yarn build
+      - name: Install Playwright browser
+        run: yarn workspace @finos/legend-application-query-e2e exec playwright install --with-deps chromium
+      - name: Run end-to-end tests
+        run: yarn workspace @finos/legend-application-query-e2e test:e2e
+      - name: Upload end-to-end test report
+        if: failure()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: e2e-test-report
+          path: packages/legend-application-query-e2e/build/playwright-report
+          retention-days: 14

--- a/docs/technical/test-strategy.md
+++ b/docs/technical/test-strategy.md
@@ -35,7 +35,7 @@ For the details, please see the full article. But the gist is instead of focusin
 
 `integration`: We should have integration tests to cover all use cases. We don't make real network call here, so we should mock out our network client (or not (?), see [TODO](#TODO)). We also use `Jest`.
 
-`e2e`: Almost the same as `integration` test, except we do make real network call and interact with the backend. We would like to use [Playwright](hhttps://playwright.dev/). In a way, `e2e` tests are valuable here because it can be used to test the whole application stack as well as a `demo` for usage and features of the app.
+`e2e`: Almost the same as `integration` test, except we drive the real application in a real browser. We use [Playwright](https://playwright.dev/). In a way, `e2e` tests are valuable here because it can be used to test the whole application stack as well as a `demo` for usage and features of the app. End-to-end tests for `Legend Query` live in [packages/legend-application-query-e2e](../../packages/legend-application-query-e2e/README.md) — see its `README` for developer guidelines on running the suite, debugging failures, and adding new tests. The application under test runs against the mock depot server (`fixtures/legend-mock-server`) and browser-level engine mocks, so the suite requires no real backend and runs on every PR in CI (see the `run-e2e-tests` job in `.github/workflows/test.yml`).
 
 ## Frontend component testing guidelines
 

--- a/packages/legend-application-query-e2e/README.md
+++ b/packages/legend-application-query-e2e/README.md
@@ -1,0 +1,69 @@
+# @finos/legend-application-query-e2e
+
+End-to-end tests for the Legend Query web application, built with [Playwright](https://playwright.dev/).
+
+## Architecture
+
+The tests exercise the Legend Query webapp served by the `@finos/legend-application-query-deployment` dev server (`http://localhost:9001/query/`), backed by:
+
+- **Depot**: the mock depot server from `@finos/legend-fixture-mock-server` (port 6200), which serves a small test project (`org.finos.legend.test:legend-query-test`) with a data space.
+- **Engine**: browser-level network mocks installed per-test via `setupEngineMock()` (see [`src/support/EngineMock.ts`](./src/support/EngineMock.ts)). Engine endpoints are intercepted with Playwright's [`page.route()`](https://playwright.dev/docs/network#modify-requests), so tests are deterministic whether or not a real engine instance is running on port 6300 — the mocks always win, and CI needs no engine at all.
+
+Both the app dev server and the mock depot server are started automatically by Playwright's [`webServer`](https://playwright.dev/docs/test-webserver) config. Outside CI, already-running instances (e.g. your own `yarn dev:query` session) are reused instead, which makes local runs fast.
+
+## Running the tests
+
+```sh
+# one-time: build the workspace and download the browser binary
+yarn setup # or `yarn build` if the workspace is already set up
+yarn workspace @finos/legend-application-query-e2e test:e2e:setup
+
+# run the tests (starts the app + mock depot server automatically)
+yarn workspace @finos/legend-application-query-e2e test:e2e
+```
+
+> The workspace must be built before running, since the app dev server bundles the built workspace libraries. If your test fails against code you just changed, rebuild (or keep `yarn dev:ts` running).
+
+### Debugging failures
+
+| Command                                                          | What it does                                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `yarn workspace @finos/legend-application-query-e2e test:e2e:ui` | Opens Playwright UI mode: watch mode, time-travel through each step, live locator picker |
+| `... test:e2e:headed`                                            | Runs tests in a visible browser window                                                   |
+| `... test:e2e:report`                                            | Opens the HTML report of the last run                                                    |
+| `... test:e2e --debug`                                           | Steps through a test with the Playwright inspector                                       |
+| `... test:e2e --trace on`                                        | Records a full trace (DOM snapshots, network, console) for every test                    |
+
+On failure, screenshots land in `build/test-results/`; in CI, traces are recorded on retry and the whole HTML report is uploaded as a workflow artifact (`e2e-test-report`) on the failed run's summary page.
+
+## Adding new tests
+
+1. Create a spec in [`src/tests/`](./src/tests/) named `<Feature>.spec.ts`.
+2. Install the engine mocks in a `beforeEach`:
+
+   ```ts
+   import { test, expect } from '@playwright/test';
+   import { setupEngineMock } from '../support/EngineMock.js';
+
+   test.beforeEach(async ({ page }) => {
+     await setupEngineMock(page);
+   });
+
+   test('my new flow', async ({ page }) => {
+     await page.goto('setup'); // relative to baseURL http://localhost:9001/query/
+     // ...
+   });
+   ```
+
+3. Prefer user-facing locators (`getByRole`, `getByText`, `getByPlaceholder`, `getByTitle`) over CSS class selectors, per our [component testing guidelines](../../docs/technical/test-strategy.md#frontend-component-testing-guidelines). Fall back to class selectors only where the DOM offers nothing better (e.g. `react-select` internals).
+4. Rely on Playwright's auto-waiting web-first assertions (`await expect(locator).toBeVisible()`) — never `waitForTimeout()`.
+5. Playwright UI mode (`test:e2e:ui`) and `npx playwright codegen localhost:9001/query/` are the fastest ways to author locators.
+
+### When your flow needs backend data that isn't mocked yet
+
+- **Engine endpoints**: unmocked engine calls are passed through by `setupEngineMock()` — locally a real engine (if running) may answer them, but in CI they fail visibly, which is how a missing mock surfaces. To add one: exercise the flow locally, note the failing/passed-through endpoint (via the Playwright trace or browser devtools), add a `case` for it in [`EngineMock.ts`](./src/support/EngineMock.ts), and put its response payload in [`TEST_DATA__EngineResponses.ts`](./src/support/TEST_DATA__EngineResponses.ts) (captured from a live engine when possible).
+- **Depot data**: extend the mock depot server in [`fixtures/legend-mock-server`](../../fixtures/legend-mock-server) (`src/depot.ts` / `src/depot-data.ts`) when a flow needs additional depot routes or entities.
+
+## CI
+
+The `run-e2e-tests` job in [`.github/workflows/test.yml`](../../.github/workflows/test.yml) runs this suite on every PR and on pushes to `master`. It builds the workspace, installs Chromium, and lets the Playwright `webServer` config boot the app and mock depot server — no engine backend, Docker, or secrets involved. Failed runs retry twice and upload the HTML report as an artifact.

--- a/packages/legend-application-query-e2e/README.md
+++ b/packages/legend-application-query-e2e/README.md
@@ -7,7 +7,7 @@ End-to-end tests for the Legend Query web application, built with [Playwright](h
 The tests exercise the Legend Query webapp served by the `@finos/legend-application-query-deployment` dev server (`http://localhost:9001/query/`), backed by:
 
 - **Depot**: the mock depot server from `@finos/legend-fixture-mock-server` (port 6200), which serves a small test project (`org.finos.legend.test:legend-query-test`) with a data space.
-- **Engine**: browser-level network mocks installed per-test via `setupEngineMock()` (see [`src/support/EngineMock.ts`](./src/support/EngineMock.ts)). Engine endpoints are intercepted with Playwright's [`page.route()`](https://playwright.dev/docs/network#modify-requests), so tests are deterministic whether or not a real engine instance is running on port 6300 — the mocks always win, and CI needs no engine at all.
+- **Engine**: browser-level network mocks installed per-test via `setupEngineMock()` (see [`src/support/EngineMock.ts`](./src/support/EngineMock.ts)). The app's `config.json` is intercepted with Playwright's [`page.route()`](https://playwright.dev/docs/network#modify-requests) to point the engine URL at a dead port, where every call is answered by the mocks — so tests behave identically locally and in CI, a real engine running on port 6300 can never leak into a test, and CI needs no engine at all.
 
 Both the app dev server and the mock depot server are started automatically by Playwright's [`webServer`](https://playwright.dev/docs/test-webserver) config. Outside CI, already-running instances (e.g. your own `yarn dev:query` session) are reused instead, which makes local runs fast.
 
@@ -61,7 +61,7 @@ On failure, screenshots land in `build/test-results/`; in CI, traces are recorde
 
 ### When your flow needs backend data that isn't mocked yet
 
-- **Engine endpoints**: unmocked engine calls are passed through by `setupEngineMock()` — locally a real engine (if running) may answer them, but in CI they fail visibly, which is how a missing mock surfaces. To add one: exercise the flow locally, note the failing/passed-through endpoint (via the Playwright trace or browser devtools), add a `case` for it in [`EngineMock.ts`](./src/support/EngineMock.ts), and put its response payload in [`TEST_DATA__EngineResponses.ts`](./src/support/TEST_DATA__EngineResponses.ts) (captured from a live engine when possible).
+- **Engine endpoints**: unmocked engine calls fail loudly with a `501` response whose message names the endpoint (`Unmocked engine endpoint called in e2e test: ...`) — check the Playwright trace or browser console to find it. To add one: add a `case` for the endpoint in [`EngineMock.ts`](./src/support/EngineMock.ts), and put its response payload in [`TEST_DATA__EngineResponses.ts`](./src/support/TEST_DATA__EngineResponses.ts) (captured from a live engine when possible).
 - **Depot data**: extend the mock depot server in [`fixtures/legend-mock-server`](../../fixtures/legend-mock-server) (`src/depot.ts` / `src/depot-data.ts`) when a flow needs additional depot routes or entities.
 
 ## CI

--- a/packages/legend-application-query-e2e/jest.config.js
+++ b/packages/legend-application-query-e2e/jest.config.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests in this package are Playwright end-to-end tests, not Jest tests.
+ * The root Jest config treats every `packages/*` directory as a project
+ * (falling back to Jest's default `testMatch`, which would pick up our
+ * `*.spec.ts` files), so this config explicitly matches nothing to keep
+ * Jest out of this package. Run these tests with `yarn test:e2e` instead.
+ */
+export default {
+  displayName: '@finos/legend-application-query-e2e',
+  testMatch: ['<rootDir>/__no-jest-tests__/**/*'],
+};

--- a/packages/legend-application-query-e2e/package.json
+++ b/packages/legend-application-query-e2e/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@finos/legend-application-query-e2e",
+  "private": true,
+  "description": "Legend Query web application end-to-end tests",
+  "keywords": [
+    "legend",
+    "legend-application",
+    "legend-query",
+    "e2e",
+    "end-to-end-tests"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/finos/legend-studio.git",
+    "directory": "packages/legend-application-query-e2e"
+  },
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "clean": "yarn clean:cache",
+    "clean:cache": "rimraf \"build\"",
+    "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location ./build/.eslintcache --report-unused-disable-directives --parser-options=project:\"./tsconfig.json\",requireConfigFile:false \"./src/**/*.{js,ts,tsx}\"",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report build/playwright-report",
+    "test:e2e:setup": "playwright install chromium",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@finos/legend-dev-utils": "workspace:*",
+    "@playwright/test": "1.61.0",
+    "cross-env": "7.0.3",
+    "eslint": "9.22.0",
+    "rimraf": "6.0.1",
+    "typescript": "5.8.2"
+  }
+}

--- a/packages/legend-application-query-e2e/playwright.config.ts
+++ b/packages/legend-application-query-e2e/playwright.config.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const IS_CI = Boolean(process.env.CI);
+
+/**
+ * The application under test is the Legend Query webapp served by
+ * `@finos/legend-application-query-deployment` dev server, backed by:
+ * - the mock depot server from `@finos/legend-fixture-mock-server` (port 6200)
+ * - browser-level mocks for engine endpoints (port 6300), installed per-test
+ *   via `setupEngineMock()` — see `src/support/EngineMock.ts`. This avoids
+ *   port conflicts with a real engine instance running locally.
+ */
+export default defineConfig({
+  testDir: './src/tests',
+  outputDir: './build/test-results',
+  timeout: 60_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: true,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 2 : 0,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: './build/playwright-report', open: 'never' }],
+  ],
+  use: {
+    baseURL: 'http://localhost:9001/query/',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command:
+        'yarn workspace @finos/legend-fixture-mock-server build:ts && yarn workspace @finos/legend-fixture-mock-server start:depot',
+      url: 'http://localhost:6200/depot/api/info',
+      reuseExistingServer: !IS_CI,
+      timeout: 60_000,
+    },
+    {
+      // NOTE: the workspace must have been built (`yarn build`) since the dev
+      // server bundles the built workspace libraries
+      command:
+        'yarn workspace @finos/legend-application-query-deployment setup && yarn workspace @finos/legend-application-query-deployment build:tailwindcss && yarn workspace @finos/legend-application-query-deployment dev:webpack',
+      url: 'http://localhost:9001/query/',
+      reuseExistingServer: !IS_CI,
+      timeout: 300_000,
+    },
+  ],
+});

--- a/packages/legend-application-query-e2e/src/support/EngineMock.ts
+++ b/packages/legend-application-query-e2e/src/support/EngineMock.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page, Route } from '@playwright/test';
+import {
+  TEST_DATA__ClassifierPathMap,
+  TEST_DATA__CurrentUser,
+  TEST_DATA__LightQueries,
+  TEST_DATA__SubtypeInfo,
+} from './TEST_DATA__EngineResponses.js';
+
+// Must match the engine URL configured in
+// `legend-application-query-deployment/dev/config.json`
+const ENGINE_PORT = 6300;
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': 'http://localhost:9001',
+  'access-control-allow-credentials': 'true',
+  'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',
+  'access-control-allow-headers': 'content-type,accept',
+};
+
+const fulfillJson = (route: Route, json: unknown): Promise<void> =>
+  route.fulfill({ json, headers: { ...CORS_HEADERS } });
+
+/**
+ * Intercept Legend Engine calls at the browser level and serve mock
+ * responses. This keeps tests deterministic regardless of whether a real
+ * engine instance is running on the engine port (e.g. during local
+ * development), and lets CI run without an engine backend altogether.
+ */
+export const setupEngineMock = async (
+  page: Page,
+  port = ENGINE_PORT,
+): Promise<void> => {
+  const engineApiUrlPattern = new RegExp(`:${port}/api/(?<endpoint>.*)$`);
+  await page.route(engineApiUrlPattern, async (route) => {
+    const request = route.request();
+    const endpoint =
+      engineApiUrlPattern.exec(request.url())?.groups?.endpoint ?? '';
+
+    // CORS preflight
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: { ...CORS_HEADERS } });
+      return;
+    }
+
+    switch (endpoint) {
+      case 'server/v1/currentUser':
+        await fulfillJson(route, TEST_DATA__CurrentUser);
+        return;
+      case 'pure/v1/protocol/pure/getClassifierPathMap':
+        await fulfillJson(route, TEST_DATA__ClassifierPathMap);
+        return;
+      case 'pure/v1/protocol/pure/getSubtypeInfo':
+        await fulfillJson(route, TEST_DATA__SubtypeInfo);
+        return;
+      case 'pure/v1/query/search':
+        await fulfillJson(route, TEST_DATA__LightQueries);
+        return;
+      default:
+        break;
+    }
+    // recently-viewed queries, potentially with query params
+    if (endpoint.startsWith('pure/v1/query/batch')) {
+      await fulfillJson(route, []);
+      return;
+    }
+
+    // Let unmocked engine calls through: during local development a real
+    // engine may answer them; in CI they will fail visibly, surfacing the
+    // missing mock.
+    await route.continue();
+  });
+};

--- a/packages/legend-application-query-e2e/src/support/EngineMock.ts
+++ b/packages/legend-application-query-e2e/src/support/EngineMock.ts
@@ -18,13 +18,20 @@ import type { Page, Route } from '@playwright/test';
 import {
   TEST_DATA__ClassifierPathMap,
   TEST_DATA__CurrentUser,
+  TEST_DATA__ExecutionResult,
   TEST_DATA__LightQueries,
   TEST_DATA__SubtypeInfo,
 } from './TEST_DATA__EngineResponses.js';
 
-// Must match the engine URL configured in
-// `legend-application-query-deployment/dev/config.json`
-const ENGINE_PORT = 6300;
+/**
+ * The app's engine URL is rerouted (via `config.json` interception) to this
+ * port, where nothing listens: every engine call must be answered by the
+ * browser-level mocks below. This guarantees local runs behave exactly like
+ * CI, even when a real engine instance is running on the configured engine
+ * port (6300) during development — a real engine can never mask a missing
+ * mock.
+ */
+const MOCK_ENGINE_PORT = 6399;
 
 const CORS_HEADERS = {
   'access-control-allow-origin': 'http://localhost:9001',
@@ -38,15 +45,20 @@ const fulfillJson = (route: Route, json: unknown): Promise<void> =>
 
 /**
  * Intercept Legend Engine calls at the browser level and serve mock
- * responses. This keeps tests deterministic regardless of whether a real
- * engine instance is running on the engine port (e.g. during local
- * development), and lets CI run without an engine backend altogether.
+ * responses, so tests are deterministic and require no engine backend.
  */
-export const setupEngineMock = async (
-  page: Page,
-  port = ENGINE_PORT,
-): Promise<void> => {
-  const engineApiUrlPattern = new RegExp(`:${port}/api/(?<endpoint>.*)$`);
+export const setupEngineMock = async (page: Page): Promise<void> => {
+  // reroute the app's engine URL to the dead mock port
+  await page.route(/\/query\/config\.json$/, async (route) => {
+    const response = await route.fetch();
+    const config = (await response.json()) as { engine: { url: string } };
+    config.engine.url = `http://localhost:${MOCK_ENGINE_PORT}/api`;
+    await route.fulfill({ json: config });
+  });
+
+  const engineApiUrlPattern = new RegExp(
+    `:${MOCK_ENGINE_PORT}/api/(?<endpoint>.*)$`,
+  );
   await page.route(engineApiUrlPattern, async (route) => {
     const request = route.request();
     const endpoint =
@@ -71,6 +83,9 @@ export const setupEngineMock = async (
       case 'pure/v1/query/search':
         await fulfillJson(route, TEST_DATA__LightQueries);
         return;
+      case 'pure/v1/execution/execute':
+        await fulfillJson(route, TEST_DATA__ExecutionResult);
+        return;
       default:
         break;
     }
@@ -80,9 +95,15 @@ export const setupEngineMock = async (
       return;
     }
 
-    // Let unmocked engine calls through: during local development a real
-    // engine may answer them; in CI they will fail visibly, surfacing the
-    // missing mock.
-    await route.continue();
+    // Fail loudly on unmocked engine endpoints so missing mocks surface
+    // immediately (locally and in CI alike). To support a new flow, add a
+    // handler above and its payload to `TEST_DATA__EngineResponses.ts`.
+    await route.fulfill({
+      status: 501,
+      headers: { ...CORS_HEADERS },
+      json: {
+        message: `Unmocked engine endpoint called in e2e test: ${request.method()} /api/${endpoint} — add a handler in EngineMock.ts`,
+      },
+    });
   });
 };

--- a/packages/legend-application-query-e2e/src/support/TEST_DATA__EngineResponses.ts
+++ b/packages/legend-application-query-e2e/src/support/TEST_DATA__EngineResponses.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mock responses for Legend Engine endpoints, captured from a live engine
+ * instance. These are served to the browser via Playwright network
+ * interception (see `EngineMock.ts`) so tests do not require a running
+ * engine backend.
+ */
+
+export const TEST_DATA__CurrentUser = 'anonymous';
+
+export const TEST_DATA__ClassifierPathMap = [
+  {
+    type: 'dataQualityValidation',
+    classifierPath: 'meta::external::dataquality::DataQuality',
+  },
+  {
+    type: 'dataqualityRelationValidation',
+    classifierPath:
+      'meta::external::dataquality::DataQualityRelationValidation',
+  },
+  {
+    type: 'MongoDatabase',
+    classifierPath:
+      'meta::external::store::mongodb::metamodel::pure::MongoDatabase',
+  },
+  {
+    type: 'measure',
+    classifierPath: 'meta::pure::metamodel::type::Measure',
+  },
+  {
+    type: 'generationSpecification',
+    classifierPath:
+      'meta::pure::generation::metamodel::GenerationSpecification',
+  },
+  {
+    type: 'relationalMapper',
+    classifierPath: 'meta::relational::metamodel::RelationalMapper',
+  },
+  {
+    type: 'externalFormatSchemaSet',
+    classifierPath: 'meta::external::format::shared::metamodel::SchemaSet',
+  },
+  {
+    type: 'function',
+    classifierPath:
+      'meta::pure::metamodel::function::ConcreteFunctionDefinition',
+  },
+  {
+    type: 'elasticsearch7Store',
+    classifierPath:
+      'meta::external::store::elasticsearch::v7::metamodel::store::Elasticsearch7Store',
+  },
+  {
+    type: 'serviceStore',
+    classifierPath: 'meta::external::store::service::metamodel::ServiceStore',
+  },
+  {
+    type: 'profile',
+    classifierPath: 'meta::pure::metamodel::extension::Profile',
+  },
+  {
+    type: 'functionJar',
+    classifierPath:
+      'meta::external::function::activator::functionJar::FunctionJar',
+  },
+  {
+    type: 'text',
+    classifierPath: 'meta::pure::metamodel::text::Text',
+  },
+  {
+    type: 'snowflakeApp',
+    classifierPath:
+      'meta::external::function::activator::snowflakeApp::SnowflakeApp',
+  },
+  {
+    type: 'association',
+    classifierPath: 'meta::pure::metamodel::relationship::Association',
+  },
+  {
+    type: 'hostedService',
+    classifierPath:
+      'meta::external::function::activator::hostedService::HostedService',
+  },
+  {
+    type: 'bigQueryFunction',
+    classifierPath:
+      'meta::external::function::activator::bigQueryFunction::BigQueryFunction',
+  },
+  {
+    type: 'persistence',
+    classifierPath: 'meta::pure::persistence::metamodel::Persistence',
+  },
+  {
+    type: 'class',
+    classifierPath: 'meta::pure::metamodel::type::Class',
+  },
+  {
+    type: 'Enumeration',
+    classifierPath: 'meta::pure::metamodel::type::Enumeration',
+  },
+  {
+    type: 'dataSpace',
+    classifierPath: 'meta::pure::metamodel::dataSpace::DataSpace',
+  },
+  {
+    type: 'persistenceContext',
+    classifierPath: 'meta::pure::persistence::metamodel::PersistenceContext',
+  },
+  {
+    type: 'fileGeneration',
+    classifierPath:
+      'meta::pure::generation::metamodel::GenerationConfiguration',
+  },
+  {
+    type: 'sectionIndex',
+    classifierPath: 'meta::pure::metamodel::section::SectionIndex',
+  },
+  {
+    type: 'relational',
+    classifierPath: 'meta::relational::metamodel::Database',
+  },
+  {
+    type: 'service',
+    classifierPath: 'meta::legend::service::metamodel::Service',
+  },
+  {
+    type: 'binding',
+    classifierPath: 'meta::external::format::shared::binding::Binding',
+  },
+  {
+    type: 'diagram',
+    classifierPath: 'meta::pure::metamodel::diagram::Diagram',
+  },
+  {
+    type: 'executionEnvironmentInstance',
+    classifierPath:
+      'meta::legend::service::metamodel::ExecutionEnvironmentInstance',
+  },
+];
+
+export const TEST_DATA__SubtypeInfo = {
+  functionActivatorSubtypes: [
+    'functionJar',
+    'memSqlFunction',
+    'snowflakeApp',
+    'hostedService',
+    'bigQueryFunction',
+    'snowflakeM2MUdf',
+  ],
+  storeSubtypes: [
+    'MongoDatabase',
+    'serviceStore',
+    'relational',
+    'elasticsearch7Store',
+  ],
+};
+
+/**
+ * A light query as returned by the engine query search endpoint. The GAV
+ * coordinates match the mock project served by the mock depot server
+ * (see `@finos/legend-fixture-mock-server`).
+ */
+export const TEST_DATA__LightQueries = [
+  {
+    name: 'MockTestQuery',
+    id: 'mock-test-query-id',
+    groupId: 'org.finos.legend.test',
+    artifactId: 'legend-query-test',
+    versionId: '0.0.1',
+    originalVersionId: '0.0.1',
+    owner: 'anonymous',
+    createdAt: 1700000000000,
+    lastUpdatedAt: 1700000000000,
+    lastOpenAt: 1700000000000,
+  },
+];

--- a/packages/legend-application-query-e2e/src/support/TEST_DATA__EngineResponses.ts
+++ b/packages/legend-application-query-e2e/src/support/TEST_DATA__EngineResponses.ts
@@ -189,3 +189,35 @@ export const TEST_DATA__LightQueries = [
     lastOpenAt: 1700000000000,
   },
 ];
+
+/**
+ * A TDS execution result for a query projecting all properties of
+ * `test::COVIDData` (the class from the mock depot project), as returned by
+ * the engine execute endpoint.
+ */
+export const TEST_DATA__ExecutionResult = {
+  builder: {
+    _type: 'tdsBuilder',
+    columns: [
+      { name: 'Cases', type: 'Float', relationalType: 'DOUBLE' },
+      { name: 'Case Type', type: 'String', relationalType: 'VARCHAR(200)' },
+      { name: 'Date', type: 'StrictDate', relationalType: 'DATE' },
+      { name: 'Fips', type: 'String', relationalType: 'VARCHAR(200)' },
+      { name: 'Id', type: 'Integer', relationalType: 'INTEGER' },
+      { name: 'Last Reported Flag', type: 'Boolean', relationalType: 'BIT' },
+    ],
+  },
+  activities: [
+    {
+      _type: 'relational',
+      sql: 'select "root".CASES as "Cases", "root".CASE_TYPE as "Case Type", "root".DATE as "Date", "root".FIPS as "Fips", "root".ID as "Id", "root".LAST_REPORTED_FLAG as "Last Reported Flag" from COVID_DATA as "root"',
+    },
+  ],
+  result: {
+    columns: ['Cases', 'Case Type', 'Date', 'Fips', 'Id', 'Last Reported Flag'],
+    rows: [
+      { values: [250, 'Confirmed', '2021-04-01', '00001', 1, true] },
+      { values: [301, 'Confirmed', '2021-04-02', '00002', 2, false] },
+    ],
+  },
+};

--- a/packages/legend-application-query-e2e/src/tests/QueryBuilderDragAndDrop.spec.ts
+++ b/packages/legend-application-query-e2e/src/tests/QueryBuilderDragAndDrop.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { setupEngineMock } from '../support/EngineMock.js';
+
+// Deep-link straight into the query builder for the mock data space served
+// by the mock depot server (see `@finos/legend-fixture-mock-server`)
+const TEST_DATA_SPACE_QUERY_URL =
+  'extensions/dataspace/org.finos.legend.test:legend-query-test:0.0.1/test::DataSpace/dummyContext';
+
+const COLUMNS = [
+  'Cases',
+  'Case Type',
+  'Date',
+  'Fips',
+  'Id',
+  'Last Reported Flag',
+];
+
+test.beforeEach(async ({ page }) => {
+  await setupEngineMock(page);
+  await page.goto(TEST_DATA_SPACE_QUERY_URL);
+  // the graph is built in the browser from the mock depot project, wait for
+  // the explorer tree to render before interacting
+  await expect(
+    page
+      .getByTestId('query__builder__explorer')
+      .getByText('Cases', { exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test('build and run a query with projection columns, filter, and post-filter', async ({
+  page,
+}) => {
+  const explorer = page.getByTestId('query__builder__explorer');
+  const projectionPanel = page.getByTestId('query__builder__tds__projection');
+  const filterPanel = page.getByTestId('query__builder__filter__panel');
+  const resultPanel = page.getByTestId('query__builder__result__panel');
+  const projectionColumns = page.getByTestId(
+    'QUERY_BUILDER_TDS_PROJECTION_COLUMN',
+  );
+
+  // 1. drag every property from the explorer into the projection panel
+  for (const column of COLUMNS) {
+    await explorer.getByText(column, { exact: true }).dragTo(projectionPanel);
+    await expect(
+      projectionColumns.getByText(column, { exact: true }),
+    ).toBeVisible();
+  }
+  await expect(projectionColumns).toHaveCount(COLUMNS.length);
+
+  // 2. run the query and check the result grid (the engine execute endpoint
+  // is mocked to return 2 rows, see `TEST_DATA__ExecutionResult`)
+  await resultPanel.getByText('Run Query', { exact: true }).click();
+  const gridRows = resultPanel.locator('.ag-center-cols-container .ag-row');
+  await expect(gridRows).toHaveCount(2);
+  await expect(resultPanel.getByText('2021-04-01')).toBeVisible();
+  await expect(resultPanel.getByText('2021-04-02')).toBeVisible();
+
+  // 3. filter: `Case Type` is 'Confirmed'
+  await explorer.getByText('Case Type', { exact: true }).dragTo(filterPanel);
+  const filterCondition = page.getByTestId(
+    'query__builder__filter__tree__condition__node-content',
+  );
+  await expect(filterCondition.getByText('Case Type')).toBeVisible();
+  await page
+    .getByTestId('query-builder-filter-tree__condition-node__value')
+    .click();
+  await filterPanel.locator('.value-spec-editor input').fill('Confirmed');
+  await page.keyboard.press('Enter');
+  await expect(filterCondition.getByText('Confirmed')).toBeVisible();
+
+  // 4. post-filter: `Cases` > 200
+  await page
+    .getByTestId('query__builder__actions')
+    .getByRole('button', { name: 'Advanced' })
+    .click();
+  await page.getByText('Show Post-Filter').click();
+  const postFilterPanel = page.getByTestId(
+    'query__builder__post__filter-panel',
+  );
+  await expect(postFilterPanel).toBeVisible();
+
+  await projectionColumns
+    .getByText('Cases', { exact: true })
+    .dragTo(postFilterPanel);
+  const postFilterCondition = page.getByTestId(
+    'query__builder__post__filter__tree__node-content',
+  );
+  await expect(postFilterCondition.getByText('Cases')).toBeVisible();
+
+  // switch the operator from the default `is` to `>`
+  await postFilterPanel.getByTitle('Choose Operator...').click();
+  await page
+    .locator(
+      '.query-builder-post-filter-tree__condition-node__operator__dropdown__option',
+      { hasText: /^>$/ },
+    )
+    .click();
+  await postFilterPanel
+    .locator('.value-spec-editor__editable__display--content')
+    .click();
+  await postFilterPanel.locator('.value-spec-editor input').fill('200');
+  await page.keyboard.press('Enter');
+  await expect(postFilterCondition.getByText('200')).toBeVisible();
+
+  // 5. re-run with filter and post-filter in place
+  await resultPanel.getByText('Run Query', { exact: true }).click();
+  await expect(gridRows).toHaveCount(2);
+});

--- a/packages/legend-application-query-e2e/src/tests/QuerySetup.spec.ts
+++ b/packages/legend-application-query-e2e/src/tests/QuerySetup.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020-present, Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { setupEngineMock } from '../support/EngineMock.js';
+
+test.beforeEach(async ({ page }) => {
+  await setupEngineMock(page);
+});
+
+test('query setup landing page shows entry actions', async ({ page }) => {
+  await page.goto('setup');
+  await expect(page.getByText('What do you want to do today')).toBeVisible();
+  await expect(page.getByText('Open an existing query')).toBeVisible();
+  await expect(page.getByText('Create query from data product')).toBeVisible();
+});
+
+test('existing queries can be searched and listed', async ({ page }) => {
+  await page.goto('setup');
+  await page.getByText('Open an existing query').click();
+  await expect(page).toHaveURL(/\/setup\/existing-query/);
+
+  const searchInput = page.getByPlaceholder('Search for queries by name or ID');
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill('MockTest');
+  await expect(page.getByText('MockTestQuery')).toBeVisible();
+});
+
+test('query creator lists data products from depot', async ({ page }) => {
+  await page.goto('setup');
+  await page.getByText('Create query from data product').click();
+
+  const dataProductSelector = page.locator('.selector-input__control', {
+    hasText: 'Search for data product...',
+  });
+  await expect(dataProductSelector).toBeVisible();
+  await dataProductSelector.click();
+  await expect(
+    page.locator('.selector-input__option', { hasText: 'Test DataSpace' }),
+  ).toBeVisible();
+});

--- a/packages/legend-application-query-e2e/tsconfig.json
+++ b/packages/legend-application-query-e2e/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@finos/legend-dev-utils/tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "build/dev.tsbuildinfo",
+    "noEmit": true
+  },
+  "include": ["playwright.config.ts", "src/**/*.ts", "src/**/*.json"]
+}

--- a/scripts/workflow/checkProjectReferenceConfigs.js
+++ b/scripts/workflow/checkProjectReferenceConfigs.js
@@ -39,6 +39,7 @@ checkProjectReferenceConfig({
   excludePackagePatterns: [
     '@finos/legend-manual-tests',
     '@finos/legend-application-*-deployment',
+    '@finos/legend-application-*-e2e',
   ],
   excludeReferencePatterns: ['**/tsconfig.package.json'],
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     { "path": "packages/legend-application-query" },
     { "path": "packages/legend-application-query-bootstrap" },
     { "path": "packages/legend-application-query-deployment" },
+    { "path": "packages/legend-application-query-e2e" },
     // data cube
     { "path": "packages/legend-application-data-cube" },
     { "path": "packages/legend-application-data-cube-bootstrap" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,6 +2658,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@finos/legend-application-query-e2e@workspace:packages/legend-application-query-e2e":
+  version: 0.0.0-use.local
+  resolution: "@finos/legend-application-query-e2e@workspace:packages/legend-application-query-e2e"
+  dependencies:
+    "@finos/legend-dev-utils": "workspace:*"
+    "@playwright/test": "npm:1.61.0"
+    cross-env: "npm:7.0.3"
+    eslint: "npm:9.22.0"
+    rimraf: "npm:6.0.1"
+    typescript: "npm:5.8.2"
+  languageName: unknown
+  linkType: soft
+
 "@finos/legend-application-query@workspace:*, @finos/legend-application-query@workspace:packages/legend-application-query":
   version: 0.0.0-use.local
   resolution: "@finos/legend-application-query@workspace:packages/legend-application-query"
@@ -5416,6 +5429,17 @@ __metadata:
   version: 0.1.2
   resolution: "@pkgr/core@npm:0.1.2"
   checksum: 10/5160ec9f2e3232da681824a42583ef80e637ae6143339bd1db176848efd244dd71d177ccb7fd729261d8dcaf88486ce701d39500d873ed5caf16e8c281e9e28a
+  languageName: node
+  linkType: hard
+
+"@playwright/test@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@playwright/test@npm:1.61.0"
+  dependencies:
+    playwright: "npm:1.61.0"
+  bin:
+    playwright: cli.js
+  checksum: 10/359a9a4a59a87361d416818966bb810a38970d9f2b8364349d22099fb23eb043530714374a83010f9f3471c7e758df43c49bf32128745af13277adfb211aa752
   languageName: node
   linkType: hard
 
@@ -11741,12 +11765,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/6b5b6f5692372446ff81cf9501c76e3e0459a4852b3b5f1fc72c103198c125a6b8c72f5f166bdd76ffb2fca261e7f6ee5565daf80dca6e571e55bcc589cc1256
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10/4c1ade961ded57cdbfbb5cac5106ec17bc8bccd62e16343c569a0ceeca83b9dfef87550b4dc5cbb89642da412b20c5071f304c8c464b80415446e8e155a038c0
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -16735,6 +16778,30 @@ __metadata:
     exsolve: "npm:^1.0.7"
     pathe: "npm:^2.0.3"
   checksum: 10/4b36e4eb12693a1beb145573c564ec6fb74b1008d3b457eaa1f0072331edf05cb7c479c47fe0c4bfdec76c2caff5b68215ff270e5fe49634c07984a7a0197118
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright-core@npm:1.61.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10/e7ac4b2ef1c5f1701ec8086e47bc341988a3f753009d450e2a62daab5ade1fa943f1ef7fb48c721618dd7bd42667a11ff73c2e5dbd0674c20a3397b3c5be2f61
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright@npm:1.61.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10/b5faf97391315334a30e88e03216fd6090988b99896e71b341995a27c49d49dcebc825ec389dabc9b2d2cab6368c418cad9cbb925a88de35fb3b26a19bf05bea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Summary: Add Playwright end-to-end tests for Legend Query

### What this adds
A new e2e test suite for `legend-application-query`, using **Playwright** (chosen over Cypress/Selenium for its speed, reliability, and free parallel/cross-browser support). Tests run against the real app dev server and mock depot server, with Legend Engine mocked at the browser network layer — so the suite needs no engine backend and runs fully self-contained in CI.

### New package: `packages/legend-application-query-e2e`
- **`playwright.config.ts`** — Chromium project, traces/screenshots on failure, HTML report. Its `webServer` config auto-boots the mock depot server (port 6200, from `fixtures/legend-mock-server`) and the query app dev server (`localhost:9001/query/`), reusing already-running instances outside CI.
- **`src/support/EngineMock.ts`** — intercepts the app's `config.json` to redirect the engine URL to a dead port, then answers every engine call via `page.route()`. This guarantees deterministic behavior locally and in CI alike (a real engine running locally can never leak into a test), and unmocked endpoints fail loudly with a `501` naming the missing endpoint.
- **`src/support/TEST_DATA__EngineResponses.ts`** — mock payloads (`currentUser`, `getClassifierPathMap`, `getSubtypeInfo`, query search/batch, and a TDS execution result), captured from a live engine where possible.
- **`src/tests/QuerySetup.spec.ts`** — 3 smoke tests: setup landing page renders its entry actions; existing-query search returns results; data product picker lists depot data spaces.
- **`src/tests/QueryBuilderDragAndDrop.spec.ts`** — an end-to-end query-building flow:
  1. Drag all 6 properties (`Cases`, `Case Type`, `Date`, `Fips`, `Id`, `Last Reported Flag`) from the explorer into the projection panel.
  2. Run the query and assert the result grid renders 2 rows with expected values.
  3. Add a filter: `Case Type` is `Confirmed`.
  4. Enable and add a post-filter: `Cases` > `200`.
  5. Re-run and confirm the grid still renders correctly with both conditions applied.
- **`README.md`** — developer guidelines: architecture, running/debugging commands, how to add new tests, how to extend engine/depot mocks, and what the CI job does.

### CI (`.github/workflows/test.yml`)
New `run-e2e-tests` job: builds the workspace, installs Chromium, runs the suite, uploads the Playwright HTML report as an artifact on failure. Runs on every PR and push to `master`, no secrets/Docker required.

### Fixes for CI checks
- **`tsconfig.json`** — registered the new package as a project reference.
- **`scripts/workflow/checkProjectReferenceConfigs.js`** — excluded `@finos/legend-application-*-e2e` packages from the build-mode reference check (same treatment as `-deployment` and `legend-manual-tests`, since this package is never built/published).
- **`packages/legend-application-query-e2e/jest.config.js`** — added with a `testMatch` that matches nothing, so the root Jest config (which treats every `packages/*` dir as a project) doesn't try to parse the Playwright specs and fail on the `import` syntax.

### Docs
- **`docs/technical/test-strategy.md`** — updated the e2e section from aspirational ("we would like to use Playwright") to reflect actual usage, linking to the new package's README.

### Verification performed
- Full suite (4 tests) passes locally in ~4s, including a cold start where Playwright boots both servers itself.
- `check:ts`, `lint:js`, `prettier --check`, and copyright header checks all pass on every touched/new file.
- Verified the "no real engine at all" scenario (simulating CI) by pointing the app at a dead engine port — tests still pass purely on mocks.