### PR TITLE
Improve subscription contract selection by showing completed contracts and adding searchable filtering in the create dialog.

### DIFF
--- a/.changeset/easy-sheep-float.md
+++ b/.changeset/easy-sheep-float.md
@@ -1,0 +1,3 @@
+---
+'@finos/legend-application-marketplace': patch
+---

--- a/.changeset/six-games-stop.md
+++ b/.changeset/six-games-stop.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-product': patch
+---
+
+Improve subscription contract selection by showing completed contracts and adding searchable filtering in the create dialog.

--- a/packages/legend-application-marketplace/style/pages/lakehouse/_lakehouse-subscriptions.scss
+++ b/packages/legend-application-marketplace/style/pages/lakehouse/_lakehouse-subscriptions.scss
@@ -61,6 +61,11 @@
     }
   }
 
+  &__contract-select-menu {
+    margin-top: -16px;
+    max-height: 400px;
+  }
+
   &__autocomplete {
     &__listbox {
       .MuiListSubheader-root {
@@ -100,21 +105,23 @@
     &__footer {
       @include flexVCenter;
 
-      font-size: 1.2rem;
-      color: var(--color-light-grey-300);
+      justify-content: space-between;
       gap: 1rem;
     }
 
     &__description {
       @include ellipsisTextOverflow;
 
-      flex: 1;
+      font-size: 1.2rem;
+      color: var(--color-light-grey-300);
     }
 
     &__id {
       @include flexVCenter;
 
       width: fit-content;
+      font-size: 1.2rem;
+      color: var(--color-light-grey-300);
     }
   }
 }

--- a/packages/legend-extension-dsl-data-product/src/components/DataProduct/Subscriptions/DataProductSubscriptionsViewer.tsx
+++ b/packages/legend-extension-dsl-data-product/src/components/DataProduct/Subscriptions/DataProductSubscriptionsViewer.tsx
@@ -29,6 +29,7 @@ import {
   FormControlLabel,
   IconButton,
   InputLabel,
+  ListSubheader,
   MenuItem,
   Select,
   Switch,
@@ -38,8 +39,10 @@ import {
 import {
   type V1_DataSubscription,
   type V1_DataSubscriptionTarget,
+  type V1_LiteDataContract,
   V1_AdhocTeam,
   V1_AWSSnowflakeIngestEnvironment,
+  V1_ContractState,
   V1_DataContract,
   V1_DataSubscriptionTargetType,
   V1_EnrichedUserApprovalStatus,
@@ -47,7 +50,7 @@ import {
   V1_SnowflakeRegion,
   V1_SnowflakeTarget,
 } from '@finos/legend-graph';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { guaranteeNonNullable } from '@finos/legend-shared';
 import { useAuth } from 'react-oidc-context';
 import {
@@ -68,13 +71,15 @@ import { MultiUserRenderer } from '../../UserRenderer/MultiUserRenderer.js';
 import {
   getOrganizationalScopeTypeDetails,
   getOrganizationalScopeTypeName,
+  stringifyOrganizationalScope,
 } from '../../../utils/LakehouseUtils.js';
 import type { DataProductAPGState } from '../../../stores/DataProduct/DataProductAPGState.js';
 import type { DataProductDataAccessState } from '../../../stores/DataProduct/DataProductDataAccessState.js';
+import type { DataProductDataAccess_LegendApplicationPlugin_Extension } from '../../../stores/DataProductDataAccess_LegendApplicationPlugin_Extension.js';
 
 const LakehouseSubscriptionsCreateDialogContractRenderer = observer(
   (props: {
-    contract: V1_DataContract;
+    contract: V1_LiteDataContract;
     dataAccessState: DataProductDataAccessState;
   }) => {
     const { contract, dataAccessState } = props;
@@ -156,6 +161,27 @@ const LakehouseSubscriptionsCreateDialogContractRenderer = observer(
   },
 );
 
+const contractMatchesSearch = (
+  contract: V1_LiteDataContract,
+  searchText: string,
+  plugins: DataProductDataAccess_LegendApplicationPlugin_Extension[],
+): boolean => {
+  const normalizedSearch = searchText.trim().toLowerCase();
+  if (!normalizedSearch) {
+    return true;
+  }
+  const searchableFields = [
+    contract.description,
+    contract.guid,
+    contract.createdBy,
+    stringifyOrganizationalScope(contract.consumer, plugins),
+    contract.members.map((member) => member.user.name).join(' '),
+  ];
+  return searchableFields.some((field) =>
+    field.toLowerCase().includes(normalizedSearch),
+  );
+};
+
 const LakehouseSubscriptionsCreateDialog = observer(
   (props: {
     open: boolean;
@@ -163,7 +189,7 @@ const LakehouseSubscriptionsCreateDialog = observer(
     apgState: DataProductAPGState;
     dataAccessState: DataProductDataAccessState;
     onSubmit: (
-      contract: V1_DataContract,
+      contract: V1_LiteDataContract,
       target: V1_DataSubscriptionTarget,
     ) => Promise<void>;
   }) => {
@@ -177,6 +203,19 @@ const LakehouseSubscriptionsCreateDialog = observer(
       );
     }, [auth, dataAccessState]);
 
+    const plugins =
+      dataAccessState.applicationStore.pluginManager.getApplicationPlugins();
+
+    // All completed (approved) contracts for this access point group, from every
+    // consumer -- not just the current user's -- sourced from the single "lite"
+    // all-contracts fetch already cached on apgState.apgContracts.
+    const selectableContracts = apgState.apgContracts.filter(
+      (_contract) => _contract.state === V1_ContractState.COMPLETED,
+    );
+
+    // Used only to derive the default selection below; the priority logic that
+    // ranks a user's contracts (see V1_USER_APPROVAL_STAGE_PRIORITY) still lives
+    // upstream in DataProductAPGState and is left untouched.
     const approvedUserContract =
       apgState.userAccessStatus === V1_EnrichedUserApprovalStatus.APPROVED &&
       apgState.associatedUserContract instanceof V1_DataContract
@@ -187,12 +226,38 @@ const LakehouseSubscriptionsCreateDialog = observer(
         .filter((_contract) => _contract.approvedUsers.length > 0)
         .map((_contract) => _contract.contract);
 
-    const [contract, setContract] = useState<V1_DataContract | undefined>(
-      approvedUserContract ??
-        (approvedSystemAccountContracts.length === 1
-          ? approvedSystemAccountContracts[0]
-          : undefined),
+    const defaultContract = (() => {
+      const defaultUserContract = selectableContracts.find(
+        (_contract) => _contract.guid === approvedUserContract?.guid,
+      );
+      if (defaultUserContract) {
+        return defaultUserContract;
+      }
+      if (approvedSystemAccountContracts.length === 1) {
+        return selectableContracts.find(
+          (_contract) =>
+            _contract.guid === approvedSystemAccountContracts[0]?.guid,
+        );
+      }
+      return undefined;
+    })();
+
+    const [contract, setContract] = useState<V1_LiteDataContract | undefined>(
+      defaultContract,
     );
+    const [contractSearchText, setContractSearchText] = useState<string>('');
+    const filteredSelectableContracts = selectableContracts.filter(
+      (_contract) =>
+        contractMatchesSearch(_contract, contractSearchText, plugins),
+    );
+    // MUI's Select re-asserts DOM focus onto the (re-rendered) MenuList/option
+    // items whenever the option list changes -- which happens on every
+    // keystroke here, since it drives the filter -- stealing focus away from
+    // this search input. Forcibly reclaim it after each render.
+    const contractSearchInputRef = useRef<HTMLInputElement | null>(null);
+    useEffect(() => {
+      contractSearchInputRef.current?.focus();
+    }, [contractSearchText, filteredSelectableContracts.length]);
     const [targetType] = useState<V1_DataSubscriptionTargetType>(
       V1_DataSubscriptionTargetType.Snowflake,
     );
@@ -284,25 +349,54 @@ const LakehouseSubscriptionsCreateDialog = observer(
               value={contract?.guid ?? ''}
               label="Contract"
               autoFocus={contract === undefined}
+              onClose={() => setContractSearchText('')}
+              renderValue={() =>
+                contract ? (
+                  <LakehouseSubscriptionsCreateDialogContractRenderer
+                    contract={contract}
+                    dataAccessState={dataAccessState}
+                  />
+                ) : (
+                  ''
+                )
+              }
               onChange={(event: SelectChangeEvent<string>) => {
                 setContract(
-                  [
-                    approvedUserContract,
-                    ...approvedSystemAccountContracts,
-                  ].find((_contract) => _contract?.guid === event.target.value),
+                  selectableContracts.find(
+                    (_contract) => _contract.guid === event.target.value,
+                  ),
                 );
               }}
+              MenuProps={{
+                autoFocus: false,
+                disableAutoFocusItem: true,
+              }}
             >
-              {[approvedUserContract, ...approvedSystemAccountContracts]
-                .filter((_contract) => _contract instanceof V1_DataContract)
-                .map((_contract) => (
-                  <MenuItem key={_contract.guid} value={_contract.guid}>
-                    <LakehouseSubscriptionsCreateDialogContractRenderer
-                      contract={_contract}
-                      dataAccessState={dataAccessState}
-                    />
-                  </MenuItem>
-                ))}
+              <ListSubheader className="marketplace-lakehouse-subscriptions__subscription-creator__contract-search">
+                <TextField
+                  inputRef={contractSearchInputRef}
+                  autoFocus={true}
+                  fullWidth={true}
+                  placeholder="Search by user, description, or creator"
+                  value={contractSearchText}
+                  onChange={(event) =>
+                    setContractSearchText(event.target.value)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Escape') {
+                      event.stopPropagation();
+                    }
+                  }}
+                />
+              </ListSubheader>
+              {filteredSelectableContracts.map((_contract) => (
+                <MenuItem key={_contract.guid} value={_contract.guid}>
+                  <LakehouseSubscriptionsCreateDialogContractRenderer
+                    contract={_contract}
+                    dataAccessState={dataAccessState}
+                  />
+                </MenuItem>
+              ))}
             </Select>
           </FormControl>
           <FormControl fullWidth={true} margin="dense">
@@ -431,7 +525,7 @@ export const DataProductSubscriptionViewer = observer(
     );
 
     const createDialogHandleSubmit = async (
-      _contract: V1_DataContract,
+      _contract: V1_LiteDataContract,
       target: V1_DataSubscriptionTarget,
     ): Promise<void> => {
       await flowResult(

--- a/packages/legend-extension-dsl-data-product/src/components/DataProduct/Subscriptions/DataProductSubscriptionsViewer.tsx
+++ b/packages/legend-extension-dsl-data-product/src/components/DataProduct/Subscriptions/DataProductSubscriptionsViewer.tsx
@@ -134,12 +134,9 @@ const LakehouseSubscriptionsCreateDialogContractRenderer = observer(
 
     return (
       <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details">
-        <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details__users">
-          User(s): {consumerComponent}
-        </Box>
         <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details__footer">
-          <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details__description">
-            Description: {contract.description}
+          <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details__users">
+            User(s): {consumerComponent}
           </Box>
           <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details__id">
             ID: {contract.guid}
@@ -155,6 +152,9 @@ const LakehouseSubscriptionsCreateDialogContractRenderer = observer(
               <CopyIcon />
             </IconButton>
           </Box>
+        </Box>
+        <Box className="marketplace-lakehouse-subscriptions__subscription-creator__contract-details__description">
+          Description: {contract.description}
         </Box>
       </Box>
     );
@@ -258,6 +258,7 @@ const LakehouseSubscriptionsCreateDialog = observer(
     useEffect(() => {
       contractSearchInputRef.current?.focus();
     }, [contractSearchText, filteredSelectableContracts.length]);
+    const contractFieldRef = useRef<HTMLDivElement>(null);
     const [targetType] = useState<V1_DataSubscriptionTargetType>(
       V1_DataSubscriptionTargetType.Snowflake,
     );
@@ -342,6 +343,7 @@ const LakehouseSubscriptionsCreateDialog = observer(
           <FormControl fullWidth={true} margin="dense">
             <InputLabel id="contract-select-label">Contract</InputLabel>
             <Select
+              ref={contractFieldRef}
               required={true}
               labelId="contract-select-label"
               id="contract-select"
@@ -370,6 +372,15 @@ const LakehouseSubscriptionsCreateDialog = observer(
               MenuProps={{
                 autoFocus: false,
                 disableAutoFocusItem: true,
+                anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+                transformOrigin: { vertical: 'top', horizontal: 'left' },
+                slotProps: {
+                  paper: {
+                    className:
+                      'marketplace-lakehouse-subscriptions__subscription-creator__contract-select-menu',
+                    style: { width: contractFieldRef.current?.offsetWidth },
+                  },
+                },
               }}
             >
               <ListSubheader className="marketplace-lakehouse-subscriptions__subscription-creator__contract-search">

--- a/packages/legend-extension-dsl-data-product/src/components/__tests__/DataProductViewer.test.tsx
+++ b/packages/legend-extension-dsl-data-product/src/components/__tests__/DataProductViewer.test.tsx
@@ -28,6 +28,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import {
   type PlainObject,
@@ -2728,6 +2729,148 @@ describe('DataProductViewer', () => {
       await waitFor(() => {
         expect(getSubscriptionsForContractSpy).toHaveBeenCalledTimes(1);
       });
+    });
+
+    test("Create New Subscription contract field lists every approved contract for the group, not just the current user's, and supports search", async () => {
+      const mockLiteContracts: V1_LiteDataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resourceId: 'MOCK_SDLC_DATAPRODUCT',
+          resourceType: V1_ResourceType.ACCESS_POINT_GROUP,
+          deploymentId: 11111,
+          accessPointGroup: 'GROUP1',
+        },
+        {
+          description: 'Other team contract',
+          guid: 'test-other-user-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'other-team-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'other-team-user-id',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resourceId: 'MOCK_SDLC_DATAPRODUCT',
+          resourceType: V1_ResourceType.ACCESS_POINT_GROUP,
+          deploymentId: 11111,
+          accessPointGroup: 'GROUP1',
+        },
+      ];
+
+      const mockDataContracts: V1_DataContract[] = [
+        {
+          description: 'Test approved contract',
+          guid: 'test-approved-contract-id',
+          version: 0,
+          state: V1_ContractState.COMPLETED,
+          members: [],
+          consumer: {
+            _type: V1_OrganizationalScopeType.AdHocTeam,
+            users: [
+              {
+                name: 'test-consumer-user-id',
+                type: V1_UserType.WORKFORCE_USER,
+              },
+            ],
+          },
+          createdBy: 'test-user',
+          createdAt: '2025-12-22T15:18:41.998+00:00',
+          resource: {
+            _type: V1_AccessPointGroupReferenceType.AccessPointGroupReference,
+            accessPointGroup: 'GROUP1',
+            dataProduct: {
+              name: 'MOCK_SDLC_DATAPRODUCT',
+              owner: {
+                appDirId: 12345,
+              },
+            },
+          },
+        },
+      ];
+
+      const { dataProductDataAccessState } =
+        await setupLakehouseDataProductTest(
+          mockSDLCDataProduct,
+          mockEntitlementsSDLCDataProduct,
+          mockLiteContracts,
+          mockDataContracts,
+        );
+
+      createSpy(
+        guaranteeNonNullable(dataProductDataAccessState)
+          .lakehouseContractServerClient,
+        'getSubscriptionsForContract',
+      ).mockResolvedValue([]);
+
+      await screen.findByText('Main Group Test');
+      fireEvent.click(await screen.findByTitle('More options'));
+      fireEvent.click(await screen.findByText('Manage Subscriptions'));
+      await screen.findByText('Data Product Subscriptions');
+
+      const createButton = await screen.findByRole('button', {
+        name: 'Create New Subscription',
+      });
+      fireEvent.click(createButton);
+
+      const contractSelectTrigger = await waitFor(() =>
+        guaranteeNonNullable(document.getElementById('contract-select')),
+      );
+      fireEvent.mouseDown(contractSelectTrigger);
+
+      const listbox = await screen.findByRole('listbox');
+
+      // Both the current user's contract and another user's contract for the
+      // same access point group should be listed -- not just the current
+      // user's, and not requiring a second, separate API call. Scoped to the
+      // listbox since the closed field's own (persistent) value display also
+      // contains the currently-selected contract's text.
+      await within(listbox).findByText(/Test approved contract/);
+      within(listbox).getByText(/Other team contract/);
+
+      const searchInput = screen.getByPlaceholderText(
+        'Search by user, description, or creator',
+      );
+
+      // Narrowing the search should filter out non-matching contracts.
+      fireEvent.change(searchInput, { target: { value: 'other-team' } });
+      await waitFor(() => {
+        expect(
+          within(listbox).queryByText(/Test approved contract/),
+        ).toBeNull();
+      });
+      within(listbox).getByText(/Other team contract/);
+
+      // Regression: typing progressively longer search terms must not cause
+      // the field to lose focus (MUI's Select/MenuList re-asserting focus
+      // onto the -- now narrower -- option list after each keystroke).
+      fireEvent.change(searchInput, { target: { value: 'o' } });
+      expect(document.activeElement).toBe(searchInput);
+      fireEvent.change(searchInput, { target: { value: 'ot' } });
+      expect(document.activeElement).toBe(searchInput);
+      fireEvent.change(searchInput, { target: { value: 'oth' } });
+      expect(document.activeElement).toBe(searchInput);
     });
   });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
