### PR TITLE
update availability classifier path

### DIFF
--- a/.changeset/availability-patch.md
+++ b/.changeset/availability-patch.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-graph': patch
+---
+
+update availability classifier path

--- a/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__AvailabilityRoundtrip.ts
+++ b/packages/legend-graph/src/graph-manager/__tests__/roundtripTestData/TEST_DATA__AvailabilityRoundtrip.ts
@@ -15,7 +15,7 @@
  */
 
 const availabilityClassifierPath =
-  'meta::external::lakehouse::specification::metamodel::Availability';
+  'meta::external::availability::specification::metamodel::Availability';
 
 const sectionIndexForSingleAvailability = {
   path: '__internal__::SectionIndex',

--- a/packages/legend-graph/src/graph/MetaModelConst.ts
+++ b/packages/legend-graph/src/graph/MetaModelConst.ts
@@ -162,7 +162,7 @@ export enum CORE_PURE_PATH {
   DATA_PRODUCT = 'meta::external::catalog::dataProduct::specification::metamodel::DataProduct',
   INGEST_DEFINITION = 'meta::external::ingest::specification::metamodel::IngestDefinition',
   COMPUTE = 'meta::external::compute::specification::metamodel::Compute',
-  AVAILABILITY = 'meta::external::lakehouse::specification::metamodel::Availability',
+  AVAILABILITY = 'meta::external::availability::specification::metamodel::Availability',
 }
 
 export const PURE_DOC_TAG = 'doc';


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary
update availability classifier path to meta::external::availability::specification::metamodel::Availability
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
