### PR TITLE
follow up: fix transitive ingest included in store on mapping

### DIFF
--- a/.changeset/fix-relational-mapping-lakehouse-tableptr-roundtrip.md
+++ b/.changeset/fix-relational-mapping-lakehouse-tableptr-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+Fix roundtrip hashCode drift for relational class mappings that reference tables from an ingest-generated (lakehouse) database via an outer `Database` `include`. When transforming a `TableAlias` back to a `V1_TablePtr`, we now preserve the user's originally-serialized database path (e.g. the outer `Database` the mapping actually referenced) whenever it differs from the synthetic `INTERNAL__LakehouseGeneratedDatabase.path`, instead of unconditionally rewriting to the owning ingest path. The guard also skips the rewrite when there is no serialized path so the resolved path is not clobbered with an empty string.

--- a/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__IngestIncludeTransitiveRoundtrip.ts
+++ b/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__IngestIncludeTransitiveRoundtrip.ts
@@ -27,31 +27,59 @@
  * check.
  */
 
-const varchar200Column = (name: string): object => ({
-  genericType: {
-    multiplicityArguments: [],
-    rawType: {
-      _type: 'packageableType',
-      fullPath: 'Varchar',
-    },
-    typeArguments: [],
-    typeVariableValues: [
-      {
-        _type: 'integer',
-        value: 200,
-      },
-    ],
-  },
-  multiplicity: {
-    lowerBound: 0,
-    upperBound: 1,
-  },
-  name,
-});
-
 export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
   {
-    path: 'zoo::store::ParkStore',
+    classifierPath: 'meta::pure::metamodel::type::Class',
+    content: {
+      _type: 'class',
+      name: 'Animal',
+      package: 'model',
+      properties: [
+        {
+          genericType: {
+            rawType: {
+              _type: 'packageableType',
+              fullPath: 'String',
+            },
+          },
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'animalId',
+        },
+        {
+          genericType: {
+            rawType: {
+              _type: 'packageableType',
+              fullPath: 'String',
+            },
+          },
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'name',
+        },
+        {
+          genericType: {
+            rawType: {
+              _type: 'packageableType',
+              fullPath: 'String',
+            },
+          },
+          multiplicity: {
+            lowerBound: 1,
+            upperBound: 1,
+          },
+          name: 'species',
+        },
+      ],
+    },
+    path: 'model::Animal',
+  },
+  {
+    classifierPath: 'meta::relational::metamodel::Database',
     content: {
       _type: 'relational',
       filters: [],
@@ -100,10 +128,10 @@ export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
       package: 'zoo::store',
       schemas: [],
     },
-    classifierPath: 'meta::relational::metamodel::Database',
+    path: 'zoo::store::ParkStore',
   },
   {
-    path: 'zoo::store::AnimalStore',
+    classifierPath: 'meta::relational::metamodel::Database',
     content: {
       _type: 'relational',
       filters: [],
@@ -160,10 +188,111 @@ export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
       package: 'zoo::store',
       schemas: [],
     },
-    classifierPath: 'meta::relational::metamodel::Database',
+    path: 'zoo::store::AnimalStore',
   },
   {
-    path: 'zoo::lakehouse::ingestDefinitions::ZOO::ANIMALS',
+    classifierPath: 'meta::pure::mapping::Mapping',
+    content: {
+      _type: 'mapping',
+      classMappings: [
+        {
+          _type: 'relational',
+          class: 'model::Animal',
+          distinct: false,
+          mainTable: {
+            _type: 'Table',
+            database: 'zoo::store::ParkStore',
+            mainTableDb: 'zoo::store::ParkStore',
+            schema: 'ZOO',
+            table: 'ANIMALS',
+          },
+          primaryKey: [
+            {
+              _type: 'column',
+              column: 'ANIMAL_ID',
+              table: {
+                _type: 'Table',
+                database: 'zoo::store::ParkStore',
+                mainTableDb: 'zoo::store::ParkStore',
+                schema: 'ZOO',
+                table: 'ANIMALS',
+              },
+              tableAlias: 'ANIMALS',
+            },
+          ],
+          propertyMappings: [
+            {
+              _type: 'relationalPropertyMapping',
+              property: {
+                class: 'model::Animal',
+                property: 'animalId',
+              },
+              relationalOperation: {
+                _type: 'column',
+                column: 'ANIMAL_ID',
+                table: {
+                  _type: 'Table',
+                  database: 'zoo::store::ParkStore',
+                  mainTableDb: 'zoo::store::ParkStore',
+                  schema: 'ZOO',
+                  table: 'ANIMALS',
+                },
+                tableAlias: 'ANIMALS',
+              },
+            },
+            {
+              _type: 'relationalPropertyMapping',
+              property: {
+                class: 'model::Animal',
+                property: 'name',
+              },
+              relationalOperation: {
+                _type: 'column',
+                column: 'NAME',
+                table: {
+                  _type: 'Table',
+                  database: 'zoo::store::ParkStore',
+                  mainTableDb: 'zoo::store::ParkStore',
+                  schema: 'ZOO',
+                  table: 'ANIMALS',
+                },
+                tableAlias: 'ANIMALS',
+              },
+            },
+            {
+              _type: 'relationalPropertyMapping',
+              property: {
+                class: 'model::Animal',
+                property: 'species',
+              },
+              relationalOperation: {
+                _type: 'column',
+                column: 'SPECIES',
+                table: {
+                  _type: 'Table',
+                  database: 'zoo::store::ParkStore',
+                  mainTableDb: 'zoo::store::ParkStore',
+                  schema: 'ZOO',
+                  table: 'ANIMALS',
+                },
+                tableAlias: 'ANIMALS',
+              },
+            },
+          ],
+          root: true,
+        },
+      ],
+      enumerationMappings: [],
+      includedMappings: [],
+      name: 'AnimalMapping',
+      package: 'model',
+      tests: [],
+    },
+    path: 'model::AnimalMapping',
+  },
+  {
+    classifierPath:
+      'meta::external::ingest::specification::metamodel::IngestDefinition',
     content: {
       _type: 'ingestDefinition',
       datasetGroup: 'ZOO',
@@ -181,11 +310,111 @@ export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
             schema: {
               _type: 'relationType',
               columns: [
-                varchar200Column('ANIMAL_ID'),
-                varchar200Column('NAME'),
-                varchar200Column('SPECIES'),
-                varchar200Column('HABITAT_ID'),
-                varchar200Column('KEEPER_ID'),
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'ANIMAL_ID',
+                },
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'NAME',
+                },
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'SPECIES',
+                },
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'HABITAT_ID',
+                },
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'KEEPER_ID',
+                },
               ],
             },
           },
@@ -218,11 +447,11 @@ export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
         _type: 'batch_milestoned',
       },
     },
-    classifierPath:
-      'meta::external::ingest::specification::metamodel::IngestDefinition',
+    path: 'zoo::lakehouse::ingestDefinitions::ZOO::ANIMALS',
   },
   {
-    path: 'zoo::lakehouse::ingestDefinitions::ZOO::HABITATS',
+    classifierPath:
+      'meta::external::ingest::specification::metamodel::IngestDefinition',
     content: {
       _type: 'ingestDefinition',
       datasetGroup: 'ZOO',
@@ -240,9 +469,69 @@ export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
             schema: {
               _type: 'relationType',
               columns: [
-                varchar200Column('HABITAT_ID'),
-                varchar200Column('NAME'),
-                varchar200Column('KEEPER_ID'),
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'HABITAT_ID',
+                },
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'NAME',
+                },
+                {
+                  genericType: {
+                    multiplicityArguments: [],
+                    rawType: {
+                      _type: 'packageableType',
+                      fullPath: 'Varchar',
+                    },
+                    typeArguments: [],
+                    typeVariableValues: [
+                      {
+                        _type: 'integer',
+                        value: 200,
+                      },
+                    ],
+                  },
+                  multiplicity: {
+                    lowerBound: 0,
+                    upperBound: 1,
+                  },
+                  name: 'KEEPER_ID',
+                },
               ],
             },
           },
@@ -275,7 +564,6 @@ export const TEST_DATA__IngestIncludeTransitiveRoundtrip = [
         _type: 'batch_milestoned',
       },
     },
-    classifierPath:
-      'meta::external::ingest::specification::metamodel::IngestDefinition',
+    path: 'zoo::lakehouse::ingestDefinitions::ZOO::HABITATS',
   },
 ];

--- a/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
+++ b/packages/legend-graph/src/graph-manager/protocol/pure/v1/transformation/pureGraph/from/V1_DatabaseTransformer.ts
@@ -203,10 +203,15 @@ export const V1_transformTableAliasToTablePointer = (
   tablePtr.database = options?.TEMPORARY__resolveToFullPath
     ? ownerRef.value.path
     : (ownerRef.valueForSerialization ?? '');
-  // make sure reference is to the owner not the generated database
+  // make sure reference is to the owner (or the outer store the user actually
+  // referenced) rather than the synthetic lakehouse-generated database. We only
+  // rewrite when the user actually serialized a non-empty path that differs
+  // from the synthetic DB path, so we don't accidentally clobber the resolved
+  // path with an empty string.
   if (
     ownerRef.value instanceof INTERNAL__LakehouseGeneratedDatabase &&
-    ownerRef.valueForSerialization === ownerRef.value.OWNER.path
+    ownerRef.valueForSerialization &&
+    ownerRef.valueForSerialization !== ownerRef.value.path
   ) {
     tablePtr.database = ownerRef.valueForSerialization;
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
- follow up to https://github.com/finos/legend-studio/pull/5439 
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
