### PR TITLE
minor fixes across datacube + query

### DIFF
--- a/.changeset/export-action-support-matrix.md
+++ b/.changeset/export-action-support-matrix.md
@@ -1,0 +1,7 @@
+---
+'@finos/legend-application-query': patch
+'@finos/legend-extension-dsl-service': patch
+'@finos/legend-query-builder': patch
+---
+
+Disable unsupported export actions for Data Product and Ingest queries, and allow export actions to provide context-specific disabled messages in the query results menu.

--- a/.changeset/lite-production-data-products-query.md
+++ b/.changeset/lite-production-data-products-query.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-query': patch
+---
+
+Switch Legend Query data product loading to the Lakehouse lite API and fetch only production data products.

--- a/.changeset/production-parallel-data-products.md
+++ b/.changeset/production-parallel-data-products.md
@@ -1,0 +1,5 @@
+---
+'@finos/legend-application-data-cube': patch
+---
+
+Fix Lakehouse DataCube consumer data product loading so switching from Production to Production (parallel) immediately refetches the data product list.

--- a/packages/legend-application-data-cube/src/components/builder/source/LakehouseConsumerDataCubeSourceBuilder.tsx
+++ b/packages/legend-application-data-cube/src/components/builder/source/LakehouseConsumerDataCubeSourceBuilder.tsx
@@ -114,6 +114,9 @@ export const LakehouseConsumerDataCubeSourceBuilder: React.FC<{
             }) => {
               sourceBuilder.setEnvMode(newVal.value);
               sourceBuilder.resetDataProduct();
+              flowResult(sourceBuilder.loadDataProducts(accessToken)).catch(
+                store.application.alertUnhandledError,
+              );
             }}
             value={{
               label:

--- a/packages/legend-application-data-cube/src/stores/builder/source/LakehouseConsumerDataCubeSourceBuilderState.ts
+++ b/packages/legend-application-data-cube/src/stores/builder/source/LakehouseConsumerDataCubeSourceBuilderState.ts
@@ -189,6 +189,7 @@ export class LakehouseConsumerDataCubeSourceBuilderState extends LegendDataCubeS
   *loadDataProducts(access_token?: string): GeneratorFn<void> {
     try {
       this.dataProductLoadingState.inProgress();
+      const requestedEnvMode = this.envMode;
       const dataProducts =
         (yield this._contractServerClient.getAllLiteDataProducts(
           this.envMode,
@@ -197,7 +198,9 @@ export class LakehouseConsumerDataCubeSourceBuilderState extends LegendDataCubeS
         )) as PlainObject<V1_EntitlementsDataProductLiteResponse>;
       const dataProductLiteDetails =
         V1_entitlementsDataProductLiteResponseToDataProductLite(dataProducts);
-      this.setDataProducts(dataProductLiteDetails);
+      if (requestedEnvMode === this.envMode) {
+        this.setDataProducts(dataProductLiteDetails);
+      }
       this.dataProductLoadingState.complete();
     } catch (error) {
       assertErrorThrown(error);

--- a/packages/legend-application-query/src/components/Core_LegendQueryApplicationPlugin.tsx
+++ b/packages/legend-application-query/src/components/Core_LegendQueryApplicationPlugin.tsx
@@ -141,6 +141,19 @@ import { LegendQueryDataProductQueryBuilderState } from '../stores/data-product/
 import { IngestLegendQueryBuilderState } from '../stores/ingest/IngestLegendQueryBuilderState.js';
 import { renderDataProductSampleQueryPanelContent } from './data-product/DataProductSampleQueryPanel.js';
 
+const isDataProductOrIngestQuery = (
+  queryBuilderState: QueryBuilderState,
+): boolean =>
+  queryBuilderState instanceof DataProductQueryBuilderState ||
+  queryBuilderState instanceof IngestLegendQueryBuilderState;
+
+const getUnsupportedExportActionMessage = (
+  queryBuilderState: QueryBuilderState,
+): string =>
+  isDataProductOrIngestQuery(queryBuilderState)
+    ? 'Not supported for Data Product or Ingest queries'
+    : 'Requires saved query';
+
 export const QUERY_DATACUBE_USAGE_TITLE = 'Legend DataCube';
 const QUERY_DATACUBE_SOURCE_TYPE = 'legendQuery';
 
@@ -387,6 +400,9 @@ export class Core_LegendQueryApplicationPlugin extends LegendQueryApplicationPlu
         title: 'Promote Curated Template query...',
         label: 'Curated Template Query',
         disableFunc: (queryBuilderState): boolean => {
+          if (isDataProductOrIngestQuery(queryBuilderState)) {
+            return true;
+          }
           if (
             queryBuilderState.workflowState.actionConfig instanceof
             QueryBuilderActionConfig_QueryApplication
@@ -463,13 +479,16 @@ export class Core_LegendQueryApplicationPlugin extends LegendQueryApplicationPlu
           }
         },
         icon: <ArrowCircleUpIcon />,
-        disableMessage: 'Requires saved query',
+        getDisableMessage: getUnsupportedExportActionMessage,
       },
       {
         key: 'legend-datacube-query',
         title: 'Launch Legend DataCube...',
         label: 'Legend DataCube',
         disableFunc: (queryBuilderState): boolean => {
+          if (isDataProductOrIngestQuery(queryBuilderState)) {
+            return true;
+          }
           if (
             queryBuilderState.workflowState.actionConfig instanceof
             QueryBuilderActionConfig_QueryApplication
@@ -515,7 +534,7 @@ export class Core_LegendQueryApplicationPlugin extends LegendQueryApplicationPlu
           }
         },
         icon: <CubeIcon />,
-        disableMessage: 'Requires saved query',
+        getDisableMessage: getUnsupportedExportActionMessage,
       },
     ];
   }

--- a/packages/legend-application-query/src/stores/QueryEditorStore.ts
+++ b/packages/legend-application-query/src/stores/QueryEditorStore.ts
@@ -1348,6 +1348,7 @@ export abstract class QueryEditorStore {
         new DataProductSelectorState(
           this.depotServerClient,
           this.applicationStore,
+          this.lakehouseState?.contractServerClient,
         ),
       onLegacyDataSpaceChange,
       undefined,
@@ -2264,6 +2265,7 @@ export class ExistingQueryEditorStore extends QueryEditorStore {
             new DataProductSelectorState(
               this.depotServerClient,
               this.applicationStore,
+              this.lakehouseState?.contractServerClient,
             ),
             () => {
               this.applicationStore.notificationService.notifyWarning(

--- a/packages/legend-application-query/src/stores/__tests__/DataProductSelectorState.test.ts
+++ b/packages/legend-application-query/src/stores/__tests__/DataProductSelectorState.test.ts
@@ -25,7 +25,12 @@ import { ResolvedDataSpaceEntityWithOrigin } from '@finos/legend-extension-dsl-d
 import { DepotEntityWithOrigin } from '@finos/legend-storage';
 import { DATA_SPACE_ELEMENT_CLASSIFIER_PATH } from '@finos/legend-extension-dsl-data-space/graph';
 import type { DepotServerClient } from '@finos/legend-server-depot';
+import type { LakehouseContractServerClient } from '@finos/legend-server-lakehouse';
 import type { LegendQueryApplicationStore } from '../LegendQueryBaseStore.js';
+import {
+  V1_DataProductOriginType,
+  V1_EntitlementsLakehouseEnvironmentType,
+} from '@finos/legend-graph';
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -47,8 +52,18 @@ const buildMockDepotServerClient = (overrides?: {
       (jest.fn() as AnyMockFn).mockResolvedValue([]),
   }) as unknown as DepotServerClient;
 
+const buildMockLakehouseContractServerClient = (overrides?: {
+  getAllLiteDataProducts?: AnyMockFn;
+}): LakehouseContractServerClient =>
+  ({
+    getAllLiteDataProducts:
+      overrides?.getAllLiteDataProducts ??
+      (jest.fn() as AnyMockFn).mockResolvedValue({ dataProducts: [] }),
+  }) as unknown as LakehouseContractServerClient;
+
 const buildMockApplicationStore = (overrides?: {
   NonProductionFeatureFlag?: boolean;
+  accessToken?: string | undefined;
 }): LegendQueryApplicationStore =>
   ({
     config: {
@@ -62,6 +77,9 @@ const buildMockApplicationStore = (overrides?: {
     logService: {
       error: jest.fn(),
     },
+    getAccessToken: jest
+      .fn<() => string | undefined>()
+      .mockReturnValue(overrides?.accessToken ?? 'test-access-token'),
   }) as unknown as LegendQueryApplicationStore;
 
 // ---------------------------------------------------------------------------
@@ -89,20 +107,6 @@ const TEST_DATA__storedDataSpaceEntity = (
         : {}),
     },
   },
-});
-
-const TEST_DATA__storedSummaryDataProductEntity = (
-  groupId: string,
-  artifactId: string,
-  versionId: string,
-  path: string,
-  classifierPath: string,
-) => ({
-  groupId,
-  artifactId,
-  versionId,
-  path,
-  classifierPath,
 });
 
 // ---------------------------------------------------------------------------
@@ -227,24 +231,39 @@ describe(unitTest('DataProductSelectorState'), () => {
       ];
 
       const mockDataProducts = [
-        TEST_DATA__storedSummaryDataProductEntity(
-          'org.finos',
-          'product-x',
-          '1.0.0',
-          'model::ProductX',
-          'meta::external::catalog::dataProduct::specification::metamodel::DataProduct',
-        ),
+        {
+          id: 'product-x',
+          deploymentId: 101,
+          title: 'Product X',
+          fullPath: 'model::ProductX',
+          origin: {
+            type: V1_DataProductOriginType.SDLC_DEPLOYMENT,
+            group: 'org.finos',
+            artifact: 'product-x',
+            version: '1.0.0',
+          },
+          lakehouseEnvironment: {
+            producerEnvironmentName: 'PROD',
+            type: V1_EntitlementsLakehouseEnvironmentType.PRODUCTION,
+          },
+        },
       ];
 
       depotClient = buildMockDepotServerClient({
         getEntitiesByClassifier: (jest.fn() as AnyMockFn).mockResolvedValue(
           mockDataSpaces,
         ),
-        getEntitiesSummaryByClassifier: (
-          jest.fn() as AnyMockFn
-        ).mockResolvedValue(mockDataProducts),
       });
-      selectorState = new DataProductSelectorState(depotClient, appStore);
+      const lakehouseClient = buildMockLakehouseContractServerClient({
+        getAllLiteDataProducts: (jest.fn() as AnyMockFn).mockResolvedValue({
+          dataProducts: mockDataProducts,
+        }),
+      });
+      selectorState = new DataProductSelectorState(
+        depotClient,
+        appStore,
+        lakehouseClient,
+      );
 
       await flowResult(selectorState.loadProducts());
 
@@ -268,11 +287,23 @@ describe(unitTest('DataProductSelectorState'), () => {
           >
         )[0]?.path,
       ).toBe('model::ProductX');
+      expect(
+        (
+          selectorState.dataProducts as NonNullable<
+            typeof selectorState.dataProducts
+          >
+        )[0]?.name,
+      ).toBe('Product X');
 
       // State flags
       expect(selectorState.loadProductsState.hasSucceeded).toBe(true);
       expect(selectorState.isCompletelyLoaded).toBe(true);
       expect(selectorState.isFetchingProducts).toBe(false);
+      expect(lakehouseClient.getAllLiteDataProducts).toHaveBeenCalledWith(
+        V1_EntitlementsLakehouseEnvironmentType.PRODUCTION,
+        undefined,
+        'test-access-token',
+      );
     },
   );
 
@@ -294,16 +325,22 @@ describe(unitTest('DataProductSelectorState'), () => {
         getEntitiesByClassifier: (jest.fn() as AnyMockFn).mockResolvedValue(
           mockDataSpaces,
         ),
-        getEntitiesSummaryByClassifier: jest.fn() as AnyMockFn,
       });
-      selectorState = new DataProductSelectorState(depotClient, appStore);
+      const lakehouseClient = buildMockLakehouseContractServerClient({
+        getAllLiteDataProducts: jest.fn() as AnyMockFn,
+      });
+      selectorState = new DataProductSelectorState(
+        depotClient,
+        appStore,
+        lakehouseClient,
+      );
       selectorState.disableDataProducts = true;
 
       await flowResult(selectorState.loadProducts());
 
       expect(selectorState.legacyDataProducts).toHaveLength(1);
       expect(selectorState.dataProducts).toHaveLength(0);
-      expect(depotClient.getEntitiesSummaryByClassifier).not.toHaveBeenCalled();
+      expect(lakehouseClient.getAllLiteDataProducts).not.toHaveBeenCalled();
       expect(selectorState.loadProductsState.hasSucceeded).toBe(true);
     },
   );

--- a/packages/legend-application-query/src/stores/data-product/DataProductSampleQueryCreatorStore.ts
+++ b/packages/legend-application-query/src/stores/data-product/DataProductSampleQueryCreatorStore.ts
@@ -120,6 +120,7 @@ export class DataProductSampleQueryCreatorStore extends BaseTemplateQueryCreator
       new DataProductSelectorState(
         this.depotServerClient,
         this.applicationStore,
+        this.lakehouseState?.contractServerClient,
       ),
     );
 

--- a/packages/legend-application-query/src/stores/data-space/DataProductQueryCreatorStore.ts
+++ b/packages/legend-application-query/src/stores/data-space/DataProductQueryCreatorStore.ts
@@ -204,6 +204,7 @@ export class DataProductQueryCreatorStore extends QueryEditorStore {
     this.productSelectorState = new DataProductSelectorState(
       depotServerClient,
       applicationStore,
+      this.lakehouseState?.contractServerClient,
     );
   }
 

--- a/packages/legend-application-query/src/stores/data-space/DataProductSelectorState.ts
+++ b/packages/legend-application-query/src/stores/data-space/DataProductSelectorState.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CORE_PURE_PATH } from '@finos/legend-graph';
 import {
   DepotScope,
   type DepotServerClient,
@@ -26,9 +25,10 @@ import {
   ActionState,
   LogEvent,
   assertErrorThrown,
+  isNonNullable,
   type GeneratorFn,
 } from '@finos/legend-shared';
-import type { DepotEntityWithOrigin } from '@finos/legend-storage';
+import { DepotEntityWithOrigin } from '@finos/legend-storage';
 import {
   DATA_SPACE_ELEMENT_CLASSIFIER_PATH,
   extractDataSpaceInfo,
@@ -38,6 +38,35 @@ import type { DataSpaceOption } from '@finos/legend-extension-dsl-data-space/app
 import { action, flow, makeObservable, observable } from 'mobx';
 import { APPLICATION_EVENT } from '@finos/legend-application';
 import type { LegendQueryApplicationStore } from '../LegendQueryBaseStore.js';
+import { type LakehouseContractServerClient } from '@finos/legend-server-lakehouse';
+import {
+  CORE_PURE_PATH,
+  type V1_EntitlementsDataProductLite,
+  V1_EntitlementsLakehouseEnvironmentType,
+  V1_SdlcDeploymentDataProductOrigin,
+  V1_entitlementsDataProductLiteResponseToDataProductLite,
+} from '@finos/legend-graph';
+
+const createDepotEntityFromLiteDataProduct = (
+  value: V1_EntitlementsDataProductLite,
+): DepotEntityWithOrigin | undefined => {
+  if (value.origin instanceof V1_SdlcDeploymentDataProductOrigin) {
+    const origin = {
+      groupId: value.origin.group,
+      artifactId: value.origin.artifact,
+      versionId: value.origin.version,
+    };
+
+    return new DepotEntityWithOrigin(
+      origin,
+      value.title ?? value.id,
+      value.fullPath ?? value.id,
+      CORE_PURE_PATH.DATA_PRODUCT,
+    );
+  }
+  // do not include non sdlc data products
+  return undefined;
+};
 
 export type DataProductOption = {
   label: string;
@@ -67,12 +96,16 @@ export class DataProductSelectorState {
   dataProducts: DepotEntityWithOrigin[] | undefined;
   readonly loadProductsState = ActionState.create();
   readonly depotServerClient: DepotServerClient;
+  readonly lakehouseContractServerClient:
+    | LakehouseContractServerClient
+    | undefined;
   readonly applicationStore: LegendQueryApplicationStore;
   disableDataProducts = false;
 
   constructor(
     depotServerClient: DepotServerClient,
     applicationStore: LegendQueryApplicationStore,
+    lakehouseContractServerClient?: LakehouseContractServerClient,
   ) {
     makeObservable(this, {
       legacyDataProducts: observable,
@@ -85,6 +118,7 @@ export class DataProductSelectorState {
     });
     this.applicationStore = applicationStore;
     this.depotServerClient = depotServerClient;
+    this.lakehouseContractServerClient = lakehouseContractServerClient;
 
     // TEMPORARY: Disable data products when NonProductionFeatureFlag is off.
     // Remove once the feature is fully tested.
@@ -116,6 +150,7 @@ export class DataProductSelectorState {
   *loadProducts(): GeneratorFn<void> {
     this.loadProductsState.inProgress();
     try {
+      const accessToken = this.applicationStore.getAccessToken();
       // Load DataSpaces
       const dataSpaces = (
         (yield this.depotServerClient.getEntitiesByClassifier(
@@ -129,17 +164,27 @@ export class DataProductSelectorState {
       });
       const dataProducts = this.disableDataProducts
         ? []
-        : (
-            (yield this.depotServerClient.getEntitiesSummaryByClassifier(
-              CORE_PURE_PATH.DATA_PRODUCT,
-              {
-                scope: DepotScope.RELEASES,
-                summary: true,
-              },
-            )) as StoredSummaryEntity[]
-          ).map((storedEntity) => {
-            return extractDepotEntityInfo(storedEntity, false);
-          });
+        : this.lakehouseContractServerClient
+          ? V1_entitlementsDataProductLiteResponseToDataProductLite(
+              yield this.lakehouseContractServerClient.getAllLiteDataProducts(
+                V1_EntitlementsLakehouseEnvironmentType.PRODUCTION,
+                undefined,
+                accessToken,
+              ),
+            )
+              .map(createDepotEntityFromLiteDataProduct)
+              .filter(isNonNullable)
+          : (
+              (yield this.depotServerClient.getEntitiesSummaryByClassifier(
+                CORE_PURE_PATH.DATA_PRODUCT,
+                {
+                  scope: DepotScope.RELEASES,
+                  summary: true,
+                },
+              )) as StoredSummaryEntity[]
+            ).map((storedEntity) => {
+              return extractDepotEntityInfo(storedEntity, false);
+            });
       // Set both lists separately
       this.legacyDataProducts = dataSpaces;
       this.dataProducts = dataProducts;

--- a/packages/legend-application-query/src/stores/data-space/DataSpaceTemplateQueryCreatorStore.ts
+++ b/packages/legend-application-query/src/stores/data-space/DataSpaceTemplateQueryCreatorStore.ts
@@ -213,6 +213,7 @@ export class DataSpaceTemplateQueryCreatorStore extends BaseTemplateQueryCreator
       new DataProductSelectorState(
         this.depotServerClient,
         this.applicationStore,
+        this.lakehouseState?.contractServerClient,
       ),
       () => {
         this.applicationStore.notificationService.notifyWarning(

--- a/packages/legend-application-query/src/stores/data-space/LegendQueryBareQueryBuilderState.ts
+++ b/packages/legend-application-query/src/stores/data-space/LegendQueryBareQueryBuilderState.ts
@@ -89,7 +89,11 @@ export class LegendQueryBareQueryBuilderState extends BaseQueryBuilderState {
     this.changeHandlers = changeHandlers;
     this.productSelectorState =
       productSelectorState ??
-      new DataProductSelectorState(depotServerClient, applicationStore);
+      new DataProductSelectorState(
+        depotServerClient,
+        applicationStore,
+        editorStore.lakehouseState?.contractServerClient,
+      );
   }
 
   override get sideBarClassName(): string | undefined {

--- a/packages/legend-extension-dsl-service/src/components/query/DSL_Service_LegendQueryApplicationPlugin.tsx
+++ b/packages/legend-extension-dsl-service/src/components/query/DSL_Service_LegendQueryApplicationPlugin.tsx
@@ -26,7 +26,54 @@ import { StoreProjectData } from '@finos/legend-server-depot';
 import { parseProjectIdentifier } from '@finos/legend-storage';
 import { buildUrl } from '@finos/legend-shared';
 import { ServiceRegisterModal } from './ServiceRegisterModal.js';
-import type { QueryBuilderMenuActionConfiguration } from '@finos/legend-query-builder';
+import {
+  type QueryBuilderMenuActionConfiguration,
+  type QueryBuilderState,
+} from '@finos/legend-query-builder';
+import {
+  QueryDataProductLakehouseExecutionContextInfo,
+  QueryDataProductModelAccessExecutionContextInfo,
+  QueryDataProductNativeExecutionContextInfo,
+  QueryIngestExecutionContextInfo,
+} from '@finos/legend-graph';
+
+const getExistingQueryEditorStore = (
+  queryBuilderState: QueryBuilderState,
+): ExistingQueryEditorStore | undefined => {
+  if (
+    queryBuilderState.workflowState.actionConfig instanceof
+    QueryBuilderActionConfig_QueryApplication
+  ) {
+    const editorStore =
+      queryBuilderState.workflowState.actionConfig.editorStore;
+    if (editorStore instanceof ExistingQueryEditorStore) {
+      return editorStore;
+    }
+  }
+  return undefined;
+};
+
+const isDataProductOrIngestQuery = (
+  queryBuilderState: QueryBuilderState,
+): boolean => {
+  const editorStore = getExistingQueryEditorStore(queryBuilderState);
+  const executionContext = editorStore?.queryInfo?.executionContext;
+
+  return (
+    executionContext instanceof QueryDataProductNativeExecutionContextInfo ||
+    executionContext instanceof
+      QueryDataProductModelAccessExecutionContextInfo ||
+    executionContext instanceof QueryDataProductLakehouseExecutionContextInfo ||
+    executionContext instanceof QueryIngestExecutionContextInfo
+  );
+};
+
+const getUnsupportedExportActionMessage = (
+  queryBuilderState: QueryBuilderState,
+): string =>
+  isDataProductOrIngestQuery(queryBuilderState)
+    ? 'Not supported for Data Product or Ingest queries'
+    : 'Requires saved query';
 
 export class DSL_Service_LegendQueryApplicationPlugin extends LegendQueryApplicationPlugin {
   constructor() {
@@ -40,15 +87,11 @@ export class DSL_Service_LegendQueryApplicationPlugin extends LegendQueryApplica
         title: 'Productionize query...',
         label: 'Productionized Query',
         disableFunc: (queryBuilderState): boolean => {
-          if (
-            queryBuilderState.workflowState.actionConfig instanceof
-            QueryBuilderActionConfig_QueryApplication
-          ) {
-            const editorStore =
-              queryBuilderState.workflowState.actionConfig.editorStore;
-            return !(editorStore instanceof ExistingQueryEditorStore);
+          const editorStore = getExistingQueryEditorStore(queryBuilderState);
+          if (isDataProductOrIngestQuery(queryBuilderState)) {
+            return true;
           }
-          return true;
+          return !editorStore;
         },
         onClick: (queryBuilderState): void => {
           if (
@@ -100,12 +143,15 @@ export class DSL_Service_LegendQueryApplicationPlugin extends LegendQueryApplica
           }
         },
         icon: <ArrowCircleUpIcon />,
-        disableMessage: 'Requires saved query',
+        getDisableMessage: getUnsupportedExportActionMessage,
       },
       {
         key: 'export-as-dev-service',
         title: 'Register query as service',
         label: 'DEV Service',
+        disableFunc: (queryBuilderState): boolean =>
+          !getExistingQueryEditorStore(queryBuilderState) ||
+          isDataProductOrIngestQuery(queryBuilderState),
         onClick: (queryBuilderState): void => {
           if (
             queryBuilderState.workflowState.actionConfig instanceof
@@ -117,6 +163,7 @@ export class DSL_Service_LegendQueryApplicationPlugin extends LegendQueryApplica
           }
         },
         icon: <RocketIcon />,
+        getDisableMessage: getUnsupportedExportActionMessage,
         renderExtraComponent: (
           queryBuilderState,
         ): React.ReactNode | undefined => {

--- a/packages/legend-query-builder/src/components/result/QueryBuilderResultPanel.tsx
+++ b/packages/legend-query-builder/src/components/result/QueryBuilderResultPanel.tsx
@@ -514,23 +514,27 @@ export const QueryBuilderResultPanel = observer(
             plugin as QueryBuilder_LegendApplicationPlugin_Extension
           ).getExtraQueryBuilderExportMenuActionConfigurations?.() ?? [],
       )
-      .map((item) => (
-        <MenuContentItem
-          key={item.key}
-          title={
-            !item.disableFunc?.(queryBuilderState)
-              ? item.title
-              : (item.disableMessage ?? 'Unsupported')
-          }
-          disabled={item.disableFunc?.(queryBuilderState) ?? false}
-          onClick={() => {
-            item.onClick(queryBuilderState);
-          }}
-        >
-          {item.icon && <MenuContentItemIcon>{item.icon}</MenuContentItemIcon>}
-          <MenuContentItemLabel>{item.label}</MenuContentItemLabel>
-        </MenuContentItem>
-      ));
+      .map((item) => {
+        const isDisabled = item.disableFunc?.(queryBuilderState) ?? false;
+        const disableMessage =
+          item.getDisableMessage?.(queryBuilderState) ?? item.disableMessage;
+
+        return (
+          <MenuContentItem
+            key={item.key}
+            title={!isDisabled ? item.title : (disableMessage ?? 'Unsupported')}
+            disabled={isDisabled}
+            onClick={() => {
+              item.onClick(queryBuilderState);
+            }}
+          >
+            {item.icon && (
+              <MenuContentItemIcon>{item.icon}</MenuContentItemIcon>
+            )}
+            <MenuContentItemLabel>{item.label}</MenuContentItemLabel>
+          </MenuContentItem>
+        );
+      });
 
     const isLoading =
       resultState.isRunningQuery || resultState.isGeneratingPlan;

--- a/packages/legend-query-builder/src/stores/QueryBuilder_LegendApplicationPlugin_Extension.ts
+++ b/packages/legend-query-builder/src/stores/QueryBuilder_LegendApplicationPlugin_Extension.ts
@@ -94,6 +94,9 @@ export type QueryBuilderMenuActionConfiguration = {
     queryBuilderState: QueryBuilderState,
   ) => React.ReactNode;
   disableMessage?: string | undefined;
+  getDisableMessage?:
+    | ((queryBuilderState: QueryBuilderState) => string | undefined)
+    | undefined;
 };
 
 export type QueryBuilderPropagateExecutionContextChangeHelper = (


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:
  1. Fork [the repository](https://github.com/finos/legend-studio) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Add a changeset to summarize your change in the changelogs.
  5. If you haven't already, complete the CLA.

  Learn more about contributing: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md
-->

## Summary


- Disable unsupported export actions for Data Product and Ingest queries, and allow export actions to provide context-specific disabled messages in the query results menu.

- Switch Legend Query data product loading to the Lakehouse lite API and fetch only production data products.
- Fix Lakehouse DataCube consumer data product loading so switching from Production to Production (parallel) immediately refetches the data product list.
<!--
  Explain the **motivation** for making this change. What existing problem(s) does this PR solve?
  Also, link the issue(s) to this PR: e.g. Fixes #1, Resolves #2
  If you also added documentation, link the PR from https://github.com/finos/legend
-->

## How did you test this change?

- [ ] Test(s) added
- [ ] Manual testing (please provide screenshots/recordings)
- [ ] No testing (please provide an explanation)

<!--
  Demonstrate the code is solid. Screenshots/videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!--
  More in-depth docs below:
  - Git workflow: https://github.com/finos/legend-studio/blob/master/docs/workflow/working-with-github.md
  - Test: https://github.com/finos/legend-studio/blob/master/docs/technical/test-strategy.md
  - Changeset: https://github.com/finos/legend-studio/blob/master/CONTRIBUTING.md#changeset
  - Dependency: https://github.com/finos/legend-studio/blob/master/docs/workflow/dependencies.md
  - UX/UI: https://github.com/finos/legend-studio/tree/master/docs/ux
-->
