### PR TITLE
Add grammar support for persistence strategy to data quality recon element

### DIFF
--- a/.changeset/mighty-planets-dress.md
+++ b/.changeset/mighty-planets-dress.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-extension-dsl-data-quality': patch
+---
+
+feat: add persistence strategy to data quality relational comparison element

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/DSL_DataQuality_GraphModifierHelper.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/DSL_DataQuality_GraphModifierHelper.ts
@@ -228,6 +228,19 @@ export const dataQualityRelationValidationConfig_setPersistenceStrategy =
     },
   );
 
+export const dataQualityRelationComparisonConfig_setPersistenceStrategy =
+  action(
+    (
+      element: DataQualityRelationComparisonConfiguration,
+      val: DataQualityPersistenceStrategy | undefined,
+      observerContext: ObserverContext,
+    ): void => {
+      element.persistenceStrategy = val
+        ? observe_DataQualityPersistenceStrategy(val, observerContext)
+        : undefined;
+    },
+  );
+
 export const dataQualityRelationComparison_setSource = action(
   (
     element: DataQualityRelationComparisonConfiguration,

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/action/changeDetection/DSL_DataQuality_ObserverHelper.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/action/changeDetection/DSL_DataQuality_ObserverHelper.ts
@@ -253,6 +253,7 @@ export const observe_DataQualityRelationComparisonConfiguration =
   skipObservedWithContext(
     (
       metamodel: DataQualityRelationComparisonConfiguration,
+      context: ObserverContext,
     ): DataQualityRelationComparisonConfiguration => {
       observe_Abstract_PackageableElement(metamodel);
       makeObservable<
@@ -266,10 +267,17 @@ export const observe_DataQualityRelationComparisonConfiguration =
         columnsToCompare: observable,
         strategy: observable,
         expectedMatch: observable,
+        persistenceStrategy: observable,
       });
       observe_DataQualityRelationQueryLambda(metamodel.source);
       observe_DataQualityRelationQueryLambda(metamodel.target);
       observe_ReconStrategy(metamodel.strategy);
+      if (metamodel.persistenceStrategy) {
+        observe_DataQualityPersistenceStrategy(
+          metamodel.persistenceStrategy,
+          context,
+        );
+      }
       return metamodel;
     },
   );

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DataQualityValidationConfiguration.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/V1_DataQualityValidationConfiguration.ts
@@ -201,6 +201,7 @@ export class V1_DataQualityRelationComparisonConfiguration
   columnsToCompare: string[] = [];
   strategy!: V1_ReconStrategy;
   expectedMatch?: number | undefined;
+  persistenceStrategy?: V1_DataQualityPersistenceStrategy | undefined;
 
   override get hashCode(): string {
     return hashArray([
@@ -211,6 +212,7 @@ export class V1_DataQualityRelationComparisonConfiguration
       hashArray(this.columnsToCompare),
       String(this.expectedMatch ?? ''),
       this.strategy,
+      this.persistenceStrategy ?? '',
     ]);
   }
 

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationBuilderHelper.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationBuilderHelper.ts
@@ -424,4 +424,10 @@ export function V1_buildDataQualityRelationComparisonConfiguration(
     );
   }
   element.expectedMatch = elementProtocol.expectedMatch;
+  element.persistenceStrategy = elementProtocol.persistenceStrategy
+    ? V1_buildDataQualityPersistenceStrategy(
+        elementProtocol.persistenceStrategy,
+        context,
+      )
+    : undefined;
 }

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationTransformer.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/V1_DSL_DataQuality_ValueSpecificationTransformer.ts
@@ -303,5 +303,11 @@ export function V1_transformDataQualityRelationComparisonConfiguration(
   protocol.columnsToCompare = metamodel.columnsToCompare;
   protocol.strategy = V1_transformReconStrategy(metamodel.strategy);
   protocol.expectedMatch = metamodel.expectedMatch;
+  protocol.persistenceStrategy = metamodel.persistenceStrategy
+    ? V1_transformDataQualityPersistenceStrategy(
+        metamodel.persistenceStrategy,
+        context,
+      )
+    : undefined;
   return protocol;
 }

--- a/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/V1_DSL_DataQuality_ProtocolHelper.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph-manager/protocol/pure/v1/transformation/pureProtocol/V1_DSL_DataQuality_ProtocolHelper.ts
@@ -315,6 +315,10 @@ const V1_dataQualityRelationComparisonModelSchema = (
       (val) => (val ? V1_deserializeReconStrategy(val) : SKIP),
     ),
     expectedMatch: optional(primitive()),
+    persistenceStrategy: optionalCustom(
+      (val) => V1_serializeDataQualityPersistenceStrategy(val, plugins),
+      (val) => V1_deserializeDataQualityPersistenceStrategy(val, plugins),
+    ),
   });
 
 export const V1_serializeDataQualityRelationComparison = (

--- a/packages/legend-extension-dsl-data-quality/src/graph/metamodel/pure/packageableElements/data-quality/DataQualityValidationConfiguration.ts
+++ b/packages/legend-extension-dsl-data-quality/src/graph/metamodel/pure/packageableElements/data-quality/DataQualityValidationConfiguration.ts
@@ -243,6 +243,7 @@ export class DataQualityRelationComparisonConfiguration
   columnsToCompare: string[] = [];
   strategy!: ReconStrategy;
   expectedMatch?: number | undefined;
+  persistenceStrategy?: DataQualityPersistenceStrategy | undefined;
 
   protected override get _elementHashCode(): string {
     return hashArray([
@@ -253,6 +254,7 @@ export class DataQualityRelationComparisonConfiguration
       hashArray(this.columnsToCompare),
       this.expectedMatch ?? '',
       this.strategy,
+      this.persistenceStrategy ?? '',
     ]);
   }
 


### PR DESCRIPTION
## Summary

Add grammar support for persistence strategy to data quality recon element. This is done in exactly the same way that was done earlier for dats quality relational element in below PR:

https://github.com/finos/legend-studio/pulls